### PR TITLE
fix(storybook): remove direct vite import to fix vercel build

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from "@storybook/react-vite";
-import { mergeConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 
 const config: StorybookConfig = {
@@ -25,10 +24,8 @@ const config: StorybookConfig = {
     reactDocgen: "react-docgen-typescript", // Generate prop types from TypeScript
   },
   viteFinal(config) {
-    // Merge with our Vite config to include Tailwind CSS v4 plugin
-    return mergeConfig(config, {
-      plugins: [tailwindcss()],
-    });
+    config.plugins = [...(config.plugins ?? []), tailwindcss()];
+    return config;
   },
 };
 


### PR DESCRIPTION
## Summary

- Removes `import { mergeConfig } from 'vite'` from `packages/react/.storybook/main.ts`
- Rewrites `viteFinal` to spread `config.plugins` directly, eliminating the need to import from `vite`
- `vite` is only a transitive dep of `@storybook/react-vite`; pnpm strict resolution on Vercel blocks access to undeclared transitive deps → `ERR_MODULE_NOT_FOUND: Cannot find package 'vite'`

## Type

Hotfix — Storybook build config only. No change to published npm package (`files` field excludes `.storybook/`).

## Versioning

No version bump, no changeset. Packages remain at `v0.1.0-rc.1`.

## Test plan

- [x] `pnpm build-storybook` passes locally (verified before cherry-pick)
- [ ] Vercel deployment succeeds after merge

## Merge instructions

Merge with **"Create a merge commit"** — never squash (per release strategy).

Made with [Cursor](https://cursor.com)