### PR TITLE
fix(storybook): remove unused vite.config.ts causing vercel build failure

### DIFF
--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -1,6 +1,0 @@
-import { defineConfig } from "vite";
-import tailwindcss from "@tailwindcss/vite";
-
-export default defineConfig({
-  plugins: [tailwindcss()],
-});


### PR DESCRIPTION
## Summary

- Deletes `packages/react/vite.config.ts` which was the root cause of the Vercel Storybook build failure
- The file imports from `"vite"` directly, but `vite` is not a direct `devDependency` of `@tinybigui/react` -- only a transitive peer dep; pnpm's strict ESM resolution on Vercel cannot find it
- The file was unused: Storybook already adds the Tailwind plugin via `viteFinal` in `.storybook/main.ts`, Vitest has its own `vitest.config.ts`, and tsup does not use Vite at all

## Test plan

- [x] `pnpm --filter @tinybigui/react build-storybook` passes locally (1257 modules, clean output)
- [x] `pnpm --filter @tinybigui/react test` passes locally (411 tests, 10 test files, all green)
- [ ] Vercel deployment succeeds after merge to `main`

## Notes

- No changeset needed (infra/tooling only, no user-facing package change)
- Merge with **merge commit** (no squash), per hotfix strategy
- After merging, sync `dev`: `git checkout dev && git merge main && git push`

Made with [Cursor](https://cursor.com)