### PR TITLE
fix(react): sync components barrel file with all 7 public exports

### DIFF
--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,7 +1,7 @@
 export { Button } from "./Button";
 export type { ButtonProps, ButtonVariant, ButtonColor, ButtonSize } from "./Button";
 
-export { IconButton } from "./IconButton";
+export { IconButton, IconButtonHeadless } from "./IconButton";
 export type {
   IconButtonProps,
   IconButtonVariant,
@@ -9,8 +9,17 @@ export type {
   IconButtonSize,
 } from "./IconButton";
 
-export { FAB } from "./FAB";
-export type { FABProps, FABSize, FABColor } from "./FAB";
+export { FAB, FABHeadless } from "./FAB";
+export type { FABProps, FABSize, FABColor, FABHeadlessProps } from "./FAB";
+
+export { TextField } from "./TextField";
+export type { TextFieldProps, TextFieldVariant, TextFieldSize } from "./TextField";
+
+export { Checkbox } from "./Checkbox";
+export type { CheckboxProps } from "./Checkbox";
+
+export { Switch } from "./Switch";
+export type { SwitchProps } from "./Switch";
 
 export { Radio, RadioGroup, RadioHeadless, RadioGroupHeadless } from "./Radio";
 export type {


### PR DESCRIPTION
## Summary

The `packages/react/src/components/index.ts` barrel file was missing re-exports for TextField, Checkbox, Switch, and was also missing the headless variants IconButtonHeadless and FABHeadless that the main entry `src/index.ts` already exposed.

This fix brings the barrel file in sync with the actual public API surface.

**Missing before this fix:**
- `TextField`, `TextFieldProps`, `TextFieldVariant`, `TextFieldSize`
- `Checkbox`, `CheckboxProps`
- `Switch`, `SwitchProps`
- `IconButtonHeadless`
- `FABHeadless`, `FABHeadlessProps`

## Merge Instructions

**Merge method: Squash merge** (feature branch into `dev`)

Made with [Cursor](https://cursor.com)