### PR TITLE
chore: add community infrastructure and visual regression testing (M12 + M13)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,10 @@
+{
+  "projectName": "tinybigui",
+  "projectOwner": "buildinclicks",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["README.md"],
+  "imageSize": 100,
+  "commit": false,
+  "contributionTypes": ["code", "doc", "bug", "test", "design", "ideas", "review"]
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,48 @@
+name: Chromatic
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chromatic:
+    name: Visual Regression Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for Chromatic to detect changes across commits
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 🎨 Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/react
+          onlyChanged: true # Only test stories affected by the diff (faster, fewer snapshots)
+          exitZeroOnChanges: true # Visual changes require human review in Chromatic; don't fail CI

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@tinybigui.dev. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thank you for considering contributing to TinyBigUI. This document provides guid
 
 ## Code of Conduct
 
-By participating in this project, you agree to maintain a respectful and inclusive environment. Be kind, constructive, and professional in all interactions.
+This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you agree to uphold its standards. Please report unacceptable behavior to [conduct@tinybigui.dev](mailto:conduct@tinybigui.dev).
 
 ## Getting Started
 
@@ -356,6 +356,6 @@ We follow Test-Driven Development (TDD):
 
 ## Questions?
 
-If you have questions about contributing, open a discussion on GitHub or reach out to the maintainers.
+If you have questions about contributing, [open a discussion on GitHub](https://github.com/buildinclicks/tinybigui/discussions) or reach out to the maintainers. GitHub Discussions is the primary place for Q&A, ideas, and community conversation.
 
 Thank you for contributing to TinyBigUI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for considering contributing to TinyBigUI. This document provides guid
 - [Development Workflow](#development-workflow)
 - [Coding Standards](#coding-standards)
 - [Testing Requirements](#testing-requirements)
+- [Visual Regression Testing](#visual-regression-testing)
 - [Commit Guidelines](#commit-guidelines)
 - [Pull Request Process](#pull-request-process)
 - [Version Management](#version-management)
@@ -188,6 +189,39 @@ pnpm test -- --coverage
 ### Test Coverage
 
 Maintain a minimum of 85% code coverage. New components should aim for 90%+.
+
+## Visual Regression Testing
+
+TinyBigUI uses [Chromatic](https://www.chromatic.com/) to catch unintended visual changes to components.
+
+### What Chromatic Does
+
+Chromatic takes pixel-perfect screenshots of every Storybook story on every PR and compares them against the baseline (the last accepted build). If any story looks different — even slightly — Chromatic flags it for human review. This catches CSS bugs, token changes, or layout regressions that unit tests cannot detect.
+
+### What to Do When Chromatic Flags a Visual Change
+
+When the Chromatic status check on your PR shows visual changes:
+
+1. Open the Chromatic dashboard link in the PR status check
+2. Review each flagged story side by side with the baseline
+
+- **Intentional change** (e.g. you updated a component's styling on purpose): click **Accept** in the Chromatic UI to approve the new baseline
+- **Unintentional change** (e.g. a CSS regression you didn't mean to introduce): fix the issue in your branch before merging
+
+### Maintainer Approval
+
+Maintainers must approve all visual changes in the Chromatic dashboard before a PR is merged. Visual changes that are not explicitly accepted will block merge by convention, even though CI itself does not fail (we use `exitZeroOnChanges: true` to avoid false-positive CI failures from intentional changes).
+
+### Running Chromatic Locally
+
+You can run a Chromatic build locally to preview results before pushing:
+
+```bash
+# From packages/react/
+CHROMATIC_PROJECT_TOKEN=<your-token> pnpm chromatic
+```
+
+The `CHROMATIC_PROJECT_TOKEN` is available to maintainers. Contributors do not need it — the Chromatic GitHub Action runs automatically on every PR.
 
 ## Commit Guidelines
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
     <a href="https://www.npmjs.com/package/@tinybigui/react">
       <img src="https://img.shields.io/npm/v/@tinybigui/react?style=flat-square" alt="npm version" />
     </a>
+    <a href="https://www.chromatic.com/builds?appId=tinybigui">
+      <img src="https://img.shields.io/badge/Chromatic-visual%20tests-FC521F?style=flat-square&logo=storybook&logoColor=white" alt="Chromatic visual tests" />
+    </a>
   </p>
 
   <p>

--- a/README.md
+++ b/README.md
@@ -325,6 +325,15 @@ Special thanks to all open-source contributors who make projects like this possi
 
 ---
 
+## Contributors
+
+Thanks to all our contributors!
+
+<!-- ALL-CONTRIBUTORS-LIST:START -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+---
+
 ## 🌟 Show Your Support
 
 If you like this project, please consider:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of TinyBigUI are currently receiving security updates:
+
+| Version | Supported |
+| ------- | --------- |
+| 0.1.x   | ✅        |
+
+Older pre-release versions (0.0.x) are not supported. Please upgrade to the latest version.
+
+## Reporting a Vulnerability
+
+**Please do NOT report security vulnerabilities via GitHub Issues.** Public issue reports expose the vulnerability before a fix is available.
+
+Instead, report vulnerabilities by emailing **security@tinybigui.dev**.
+
+Your report should include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce the issue (proof of concept if possible)
+- Any relevant versions, environment details, or configuration
+
+### What to Expect
+
+- **Within 48 hours**: You will receive an acknowledgement confirming we have received your report.
+- **Within 7 days**: We will provide an initial assessment and an estimated timeline for a fix.
+- **After a fix is released**: We will publicly disclose the vulnerability in the release notes, crediting you (unless you prefer to remain anonymous).
+
+We follow responsible disclosure: we ask that you do not publicly disclose the vulnerability until we have released a fix and notified you.
+
+Thank you for helping keep TinyBigUI and its users safe.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,7 +56,8 @@
     "test:watch": "vitest",
     "clean": "rm -rf dist",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
     "@material/material-color-utilities": "^0.3.0",
@@ -83,6 +84,7 @@
     "@types/react-dom": "^18.3.5",
     "@vitest/browser-playwright": "^4.0.16",
     "@vitest/coverage-v8": "^4.0.16",
+    "chromatic": "^16.3.0",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
         version: 4.0.16(@vitest/browser@4.0.16(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16))(vitest@4.0.16)
+      chromatic:
+        specifier: ^16.3.0
+        version: 16.3.0
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -2156,6 +2159,21 @@ packages:
       '@chromatic-com/cypress':
         optional: true
       '@chromatic-com/playwright':
+        optional: true
+
+  chromatic@16.3.0:
+    resolution: {integrity: sha512-PvXUpXP3l8p2NxLEYhMgo4kGNNBQgCgbslMu+O4Bb37ujiiDWk8QExX/Jk7JeHUewNgK2wg98rtw3gdfz3U+Kg==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
         optional: true
 
   class-variance-authority@0.7.1:
@@ -6939,6 +6957,8 @@ snapshots:
       readdirp: 4.1.2
 
   chromatic@13.3.4: {}
+
+  chromatic@16.3.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:


### PR DESCRIPTION
## Summary

This PR merges M12 (Chromatic visual regression) and M13 (Community infrastructure) into `dev`, completing the final blockers before the v0.1.0 release.

### M12 — Visual Regression Testing (Chromatic)
- Set up Chromatic in `packages/react` for visual regression testing
- Added `.github/workflows/chromatic.yml` to run Chromatic on pushes/PRs to `main` and `dev`
- Updated `CONTRIBUTING.md` with the visual review process

### M13 — Community Infrastructure
- Added `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1)
- Added `SECURITY.md` with vulnerability reporting policy
- Enabled Dependabot for npm and github-actions
- Added all-contributors configuration
- Updated `README.md` and `CONTRIBUTING.md` with community links

## Merge Instructions

**Merge method: Squash merge** (feature branch into `dev`)

## Related

- Milestone 12: Visual Regression Testing
- Milestone 13: Community Infrastructure
- Unblocks: Milestone 14 (v0.1.0 Release)

Made with [Cursor](https://cursor.com)