### PR TITLE
fix: add changeset for readme npm display correction

### DIFF
--- a/.changeset/readme-npm-display.md
+++ b/.changeset/readme-npm-display.md
@@ -1,0 +1,6 @@
+---
+"@tinybigui/react": patch
+"@tinybigui/tokens": patch
+---
+
+fix misleading pre-release language in npm readme


### PR DESCRIPTION
## Summary

Adds a patch changeset for both `@tinybigui/react` and `@tinybigui/tokens` to drive a v0.1.1 release.

The v0.1.0 packages on npmjs.com still show the old README with "Work in Progress" and "not yet published to npm". Since npmjs.com displays the README baked into the tarball at publish time, a new version is required to update it.

The corrected READMEs were merged via PR #22. This changeset will consume them in the upcoming `release/v0.1.1` branch.

## Changeset

- `@tinybigui/react`: patch
- `@tinybigui/tokens`: patch

Made with [Cursor](https://cursor.com)