### PR TITLE
fix(storybook): remove direct vite import to fix vercel build

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from "@storybook/react-vite";
-import { mergeConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 
 const config: StorybookConfig = {
@@ -25,10 +24,8 @@ const config: StorybookConfig = {
     reactDocgen: "react-docgen-typescript", // Generate prop types from TypeScript
   },
   viteFinal(config) {
-    // Merge with our Vite config to include Tailwind CSS v4 plugin
-    return mergeConfig(config, {
-      plugins: [tailwindcss()],
-    });
+    config.plugins = [...(config.plugins ?? []), tailwindcss()];
+    return config;
   },
 };
 


### PR DESCRIPTION
## Summary

- Removes `import { mergeConfig } from 'vite'` from `.storybook/main.ts`
- Rewrites `viteFinal` to spread `config.plugins` directly instead of calling `mergeConfig`
- `vite` is only a transitive dependency of `@storybook/react-vite`; pnpm's strict module resolution on Vercel blocks access to undeclared transitive deps, causing `ERR_MODULE_NOT_FOUND: Cannot find package 'vite'`

## Test plan

- [x] `pnpm build-storybook` runs successfully locally
- [ ] Vercel deployment succeeds after merging to `main`

## Notes

No changeset needed — this is a Storybook build config change, not a user-facing API change.

Merge with **squash merge** per release strategy.

Made with [Cursor](https://cursor.com)