### PR TITLE
docs: update readmes and project docs for v0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
 
 ## ⚙️ Development Status
 
-> **Pre-release: v0.0.x**
+> **Released: v0.1.0** (2026-04-15)
 >
-> Phase 1a (Button, IconButton, FAB) and Phase 1b (TextField, Checkbox, Switch, Radio) are complete. The library is approaching its first public release (**v0.1.0**) and is **not yet published to npm**.
+> Phase 1a (Button, IconButton, FAB) and Phase 1b (TextField, Checkbox, Switch, Radio, RadioGroup) are complete and published to npm.
 >
 > Watch this repository to follow our progress!
 
@@ -56,8 +56,6 @@
 
 ## 🚀 Installation
 
-> **v0.1.0 is in preparation.** The package will be published to npm as part of the upcoming v0.1.0 release.
-
 ```bash
 npm install @tinybigui/react
 # or
@@ -70,10 +68,7 @@ yarn add @tinybigui/react
 
 ## 📖 Quick Start
 
-> **Coming Soon!** Full documentation will be available at [tinybigui.dev](https://tinybigui.dev)
-
 ```tsx
-// Preview of how it will work:
 import { Button } from "@tinybigui/react";
 import "@tinybigui/react/styles.css";
 
@@ -97,10 +92,10 @@ function App() {
 
 This is a monorepo containing multiple packages:
 
-| Package                                  | Description                   | Version     | Status                          |
-| ---------------------------------------- | ----------------------------- | ----------- | ------------------------------- |
-| [`@tinybigui/react`](./packages/react)   | React components              | Coming soon | Pre-release: v0.1.0 coming soon |
-| [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | Coming soon | Pre-release: v0.1.0 coming soon |
+| Package                                  | Description                   | Version | Status   |
+| ---------------------------------------- | ----------------------------- | ------- | -------- |
+| [`@tinybigui/react`](./packages/react)   | React components              | 0.1.0   | Released |
+| [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | 0.1.0   | Released |
 
 ---
 
@@ -134,7 +129,7 @@ This is a monorepo containing multiple packages:
 - [x] Checkbox component (49 tests)
 - [x] Radio component (47 tests)
 - [x] Switch component (50 tests)
-- [ ] First npm release (v0.1.0) — in preparation
+- [x] First npm release (v0.1.0) — released 2026-04-15
 
 ### Phase 2: Layout & Navigation
 
@@ -268,8 +263,8 @@ pnpm typecheck
 
 - **GitHub Repository**: [github.com/buildinclicks/tinybigui](https://github.com/buildinclicks/tinybigui)
 - **Documentation Site**: Coming soon at [tinybigui.dev](https://tinybigui.dev)
-- **Storybook**: Coming soon (interactive component playground)
-- **QA Phases**: See [/.qa-phases](.qa-phases) for milestone tracking toward v0.1.0
+- **Storybook**: Storybook 10 is set up — run `pnpm storybook` in `packages/react` to explore components locally
+- **QA Phases**: See [/.qa-phases](.qa-phases) for milestone tracking
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,13 +56,9 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 
 ## In Progress
 
-### v0.1.0 Release Preparation
+### v0.2.0 Phase 2 — Navigation (Next)
 
-- QA milestones (`.qa-phases/phase-0/`) in progress
-- Documentation updates
-- CHANGELOG creation (M8)
-- npm publishing infrastructure (M9)
-- Release workflow automation (M10)
+Planning in progress. See Planned Work below.
 
 ## Planned Work
 
@@ -122,4 +118,4 @@ Have an idea for a new component or feature? Open a [feature request](https://gi
 ## Stay Updated
 
 - Watch this repository for release notifications
-- Check the [Changelog](CHANGELOG.md) for release notes _(CHANGELOG will be created as part of v0.1.0 release — M8)_
+- Check the [Changelog](CHANGELOG.md) for release notes

--- a/TASKS.md
+++ b/TASKS.md
@@ -213,32 +213,32 @@
 
 ---
 
-## Phase 0.5: Pre-Release Setup (DO LATER)
+## Phase 0.5: Pre-Release Setup ✅
 
-> **When**: After Phase 1a code is complete, before v0.1.0 release  
+> **Completed**: All infrastructure completed as part of v0.1.0 release (2026-04-15)  
 > **Goal**: Full open-source infrastructure
 
 | Status | Task               | Description                          |
 | ------ | ------------------ | ------------------------------------ |
-| ⬜     | NPM organization   | Create `@tinybigui` org on npmjs.com |
-| ⬜     | NPM access token   | Generate automation token            |
-| ⬜     | GitHub Secrets     | Add `NPM_TOKEN` for publishing       |
-| ⬜     | Release workflow   | Auto-publish to NPM on release       |
-| ⬜     | Changesets setup   | Version management                   |
+| ✅     | NPM organization   | Create `@tinybigui` org on npmjs.com |
+| ✅     | NPM access token   | Generate automation token            |
+| ✅     | GitHub Secrets     | Add `NPM_TOKEN` for publishing       |
+| ✅     | Release workflow   | Auto-publish to NPM on release       |
+| ✅     | Changesets setup   | Version management                   |
 | ⬜     | Storybook deploy   | Vercel deployment workflow           |
-| ⬜     | Chromatic setup    | Visual regression testing            |
+| ✅     | Chromatic setup    | Visual regression testing            |
 | ⬜     | GitHub Discussions | Enable and configure categories      |
 | ⬜     | Issue labels       | Create standard labels               |
 | ⬜     | Milestones         | Create v0.1.0, v0.2.0, v1.0.0        |
 | ⬜     | Issue templates    | Bug report, feature request          |
 | ⬜     | PR template        | Pull request template                |
 | ⬜     | CONTRIBUTING.md    | Full contribution guide              |
-| ⬜     | CODE_OF_CONDUCT.md | Contributor Covenant                 |
-| ⬜     | SECURITY.md        | Security policy                      |
-| ⬜     | Dependabot         | Enable security updates              |
+| ✅     | CODE_OF_CONDUCT.md | Contributor Covenant                 |
+| ✅     | SECURITY.md        | Security policy                      |
+| ✅     | Dependabot         | Enable security updates              |
 | ⬜     | All Contributors   | Install bot                          |
-| ⬜     | Full README        | Complete documentation               |
-| ⬜     | First release      | Publish v0.1.0                       |
+| ✅     | Full README        | Complete documentation               |
+| ✅     | First release      | Publish v0.1.0                       |
 
 ---
 
@@ -252,7 +252,8 @@
 
 ### Next Steps
 
-1. Work through `.qa-phases/phase-0/` milestones toward v0.1.0
+1. v0.1.0 released 2026-04-15 ✅
+2. Begin Phase 2 (Navigation components: AppBar, Tabs, Drawer, Bottom Navigation)
 
 ---
 
@@ -265,4 +266,4 @@
 
 ---
 
-_Last Updated: April 13, 2026_
+_Last Updated: April 15, 2026_

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -10,11 +10,11 @@ A modern, accessible React component library implementing Google's Material Desi
 
 ---
 
-## ⚠️ Status
+## ✅ Status
 
-> **🚧 Work in Progress**
+> **Released: v0.1.0** (2026-04-15)
 >
-> This package is currently in active development (Phase 0) and is **not yet published to npm**.
+> This package is published to npm. Install it with `npm install @tinybigui/react`.
 >
 > Follow our [GitHub repository](https://github.com/buildinclicks/tinybigui) for updates!
 
@@ -36,8 +36,6 @@ A modern, accessible React component library implementing Google's Material Desi
 ---
 
 ## 📦 Installation
-
-> **Coming Soon!** This package will be available once we reach Phase 1b.
 
 ```bash
 npm install @tinybigui/react
@@ -74,18 +72,16 @@ import "@tinybigui/react/styles.css";
 ### 2. Use Components
 
 ```tsx
-import { Button, TextField, Card } from "@tinybigui/react";
+import { Button, TextField, Checkbox } from "@tinybigui/react";
 
 function App() {
   return (
     <div>
-      <Card>
-        <h1>Welcome to TinyBigUI</h1>
-        <TextField label="Email" type="email" />
-        <Button variant="filled" color="primary">
-          Sign Up
-        </Button>
-      </Card>
+      <TextField label="Email" type="email" />
+      <Checkbox label="Accept terms" />
+      <Button variant="filled" color="primary">
+        Sign Up
+      </Button>
     </div>
   );
 }
@@ -106,23 +102,23 @@ Override CSS variables to customize the theme:
 
 ## 📚 Components
 
-### Phase 1a: Core Buttons (In Progress)
+### Phase 1a: Core Buttons ✅
 
-| Component              | Status | Description                   |
-| ---------------------- | ------ | ----------------------------- |
-| `Button`               | 🚧     | Standard button with variants |
-| `IconButton`           | 🚧     | Button with icon only         |
-| `FloatingActionButton` | 🚧     | FAB for primary actions       |
+| Component    | Status | Description                   |
+| ------------ | ------ | ----------------------------- |
+| `Button`     | ✅     | Standard button with variants |
+| `IconButton` | ✅     | Button with icon only         |
+| `FAB`        | ✅     | FAB for primary actions       |
 
-### Phase 1b: Form Components (Planned)
+### Phase 1b: Form Components ✅
 
-| Component   | Status | Description           |
-| ----------- | ------ | --------------------- |
-| `TextField` | 📋     | Text input with label |
-| `Select`    | 📋     | Dropdown selection    |
-| `Checkbox`  | 📋     | Checkbox input        |
-| `Radio`     | 📋     | Radio button input    |
-| `Switch`    | 📋     | Toggle switch         |
+| Component    | Status | Description           |
+| ------------ | ------ | --------------------- |
+| `TextField`  | ✅     | Text input with label |
+| `Checkbox`   | ✅     | Checkbox input        |
+| `Radio`      | ✅     | Radio button input    |
+| `RadioGroup` | ✅     | Radio group container |
+| `Switch`     | ✅     | Toggle switch         |
 
 ### Phase 2: Layout & Navigation (Planned)
 
@@ -332,7 +328,7 @@ Components work seamlessly with Tailwind utilities:
 
 - **GitHub Repository**: [github.com/buildinclicks/tinybigui](https://github.com/buildinclicks/tinybigui)
 - **Documentation Site**: Coming soon at [tinybigui.dev](https://tinybigui.dev)
-- **Storybook**: Coming soon (interactive component playground)
+- **Storybook**: Storybook 10 is set up in `packages/react/.storybook/` — run `pnpm storybook` to explore components locally
 - **API Reference**: Coming soon
 
 ---

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -10,11 +10,11 @@ A comprehensive collection of Material Design 3 design tokens implemented as CSS
 
 ---
 
-## ⚠️ Status
+## ✅ Status
 
-> **Pre-release: v0.0.x**
+> **Released: v0.1.0** (2026-04-15)
 >
-> This package is complete and approaching its first public release (**v0.1.0**). It is **not yet published to npm**.
+> This package is published to npm. Install it with `npm install @tinybigui/tokens`.
 >
 > Follow our [GitHub repository](https://github.com/buildinclicks/tinybigui) for updates!
 
@@ -48,8 +48,6 @@ Design tokens are the **visual design atoms** of a design system. They're named 
 ---
 
 ## 📦 Installation
-
-> **v0.1.0 is in preparation.** This package will be available on npm as part of the upcoming v0.1.0 release.
 
 ```bash
 npm install @tinybigui/tokens


### PR DESCRIPTION
## Summary

- Updates all five stale documentation files to reflect the v0.1.0 release shipped on 2026-04-15
- Removes all "not yet published", "Coming Soon", and pre-release language
- Corrects component status tables (Phase 1a + 1b all complete), adds missing `RadioGroup`
- Fixes Quick Start example in `packages/react/README.md` to use components that actually exist
- Updates `ROADMAP.md` In Progress section to point at Phase 2 instead of v0.1.0 prep
- Updates `TASKS.md` Phase 0.5 to mark completed infrastructure items

## Files changed

- `packages/react/README.md`
- `packages/tokens/README.md`
- `README.md`
- `ROADMAP.md`
- `TASKS.md`

## Test plan

- [ ] Read each updated file and confirm no pre-release language remains
- [ ] Confirm component tables are accurate against `packages/react/src/index.ts`

Made with [Cursor](https://cursor.com)