### PR TITLE
feat(appbar): implement md3 top app bar component

### DIFF
--- a/.changeset/appbar-component.md
+++ b/.changeset/appbar-component.md
@@ -1,0 +1,6 @@
+---
+"@tinybigui/react": minor
+"@tinybigui/tokens": minor
+---
+
+Add MD3 Top App Bar component with four size variants (small, center-aligned, medium, large), composable navigation and action icon slots, scroll-triggered elevation, and useScrollElevation hook. Add typography, motion, easing, and spacing token mappings to Tailwind @theme.

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ info.txt
 .cursor/
 .prompts/
 .qa-phases/
+.github-issues/
 learning-docs/
 
 

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# Strip auto-injected attribution trailers (e.g. Made-with: *) from commit messages
+# before commitlint validation runs.
+sed -i.bak '/^Made-with:/d' "$1"
+rm -f "$1.bak"

--- a/packages/react/src/components/AppBar/AppBar.stories.tsx
+++ b/packages/react/src/components/AppBar/AppBar.stories.tsx
@@ -1,0 +1,517 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AppBar } from "./AppBar";
+import React from "react";
+
+// ─── Icon primitives for stories ─────────────────────────────────────────────
+
+const IconMenu = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
+  </svg>
+);
+
+const IconArrowBack = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+  </svg>
+);
+
+const IconSearch = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+  </svg>
+);
+
+const IconShare = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
+  </svg>
+);
+
+const IconMoreVert = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+  </svg>
+);
+
+// ─── Button wrappers (styled as plain accessible buttons for story context) ───
+
+const NavButton = ({ label }: { label: string }): React.ReactElement => (
+  <button
+    type="button"
+    aria-label={label}
+    className="text-on-surface-variant hover:bg-on-surface/8 focus-visible:outline-primary relative inline-flex h-10 w-10 items-center justify-center rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+  >
+    <IconMenu />
+  </button>
+);
+
+const BackButton = (): React.ReactElement => (
+  <button
+    type="button"
+    aria-label="Go back"
+    className="text-on-surface-variant hover:bg-on-surface/8 focus-visible:outline-primary relative inline-flex h-10 w-10 items-center justify-center rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+  >
+    <IconArrowBack />
+  </button>
+);
+
+const ActionButton = ({
+  label,
+  Icon,
+}: {
+  label: string;
+  Icon: () => React.ReactElement;
+}): React.ReactElement => (
+  <button
+    type="button"
+    aria-label={label}
+    className="text-on-surface-variant hover:bg-on-surface/8 focus-visible:outline-primary relative inline-flex h-10 w-10 items-center justify-center rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+  >
+    <Icon />
+  </button>
+);
+
+// ─── Meta ──────────────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof AppBar> = {
+  title: "Components/AppBar",
+  component: AppBar,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Material Design 3 Top App Bar. Provides context and actions for the current screen. Supports four size variants (small, center-aligned, medium, large) with composable navigation icon and action icon slots.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["small", "center-aligned", "medium", "large"],
+      description: "Size variant — controls bar height, title position, and type scale",
+    },
+    scrolled: {
+      control: "boolean",
+      description:
+        "Controlled scroll state. When true, applies elevated surface (shadow-elevation-2)",
+    },
+    title: {
+      control: "text",
+      description: "Title content. Accepts string or ReactNode.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AppBar>;
+
+// ─── Default ───────────────────────────────────────────────────────────────────
+
+export const Default: Story = {
+  args: {
+    title: "Page Title",
+    variant: "small",
+    navigationIcon: <NavButton label="Open navigation menu" />,
+    actions: <ActionButton label="Search" Icon={IconSearch} />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The default small AppBar with navigation icon, title, and one action icon. 64dp height with title-large type scale.",
+      },
+    },
+  },
+};
+
+// ─── All Variants ──────────────────────────────────────────────────────────────
+
+export const Variants: Story = {
+  render: () => (
+    <div className="divide-outline-variant flex flex-col gap-0 divide-y">
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">
+          small (default) — 64dp, title-large
+        </p>
+        <AppBar
+          variant="small"
+          title="Small App Bar"
+          navigationIcon={<NavButton label="Open navigation menu" />}
+          actions={<ActionButton label="Search" Icon={IconSearch} />}
+        />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">
+          center-aligned — 64dp, title-large, centered
+        </p>
+        <AppBar
+          variant="center-aligned"
+          title="Center Aligned"
+          navigationIcon={<NavButton label="Open navigation menu" />}
+          actions={<ActionButton label="Search" Icon={IconSearch} />}
+        />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">
+          medium — 112dp, headline-small
+        </p>
+        <AppBar
+          variant="medium"
+          title="Medium App Bar"
+          navigationIcon={<BackButton />}
+          actions={<ActionButton label="More options" Icon={IconMoreVert} />}
+        />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">
+          large — 152dp, display-small
+        </p>
+        <AppBar
+          variant="large"
+          title="Large App Bar"
+          navigationIcon={<BackButton />}
+          actions={<ActionButton label="More options" Icon={IconMoreVert} />}
+        />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All four MD3 Top App Bar size variants. Each variant uses a different bar height and title type scale per MD3 specifications.",
+      },
+    },
+  },
+};
+
+// ─── Small Variant ─────────────────────────────────────────────────────────────
+
+export const Small: Story = {
+  args: {
+    variant: "small",
+    title: "Page Title",
+    navigationIcon: <NavButton label="Open navigation menu" />,
+    actions: <ActionButton label="Search" Icon={IconSearch} />,
+  },
+};
+
+// ─── Center-Aligned ────────────────────────────────────────────────────────────
+
+export const CenterAligned: Story = {
+  args: {
+    variant: "center-aligned",
+    title: "My App",
+    navigationIcon: <NavButton label="Open navigation menu" />,
+    actions: <ActionButton label="Search" Icon={IconSearch} />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Center-aligned variant. Same 64dp height as small, but the title is horizontally centered. Common for brand-focused app bars.",
+      },
+    },
+  },
+};
+
+// ─── Medium Variant ────────────────────────────────────────────────────────────
+
+export const Medium: Story = {
+  args: {
+    variant: "medium",
+    title: "Article Title",
+    navigationIcon: <BackButton />,
+    actions: (
+      <>
+        <ActionButton label="Share" Icon={IconShare} />
+        <ActionButton label="More options" Icon={IconMoreVert} />
+      </>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Medium variant with 112dp height. The title sits in the bottom-left of the expanded area using headline-small type scale. Ideal for content screens.",
+      },
+    },
+  },
+};
+
+// ─── Large Variant ─────────────────────────────────────────────────────────────
+
+export const Large: Story = {
+  args: {
+    variant: "large",
+    title: "Settings",
+    navigationIcon: <BackButton />,
+    actions: <ActionButton label="More options" Icon={IconMoreVert} />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Large variant with 152dp height. The title sits at the bottom using display-small type scale. Use for top-level screens that need strong visual hierarchy.",
+      },
+    },
+  },
+};
+
+// ─── Scroll Behavior ───────────────────────────────────────────────────────────
+
+const ScrollBehaviorDemo = (): React.ReactElement => {
+  const [scrolled, setScrolled] = React.useState(false);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <AppBar
+        title="Scroll Demo"
+        variant="small"
+        navigationIcon={<NavButton label="Open navigation menu" />}
+        actions={<ActionButton label="Search" Icon={IconSearch} />}
+        scrolled={scrolled}
+        onScrollStateChange={setScrolled}
+      />
+      <div className="mt-2 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setScrolled((s) => !s)}
+          className="bg-primary text-on-primary text-label-large rounded-full px-4 py-2"
+        >
+          Toggle scrolled: {scrolled ? "ON" : "OFF"}
+        </button>
+        <span className="text-body-medium text-on-surface-variant">
+          Surface: {scrolled ? "Elevated (shadow-elevation-2)" : "Flat (shadow-elevation-0)"}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export const ScrollBehavior: Story = {
+  render: () => <ScrollBehaviorDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "MD3 AppBar transitions from a flat surface at rest to `shadow-elevation-2` when the page is scrolled. Toggle the controlled `scrolled` state with the button below.",
+      },
+    },
+  },
+};
+
+// ─── Navigation Icon Variants ──────────────────────────────────────────────────
+
+export const WithNavigationIcon: Story = {
+  render: () => (
+    <div className="divide-outline-variant flex flex-col gap-0 divide-y">
+      <AppBar
+        variant="small"
+        title="With Navigation Icon"
+        navigationIcon={<NavButton label="Open navigation menu" />}
+      />
+      <AppBar variant="small" title="Without Navigation Icon" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The navigation icon slot is optional. When omitted, the title expands to fill the leading area.",
+      },
+    },
+  },
+};
+
+// ─── Action Slots ──────────────────────────────────────────────────────────────
+
+export const WithActions: Story = {
+  render: () => (
+    <div className="divide-outline-variant flex flex-col gap-0 divide-y">
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">1 action icon</p>
+        <AppBar
+          variant="small"
+          title="Page Title"
+          navigationIcon={<NavButton label="Open navigation menu" />}
+          actions={<ActionButton label="Search" Icon={IconSearch} />}
+        />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">2 action icons</p>
+        <AppBar
+          variant="small"
+          title="Page Title"
+          navigationIcon={<NavButton label="Open navigation menu" />}
+          actions={
+            <>
+              <ActionButton label="Search" Icon={IconSearch} />
+              <ActionButton label="Share" Icon={IconShare} />
+            </>
+          }
+        />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">
+          3 action icons (maximum)
+        </p>
+        <AppBar
+          variant="small"
+          title="Page Title"
+          navigationIcon={<NavButton label="Open navigation menu" />}
+          actions={
+            <>
+              <ActionButton label="Search" Icon={IconSearch} />
+              <ActionButton label="Share" Icon={IconShare} />
+              <ActionButton label="More options" Icon={IconMoreVert} />
+            </>
+          }
+        />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">No actions</p>
+        <AppBar
+          variant="small"
+          title="Page Title"
+          navigationIcon={<NavButton label="Open navigation menu" />}
+        />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "MD3 supports up to 3 trailing action icons. Pass them as React nodes into the `actions` prop. Each should be an accessible button with `aria-label`.",
+      },
+    },
+  },
+};
+
+// ─── Scrolled State ────────────────────────────────────────────────────────────
+
+export const ScrolledState: Story = {
+  render: () => (
+    <div className="divide-outline-variant flex flex-col gap-0 divide-y">
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">
+          At rest (shadow-elevation-0)
+        </p>
+        <AppBar
+          variant="small"
+          title="Page Title"
+          navigationIcon={<NavButton label="Open navigation menu" />}
+          scrolled={false}
+        />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant px-4 py-2">
+          Scrolled (shadow-elevation-2)
+        </p>
+        <AppBar
+          variant="small"
+          title="Page Title"
+          navigationIcon={<NavButton label="Open navigation menu" />}
+          scrolled={true}
+        />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Flat vs elevated surface comparison. The elevation transition uses MD3 motion tokens (duration-medium2, ease-standard).",
+      },
+    },
+  },
+};
+
+// ─── Accessibility ─────────────────────────────────────────────────────────────
+
+export const Accessibility: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 p-4">
+      <p className="text-body-medium text-on-surface-variant">
+        The AppBar renders as{" "}
+        <code className="bg-surface-container rounded px-1 font-mono text-sm">
+          {'<header role="banner">'}
+        </code>{" "}
+        — a landmark region recognized by screen readers. Navigation and action icons should always
+        have descriptive{" "}
+        <code className="bg-surface-container rounded px-1 font-mono text-sm">aria-label</code>{" "}
+        attributes.
+      </p>
+      <AppBar
+        variant="small"
+        title="Accessible App Bar"
+        navigationIcon={<NavButton label="Open navigation menu" />}
+        actions={
+          <>
+            <ActionButton label="Search for content" Icon={IconSearch} />
+            <ActionButton label="More options" Icon={IconMoreVert} />
+          </>
+        }
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Accessibility considerations: the `<header>` element provides the `banner` landmark role. Every icon button needs an `aria-label` describing its action. Focus indicators are always visible.",
+      },
+    },
+  },
+};
+
+// ─── Medium and Large ──────────────────────────────────────────────────────────
+
+export const MediumAndLarge: Story = {
+  render: () => (
+    <div className="divide-outline-variant flex flex-col gap-0 divide-y">
+      <AppBar
+        variant="medium"
+        title="Medium Expanded Title"
+        navigationIcon={<BackButton />}
+        actions={<ActionButton label="More options" Icon={IconMoreVert} />}
+      />
+      <AppBar
+        variant="large"
+        title="Large Hero Title"
+        navigationIcon={<BackButton />}
+        actions={<ActionButton label="More options" Icon={IconMoreVert} />}
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Medium (112dp, headline-small) and Large (152dp, display-small) variants. Both place the title in the bottom-left of the expanded area, and use a fixed 64dp top row for the navigation icon and actions.",
+      },
+    },
+  },
+};
+
+// ─── Interactive Playground ────────────────────────────────────────────────────
+
+export const Interactive: Story = {
+  args: {
+    variant: "small",
+    title: "Interactive App Bar",
+    scrolled: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use the controls panel to explore all AppBar props. Toggle `scrolled` to see the elevation change, switch `variant` to see the different sizes.",
+      },
+    },
+  },
+};

--- a/packages/react/src/components/AppBar/AppBar.test.tsx
+++ b/packages/react/src/components/AppBar/AppBar.test.tsx
@@ -1,0 +1,442 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import { axe } from "vitest-axe";
+import { AppBar } from "./AppBar";
+import { AppBarHeadless } from "./AppBarHeadless";
+import React from "react";
+import { isKeyboardAccessible } from "../../../test/helpers";
+
+// Mock icon components for testing
+const IconMenu = (): React.ReactElement => <svg data-testid="icon-menu" aria-hidden="true" />;
+const IconSearch = (): React.ReactElement => <svg data-testid="icon-search" aria-hidden="true" />;
+
+const NavIcon = (): React.ReactElement => (
+  <button aria-label="Open navigation menu" type="button">
+    <IconMenu />
+  </button>
+);
+
+const ActionIcon = ({ label }: { label: string }): React.ReactElement => (
+  <button aria-label={label} type="button">
+    <IconSearch />
+  </button>
+);
+
+describe("AppBar", () => {
+  describe("Rendering", () => {
+    test("renders with required title prop", () => {
+      render(<AppBar title="Page Title" />);
+      expect(screen.getByText("Page Title")).toBeInTheDocument();
+    });
+
+    test("renders as header element with role=banner", () => {
+      render(<AppBar title="Page Title" />);
+      expect(screen.getByRole("banner")).toBeInTheDocument();
+    });
+
+    test("renders small variant by default", () => {
+      render(<AppBar title="Page Title" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("h-appbar-small");
+    });
+
+    test("renders with navigationIcon slot", () => {
+      render(<AppBar title="Page Title" navigationIcon={<NavIcon />} />);
+      expect(screen.getByTestId("icon-menu")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Open navigation menu" })).toBeInTheDocument();
+    });
+
+    test("renders without navigationIcon when not provided", () => {
+      render(<AppBar title="Page Title" />);
+      expect(screen.queryByTestId("icon-menu")).not.toBeInTheDocument();
+    });
+
+    test("renders with single action icon", () => {
+      render(<AppBar title="Page Title" actions={<ActionIcon label="Search" />} />);
+      expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    });
+
+    test("renders with multiple action icons", () => {
+      render(
+        <AppBar
+          title="Page Title"
+          actions={
+            <>
+              <ActionIcon label="Search" />
+              <ActionIcon label="Share" />
+              <ActionIcon label="More options" />
+            </>
+          }
+        />
+      );
+      expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "More options" })).toBeInTheDocument();
+    });
+
+    test("renders without actions when not provided", () => {
+      render(<AppBar title="Page Title" />);
+      // No action buttons should be present
+      expect(screen.queryAllByRole("button")).toHaveLength(0);
+    });
+
+    test("merges custom className", () => {
+      render(<AppBar title="Page Title" className="custom-class" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("custom-class");
+    });
+
+    test("renders title as ReactNode", () => {
+      render(<AppBar title={<span data-testid="custom-title">Custom Title</span>} />);
+      expect(screen.getByTestId("custom-title")).toBeInTheDocument();
+    });
+
+    test("forwards ref to header element", () => {
+      const ref = React.createRef<HTMLElement>();
+      render(<AppBar title="Page Title" ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+      expect(ref.current?.tagName.toLowerCase()).toBe("header");
+    });
+  });
+
+  describe("Variants", () => {
+    test("renders small variant with correct height class", () => {
+      render(<AppBar title="Page Title" variant="small" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("h-appbar-small");
+    });
+
+    test("renders center-aligned variant with correct height class", () => {
+      render(<AppBar title="Page Title" variant="center-aligned" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("h-appbar-small");
+    });
+
+    test("renders medium variant with correct height class", () => {
+      render(<AppBar title="Page Title" variant="medium" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("h-appbar-medium");
+    });
+
+    test("renders large variant with correct height class", () => {
+      render(<AppBar title="Page Title" variant="large" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("h-appbar-large");
+    });
+
+    test("renders small variant with surface background", () => {
+      render(<AppBar title="Page Title" variant="small" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("bg-surface");
+    });
+
+    test("renders center-aligned variant with centered title", () => {
+      render(<AppBar title="Page Title" variant="center-aligned" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("variant-center-aligned");
+    });
+
+    test("renders medium variant with title in bottom area", () => {
+      render(<AppBar title="Bottom Title" variant="medium" />);
+      // Title should be present and in the expanded area
+      expect(screen.getByText("Bottom Title")).toBeInTheDocument();
+    });
+
+    test("renders large variant with title in bottom area", () => {
+      render(<AppBar title="Large Title" variant="large" />);
+      expect(screen.getByText("Large Title")).toBeInTheDocument();
+    });
+
+    test("title in small variant has title-large typography class", () => {
+      render(<AppBar title="Page Title" variant="small" />);
+      const titleEl = screen.getByTestId("appbar-title");
+      expect(titleEl).toHaveClass("text-title-large");
+    });
+
+    test("title in center-aligned variant has title-large typography class", () => {
+      render(<AppBar title="Page Title" variant="center-aligned" />);
+      const titleEl = screen.getByTestId("appbar-title");
+      expect(titleEl).toHaveClass("text-title-large");
+    });
+
+    test("title in medium variant has headline-small typography class", () => {
+      render(<AppBar title="Page Title" variant="medium" />);
+      const titleEl = screen.getByTestId("appbar-title");
+      expect(titleEl).toHaveClass("text-headline-small");
+    });
+
+    test("title in large variant has display-small typography class", () => {
+      render(<AppBar title="Page Title" variant="large" />);
+      const titleEl = screen.getByTestId("appbar-title");
+      expect(titleEl).toHaveClass("text-display-small");
+    });
+  });
+
+  describe("Scroll State", () => {
+    test("renders without elevation by default (unscrolled)", () => {
+      render(<AppBar title="Page Title" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("shadow-elevation-0");
+    });
+
+    test("renders with elevation when scrolled={true} (controlled)", () => {
+      render(<AppBar title="Page Title" scrolled={true} />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("shadow-elevation-2");
+    });
+
+    test("renders without elevation when scrolled={false} (controlled)", () => {
+      render(<AppBar title="Page Title" scrolled={false} />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("shadow-elevation-0");
+    });
+
+    test("has elevation transition classes for smooth animation", () => {
+      render(<AppBar title="Page Title" />);
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("transition-shadow");
+    });
+
+    test("calls onScrollStateChange when scroll state changes (uncontrolled)", () => {
+      const onScrollStateChange = vi.fn();
+      render(<AppBar title="Page Title" onScrollStateChange={onScrollStateChange} />);
+      // Simulate scroll event on document/window
+      fireEvent.scroll(window, { target: { scrollY: 100 } });
+      expect(onScrollStateChange).toHaveBeenCalledWith(true);
+    });
+
+    test("does not call onScrollStateChange when controlled", () => {
+      const onScrollStateChange = vi.fn();
+      // When scrolled prop is provided (controlled), internal listener should not fire
+      render(
+        <AppBar title="Page Title" scrolled={false} onScrollStateChange={onScrollStateChange} />
+      );
+      fireEvent.scroll(window, { target: { scrollY: 100 } });
+      // In controlled mode, the consumer manages state; callback is informational only
+      // The visual state stays false (controlled)
+      const header = screen.getByRole("banner");
+      expect(header).toHaveClass("shadow-elevation-0");
+    });
+
+    test("transitions from unscrolled to scrolled state", () => {
+      const { rerender } = render(<AppBar title="Page Title" scrolled={false} />);
+      let header = screen.getByRole("banner");
+      expect(header).toHaveClass("shadow-elevation-0");
+
+      rerender(<AppBar title="Page Title" scrolled={true} />);
+      header = screen.getByRole("banner");
+      expect(header).toHaveClass("shadow-elevation-2");
+    });
+  });
+
+  describe("Accessibility", () => {
+    test("header has role=banner landmark", () => {
+      render(<AppBar title="Page Title" />);
+      expect(screen.getByRole("banner")).toBeInTheDocument();
+    });
+
+    test("has no accessibility violations - small variant", async () => {
+      const { container } = render(<AppBar title="Page Title" variant="small" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations - center-aligned variant", async () => {
+      const { container } = render(<AppBar title="Page Title" variant="center-aligned" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations - medium variant", async () => {
+      const { container } = render(<AppBar title="Page Title" variant="medium" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations - large variant", async () => {
+      const { container } = render(<AppBar title="Page Title" variant="large" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations with navigation icon and actions", async () => {
+      const { container } = render(
+        <AppBar
+          title="Page Title"
+          navigationIcon={<NavIcon />}
+          actions={<ActionIcon label="Search" />}
+        />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations when scrolled", async () => {
+      const { container } = render(<AppBar title="Page Title" scrolled={true} />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("navigation icon slot is keyboard accessible when it contains a button", () => {
+      render(<AppBar title="Page Title" navigationIcon={<NavIcon />} />);
+      const navBtn = screen.getByRole("button", { name: "Open navigation menu" });
+      expect(isKeyboardAccessible(navBtn)).toBe(true);
+    });
+
+    test("action buttons in slot are keyboard accessible", () => {
+      render(<AppBar title="Page Title" actions={<ActionIcon label="Search" />} />);
+      const actionBtn = screen.getByRole("button", { name: "Search" });
+      expect(isKeyboardAccessible(actionBtn)).toBe(true);
+    });
+  });
+
+  describe("Layout Structure", () => {
+    test("renders navigation icon in leading position", () => {
+      render(
+        <AppBar
+          title="Page Title"
+          navigationIcon={<NavIcon />}
+          actions={<ActionIcon label="Search" />}
+        />
+      );
+      const header = screen.getByRole("banner");
+      const navContainer = header.querySelector("[data-slot='navigation']");
+      expect(navContainer).toBeInTheDocument();
+    });
+
+    test("renders actions in trailing position", () => {
+      render(<AppBar title="Page Title" actions={<ActionIcon label="Search" />} />);
+      const header = screen.getByRole("banner");
+      const actionsContainer = header.querySelector("[data-slot='actions']");
+      expect(actionsContainer).toBeInTheDocument();
+    });
+
+    test("renders title with data-testid for targeting", () => {
+      render(<AppBar title="My Title" />);
+      expect(screen.getByTestId("appbar-title")).toBeInTheDocument();
+    });
+
+    test("small and center-aligned render title in top row", () => {
+      render(<AppBar title="Top Title" variant="small" />);
+      const header = screen.getByRole("banner");
+      const topRow = header.querySelector("[data-slot='top-row']");
+      expect(topRow).toBeInTheDocument();
+      expect(topRow).toHaveTextContent("Top Title");
+    });
+
+    test("medium renders title in expanded bottom area", () => {
+      render(<AppBar title="Bottom Title" variant="medium" />);
+      const header = screen.getByRole("banner");
+      const expandedRow = header.querySelector("[data-slot='expanded-title']");
+      expect(expandedRow).toBeInTheDocument();
+      expect(expandedRow).toHaveTextContent("Bottom Title");
+    });
+
+    test("large renders title in expanded bottom area", () => {
+      render(<AppBar title="Bottom Title" variant="large" />);
+      const header = screen.getByRole("banner");
+      const expandedRow = header.querySelector("[data-slot='expanded-title']");
+      expect(expandedRow).toBeInTheDocument();
+      expect(expandedRow).toHaveTextContent("Bottom Title");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    test("renders with empty string title", () => {
+      render(<AppBar title="" />);
+      expect(screen.getByRole("banner")).toBeInTheDocument();
+    });
+
+    test("renders all four variants without crashing", () => {
+      const variants = ["small", "center-aligned", "medium", "large"] as const;
+      variants.forEach((variant) => {
+        const { unmount } = render(<AppBar title={`${variant} title`} variant={variant} />);
+        expect(screen.getByRole("banner")).toBeInTheDocument();
+        unmount();
+      });
+    });
+
+    test("renders all slots populated simultaneously", () => {
+      render(
+        <AppBar
+          title="Full AppBar"
+          variant="small"
+          navigationIcon={<NavIcon />}
+          actions={
+            <>
+              <ActionIcon label="Search" />
+              <ActionIcon label="Share" />
+            </>
+          }
+        />
+      );
+      expect(screen.getByRole("banner")).toBeInTheDocument();
+      expect(screen.getByText("Full AppBar")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Open navigation menu" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument();
+    });
+
+    test("handles null navigationIcon gracefully", () => {
+      render(<AppBar title="Page Title" navigationIcon={null} />);
+      expect(screen.getByRole("banner")).toBeInTheDocument();
+    });
+
+    test("handles null actions gracefully", () => {
+      render(<AppBar title="Page Title" actions={null} />);
+      expect(screen.getByRole("banner")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("AppBarHeadless", () => {
+  test("renders as header element", () => {
+    render(<AppBarHeadless>Content</AppBarHeadless>);
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+  });
+
+  test("renders children", () => {
+    render(<AppBarHeadless>Headless Content</AppBarHeadless>);
+    expect(screen.getByText("Headless Content")).toBeInTheDocument();
+  });
+
+  test("applies className", () => {
+    render(<AppBarHeadless className="custom-class">Content</AppBarHeadless>);
+    expect(screen.getByRole("banner")).toHaveClass("custom-class");
+  });
+
+  test("forwards ref to header element", () => {
+    const ref = React.createRef<HTMLElement>();
+    render(<AppBarHeadless ref={ref}>Content</AppBarHeadless>);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+
+  test("manages uncontrolled scroll state internally", () => {
+    render(<AppBarHeadless>Content</AppBarHeadless>);
+    // No scroll by default -- just verify it renders
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+  });
+
+  test("uses controlled scrolled prop when provided", () => {
+    const { rerender } = render(<AppBarHeadless scrolled={false}>Content</AppBarHeadless>);
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+
+    rerender(<AppBarHeadless scrolled={true}>Content</AppBarHeadless>);
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+  });
+
+  test("calls onScrollStateChange when scroll occurs (uncontrolled)", () => {
+    const onScrollStateChange = vi.fn();
+    render(<AppBarHeadless onScrollStateChange={onScrollStateChange}>Content</AppBarHeadless>);
+    fireEvent.scroll(window, { target: { scrollY: 50 } });
+    expect(onScrollStateChange).toHaveBeenCalled();
+  });
+
+  test("has no accessibility violations", async () => {
+    const { container } = render(<AppBarHeadless>Headless</AppBarHeadless>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/react/src/components/AppBar/AppBar.tsx
+++ b/packages/react/src/components/AppBar/AppBar.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { forwardRef } from "react";
+import { AppBarHeadless } from "./AppBarHeadless";
+import { appBarVariants, appBarTitleVariants } from "./AppBar.variants";
+import { cn } from "../../utils/cn";
+import { useScrollElevation } from "../../hooks/useScrollElevation";
+import type { AppBarProps } from "./AppBar.types";
+
+/**
+ * Material Design 3 Top App Bar Component
+ *
+ * Provides context and actions for the current screen. Supports four size variants,
+ * a navigation icon slot, title, and trailing action icon slots. Implements
+ * scroll-triggered elevation changes per MD3 specification.
+ *
+ * **Architecture:**
+ * - Layer 3 (this file): MD3 styled, CVA variants, layout composition
+ * - Layer 2: `AppBarHeadless` — `<header role="banner">`, scroll state
+ * - Layer 1: React Aria via `<IconButton>` in consumer slots
+ *
+ * **Key Features:**
+ * - 4 MD3 variants: small, center-aligned, medium, large
+ * - Composable API: pass `<IconButton>` nodes into navigation and action slots
+ * - Scroll elevation: flat at rest → elevated on scroll (MD3 motion tokens)
+ * - Controlled and uncontrolled scroll state
+ * - WCAG 2.1 AA: `role="banner"` landmark, keyboard accessible slots
+ * - Dark mode via existing token system
+ *
+ * @example
+ * ```tsx
+ * // Small variant (default)
+ * <AppBar
+ *   title="Page Title"
+ *   navigationIcon={
+ *     <IconButton aria-label="Open navigation menu">
+ *       <MenuIcon />
+ *     </IconButton>
+ *   }
+ *   actions={
+ *     <IconButton aria-label="Search">
+ *       <SearchIcon />
+ *     </IconButton>
+ *   }
+ * />
+ *
+ * // Center-aligned with scroll elevation
+ * <AppBar
+ *   variant="center-aligned"
+ *   title="My App"
+ *   scrolled={isScrolled}
+ *   onScrollStateChange={setIsScrolled}
+ * />
+ *
+ * // Medium with expanded title area
+ * <AppBar
+ *   variant="medium"
+ *   title="Article Title"
+ *   navigationIcon={
+ *     <IconButton aria-label="Go back">
+ *       <ArrowBackIcon />
+ *     </IconButton>
+ *   }
+ * />
+ * ```
+ */
+export const AppBar = forwardRef<HTMLElement, AppBarProps>(
+  (
+    {
+      variant = "small",
+      title,
+      navigationIcon,
+      actions,
+      scrolled: scrolledProp,
+      onScrollStateChange,
+      className,
+    },
+    ref
+  ) => {
+    const { isScrolled } = useScrollElevation({
+      scrolled: scrolledProp,
+      onScrollStateChange,
+    });
+
+    const isExpandedVariant = variant === "medium" || variant === "large";
+
+    return (
+      <AppBarHeadless
+        ref={ref}
+        // Pass scrolled as controlled (already resolved by useScrollElevation above)
+        scrolled={isScrolled}
+        className={cn(appBarVariants({ variant, scrolled: isScrolled }), className)}
+      >
+        {/* Top row: navigation icon + title (small/center-aligned) + actions */}
+        <div
+          data-slot="top-row"
+          className={cn(
+            "flex items-center",
+            "px-1",
+            // Small and center-aligned: fill the full bar height
+            !isExpandedVariant && "flex-1",
+            // Expanded variants: fixed height for the top row (64dp)
+            isExpandedVariant && "h-16 shrink-0"
+          )}
+        >
+          {/* Navigation icon slot (leading) */}
+          {navigationIcon != null && (
+            <div data-slot="navigation" className="flex shrink-0 items-center">
+              {navigationIcon}
+            </div>
+          )}
+
+          {/* Title — rendered in top row for small and center-aligned variants */}
+          {!isExpandedVariant && (
+            <span
+              data-testid="appbar-title"
+              className={cn(
+                "min-w-0 flex-1 px-1",
+                appBarTitleVariants({ variant }),
+                // Center-aligned: center the title text
+                variant === "center-aligned" && "text-center"
+              )}
+            >
+              {title}
+            </span>
+          )}
+
+          {/* Actions slot (trailing) */}
+          {actions != null && (
+            <div data-slot="actions" className="flex shrink-0 items-center gap-0.5">
+              {actions}
+            </div>
+          )}
+        </div>
+
+        {/* Expanded title row — only for medium and large variants */}
+        {isExpandedVariant && (
+          <div data-slot="expanded-title" className={cn("flex flex-1 items-end", "px-4 pb-4")}>
+            <span
+              data-testid="appbar-title"
+              className={cn("min-w-0 truncate", appBarTitleVariants({ variant }))}
+            >
+              {title}
+            </span>
+          </div>
+        )}
+      </AppBarHeadless>
+    );
+  }
+);
+
+AppBar.displayName = "AppBar";

--- a/packages/react/src/components/AppBar/AppBar.types.ts
+++ b/packages/react/src/components/AppBar/AppBar.types.ts
@@ -1,0 +1,170 @@
+import type React from "react";
+
+/**
+ * MD3 Top App Bar size variants
+ *
+ * Each variant differs in height, title alignment, and type scale.
+ * - `small`: 64dp height, title left-aligned, title-large type scale
+ * - `center-aligned`: 64dp height, title centered, title-large type scale
+ * - `medium`: 112dp height, title bottom-left, headline-small type scale
+ * - `large`: 152dp height, title bottom-left, display-small type scale
+ *
+ * @see https://m3.material.io/components/top-app-bar/specs
+ */
+export type AppBarVariant = "small" | "center-aligned" | "medium" | "large";
+
+/**
+ * Material Design 3 Top App Bar Component Props
+ *
+ * Provides a top app bar with navigation icon, title, and trailing action icon slots.
+ * Supports scroll-triggered elevation changes with both controlled and uncontrolled modes.
+ *
+ * **Usage:**
+ * - Pass existing `<IconButton>` components into `navigationIcon` and `actions` slots
+ * - No hardcoded slot components — fully composable API
+ *
+ * @example
+ * ```tsx
+ * // Small variant with navigation icon and actions
+ * <AppBar
+ *   title="Page Title"
+ *   navigationIcon={
+ *     <IconButton aria-label="Open navigation">
+ *       <MenuIcon />
+ *     </IconButton>
+ *   }
+ *   actions={
+ *     <IconButton aria-label="Search">
+ *       <SearchIcon />
+ *     </IconButton>
+ *   }
+ * />
+ *
+ * // Center-aligned with controlled scroll state
+ * <AppBar
+ *   variant="center-aligned"
+ *   title="My App"
+ *   scrolled={isScrolled}
+ *   onScrollStateChange={setIsScrolled}
+ * />
+ *
+ * // Large variant for hero/expanded layouts
+ * <AppBar
+ *   variant="large"
+ *   title="Article Title"
+ * />
+ * ```
+ */
+export interface AppBarProps {
+  /**
+   * Size variant of the Top App Bar
+   * Controls height, title position, and type scale
+   * @default 'small'
+   */
+  variant?: AppBarVariant;
+
+  /**
+   * The title content. Accepts a string or any React node.
+   * Typography scale is automatically applied based on `variant`.
+   */
+  title: React.ReactNode;
+
+  /**
+   * Navigation icon slot (leading position, optional).
+   * Expects a React node — typically an `<IconButton>` with `aria-label`.
+   *
+   * @example
+   * ```tsx
+   * navigationIcon={
+   *   <IconButton aria-label="Open navigation menu">
+   *     <MenuIcon />
+   *   </IconButton>
+   * }
+   * ```
+   */
+  navigationIcon?: React.ReactNode;
+
+  /**
+   * Trailing action icon slots (up to 3, optional).
+   * Expects one or more React nodes — typically `<IconButton>` components.
+   *
+   * @example
+   * ```tsx
+   * actions={
+   *   <>
+   *     <IconButton aria-label="Search"><SearchIcon /></IconButton>
+   *     <IconButton aria-label="More options"><MoreIcon /></IconButton>
+   *   </>
+   * }
+   * ```
+   */
+  actions?: React.ReactNode;
+
+  /**
+   * Controlled scroll state.
+   * When provided, the component operates in controlled mode — the consumer
+   * is responsible for managing this value.
+   * When `undefined`, internal scroll detection is used (uncontrolled mode).
+   *
+   * - `false` (default): flat surface, `shadow-elevation-0`
+   * - `true`: elevated surface, `shadow-elevation-2`
+   */
+  scrolled?: boolean;
+
+  /**
+   * Callback fired when the scroll elevation state changes.
+   * In uncontrolled mode, this fires when the user scrolls past the threshold.
+   * In controlled mode, this is an informational callback — the consumer
+   * decides whether to update `scrolled`.
+   *
+   * @param scrolled - The new scroll state
+   */
+  onScrollStateChange?: (scrolled: boolean) => void;
+
+  /**
+   * Additional CSS classes to merge onto the root `<header>` element.
+   * Uses Tailwind CSS — conflicting classes are resolved by `cn()`.
+   */
+  className?: string;
+}
+
+/**
+ * AppBarHeadless Component Props
+ *
+ * Unstyled primitive for the Top App Bar.
+ * Renders a `<header role="banner">` and manages scroll elevation state.
+ * Use this for full visual control when the styled `AppBar` is not sufficient.
+ *
+ * @example
+ * ```tsx
+ * <AppBarHeadless
+ *   className="my-custom-appbar"
+ *   scrolled={scrolled}
+ *   onScrollStateChange={setScrolled}
+ * >
+ *   <div>My custom layout</div>
+ * </AppBarHeadless>
+ * ```
+ */
+export interface AppBarHeadlessProps {
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+
+  /**
+   * The content to render inside the header
+   */
+  children: React.ReactNode;
+
+  /**
+   * Controlled scroll state.
+   * When `undefined`, the component uses internal scroll detection.
+   */
+  scrolled?: boolean;
+
+  /**
+   * Callback fired when scroll state changes
+   */
+  onScrollStateChange?: (scrolled: boolean) => void;
+}

--- a/packages/react/src/components/AppBar/AppBar.variants.ts
+++ b/packages/react/src/components/AppBar/AppBar.variants.ts
@@ -1,0 +1,85 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Top App Bar Variants (CVA)
+ *
+ * Type-safe variant management for AppBar component.
+ * Uses Tailwind CSS classes mapped to MD3 design tokens.
+ *
+ * Variants:
+ * - `small`: 64dp height (h-appbar-small), title left-aligned
+ * - `center-aligned`: 64dp height (h-appbar-small), title centered
+ * - `medium`: 112dp height (h-appbar-medium), title bottom-left
+ * - `large`: 152dp height (h-appbar-large), title bottom-left
+ *
+ * Scroll state:
+ * - `false`: flat surface, shadow-elevation-0
+ * - `true`: elevated surface, shadow-elevation-2
+ *
+ * @see https://m3.material.io/components/top-app-bar/specs
+ */
+export const appBarVariants = cva(
+  [
+    // Base classes (always applied)
+    "w-full",
+    "bg-surface text-on-surface",
+    "flex flex-col",
+    // Elevation transition using MD3 motion tokens
+    "transition-shadow duration-medium2 ease-standard",
+  ],
+  {
+    variants: {
+      /**
+       * Size variant (MD3 specification)
+       * Controls bar height, title placement, and type scale
+       */
+      variant: {
+        /** 64dp, title left-aligned, title-large */
+        small: "h-appbar-small",
+        /** 64dp, title centered, title-large */
+        "center-aligned": "h-appbar-small variant-center-aligned",
+        /** 112dp, title bottom-left, headline-small */
+        medium: "h-appbar-medium",
+        /** 152dp, title bottom-left, display-small */
+        large: "h-appbar-large",
+      },
+
+      /**
+       * Scroll state — controls surface elevation
+       * MD3: flat at rest, elevated on scroll
+       */
+      scrolled: {
+        false: "shadow-elevation-0",
+        true: "shadow-elevation-2",
+      },
+    },
+
+    defaultVariants: {
+      variant: "small",
+      scrolled: false,
+    },
+  }
+);
+
+/**
+ * Title typography classes per variant
+ * Used to apply the correct MD3 type scale to the title element
+ */
+export const appBarTitleVariants = cva("text-on-surface font-normal truncate", {
+  variants: {
+    variant: {
+      small: "text-title-large",
+      "center-aligned": "text-title-large",
+      medium: "text-headline-small",
+      large: "text-display-small",
+    },
+  },
+  defaultVariants: {
+    variant: "small",
+  },
+});
+
+/**
+ * Extract variant prop types from CVA
+ */
+export type AppBarVariants = VariantProps<typeof appBarVariants>;

--- a/packages/react/src/components/AppBar/AppBarHeadless.tsx
+++ b/packages/react/src/components/AppBar/AppBarHeadless.tsx
@@ -1,0 +1,53 @@
+import { forwardRef } from "react";
+import { useScrollElevation } from "../../hooks/useScrollElevation";
+import type { AppBarHeadlessProps } from "./AppBar.types";
+
+/**
+ * Headless AppBar Component (Layer 2)
+ *
+ * Unstyled Top App Bar primitive. Renders a `<header role="banner">` landmark
+ * and manages scroll elevation state via the `useScrollElevation` hook.
+ *
+ * Features:
+ * - Semantic `<header>` element with `role="banner"` ARIA landmark
+ * - Controlled scroll state via `scrolled` prop
+ * - Uncontrolled scroll state with internal `window` scroll detection
+ * - `onScrollStateChange` callback for both modes
+ * - Full ref forwarding to the header element
+ *
+ * Use this layer when you need full visual control beyond what the styled
+ * `AppBar` provides.
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled (auto scroll detection)
+ * <AppBarHeadless className="my-custom-appbar">
+ *   <div>My custom layout</div>
+ * </AppBarHeadless>
+ *
+ * // Controlled scroll state
+ * <AppBarHeadless
+ *   scrolled={isScrolled}
+ *   onScrollStateChange={setIsScrolled}
+ *   className="my-custom-appbar"
+ * >
+ *   <div>My custom layout</div>
+ * </AppBarHeadless>
+ * ```
+ */
+export const AppBarHeadless = forwardRef<HTMLElement, AppBarHeadlessProps>(
+  ({ className, children, scrolled: scrolledProp, onScrollStateChange }, ref) => {
+    const { isScrolled } = useScrollElevation({
+      scrolled: scrolledProp,
+      onScrollStateChange,
+    });
+
+    return (
+      <header ref={ref} role="banner" className={className} data-scrolled={isScrolled}>
+        {children}
+      </header>
+    );
+  }
+);
+
+AppBarHeadless.displayName = "AppBarHeadless";

--- a/packages/react/src/components/AppBar/index.ts
+++ b/packages/react/src/components/AppBar/index.ts
@@ -1,0 +1,11 @@
+// Layer 3: MD3 Styled Component (most users use this)
+export { AppBar } from "./AppBar";
+
+// Layer 2: Headless Component (for advanced customization)
+export { AppBarHeadless } from "./AppBarHeadless";
+
+// CVA Variants
+export { appBarVariants, appBarTitleVariants, type AppBarVariants } from "./AppBar.variants";
+
+// Types
+export type { AppBarProps, AppBarHeadlessProps, AppBarVariant } from "./AppBar.types";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,3 +1,6 @@
+export { AppBar, AppBarHeadless } from "./AppBar";
+export type { AppBarProps, AppBarHeadlessProps, AppBarVariant } from "./AppBar";
+
 export { Button } from "./Button";
 export type { ButtonProps, ButtonVariant, ButtonColor, ButtonSize } from "./Button";
 

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useRipple } from "./useRipple";
+export { useScrollElevation } from "./useScrollElevation";

--- a/packages/react/src/hooks/useScrollElevation.ts
+++ b/packages/react/src/hooks/useScrollElevation.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * Options for useScrollElevation hook
+ */
+interface UseScrollElevationOptions {
+  /**
+   * Controlled scroll state.
+   * When provided, the hook operates in controlled mode and does not
+   * attach a scroll listener — the consumer manages state externally.
+   * When `undefined`, the hook uses internal scroll detection (uncontrolled).
+   */
+  scrolled?: boolean | undefined;
+
+  /**
+   * Callback fired when scroll elevation state changes.
+   * In uncontrolled mode: fires when user scrolls past threshold.
+   * In controlled mode: fires to inform the consumer of scroll events.
+   */
+  onScrollStateChange?: ((scrolled: boolean) => void) | undefined;
+
+  /**
+   * Scroll threshold in pixels before elevation activates
+   * @default 0
+   */
+  threshold?: number | undefined;
+}
+
+/**
+ * Hook for MD3 AppBar scroll-triggered elevation behavior.
+ *
+ * Manages the transition between flat (at rest) and elevated (on scroll)
+ * surface states per the Material Design 3 Top App Bar spec.
+ *
+ * Supports both controlled and uncontrolled modes:
+ * - **Uncontrolled**: Attaches a `scroll` listener to `window` and manages
+ *   elevation state internally. Calls `onScrollStateChange` when the state changes.
+ * - **Controlled**: Uses the `scrolled` prop directly. No internal scroll listener
+ *   is attached. The consumer is responsible for updating `scrolled`.
+ *
+ * @example Uncontrolled (recommended for most cases)
+ * ```tsx
+ * const { isScrolled } = useScrollElevation({
+ *   onScrollStateChange: (scrolled) => console.log('scrolled:', scrolled),
+ * });
+ * ```
+ *
+ * @example Controlled
+ * ```tsx
+ * const [scrolled, setScrolled] = useState(false);
+ * const { isScrolled } = useScrollElevation({ scrolled, onScrollStateChange: setScrolled });
+ * ```
+ */
+export function useScrollElevation(options: UseScrollElevationOptions = {}): {
+  isScrolled: boolean;
+} {
+  const { scrolled: controlledScrolled, onScrollStateChange, threshold = 0 } = options;
+
+  const isControlled = controlledScrolled !== undefined;
+
+  const [internalScrolled, setInternalScrolled] = useState(false);
+
+  const handleScroll = useCallback(() => {
+    const currentlyScrolled = window.scrollY > threshold;
+    setInternalScrolled((prev) => {
+      if (prev !== currentlyScrolled) {
+        onScrollStateChange?.(currentlyScrolled);
+        return currentlyScrolled;
+      }
+      return prev;
+    });
+  }, [threshold, onScrollStateChange]);
+
+  useEffect(() => {
+    // Only attach the scroll listener in uncontrolled mode
+    if (isControlled) return;
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    // Check initial scroll position
+    handleScroll();
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [isControlled, handleScroll]);
+
+  return {
+    isScrolled: isControlled ? controlledScrolled : internalScrolled,
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -41,6 +41,9 @@ export {
 } from "./utils";
 
 // Components
+export { AppBar, AppBarHeadless } from "./components/AppBar";
+export type { AppBarProps, AppBarHeadlessProps, AppBarVariant } from "./components/AppBar";
+
 export { Button } from "./components/Button";
 export type { ButtonProps, ButtonVariant, ButtonColor, ButtonSize } from "./components/Button";
 

--- a/packages/tokens/src/tokens.css
+++ b/packages/tokens/src/tokens.css
@@ -404,4 +404,79 @@ body {
   --opacity-8: 0.08;
   --opacity-12: 0.12;
   --opacity-38: 0.38;
+
+  /* Typography utilities
+     Maps MD3 type scale to Tailwind font-size/line-height utilities
+     Usage: text-title-large, text-headline-small, text-display-small, etc.
+     These produce font-size + line-height pairs via Tailwind v4 @theme */
+
+  /* Display scale */
+  --font-size-display-large: var(--md-sys-typescale-display-large-size);
+  --line-height-display-large: var(--md-sys-typescale-display-large-line-height);
+  --font-size-display-medium: var(--md-sys-typescale-display-medium-size);
+  --line-height-display-medium: var(--md-sys-typescale-display-medium-line-height);
+  --font-size-display-small: var(--md-sys-typescale-display-small-size);
+  --line-height-display-small: var(--md-sys-typescale-display-small-line-height);
+
+  /* Headline scale */
+  --font-size-headline-large: var(--md-sys-typescale-headline-large-size);
+  --line-height-headline-large: var(--md-sys-typescale-headline-large-line-height);
+  --font-size-headline-medium: var(--md-sys-typescale-headline-medium-size);
+  --line-height-headline-medium: var(--md-sys-typescale-headline-medium-line-height);
+  --font-size-headline-small: var(--md-sys-typescale-headline-small-size);
+  --line-height-headline-small: var(--md-sys-typescale-headline-small-line-height);
+
+  /* Title scale */
+  --font-size-title-large: var(--md-sys-typescale-title-large-size);
+  --line-height-title-large: var(--md-sys-typescale-title-large-line-height);
+  --font-size-title-medium: var(--md-sys-typescale-title-medium-size);
+  --line-height-title-medium: var(--md-sys-typescale-title-medium-line-height);
+  --font-size-title-small: var(--md-sys-typescale-title-small-size);
+  --line-height-title-small: var(--md-sys-typescale-title-small-line-height);
+
+  /* Body scale */
+  --font-size-body-large: var(--md-sys-typescale-body-large-size);
+  --line-height-body-large: var(--md-sys-typescale-body-large-line-height);
+  --font-size-body-medium: var(--md-sys-typescale-body-medium-size);
+  --line-height-body-medium: var(--md-sys-typescale-body-medium-line-height);
+  --font-size-body-small: var(--md-sys-typescale-body-small-size);
+  --line-height-body-small: var(--md-sys-typescale-body-small-line-height);
+
+  /* Label scale */
+  --font-size-label-large: var(--md-sys-typescale-label-large-size);
+  --line-height-label-large: var(--md-sys-typescale-label-large-line-height);
+  --font-size-label-medium: var(--md-sys-typescale-label-medium-size);
+  --line-height-label-medium: var(--md-sys-typescale-label-medium-line-height);
+  --font-size-label-small: var(--md-sys-typescale-label-small-size);
+  --line-height-label-small: var(--md-sys-typescale-label-small-line-height);
+
+  /* Motion utilities
+     Maps MD3 motion duration tokens to Tailwind transition-duration utilities
+     Usage: duration-short2, duration-medium2, duration-long1, etc. */
+  --transition-duration-short1: var(--md-sys-motion-duration-short1);
+  --transition-duration-short2: var(--md-sys-motion-duration-short2);
+  --transition-duration-short3: var(--md-sys-motion-duration-short3);
+  --transition-duration-short4: var(--md-sys-motion-duration-short4);
+  --transition-duration-medium1: var(--md-sys-motion-duration-medium1);
+  --transition-duration-medium2: var(--md-sys-motion-duration-medium2);
+  --transition-duration-medium3: var(--md-sys-motion-duration-medium3);
+  --transition-duration-medium4: var(--md-sys-motion-duration-medium4);
+  --transition-duration-long1: var(--md-sys-motion-duration-long1);
+  --transition-duration-long2: var(--md-sys-motion-duration-long2);
+  --transition-duration-long3: var(--md-sys-motion-duration-long3);
+  --transition-duration-long4: var(--md-sys-motion-duration-long4);
+
+  /* Easing utilities
+     Maps MD3 easing tokens to Tailwind transition-timing-function utilities
+     Usage: ease-standard, ease-emphasized, etc. */
+  --ease-standard: var(--md-sys-motion-easing-standard);
+  --ease-emphasized: var(--md-sys-motion-easing-emphasized);
+  --ease-emphasized-decelerate: var(--md-sys-motion-easing-emphasized-decelerate);
+  --ease-emphasized-accelerate: var(--md-sys-motion-easing-emphasized-accelerate);
+
+  /* Spacing utilities for MD3 component heights
+     Usage: h-appbar-small (64px), h-appbar-medium (112px), h-appbar-large (152px) */
+  --spacing-appbar-small: 4rem; /* 64px */
+  --spacing-appbar-medium: 7rem; /* 112px */
+  --spacing-appbar-large: 9.5rem; /* 152px */
 }


### PR DESCRIPTION
## Summary

Implement the Material Design 3 Top App Bar component for `@tinybigui/react` as part of the Phase 2 Navigation milestone (v0.2.0).

- 4 MD3 size variants: small, center-aligned, medium, large
- Composable API: navigation icon and action icon slots accept React nodes
- Scroll-triggered elevation: flat at rest, shadow-elevation-2 on scroll
- Controlled and uncontrolled scroll state via useScrollElevation hook
- Three-layer architecture: React Aria (via IconButton) -> AppBarHeadless -> AppBar
- WCAG 2.1 AA: header role=banner landmark, axe audit zero violations

## Deliverables

- `AppBar.tsx` — MD3 styled layer with CVA variants
- `AppBarHeadless.tsx` — Headless primitive with role=banner
- `AppBar.variants.ts` — CVA definitions for variant + scrolled
- `AppBar.types.ts` — TypeScript interfaces
- `AppBar.test.tsx` — 58 tests (rendering, variants, slots, scroll, a11y, edge cases)
- `AppBar.stories.tsx` — Storybook stories for all variants and states
- `useScrollElevation.ts` — Reusable scroll state management hook
- `tokens.css` — Typography, motion, easing, and spacing token mappings added to @theme
- `.changeset/appbar-component.md` — Minor version bump for @tinybigui/react and @tinybigui/tokens

## Test Plan

- [x] 58 unit + accessibility tests passing
- [x] axe audit: zero violations for all 4 variants
- [x] Controlled and uncontrolled scroll state tested
- [x] All slot combinations tested (nav icon, 1-3 actions, empty)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — 0 errors
- [x] Full test suite: 469 tests passing (no regressions)

Made with [Cursor](https://cursor.com)