### PR TITLE
chore: release v0.1.1

### DIFF
--- a/.changeset/readme-npm-display.md
+++ b/.changeset/readme-npm-display.md
@@ -1,0 +1,6 @@
+---
+"@tinybigui/react": patch
+"@tinybigui/tokens": patch
+---
+
+fix misleading pre-release language in npm readme

--- a/.changeset/readme-npm-display.md
+++ b/.changeset/readme-npm-display.md
@@ -1,6 +1,0 @@
----
-"@tinybigui/react": patch
-"@tinybigui/tokens": patch
----
-
-fix misleading pre-release language in npm readme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-15
+
+### Fixed
+
+- **`@tinybigui/react`** — Updated npm README to remove misleading "Work in Progress" / "not yet published" language; reflects actual v0.1.0 released state
+- **`@tinybigui/tokens`** — Updated npm README to remove misleading "Work in Progress" / "not yet published" language; reflects actual v0.1.0 released state
+
 ## [0.1.0] - 2026-04-15
 
 ### Added
@@ -48,5 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Checkbox inline styles** — Replaced `style={{ fill: "var(--color-on-primary)" }}` with a Tailwind CSS class, eliminating the only inline style violation in the codebase
 - **Axe accessibility coverage** — Verified all 7 components pass automated axe checks; added axe test coverage across the test suite
 
-[Unreleased]: https://github.com/buildinclicks/tinybigui/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/buildinclicks/tinybigui/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/buildinclicks/tinybigui/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/buildinclicks/tinybigui/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
 
 ## ⚙️ Development Status
 
-> **Pre-release: v0.0.x**
+> **Released: v0.1.0** (2026-04-15)
 >
-> Phase 1a (Button, IconButton, FAB) and Phase 1b (TextField, Checkbox, Switch, Radio) are complete. The library is approaching its first public release (**v0.1.0**) and is **not yet published to npm**.
+> Phase 1a (Button, IconButton, FAB) and Phase 1b (TextField, Checkbox, Switch, Radio, RadioGroup) are complete and published to npm.
 >
 > Watch this repository to follow our progress!
 
@@ -56,8 +56,6 @@
 
 ## 🚀 Installation
 
-> **v0.1.0 is in preparation.** The package will be published to npm as part of the upcoming v0.1.0 release.
-
 ```bash
 npm install @tinybigui/react
 # or
@@ -70,10 +68,7 @@ yarn add @tinybigui/react
 
 ## 📖 Quick Start
 
-> **Coming Soon!** Full documentation will be available at [tinybigui.dev](https://tinybigui.dev)
-
 ```tsx
-// Preview of how it will work:
 import { Button } from "@tinybigui/react";
 import "@tinybigui/react/styles.css";
 
@@ -97,10 +92,10 @@ function App() {
 
 This is a monorepo containing multiple packages:
 
-| Package                                  | Description                   | Version     | Status                          |
-| ---------------------------------------- | ----------------------------- | ----------- | ------------------------------- |
-| [`@tinybigui/react`](./packages/react)   | React components              | Coming soon | Pre-release: v0.1.0 coming soon |
-| [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | Coming soon | Pre-release: v0.1.0 coming soon |
+| Package                                  | Description                   | Version | Status   |
+| ---------------------------------------- | ----------------------------- | ------- | -------- |
+| [`@tinybigui/react`](./packages/react)   | React components              | 0.1.0   | Released |
+| [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | 0.1.0   | Released |
 
 ---
 
@@ -134,7 +129,7 @@ This is a monorepo containing multiple packages:
 - [x] Checkbox component (49 tests)
 - [x] Radio component (47 tests)
 - [x] Switch component (50 tests)
-- [ ] First npm release (v0.1.0) — in preparation
+- [x] First npm release (v0.1.0) — released 2026-04-15
 
 ### Phase 2: Layout & Navigation
 
@@ -268,8 +263,8 @@ pnpm typecheck
 
 - **GitHub Repository**: [github.com/buildinclicks/tinybigui](https://github.com/buildinclicks/tinybigui)
 - **Documentation Site**: Coming soon at [tinybigui.dev](https://tinybigui.dev)
-- **Storybook**: Coming soon (interactive component playground)
-- **QA Phases**: See [/.qa-phases](.qa-phases) for milestone tracking toward v0.1.0
+- **Storybook**: Storybook 10 is set up — run `pnpm storybook` in `packages/react` to explore components locally
+- **QA Phases**: See [/.qa-phases](.qa-phases) for milestone tracking
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,13 +56,9 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 
 ## In Progress
 
-### v0.1.0 Release Preparation
+### v0.2.0 Phase 2 — Navigation (Next)
 
-- QA milestones (`.qa-phases/phase-0/`) in progress
-- Documentation updates
-- CHANGELOG creation (M8)
-- npm publishing infrastructure (M9)
-- Release workflow automation (M10)
+Planning in progress. See Planned Work below.
 
 ## Planned Work
 
@@ -122,4 +118,4 @@ Have an idea for a new component or feature? Open a [feature request](https://gi
 ## Stay Updated
 
 - Watch this repository for release notifications
-- Check the [Changelog](CHANGELOG.md) for release notes _(CHANGELOG will be created as part of v0.1.0 release — M8)_
+- Check the [Changelog](CHANGELOG.md) for release notes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,19 +4,19 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 
 ## Current Status
 
-**Current Version:** Pre-release (v0.0.x)  
-**Next Release:** v0.1.0  
-**Status:** Phase 1a + 1b complete, approaching v0.1.0
+**Current Version:** v0.1.0 (released 2026-04-15)  
+**Next Release:** v0.2.0  
+**Status:** v0.1.0 published to NPM; Phase 2 (Navigation) planned next
 
 ## Release Timeline
 
-| Version | Phase   | Components                                                  | Status         |
-| ------- | ------- | ----------------------------------------------------------- | -------------- |
-| v0.1.0  | 1a + 1b | Button, IconButton, FAB, TextField, Checkbox, Switch, Radio | In Preparation |
-| v0.2.0  | 2       | AppBar, Tabs, Drawer, Bottom Navigation                     | Planned        |
-| v0.3.0  | 3       | Dialog, Snackbar, Menu, Progress Indicators                 | Planned        |
-| v0.4.0  | 4       | Card, List, Chip, Table                                     | Planned        |
-| v1.0.0  | -       | Stable release, API frozen                                  | Planned        |
+| Version | Phase   | Components                                                  | Status              |
+| ------- | ------- | ----------------------------------------------------------- | ------------------- |
+| v0.1.0  | 1a + 1b | Button, IconButton, FAB, TextField, Checkbox, Switch, Radio | Released 2026-04-15 |
+| v0.2.0  | 2       | AppBar, Tabs, Drawer, Bottom Navigation                     | Planned             |
+| v0.3.0  | 3       | Dialog, Snackbar, Menu, Progress Indicators                 | Planned             |
+| v0.4.0  | 4       | Card, List, Chip, Table                                     | Planned             |
+| v1.0.0  | -       | Stable release, API frozen                                  | Planned             |
 
 ## Completed Work
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -213,32 +213,32 @@
 
 ---
 
-## Phase 0.5: Pre-Release Setup (DO LATER)
+## Phase 0.5: Pre-Release Setup ✅
 
-> **When**: After Phase 1a code is complete, before v0.1.0 release  
+> **Completed**: All infrastructure completed as part of v0.1.0 release (2026-04-15)  
 > **Goal**: Full open-source infrastructure
 
 | Status | Task               | Description                          |
 | ------ | ------------------ | ------------------------------------ |
-| ⬜     | NPM organization   | Create `@tinybigui` org on npmjs.com |
-| ⬜     | NPM access token   | Generate automation token            |
-| ⬜     | GitHub Secrets     | Add `NPM_TOKEN` for publishing       |
-| ⬜     | Release workflow   | Auto-publish to NPM on release       |
-| ⬜     | Changesets setup   | Version management                   |
+| ✅     | NPM organization   | Create `@tinybigui` org on npmjs.com |
+| ✅     | NPM access token   | Generate automation token            |
+| ✅     | GitHub Secrets     | Add `NPM_TOKEN` for publishing       |
+| ✅     | Release workflow   | Auto-publish to NPM on release       |
+| ✅     | Changesets setup   | Version management                   |
 | ⬜     | Storybook deploy   | Vercel deployment workflow           |
-| ⬜     | Chromatic setup    | Visual regression testing            |
+| ✅     | Chromatic setup    | Visual regression testing            |
 | ⬜     | GitHub Discussions | Enable and configure categories      |
 | ⬜     | Issue labels       | Create standard labels               |
 | ⬜     | Milestones         | Create v0.1.0, v0.2.0, v1.0.0        |
 | ⬜     | Issue templates    | Bug report, feature request          |
 | ⬜     | PR template        | Pull request template                |
 | ⬜     | CONTRIBUTING.md    | Full contribution guide              |
-| ⬜     | CODE_OF_CONDUCT.md | Contributor Covenant                 |
-| ⬜     | SECURITY.md        | Security policy                      |
-| ⬜     | Dependabot         | Enable security updates              |
+| ✅     | CODE_OF_CONDUCT.md | Contributor Covenant                 |
+| ✅     | SECURITY.md        | Security policy                      |
+| ✅     | Dependabot         | Enable security updates              |
 | ⬜     | All Contributors   | Install bot                          |
-| ⬜     | Full README        | Complete documentation               |
-| ⬜     | First release      | Publish v0.1.0                       |
+| ✅     | Full README        | Complete documentation               |
+| ✅     | First release      | Publish v0.1.0                       |
 
 ---
 
@@ -252,7 +252,8 @@
 
 ### Next Steps
 
-1. Work through `.qa-phases/phase-0/` milestones toward v0.1.0
+1. v0.1.0 released 2026-04-15 ✅
+2. Begin Phase 2 (Navigation components: AppBar, Tabs, Drawer, Bottom Navigation)
 
 ---
 
@@ -265,4 +266,4 @@
 
 ---
 
-_Last Updated: April 13, 2026_
+_Last Updated: April 15, 2026_

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinybigui/react
 
+## 0.1.1
+
+### Patch Changes
+
+- 9a84c28: fix misleading pre-release language in npm readme
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -10,11 +10,11 @@ A modern, accessible React component library implementing Google's Material Desi
 
 ---
 
-## ⚠️ Status
+## ✅ Status
 
-> **🚧 Work in Progress**
+> **Released: v0.1.0** (2026-04-15)
 >
-> This package is currently in active development (Phase 0) and is **not yet published to npm**.
+> This package is published to npm. Install it with `npm install @tinybigui/react`.
 >
 > Follow our [GitHub repository](https://github.com/buildinclicks/tinybigui) for updates!
 
@@ -36,8 +36,6 @@ A modern, accessible React component library implementing Google's Material Desi
 ---
 
 ## 📦 Installation
-
-> **Coming Soon!** This package will be available once we reach Phase 1b.
 
 ```bash
 npm install @tinybigui/react
@@ -74,18 +72,16 @@ import "@tinybigui/react/styles.css";
 ### 2. Use Components
 
 ```tsx
-import { Button, TextField, Card } from "@tinybigui/react";
+import { Button, TextField, Checkbox } from "@tinybigui/react";
 
 function App() {
   return (
     <div>
-      <Card>
-        <h1>Welcome to TinyBigUI</h1>
-        <TextField label="Email" type="email" />
-        <Button variant="filled" color="primary">
-          Sign Up
-        </Button>
-      </Card>
+      <TextField label="Email" type="email" />
+      <Checkbox label="Accept terms" />
+      <Button variant="filled" color="primary">
+        Sign Up
+      </Button>
     </div>
   );
 }
@@ -106,23 +102,23 @@ Override CSS variables to customize the theme:
 
 ## 📚 Components
 
-### Phase 1a: Core Buttons (In Progress)
+### Phase 1a: Core Buttons ✅
 
-| Component              | Status | Description                   |
-| ---------------------- | ------ | ----------------------------- |
-| `Button`               | 🚧     | Standard button with variants |
-| `IconButton`           | 🚧     | Button with icon only         |
-| `FloatingActionButton` | 🚧     | FAB for primary actions       |
+| Component    | Status | Description                   |
+| ------------ | ------ | ----------------------------- |
+| `Button`     | ✅     | Standard button with variants |
+| `IconButton` | ✅     | Button with icon only         |
+| `FAB`        | ✅     | FAB for primary actions       |
 
-### Phase 1b: Form Components (Planned)
+### Phase 1b: Form Components ✅
 
-| Component   | Status | Description           |
-| ----------- | ------ | --------------------- |
-| `TextField` | 📋     | Text input with label |
-| `Select`    | 📋     | Dropdown selection    |
-| `Checkbox`  | 📋     | Checkbox input        |
-| `Radio`     | 📋     | Radio button input    |
-| `Switch`    | 📋     | Toggle switch         |
+| Component    | Status | Description           |
+| ------------ | ------ | --------------------- |
+| `TextField`  | ✅     | Text input with label |
+| `Checkbox`   | ✅     | Checkbox input        |
+| `Radio`      | ✅     | Radio button input    |
+| `RadioGroup` | ✅     | Radio group container |
+| `Switch`     | ✅     | Toggle switch         |
 
 ### Phase 2: Layout & Navigation (Planned)
 
@@ -332,7 +328,7 @@ Components work seamlessly with Tailwind utilities:
 
 - **GitHub Repository**: [github.com/buildinclicks/tinybigui](https://github.com/buildinclicks/tinybigui)
 - **Documentation Site**: Coming soon at [tinybigui.dev](https://tinybigui.dev)
-- **Storybook**: Coming soon (interactive component playground)
+- **Storybook**: Storybook 10 is set up in `packages/react/.storybook/` — run `pnpm storybook` to explore components locally
 - **API Reference**: Coming soon
 
 ---

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Material Design 3 React components built with Tailwind CSS",
   "keywords": [
     "react",

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinybigui/tokens
 
+## 0.1.1
+
+### Patch Changes
+
+- 9a84c28: fix misleading pre-release language in npm readme
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -10,11 +10,11 @@ A comprehensive collection of Material Design 3 design tokens implemented as CSS
 
 ---
 
-## ⚠️ Status
+## ✅ Status
 
-> **Pre-release: v0.0.x**
+> **Released: v0.1.0** (2026-04-15)
 >
-> This package is complete and approaching its first public release (**v0.1.0**). It is **not yet published to npm**.
+> This package is published to npm. Install it with `npm install @tinybigui/tokens`.
 >
 > Follow our [GitHub repository](https://github.com/buildinclicks/tinybigui) for updates!
 
@@ -48,8 +48,6 @@ Design tokens are the **visual design atoms** of a design system. They're named 
 ---
 
 ## 📦 Installation
-
-> **v0.1.0 is in preparation.** This package will be available on npm as part of the upcoming v0.1.0 release.
 
 ```bash
 npm install @tinybigui/tokens

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/tokens",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Material Design 3 design tokens as CSS variables",
   "keywords": [
     "material-design",


### PR DESCRIPTION
## Summary

Patch release v0.1.1 — fixes misleading pre-release language on npmjs.com.

## Changes

Both `@tinybigui/react` and `@tinybigui/tokens` were published at v0.1.0 with READMEs that said "Work in Progress" and "not yet published to npm". Since npmjs.com displays the README baked into the tarball at publish time, a new version is required to update it.

## Changelog

### Fixed

- `@tinybigui/react` — Updated npm README to remove misleading pre-release language
- `@tinybigui/tokens` — Updated npm README to remove misleading pre-release language

## Merge Instructions

**IMPORTANT: Merge with "Create a merge commit" — never squash this PR.**

Made with [Cursor](https://cursor.com)