### PR TITLE
feat(navigation-bar): implement MD3 Navigation Bar (Bottom Navigation) component

### DIFF
--- a/.changeset/navigation-bar-component.md
+++ b/.changeset/navigation-bar-component.md
@@ -1,0 +1,28 @@
+---
+"@tinybigui/react": minor
+---
+
+feat(navigation-bar): add MD3 Navigation Bar (Bottom Navigation) component
+
+Implements the Material Design 3 Navigation Bar component with full
+accessibility support, three-layer architecture, and TDD.
+
+**Features:**
+
+- `NavigationBar` — fixed bottom bar, 3–5 destination items, MD3 styled
+- `NavigationBarItem` — standalone styled item with animated indicator pill
+- `HeadlessNavigationBar` — headless layer using React Aria's `useTabList`/`useTabListState`
+- `HeadlessNavigationBarItem` — headless item using React Aria's `useTab`/`useFocusRing`
+
+**Highlights:**
+
+- Animated active indicator pill (MD3 motion tokens: `duration-medium2`, `ease-emphasized`)
+- Badge support: dot indicator, numeric count, "999+" truncation, hidden at 0
+- `hideLabels` prop for icon-only mode (requires `aria-label` per WCAG)
+- Controlled (`activeKey`/`onActiveChange`) and uncontrolled (`defaultActiveKey`) usage
+- Full keyboard navigation: Arrow Left/Right, Home, End, roving `tabIndex`
+- WCAG 2.1 AA: `role="navigation"` + `aria-label`, `role="tablist"`, `role="tab"` + `aria-selected`
+- Dev warning for item count outside 3–5 range
+- Ripple effect via `useRipple`
+- State layers: hover `opacity-8`, pressed `opacity-12`
+- 46 unit/integration tests including axe accessibility audit

--- a/.github-issues/v0.2.0/001-appbar.md
+++ b/.github-issues/v0.2.0/001-appbar.md
@@ -1,0 +1,108 @@
+---
+title: "feat(appbar): Implement MD3 Top App Bar component"
+labels: ["enhancement", "component", "phase-2", "v0.2.0", "accessibility", "good first issue"]
+milestone: "v0.2.0"
+assignees: []
+---
+
+## Summary
+
+Implement the Material Design 3 **Top App Bar** component for `@tinybigui/react` as part of the Phase 2 Navigation milestone. The Top App Bar provides content and actions related to the current screen. It supports four size variants (Small, Center-aligned, Medium, Large), a navigation icon slot, a title, and trailing action icon slots, with scroll-triggered elevation changes.
+
+This component is foundational to Phase 2 — most navigation-heavy layouts will compose the AppBar with Tabs, Drawer, and/or the Navigation Bar delivered in this same milestone.
+
+## Design Reference
+
+- [MD3 Top App Bar — Overview](https://m3.material.io/components/top-app-bar/overview)
+- [MD3 Top App Bar — Specs](https://m3.material.io/components/top-app-bar/specs)
+
+## Scope
+
+### Variants
+
+- [ ] `small` — 64dp height, title left-aligned, `title-large` type scale
+- [ ] `center-aligned` — 64dp height, title centered, `title-large` type scale
+- [ ] `medium` — 112dp height, title bottom-left, `headline-small` type scale
+- [ ] `large` — 152dp height, title bottom-left, `display-small` type scale (default: `small`)
+
+### Features
+
+- [ ] Navigation icon slot (leading, optional) — renders an `IconButton`; accessible name required
+- [ ] Title slot — accepts a string or React node
+- [ ] Trailing action icon slots (up to 3) — each renders an `IconButton`
+- [ ] Scroll elevation behavior — flat (`shadow-none`) at rest, elevated (`shadow-elevation-2`) on scroll, with MD3 motion transition
+- [ ] Controlled scroll state via `scrolled` prop and `onScrollStateChange` callback
+- [ ] Composable API — navigation icon and action icons passed as React nodes (no hardcoded slots)
+- [ ] Dark mode support via existing token system
+
+### Deliverables
+
+- [ ] `AppBar.tsx` — MD3 styled layer (`'use client'`, `forwardRef`, CVA)
+- [ ] `AppBarHeadless.tsx` — React Aria headless primitive
+- [ ] `AppBar.variants.ts` — CVA variant definitions
+- [ ] `AppBar.types.ts` — TypeScript types extending React Aria props
+- [ ] `AppBar.test.tsx` — unit + accessibility tests (≥ 85% coverage)
+- [ ] `AppBar.stories.tsx` — Storybook stories for all variants and states
+- [ ] `index.ts` — named exports for styled, headless, variants, and types
+
+## Architecture
+
+This component follows the established **three-layer architecture** used by all TinyBigUI components:
+
+```
+Layer 3 — AppBar.tsx          (MD3 styled, CVA variants, 'use client')
+Layer 2 — AppBarHeadless.tsx  (React Aria: useButton for icon slots, role="banner")
+Layer 1 — React Aria          (useButton, focus management)
+```
+
+**React Aria hooks:**
+
+- `useButton` — for the navigation icon button and each trailing action icon button
+- `role="banner"` — on the `<header>` container as the ARIA landmark
+
+**CVA variants:** `variant` (`small` | `center-aligned` | `medium` | `large`), `scrolled` (`true` | `false`)
+
+**Token usage (no arbitrary values):**
+
+- Surface: `bg-surface`
+- Text: `text-on-surface`, `text-on-surface-variant`
+- Elevation: `shadow-elevation-2` (scrolled state)
+- State layers: `opacity-8` (hover), `opacity-12` (pressed)
+
+## Acceptance Criteria
+
+- [ ] All four MD3 size variants render correctly with correct height, alignment, and type scale
+- [ ] Navigation icon and action icons accept any React node and render as accessible `IconButton`s
+- [ ] `aria-label` is required on navigation icon and all action icon buttons (enforced via TypeScript)
+- [ ] `role="banner"` is applied to the outer `<header>` container
+- [ ] Scroll elevation state is supported in both controlled (`scrolled` prop) and uncontrolled (internal state) modes
+- [ ] Elevation transition uses MD3 motion tokens (no hardcoded `transition` values)
+- [ ] All interactive elements have visible focus indicators
+- [ ] Component passes `axe` accessibility audit with zero violations
+- [ ] Test coverage ≥ 85% (unit + accessibility + interaction tests)
+- [ ] Storybook stories cover all 4 variants, scrolled state, with and without navigation icon, 1–3 action icons
+- [ ] No hardcoded hex values or arbitrary Tailwind classes
+- [ ] ESLint error-free and Prettier-formatted
+- [ ] Named exports only; `index.ts` re-exports all public API
+
+## Dependencies
+
+- `v0.1.0` released (Button, IconButton, FAB, TextField, Checkbox, Switch, Radio)
+- `@tinybigui/tokens` — existing MD3 token system (`packages/tokens/src/tokens.css`)
+- `IconButton` component from Phase 1 (reuse for navigation and action icon slots)
+- `useRipple` hook (reuse existing `packages/react/src/hooks/useRipple`)
+
+## Out of Scope
+
+- **Bottom App Bar** — separate component, separate issue
+- **Search mode** (AppBar transforming into a search field) — Phase 3+
+- **Custom color theming** beyond the standard MD3 color roles
+
+## Resources
+
+- [MD3 Top App Bar Spec](https://m3.material.io/components/top-app-bar/specs)
+- [React Aria `useButton`](https://react-spectrum.adobe.com/react-aria/useButton.html)
+- [TinyBigUI Architecture Rule](.cursor/rules/architecture.mdc)
+- [TinyBigUI Code Style Rule](.cursor/rules/code-style.mdc)
+- [Existing reference: `Button` component](packages/react/src/components/Button/)
+- [Existing reference: `IconButton` component](packages/react/src/components/IconButton/)

--- a/.github-issues/v0.2.0/002-tabs.md
+++ b/.github-issues/v0.2.0/002-tabs.md
@@ -1,0 +1,126 @@
+---
+title: "feat(tabs): Implement MD3 Tabs component"
+labels: ["enhancement", "component", "phase-2", "v0.2.0", "accessibility"]
+milestone: "v0.2.0"
+assignees: []
+---
+
+## Summary
+
+Implement the Material Design 3 **Tabs** component for `@tinybigui/react` as part of the Phase 2 Navigation milestone. Tabs organize content across different screens, data sets, and other interactions. This implementation supports two variants (Primary and Secondary), both fixed and scrollable layouts, three tab content modes (icon-only, label-only, icon + label), an animated active indicator, optional badges per tab, and full keyboard navigation via React Aria.
+
+## Design Reference
+
+- [MD3 Tabs — Overview](https://m3.material.io/components/tabs/overview)
+- [MD3 Tabs — Specs](https://m3.material.io/components/tabs/specs)
+
+## Scope
+
+### Variants
+
+- [ ] `primary` — active indicator: full-width underline using `bg-primary`; active label/icon `text-primary`
+- [ ] `secondary` — active indicator: full-width underline using `bg-on-surface-variant`; active label/icon `text-on-surface`
+
+### Layouts
+
+- [ ] `fixed` — tabs fill available width equally
+- [ ] `scrollable` — tabs overflow horizontally, no wrapping; scroll affordance shown when needed
+
+### Tab Content Modes
+
+- [ ] Icon-only (`icon` prop only)
+- [ ] Label-only (`label` prop only)
+- [ ] Icon + label stacked (`icon` + `label` props)
+
+### Features
+
+- [ ] Animated active indicator — sliding underline driven by MD3 motion tokens (no CSS-in-JS)
+- [ ] Badge support — optional `badge` prop on `Tab` (numeric count, dot indicator, or 999+)
+- [ ] Disabled tab support
+- [ ] Controlled (`selectedKey`) and uncontrolled (`defaultSelectedKey`) usage via `Tabs` wrapper
+- [ ] Full keyboard navigation — Arrow Left/Right, Home, End, roving `tabIndex`
+- [ ] Dark mode support via existing token system
+
+### Deliverables
+
+- [ ] `Tabs.tsx` — context provider wrapper; manages shared selected state
+- [ ] `TabList.tsx` — MD3 styled tab row container
+- [ ] `Tab.tsx` — individual tab item (styled layer)
+- [ ] `TabPanel.tsx` — associated content panel
+- [ ] `TabsHeadless.tsx` — React Aria headless primitives (`HeadlessTabList`, `HeadlessTab`, `HeadlessTabPanel`)
+- [ ] `Tabs.variants.ts` — CVA variant definitions
+- [ ] `Tabs.types.ts` — TypeScript types extending React Aria props
+- [ ] `Tabs.test.tsx` — unit + accessibility tests (≥ 85% coverage)
+- [ ] `Tabs.stories.tsx` — Storybook stories for all variants, layouts, content modes, badge, disabled
+- [ ] `index.ts` — named exports for all public sub-components, headless, variants, and types
+
+## Architecture
+
+This component follows the established **three-layer architecture** used by all TinyBigUI components:
+
+```
+Layer 3 — Tabs.tsx / TabList.tsx / Tab.tsx / TabPanel.tsx  (MD3 styled, CVA variants, 'use client')
+Layer 2 — TabsHeadless.tsx                                 (React Aria: useTabList, useTab, useTabPanel)
+Layer 1 — React Aria                                       (useTabList, useTab, useTabPanel, FocusRing)
+```
+
+**React Aria hooks:**
+
+- `useTabList` — on the `<TabList>` container (manages `role="tablist"`, keyboard navigation)
+- `useTab` — on each `<Tab>` item (`role="tab"`, `aria-selected`, `aria-disabled`, roving `tabIndex`)
+- `useTabPanel` — on each `<TabPanel>` (`role="tabpanel"`, `aria-labelledby`)
+
+**CVA variants:** `variant` (`primary` | `secondary`), `layout` (`fixed` | `scrollable`), `contentMode` (`icon` | `label` | `icon-label`)
+
+**Token usage (no arbitrary values):**
+
+- Container: `bg-surface`
+- Primary active indicator: `bg-primary`; active text: `text-primary`
+- Secondary active indicator: `bg-on-surface-variant`; active text: `text-on-surface`
+- Inactive text: `text-on-surface-variant`
+- Type scale: `title-small` (per MD3 Tab spec)
+- State layers: `opacity-8` (hover), `opacity-12` (pressed)
+
+## Acceptance Criteria
+
+- [ ] `Tabs` wrapper correctly manages shared selected state across `TabList` and `TabPanel`
+- [ ] Both `primary` and `secondary` variant styles match MD3 specifications
+- [ ] Fixed layout distributes tab widths equally; scrollable layout overflows horizontally without wrapping
+- [ ] All three content modes (icon-only, label-only, icon + label) render correctly
+- [ ] Active indicator slides to the newly selected tab using MD3 motion tokens
+- [ ] Badge renders correctly for numeric values, dot indicator, and truncates to "999+" beyond 999
+- [ ] Badge is hidden when numeric value is `0`
+- [ ] Disabled tabs are not focusable and cannot be selected
+- [ ] Full keyboard navigation: Arrow Left/Right cycles tabs, Home/End jump to first/last
+- [ ] `role="tablist"`, `role="tab"`, and `role="tabpanel"` are applied correctly
+- [ ] `aria-selected`, `aria-controls`, `aria-labelledby`, and `aria-disabled` attributes are wired correctly
+- [ ] Component passes `axe` accessibility audit with zero violations
+- [ ] Test coverage ≥ 85% (unit + accessibility + keyboard interaction tests)
+- [ ] Storybook stories cover Primary/Secondary variants, fixed/scrollable layouts, all content modes, badge, disabled tab
+- [ ] No hardcoded hex values or arbitrary Tailwind classes
+- [ ] ESLint error-free and Prettier-formatted
+- [ ] Named exports only; `index.ts` re-exports all public API
+
+## Dependencies
+
+- `v0.1.0` released (Button, IconButton, FAB, TextField, Checkbox, Switch, Radio)
+- `@tinybigui/tokens` — existing MD3 token system (`packages/tokens/src/tokens.css`)
+- `useRipple` hook (reuse existing `packages/react/src/hooks/useRipple`)
+
+## Out of Scope
+
+- **Vertical tabs** — not part of MD3 Tabs spec
+- **Nested tabs** — not supported by MD3
+- **Lazy-loading of tab panels** — future enhancement
+- **Separate `Badge` component** — badge is a simple inline implementation within `Tab` for now
+
+## Resources
+
+- [MD3 Tabs Spec](https://m3.material.io/components/tabs/specs)
+- [React Aria `useTabList`](https://react-spectrum.adobe.com/react-aria/useTabList.html)
+- [React Aria `useTab`](https://react-spectrum.adobe.com/react-aria/useTab.html)
+- [React Aria `useTabPanel`](https://react-spectrum.adobe.com/react-aria/useTabPanel.html)
+- [TinyBigUI Architecture Rule](.cursor/rules/architecture.mdc)
+- [TinyBigUI Code Style Rule](.cursor/rules/code-style.mdc)
+- [Existing reference: `Button` component](packages/react/src/components/Button/)
+- [Existing reference: `Radio` component](packages/react/src/components/Radio/) (group + item pattern)

--- a/.github-issues/v0.2.0/003-drawer.md
+++ b/.github-issues/v0.2.0/003-drawer.md
@@ -1,0 +1,137 @@
+---
+title: "feat(drawer): Implement MD3 Navigation Drawer component"
+labels: ["enhancement", "component", "phase-2", "v0.2.0", "accessibility"]
+milestone: "v0.2.0"
+assignees: []
+---
+
+## Summary
+
+Implement the Material Design 3 **Navigation Drawer** component for `@tinybigui/react` as part of the Phase 2 Navigation milestone. The Navigation Drawer provides access to destinations and app functionality, such as switching accounts. It can appear on the left side of a layout as a permanently visible panel (Standard variant) or as a dismissible overlay (Modal variant). This implementation includes `DrawerItem` and `DrawerSection` sub-components, a scrim overlay for the modal variant, full focus management, and animated entry/exit transitions.
+
+## Design Reference
+
+- [MD3 Navigation Drawer — Overview](https://m3.material.io/components/navigation-drawer/overview)
+- [MD3 Navigation Drawer — Specs](https://m3.material.io/components/navigation-drawer/specs)
+
+## Scope
+
+### Variants
+
+- [ ] `standard` — inline `<nav>` landmark, no overlay; supports controlled `open` prop for collapsible layouts
+- [ ] `modal` — overlay with scrim backdrop, slide-in animation, focus trap, `Escape` to close
+
+### Sub-components
+
+- [ ] `DrawerItem` — navigation destination row: optional leading icon, label, optional trailing badge or secondary text, active indicator pill
+- [ ] `DrawerSection` — groups items with an optional header label and a divider
+
+### Features
+
+- [ ] Active item indicator — pill shape behind active `DrawerItem`, `bg-secondary-container` / `text-on-secondary-container`
+- [ ] Scrim backdrop (modal only) — `bg-scrim` at `opacity-32`; clicking scrim closes the drawer
+- [ ] Focus trap (modal only) — keyboard focus is contained within the open drawer via `FocusScope`
+- [ ] Focus restoration — focus returns to the trigger element when the modal drawer closes
+- [ ] `Escape` key closes the modal drawer
+- [ ] Slide-in/out animation — `translate-x` driven by MD3 motion tokens
+- [ ] `href` support on `DrawerItem` — renders as `<a>` with `useLink`; without `href` renders as `<button>` with `useButton`
+- [ ] Disabled `DrawerItem` support
+- [ ] Controlled (`open` / `onOpenChange`) and uncontrolled usage
+- [ ] Dark mode support via existing token system
+- [ ] Token audit — add `--color-scrim` to `packages/tokens/src/tokens.css` if absent
+
+### Deliverables
+
+- [ ] `Drawer.tsx` — MD3 styled layer, both variants (`'use client'`, `forwardRef`, CVA)
+- [ ] `DrawerHeadless.tsx` — React Aria headless primitives (`HeadlessDrawer`, `HeadlessDrawerItem`)
+- [ ] `DrawerItem.tsx` — styled navigation item sub-component
+- [ ] `DrawerSection.tsx` — styled section header + divider sub-component
+- [ ] `Drawer.variants.ts` — CVA variant definitions
+- [ ] `Drawer.types.ts` — TypeScript types extending React Aria props
+- [ ] `Drawer.test.tsx` — unit + accessibility tests (≥ 85% coverage)
+- [ ] `Drawer.stories.tsx` — Storybook stories for both variants and all interaction states
+- [ ] `index.ts` — named exports for all public sub-components, headless, variants, and types
+
+## Architecture
+
+This component follows the established **three-layer architecture** used by all TinyBigUI components:
+
+```
+Layer 3 — Drawer.tsx / DrawerItem.tsx / DrawerSection.tsx  (MD3 styled, CVA variants, 'use client')
+Layer 2 — DrawerHeadless.tsx                               (React Aria: useDialog, useOverlay, FocusScope)
+Layer 1 — React Aria                                       (useDialog, useOverlay, usePreventScroll, FocusScope, useLink, useButton)
+```
+
+**React Aria hooks:**
+
+- `useDialog` — on the modal drawer container (`role="dialog"`, `aria-modal="true"`, `aria-label`)
+- `useOverlay` — manages dismiss on click-outside and `Escape` key for modal variant
+- `usePreventScroll` — locks body scroll when modal drawer is open
+- `FocusScope` — contains focus within the open modal drawer; `restoreFocus` returns focus on close
+- `useOverlayTriggerState` (react-stately) — manages `open`/`closed` state
+- `useLink` — on `DrawerItem` when `href` is provided
+- `useButton` — on `DrawerItem` when no `href` (click-based selection)
+- `role="navigation"` — on the outer `<nav>` wrapper for both variants
+
+**CVA variants:** `variant` (`standard` | `modal`), `open` (`true` | `false`)
+
+**Token usage (no arbitrary values):**
+
+- Standard surface: `bg-surface-container-low`
+- Modal surface: `bg-surface-container`
+- Active indicator: `bg-secondary-container`; active icon/label: `text-on-secondary-container`
+- Inactive item: `text-on-surface-variant`
+- Scrim: `bg-scrim` `opacity-32` (requires `--color-scrim` in tokens)
+- Divider: `border-outline-variant`
+- Drawer width: 360dp — map to a Tailwind width utility via `@theme`
+- Elevation (modal): `shadow-elevation-1`
+- State layers: `opacity-8` (hover), `opacity-12` (pressed)
+
+## Acceptance Criteria
+
+- [ ] Standard variant renders as an inline `<nav>` with no overlay or focus trap
+- [ ] Modal variant renders as an overlay dialog with scrim, focus trap, and slide-in animation
+- [ ] `role="navigation"` is applied to the outer container in both variants
+- [ ] `role="dialog"` and `aria-modal="true"` are applied to the modal drawer panel
+- [ ] `aria-label` is required on the drawer (enforced via TypeScript)
+- [ ] `Escape` key closes the modal drawer
+- [ ] Clicking the scrim closes the modal drawer
+- [ ] Focus is trapped inside the open modal drawer
+- [ ] Focus returns to the trigger element when the modal drawer closes
+- [ ] `aria-current="page"` is applied to the active `DrawerItem`
+- [ ] `DrawerItem` renders as `<a>` when `href` is provided, `<button>` otherwise
+- [ ] Disabled `DrawerItem` is not focusable and not interactive
+- [ ] Slide-in/out animation uses MD3 motion tokens (no hardcoded `transition` values)
+- [ ] `--color-scrim` token exists in `packages/tokens/src/tokens.css`; added if missing
+- [ ] Component passes `axe` accessibility audit with zero violations
+- [ ] Test coverage ≥ 85% (unit + accessibility + interaction + focus management tests)
+- [ ] Storybook stories cover both variants, open/close, active item, sections, disabled item, with and without icons
+- [ ] No hardcoded hex values or arbitrary Tailwind classes
+- [ ] ESLint error-free and Prettier-formatted
+- [ ] Named exports only; `index.ts` re-exports all public API
+
+## Dependencies
+
+- `v0.1.0` released (Button, IconButton, FAB, TextField, Checkbox, Switch, Radio)
+- `@tinybigui/tokens` — existing MD3 token system (`packages/tokens/src/tokens.css`)
+- `useRipple` hook (reuse existing `packages/react/src/hooks/useRipple`)
+- `IconButton` component from Phase 1 (optional close button in modal header)
+
+## Out of Scope
+
+- **End-aligned (right-side) drawer** — not a standard MD3 Navigation Drawer pattern
+- **Permanently expanded wide drawer** (rail → drawer expansion) — Navigation Rail is a Phase 5+ component
+- **Multi-level nested navigation** — not part of MD3 Navigation Drawer spec
+- **Swipe-to-open gesture** — touch gesture enhancement, Phase 3+
+
+## Resources
+
+- [MD3 Navigation Drawer Spec](https://m3.material.io/components/navigation-drawer/specs)
+- [React Aria `useDialog`](https://react-spectrum.adobe.com/react-aria/useDialog.html)
+- [React Aria `useOverlay`](https://react-spectrum.adobe.com/react-aria/useOverlay.html)
+- [React Aria `FocusScope`](https://react-spectrum.adobe.com/react-aria/FocusScope.html)
+- [React Aria `useLink`](https://react-spectrum.adobe.com/react-aria/useLink.html)
+- [TinyBigUI Architecture Rule](.cursor/rules/architecture.mdc)
+- [TinyBigUI Code Style Rule](.cursor/rules/code-style.mdc)
+- [Existing reference: `Button` component](packages/react/src/components/Button/)
+- [Existing reference: `IconButton` component](packages/react/src/components/IconButton/)

--- a/.github-issues/v0.2.0/004-bottom-navigation.md
+++ b/.github-issues/v0.2.0/004-bottom-navigation.md
@@ -1,0 +1,126 @@
+---
+title: "feat(navigation-bar): Implement MD3 Navigation Bar component"
+labels: ["enhancement", "component", "phase-2", "v0.2.0", "accessibility"]
+milestone: "v0.2.0"
+assignees: []
+---
+
+## Summary
+
+Implement the Material Design 3 **Navigation Bar** (Bottom Navigation) component for `@tinybigui/react` as part of the Phase 2 Navigation milestone. The Navigation Bar lets people switch between UI views on smaller devices. It renders a fixed bottom bar with 3–5 destination items, each comprising an icon, optional label, an animated active indicator pill, and an optional badge. The component uses React Aria's `useTabList`/`useTab` for full keyboard navigation and ARIA semantics, and supports both controlled and uncontrolled usage patterns.
+
+## Design Reference
+
+- [MD3 Navigation Bar — Overview](https://m3.material.io/components/navigation-bar/overview)
+- [MD3 Navigation Bar — Specs](https://m3.material.io/components/navigation-bar/specs)
+
+## Scope
+
+### Constraints
+
+- [ ] Enforces 3–5 destination items via TypeScript type (`MinMax<3, 5>` or equivalent); dev-only runtime warning for violations
+
+### Features
+
+- [ ] Active indicator pill — animated `rounded-full` pill behind the active icon; scales and fades in on activation using MD3 motion tokens
+- [ ] Icon slot — required on each `NavigationBarItem`; accessible name required for icon-only mode
+- [ ] Label slot — optional per item; hidden globally via `hideLabels` prop on `NavigationBar`
+- [ ] Badge support — optional `badge` prop on `NavigationBarItem`:
+  - Dot indicator (no value)
+  - Numeric count (shown as-is)
+  - Truncated to `"999+"` when value > 999
+  - Hidden when numeric value is `0`
+- [ ] Disabled destination support
+- [ ] Controlled usage — `activeKey` + `onActiveChange` props
+- [ ] Uncontrolled usage — `defaultActiveKey` prop
+- [ ] Dark mode support via existing token system
+
+### Deliverables
+
+- [ ] `NavigationBar.tsx` — MD3 styled bar container (`'use client'`, `forwardRef`, CVA)
+- [ ] `NavigationBarItem.tsx` — styled individual destination item
+- [ ] `NavigationBarHeadless.tsx` — React Aria headless primitives (`HeadlessNavigationBar`, `HeadlessNavigationBarItem`)
+- [ ] `NavigationBar.variants.ts` — CVA variant definitions
+- [ ] `NavigationBar.types.ts` — TypeScript types extending React Aria props
+- [ ] `NavigationBar.test.tsx` — unit + accessibility tests (≥ 85% coverage)
+- [ ] `NavigationBar.stories.tsx` — Storybook stories for all states, item counts, badge, hideLabels
+- [ ] `index.ts` — named exports for all public sub-components, headless, variants, and types
+
+## Architecture
+
+This component follows the established **three-layer architecture** used by all TinyBigUI components:
+
+```
+Layer 3 — NavigationBar.tsx / NavigationBarItem.tsx  (MD3 styled, CVA variants, 'use client')
+Layer 2 — NavigationBarHeadless.tsx                  (React Aria: useTabList, useTab)
+Layer 1 — React Aria                                 (useTabList, useTab, FocusRing)
+```
+
+**React Aria hooks:**
+
+- `useTabList` — on the inner `<div role="tablist">` container (manages keyboard navigation: Arrow Left/Right, Home, End, roving `tabIndex`)
+- `useTab` — on each `NavigationBarItem` (`role="tab"`, `aria-selected`, `aria-disabled`)
+- `role="navigation"` with `aria-label` — on the outer `<nav>` wrapper
+- `role="tablist"` — on the inner item container
+
+**CVA variants:** `hideLabels` (`true` | `false`), `itemCount` (`3` | `4` | `5`)
+
+**Token usage (no arbitrary values):**
+
+- Bar surface: `bg-surface-container`
+- Active indicator pill: `bg-secondary-container`; active icon: `text-on-secondary-container`
+- Inactive icon: `text-on-surface-variant`
+- Active label: `text-on-surface`; inactive label: `text-on-surface-variant`
+- Bar height: 80dp; icon size: 24dp; indicator pill: 64dp × 32dp
+- Elevation: none by default; `shadow-elevation-2` for floating variant (future)
+- State layers: `opacity-8` (hover), `opacity-12` (pressed)
+
+## Acceptance Criteria
+
+- [ ] Component enforces 3–5 destination items at the TypeScript type level
+- [ ] A dev-only `console.warn` fires at runtime when item count is outside the 3–5 range
+- [ ] Active indicator pill animates to the newly selected item using MD3 motion tokens
+- [ ] `hideLabels` prop hides labels on all items globally
+- [ ] Badge renders correctly for dot, numeric, and `999+` cases; hidden when value is `0`
+- [ ] Disabled items are not focusable and cannot be activated
+- [ ] Controlled usage works correctly via `activeKey` + `onActiveChange`
+- [ ] Uncontrolled usage works correctly via `defaultActiveKey`
+- [ ] `role="navigation"` with a descriptive `aria-label` is applied to the outer `<nav>`
+- [ ] `role="tablist"` is applied to the inner item container
+- [ ] `role="tab"` and `aria-selected` are applied to each destination item
+- [ ] `aria-label` is required on icon-only `NavigationBarItem`s (enforced via TypeScript)
+- [ ] Full keyboard navigation: Arrow Left/Right cycles destinations, Home/End jump to first/last
+- [ ] Component passes `axe` accessibility audit with zero violations
+- [ ] Test coverage ≥ 85% (unit + accessibility + keyboard interaction + badge + controlled/uncontrolled tests)
+- [ ] Storybook stories cover 3/4/5 item counts, active state, badge (dot/numeric/999+), `hideLabels`, disabled item
+- [ ] No hardcoded hex values or arbitrary Tailwind classes
+- [ ] ESLint error-free and Prettier-formatted
+- [ ] Named exports only; `index.ts` re-exports all public API
+
+## Dependencies
+
+- `v0.1.0` released (Button, IconButton, FAB, TextField, Checkbox, Switch, Radio)
+- `@tinybigui/tokens` — existing MD3 token system (`packages/tokens/src/tokens.css`)
+- `useRipple` hook (reuse existing `packages/react/src/hooks/useRipple`)
+
+## Out of Scope
+
+- **Navigation Rail** (landscape adaptation) — documented as a future concern; the `NavigationBar` does not implement responsive transformation to a Rail. This is tracked as a separate Phase 5+ item.
+- **Floating Navigation Bar** — elevated surface variant; elevation token is noted but not required in this issue
+- **Custom animation curves** beyond MD3 motion tokens
+- **Route-aware active state** — consumers are responsible for passing `activeKey` based on their router
+
+## Future Considerations
+
+> **Navigation Rail (landscape):** On wider viewports, a Navigation Bar commonly transitions to a Navigation Rail layout (vertical, left-aligned). This is not part of this issue. A separate issue should be created under a future phase to implement `NavigationRail` and a responsive `useNavigationVariant` hook that switches between `NavigationBar` and `NavigationRail` based on viewport width.
+
+## Resources
+
+- [MD3 Navigation Bar Spec](https://m3.material.io/components/navigation-bar/specs)
+- [React Aria `useTabList`](https://react-spectrum.adobe.com/react-aria/useTabList.html)
+- [React Aria `useTab`](https://react-spectrum.adobe.com/react-aria/useTab.html)
+- [TinyBigUI Architecture Rule](.cursor/rules/architecture.mdc)
+- [TinyBigUI Code Style Rule](.cursor/rules/code-style.mdc)
+- [Existing reference: `Button` component](packages/react/src/components/Button/)
+- [Existing reference: `Radio` component](packages/react/src/components/Radio/) (group + item pattern)
+- [Related issue: `002-tabs.md`](.github-issues/v0.2.0/002-tabs.md) (shares `useTabList`/`useTab` patterns)

--- a/.github-issues/v0.3.0/001-dialog.md
+++ b/.github-issues/v0.3.0/001-dialog.md
@@ -1,0 +1,137 @@
+---
+title: "feat(dialog): Implement MD3 Dialog component"
+labels: ["enhancement", "component", "phase-3", "v0.3.0", "accessibility"]
+milestone: "v0.3.0"
+assignees: []
+---
+
+## Summary
+
+Implement the Material Design 3 **Dialog** component for `@tinybigui/react` as part of the Phase 3 Feedback milestone. Dialogs provide important prompts in a user flow and can communicate information, require decisions, or involve tasks. This implementation supports two structural variants — Basic dialog (with optional icon, title, supporting text, and 1–2 action buttons) and Full-screen dialog (for complex content or tasks that require a dedicated view on mobile) — with a scrim overlay, full focus management, and MD3-compliant animation.
+
+## Design Reference
+
+- [MD3 Dialogs — Overview](https://m3.material.io/components/dialogs/overview)
+- [MD3 Dialogs — Specs](https://m3.material.io/components/dialogs/specs)
+
+## Scope
+
+### Variants
+
+- [ ] `basic` — centered overlay with optional icon, title, body text, and up to 2 action buttons; default `role="alertdialog"` when requiring a decision, `role="dialog"` otherwise
+- [ ] `full-screen` — occupies the full viewport on mobile; includes a header bar with close icon and confirm action; `role="dialog"`
+
+### Sub-components / Slots
+
+- [ ] `DialogIcon` — optional leading icon above the title (basic variant only)
+- [ ] `DialogTitle` — required heading; maps to `aria-labelledby`
+- [ ] `DialogContent` — scrollable body area; maps to `aria-describedby`
+- [ ] `DialogActions` — container for action buttons (1–2 text/filled buttons)
+
+### Features
+
+- [ ] Scrim backdrop — `bg-scrim` at `opacity-32`; clicking scrim closes dialog (configurable via `closeOnScrimClick` prop)
+- [ ] Focus trap — keyboard focus contained within the open dialog via `FocusScope`
+- [ ] Focus restoration — focus returns to the trigger element when the dialog closes
+- [ ] `Escape` key closes the dialog
+- [ ] Body scroll lock — `usePreventScroll` prevents background scrolling when open
+- [ ] Entry/exit animation — fade + scale using MD3 motion tokens (`emphasized-decelerate` easing for open, `emphasized-accelerate` for close)
+- [ ] Controlled (`open` / `onOpenChange`) and uncontrolled usage
+- [ ] Dark mode support via existing token system
+- [ ] Token audit — add `--color-scrim` to `packages/tokens/src/tokens.css` if absent (may already be added by Drawer implementation)
+
+### Deliverables
+
+- [ ] `Dialog.tsx` — MD3 styled layer, both variants (`'use client'`, `forwardRef`, CVA)
+- [ ] `DialogHeadless.tsx` — React Aria headless primitive (`HeadlessDialog`)
+- [ ] `DialogIcon.tsx` — styled icon slot sub-component
+- [ ] `DialogTitle.tsx` — styled title sub-component
+- [ ] `DialogContent.tsx` — styled scrollable content sub-component
+- [ ] `DialogActions.tsx` — styled actions container sub-component
+- [ ] `Dialog.variants.ts` — CVA variant definitions
+- [ ] `Dialog.types.ts` — TypeScript types extending React Aria props
+- [ ] `Dialog.test.tsx` — unit + accessibility tests (≥ 85% coverage)
+- [ ] `Dialog.stories.tsx` — Storybook stories for both variants and all interaction states
+- [ ] `index.ts` — named exports for all public sub-components, headless, variants, and types
+
+## Architecture
+
+This component follows the established **three-layer architecture** used by all TinyBigUI components:
+
+```
+Layer 3 — Dialog.tsx + sub-components        (MD3 styled, CVA variants, 'use client')
+Layer 2 — DialogHeadless.tsx                 (React Aria: useDialog, useOverlay, FocusScope)
+Layer 1 — React Aria                         (useDialog, useOverlay, usePreventScroll, FocusScope)
+```
+
+**React Aria hooks:**
+
+- `useDialog` — on the dialog panel (`role="dialog"` or `role="alertdialog"`, `aria-labelledby`, `aria-describedby`)
+- `useOverlay` — manages dismiss on click-outside (`closeOnScrimClick`) and `Escape` key
+- `usePreventScroll` — locks body scroll while dialog is open
+- `FocusScope` — contains focus within the open dialog; `restoreFocus` prop returns focus on close
+- `useOverlayTriggerState` (react-stately) — manages `open`/`closed` state for uncontrolled usage
+
+**CVA variants:** `variant` (`basic` | `full-screen`), `open` (`true` | `false`)
+
+**Token usage (no arbitrary values):**
+
+- Dialog surface: `bg-surface-container-high`
+- Text: `text-on-surface` (title), `text-on-surface-variant` (body)
+- Scrim: `bg-scrim` `opacity-32`
+- Elevation: `shadow-elevation-3`
+- Shape: `rounded-[28px]` → maps to MD3 `shape-corner-extra-large` token
+- Icon (optional): `text-secondary`
+- Action buttons: reuse existing `Button` component (`text` variant)
+- State layers: `opacity-8` (hover), `opacity-12` (pressed)
+
+## Acceptance Criteria
+
+- [ ] Basic variant renders with optional icon, title, body, and 1–2 action buttons centered in the viewport
+- [ ] Full-screen variant renders occupying the full viewport; includes header bar with close icon and confirm action
+- [ ] `role="dialog"` (informational) or `role="alertdialog"` (decision-required) is applied based on a `type` prop
+- [ ] `aria-labelledby` wired to `DialogTitle` element
+- [ ] `aria-describedby` wired to `DialogContent` element
+- [ ] `aria-modal="true"` is set on the dialog panel
+- [ ] `Escape` key closes the dialog and restores focus to the trigger
+- [ ] Clicking the scrim closes the dialog when `closeOnScrimClick` is `true` (default)
+- [ ] Focus is trapped inside the open dialog via `FocusScope`
+- [ ] Focus returns to the trigger element when the dialog closes
+- [ ] Body scroll is prevented while the dialog is open
+- [ ] Entry and exit animations use MD3 motion tokens (no hardcoded `transition` or `animation` values)
+- [ ] Controlled usage works via `open` + `onOpenChange` props
+- [ ] Uncontrolled usage works via internal state
+- [ ] `--color-scrim` token exists in `packages/tokens/src/tokens.css`
+- [ ] Component passes `axe` accessibility audit with zero violations
+- [ ] Test coverage ≥ 85% (unit + accessibility + interaction + focus management tests)
+- [ ] Storybook stories cover both variants, with/without icon, 1 and 2 action buttons, long body content (scrollable), controlled and uncontrolled
+- [ ] No hardcoded hex values or arbitrary Tailwind classes
+- [ ] ESLint error-free and Prettier-formatted
+- [ ] Named exports only; `index.ts` re-exports all public API
+
+## Dependencies
+
+- `v0.2.0` released (AppBar, Tabs, Drawer, Bottom Navigation)
+- `@tinybigui/tokens` — existing MD3 token system (`packages/tokens/src/tokens.css`); `--color-scrim` may be added by Drawer in v0.2.0
+- `Button` component from Phase 1 (reuse `text` variant for dialog action buttons)
+- `IconButton` component from Phase 1 (reuse for full-screen dialog close button)
+- `useRipple` hook (reuse existing `packages/react/src/hooks/useRipple`)
+
+## Out of Scope
+
+- **Date picker dialog** — composite component, tracked as Phase 5+
+- **Time picker dialog** — composite component, tracked as Phase 5+
+- **Alert dialog with destructive action styling** — destructive color variant for action button is a future enhancement
+- **Bottom sheet** — a separate MD3 pattern, not part of Dialog spec
+
+## Resources
+
+- [MD3 Dialogs Spec](https://m3.material.io/components/dialogs/specs)
+- [React Aria `useDialog`](https://react-spectrum.adobe.com/react-aria/useDialog.html)
+- [React Aria `useOverlay`](https://react-spectrum.adobe.com/react-aria/useOverlay.html)
+- [React Aria `FocusScope`](https://react-spectrum.adobe.com/react-aria/FocusScope.html)
+- [TinyBigUI Architecture Rule](.cursor/rules/architecture.mdc)
+- [TinyBigUI Code Style Rule](.cursor/rules/code-style.mdc)
+- [Existing reference: `Button` component](packages/react/src/components/Button/)
+- [Existing reference: `IconButton` component](packages/react/src/components/IconButton/)
+- [Related v0.2.0 reference: `Drawer` component](.github-issues/v0.2.0/003-drawer.md) (shares overlay/focus trap patterns)

--- a/.github-issues/v0.3.0/002-snackbar.md
+++ b/.github-issues/v0.3.0/002-snackbar.md
@@ -1,0 +1,120 @@
+---
+title: "feat(snackbar): Implement MD3 Snackbar component"
+labels: ["enhancement", "component", "phase-3", "v0.3.0", "accessibility"]
+milestone: "v0.3.0"
+assignees: []
+---
+
+## Summary
+
+Implement the Material Design 3 **Snackbar** component for `@tinybigui/react` as part of the Phase 3 Feedback milestone. Snackbars provide brief messages about app processes at the bottom of the screen. They appear temporarily and do not require user interaction to disappear, though they may optionally include a single action or a close icon. This implementation covers single-line and two-line layouts, auto-dismiss with configurable duration, an optional action button, an optional close icon, queue management (one snackbar visible at a time), and full screen-reader announcement support.
+
+## Design Reference
+
+- [MD3 Snackbar — Overview](https://m3.material.io/components/snackbar/overview)
+- [MD3 Snackbar — Specs](https://m3.material.io/components/snackbar/specs)
+
+## Scope
+
+### Variants (layout)
+
+- [ ] `single-line` — message and optional action on the same row
+- [ ] `two-line` — message wraps to a second line; action (if present) is stacked below
+
+### Feature Matrix
+
+- [ ] Auto-dismiss — configurable `duration` prop (default: 4000ms); `Infinity` disables auto-dismiss
+- [ ] Action button (optional) — `action` prop accepts a label string; clicking fires `onAction` callback and dismisses the snackbar
+- [ ] Close icon button (optional) — `showCloseButton` prop renders an `IconButton` (`×`); always accessible regardless of `duration`
+- [ ] Queue management — a `SnackbarProvider` (context + `useSnackbar` hook) manages a FIFO queue; only one snackbar is visible at a time; subsequent calls queue and show after the current one dismisses
+- [ ] Programmatic API — `useSnackbar()` hook exposes `show(options)` and `dismiss()` for imperative usage
+- [ ] Entry/exit animation — slide up from bottom + fade in on open; fade out on close, using MD3 motion tokens
+- [ ] Fixed bottom-center positioning (`fixed bottom-4 left-1/2 -translate-x-1/2`)
+- [ ] Dark mode support via existing token system
+- [ ] Token audit — add `--color-inverse-surface`, `--color-inverse-on-surface`, `--color-inverse-primary` to `packages/tokens/src/tokens.css` if absent
+
+### Deliverables
+
+- [ ] `Snackbar.tsx` — MD3 styled snackbar surface (`'use client'`, `forwardRef`, CVA)
+- [ ] `SnackbarHeadless.tsx` — React Aria headless primitive using live region and `useButton` for action
+- [ ] `SnackbarProvider.tsx` — context provider that manages the queue and renders a single `Snackbar`
+- [ ] `useSnackbar.ts` — hook for imperative `show`/`dismiss` API; consumed by `SnackbarProvider`
+- [ ] `Snackbar.variants.ts` — CVA variant definitions
+- [ ] `Snackbar.types.ts` — TypeScript types
+- [ ] `Snackbar.test.tsx` — unit + accessibility tests (≥ 85% coverage)
+- [ ] `Snackbar.stories.tsx` — Storybook stories for all layout/feature combinations
+- [ ] `index.ts` — named exports for all public components, provider, hook, variants, and types
+
+## Architecture
+
+This component follows the established **three-layer architecture** used by all TinyBigUI components, with a provider layer added for queue management:
+
+```
+Layer 3 — Snackbar.tsx + SnackbarProvider   (MD3 styled, CVA variants, 'use client')
+Layer 2 — SnackbarHeadless.tsx              (React Aria: live region, useButton for action)
+Layer 1 — React Aria + ARIA live regions    (useButton, role="status", aria-live="polite")
+```
+
+**React Aria hooks:**
+
+- `useButton` — for the optional action button and the close icon button
+- `role="status"` + `aria-live="polite"` — on the snackbar container so screen readers announce the message without interrupting the user; use `aria-atomic="true"` to announce the full message each time
+- `aria-label` — required on the close icon button
+
+**Accessibility note:** React Aria does not have a dedicated `useToast` hook in all versions. If `useToast`/`useToastRegion` are available in the installed version of `react-aria`, prefer them; otherwise compose using `role="status"` + `aria-live="polite"` on a visually persistent but screen-reader-accessible live region container.
+
+**CVA variants:** `layout` (`single-line` | `two-line`), `hasAction` (`true` | `false`), `hasCloseButton` (`true` | `false`)
+
+**Token usage (no arbitrary values):**
+
+- Surface: `bg-inverse-surface`
+- Message text: `text-inverse-on-surface`
+- Action button text: `text-inverse-primary`
+- Close icon: `text-inverse-on-surface`
+- Elevation: `shadow-elevation-3`
+- Shape: `rounded-xs` → maps to MD3 `shape-corner-extra-small` (4dp)
+- State layers on action/close: `opacity-8` (hover), `opacity-12` (pressed)
+
+## Acceptance Criteria
+
+- [ ] Single-line and two-line layouts render correctly per MD3 specs
+- [ ] Message is announced by screen readers via `role="status"` + `aria-live="polite"` + `aria-atomic="true"` (or `useToastRegion` if available)
+- [ ] Auto-dismiss fires after `duration` ms and calls `onDismiss`; `Infinity` disables auto-dismiss
+- [ ] Hovering or focusing the snackbar (action button or close button) pauses the auto-dismiss timer; timer resumes on blur/mouse-leave
+- [ ] Action button fires `onAction` and dismisses the snackbar when clicked
+- [ ] Close icon button dismisses the snackbar when clicked or activated via keyboard; `aria-label` is present
+- [ ] `SnackbarProvider` queues multiple calls to `show()` and displays them one at a time
+- [ ] `useSnackbar()` hook is usable outside the component tree (throws a clear error when used without `SnackbarProvider`)
+- [ ] Entry animation uses MD3 motion tokens (slide up + fade in); exit animation uses MD3 motion tokens (fade out)
+- [ ] `--color-inverse-surface`, `--color-inverse-on-surface`, `--color-inverse-primary` tokens exist in `packages/tokens/src/tokens.css`
+- [ ] Component passes `axe` accessibility audit with zero violations
+- [ ] Test coverage ≥ 85% (unit + accessibility + timer + queue tests)
+- [ ] Storybook stories cover: single-line, two-line, with action, with close button, with both, auto-dismiss, persistent, queue demo
+- [ ] No hardcoded hex values or arbitrary Tailwind classes
+- [ ] ESLint error-free and Prettier-formatted
+- [ ] Named exports only; `index.ts` re-exports all public API
+
+## Dependencies
+
+- `v0.2.0` released (AppBar, Tabs, Drawer, Bottom Navigation)
+- `@tinybigui/tokens` — existing MD3 token system; inverse surface tokens must be added if absent
+- `IconButton` component from Phase 1 (reuse for the close icon button)
+- `Button` component from Phase 1 (action button inherits text style; may be styled inline for inverse surface)
+- `useRipple` hook (reuse existing `packages/react/src/hooks/useRipple`)
+
+## Out of Scope
+
+- **Toast stacking** — showing multiple snackbars simultaneously is not part of MD3 Snackbar spec; queue (FIFO) is used instead
+- **Persistent snackbar without a close button** — MD3 strongly discourages indefinite auto-dismiss without a close affordance; if `duration` is `Infinity`, `showCloseButton` must be `true` (enforce via TypeScript and a dev-mode warning)
+- **Rich content snackbars** (images, custom components in body) — future enhancement
+- **Top-positioned snackbar** — MD3 specifies bottom positioning; top is out of scope
+
+## Resources
+
+- [MD3 Snackbar Spec](https://m3.material.io/components/snackbar/specs)
+- [React Aria `useButton`](https://react-spectrum.adobe.com/react-aria/useButton.html)
+- [MDN ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
+- [TinyBigUI Architecture Rule](.cursor/rules/architecture.mdc)
+- [TinyBigUI Code Style Rule](.cursor/rules/code-style.mdc)
+- [Existing reference: `Button` component](packages/react/src/components/Button/)
+- [Existing reference: `IconButton` component](packages/react/src/components/IconButton/)

--- a/.github-issues/v0.3.0/003-menu.md
+++ b/.github-issues/v0.3.0/003-menu.md
@@ -1,0 +1,138 @@
+---
+title: "feat(menu): Implement MD3 Menu component"
+labels: ["enhancement", "component", "phase-3", "v0.3.0", "accessibility"]
+milestone: "v0.3.0"
+assignees: []
+---
+
+## Summary
+
+Implement the Material Design 3 **Menu** component for `@tinybigui/react` as part of the Phase 3 Feedback milestone. Menus display a list of choices on a temporary surface. They appear when users interact with a button, action, or other control. This implementation covers the Standard menu (flat item list) and Sub-menu (cascading nested items), with full keyboard navigation, type-ahead selection, smart positioning relative to the trigger, optional leading icons and trailing supporting text per item, section dividers, and disabled item support.
+
+## Design Reference
+
+- [MD3 Menus — Overview](https://m3.material.io/components/menus/overview)
+- [MD3 Menus — Specs](https://m3.material.io/components/menus/specs)
+
+## Scope
+
+### Variants
+
+- [ ] `standard` — flat list of `MenuItem`s with optional sections and dividers
+- [ ] `submenu` — `MenuItem` may have a `children` prop that renders a nested `Menu` on hover/focus; indicated by a trailing chevron icon
+
+### Sub-components
+
+- [ ] `MenuTrigger` — wraps any trigger element (typically a `Button` or `IconButton`); manages open/close state
+- [ ] `Menu` — the floating menu surface container; renders a list of items
+- [ ] `MenuItem` — individual selectable item: optional leading icon, label, optional trailing supporting text or keyboard shortcut hint, optional sub-menu indicator
+- [ ] `MenuSection` — groups `MenuItem`s under an optional header label with a divider
+
+### Features
+
+- [ ] Trigger opens/closes menu on click; `ArrowDown` on the trigger opens the menu and focuses the first item
+- [ ] Smart positioning — menu positions itself above or below, left or right of the trigger to stay within the viewport; default: below-start
+- [ ] Keyboard navigation — Arrow Up/Down moves focus between items; Home/End jump to first/last; type-ahead jumps to the matching item; `Enter`/`Space` selects the focused item; `Escape` closes and returns focus to the trigger
+- [ ] Selection modes — `selectionMode` prop: `none` (no selection state), `single` (one item selected at a time), `multiple` (multiple items selected, with checkmarks)
+- [ ] Disabled item support — `isDisabled` on `MenuItem` skips the item during keyboard navigation
+- [ ] Sub-menu opens on `ArrowRight` (and closes on `ArrowLeft`) when the focused item has nested items
+- [ ] Click outside or `Escape` closes the menu and returns focus to the trigger
+- [ ] Dark mode support via existing token system
+
+### Deliverables
+
+- [ ] `Menu.tsx` — MD3 styled menu surface (`'use client'`, `forwardRef`, CVA)
+- [ ] `MenuHeadless.tsx` — React Aria headless primitives (`HeadlessMenu`, `HeadlessMenuItem`, `HeadlessMenuTrigger`)
+- [ ] `MenuTrigger.tsx` — trigger wrapper managing open/close state
+- [ ] `MenuItem.tsx` — styled menu item sub-component
+- [ ] `MenuSection.tsx` — styled section header + divider sub-component
+- [ ] `Menu.variants.ts` — CVA variant definitions
+- [ ] `Menu.types.ts` — TypeScript types extending React Aria props
+- [ ] `Menu.test.tsx` — unit + accessibility tests (≥ 85% coverage)
+- [ ] `Menu.stories.tsx` — Storybook stories for all variants and interaction states
+- [ ] `index.ts` — named exports for all public sub-components, headless, variants, and types
+
+## Architecture
+
+This component follows the established **three-layer architecture** used by all TinyBigUI components:
+
+```
+Layer 3 — Menu.tsx / MenuItem.tsx / MenuSection.tsx / MenuTrigger.tsx  (MD3 styled, CVA, 'use client')
+Layer 2 — MenuHeadless.tsx                                             (React Aria: useMenu, useMenuItem, useMenuTrigger)
+Layer 1 — React Aria                                                   (useMenu, useMenuItem, useMenuTrigger, useTreeState)
+```
+
+**React Aria hooks:**
+
+- `useMenuTrigger` — on the trigger element; wires `aria-haspopup="menu"`, `aria-expanded`, and open/close toggling
+- `useMenu` — on the `<Menu>` container (`role="menu"`, keyboard navigation, type-ahead)
+- `useMenuItem` — on each `<MenuItem>` (`role="menuitem"` / `"menuitemradio"` / `"menuitemcheckbox"` based on `selectionMode`, `aria-disabled`)
+- `useMenuTriggerState` (react-stately) — manages `open`/`closed` state
+- `useTreeState` (react-stately) — manages `selectedKeys` for `single`/`multiple` selection modes
+- `useOverlay` — manages click-outside dismiss and `Escape`
+- `useButton` — on the trigger element
+
+**Positioning:** Use CSS absolute positioning anchored to the trigger. Implement a `useMenuPosition` hook that detects viewport overflow and flips the menu (bottom → top, start → end) accordingly. Do not add a third-party positioning library unless it is already in the project's dependencies.
+
+**CVA variants:** `selectionMode` (`none` | `single` | `multiple`)
+
+**Token usage (no arbitrary values):**
+
+- Menu surface: `bg-surface-container`
+- Item text: `text-on-surface`
+- Icon/supporting text: `text-on-surface-variant`
+- Divider: `border-outline-variant`
+- Elevation: `shadow-elevation-2`
+- Shape: `rounded-xs` → maps to MD3 `shape-corner-extra-small` (4dp)
+- Selected item indicator (single/multiple): `bg-secondary-container` / `text-on-secondary-container`
+- State layers: `opacity-8` (hover), `opacity-12` (pressed)
+
+## Acceptance Criteria
+
+- [ ] Standard menu opens below the trigger by default; repositions to avoid viewport overflow
+- [ ] Sub-menu variant opens nested `Menu` on `ArrowRight` from a parent `MenuItem`; closes on `ArrowLeft` or `Escape`
+- [ ] `role="menu"` on the menu container; `role="menuitem"`, `role="menuitemradio"`, or `role="menuitemcheckbox"` on items based on `selectionMode`
+- [ ] `aria-haspopup="menu"` and `aria-expanded` are set correctly on the trigger
+- [ ] `aria-disabled="true"` on disabled items; disabled items are skipped during keyboard navigation
+- [ ] `ArrowDown` on the trigger opens the menu and moves focus to the first non-disabled item
+- [ ] Arrow Up/Down cycles through items; wraps at top and bottom
+- [ ] Home/End jump to first/last non-disabled item
+- [ ] Type-ahead focuses the first item whose label starts with the typed character
+- [ ] `Enter` or `Space` selects the focused item and closes the menu (unless sub-menu)
+- [ ] `Escape` closes the menu and returns focus to the trigger
+- [ ] Click outside the menu closes it and returns focus to the trigger
+- [ ] `selectionMode="single"` — only one item selected at a time; selected item shows a checkmark
+- [ ] `selectionMode="multiple"` — multiple items selected; each selected item shows a checkmark
+- [ ] Ripple effect on each `MenuItem` via `useRipple`
+- [ ] Component passes `axe` accessibility audit with zero violations
+- [ ] Test coverage ≥ 85% (unit + accessibility + keyboard interaction + positioning tests)
+- [ ] Storybook stories cover: standard menu, menu with icons, menu with sections, disabled items, single/multiple selection, sub-menu, long list (scrollable), all open/close interactions
+- [ ] No hardcoded hex values or arbitrary Tailwind classes
+- [ ] ESLint error-free and Prettier-formatted
+- [ ] Named exports only; `index.ts` re-exports all public API
+
+## Dependencies
+
+- `v0.2.0` released (AppBar, Tabs, Drawer, Bottom Navigation)
+- `@tinybigui/tokens` — existing MD3 token system (`packages/tokens/src/tokens.css`)
+- `Button` and `IconButton` components from Phase 1 (reuse as trigger elements in stories)
+- `useRipple` hook (reuse existing `packages/react/src/hooks/useRipple`)
+
+## Out of Scope
+
+- **Context menu (right-click)** — not part of MD3 Menu spec; separate component if needed
+- **Select / Dropdown menu** — MD3 specifies this as a separate "Exposed dropdown menu" component; tracked separately
+- **Autocomplete** — Phase 5+ component
+- **Third-party floating-ui / popper.js dependency** — use a lightweight custom `useMenuPosition` hook to avoid adding a new dependency
+
+## Resources
+
+- [MD3 Menus Spec](https://m3.material.io/components/menus/specs)
+- [React Aria `useMenu`](https://react-spectrum.adobe.com/react-aria/useMenu.html)
+- [React Aria `useMenuItem`](https://react-spectrum.adobe.com/react-aria/useMenuItem.html)
+- [React Aria `useMenuTrigger`](https://react-spectrum.adobe.com/react-aria/useMenuTrigger.html)
+- [TinyBigUI Architecture Rule](.cursor/rules/architecture.mdc)
+- [TinyBigUI Code Style Rule](.cursor/rules/code-style.mdc)
+- [Existing reference: `Button` component](packages/react/src/components/Button/)
+- [Existing reference: `IconButton` component](packages/react/src/components/IconButton/)
+- [Related v0.2.0 reference: `Drawer` component](.github-issues/v0.2.0/003-drawer.md) (shares overlay dismiss pattern)

--- a/.github-issues/v0.3.0/004-progress-indicators.md
+++ b/.github-issues/v0.3.0/004-progress-indicators.md
@@ -1,0 +1,148 @@
+---
+title: "feat(progress): Implement MD3 Progress Indicator components"
+labels: ["enhancement", "component", "phase-3", "v0.3.0", "accessibility"]
+milestone: "v0.3.0"
+assignees: []
+---
+
+## Summary
+
+Implement the Material Design 3 **Progress Indicator** components for `@tinybigui/react` as part of the Phase 3 Feedback milestone. Progress indicators inform users about the status of ongoing processes such as loading an app, submitting a form, or saving updates. This implementation covers two component shapes — **Linear** (a horizontal bar) and **Circular** (an SVG ring) — each with two modes: **determinate** (known percentage) and **indeterminate** (unknown duration). Both components are accessible via `role="progressbar"` and React Aria's `useProgressBar`, and use MD3 motion tokens for their indeterminate animations.
+
+## Design Reference
+
+- [MD3 Progress Indicators — Overview](https://m3.material.io/components/progress-indicators/overview)
+- [MD3 Progress Indicators — Specs](https://m3.material.io/components/progress-indicators/specs)
+
+## Scope
+
+### Components
+
+- [ ] `LinearProgress` — horizontal track + indicator bar
+- [ ] `CircularProgress` — SVG ring with animated stroke
+
+### Modes (both components)
+
+- [ ] `determinate` — `value` prop (0–`maxValue`) drives the indicator width/stroke-dashoffset; `aria-valuenow` is set
+- [ ] `indeterminate` — no `value` prop; continuous CSS animation using MD3 motion tokens; `aria-valuenow` is omitted per ARIA spec
+
+### Features
+
+- [ ] `value` prop — current progress value (0 to `maxValue`)
+- [ ] `maxValue` prop — maximum value (default: `100`)
+- [ ] `minValue` prop — minimum value (default: `0`)
+- [ ] `aria-label` prop — required accessible name (enforced via TypeScript)
+- [ ] `aria-labelledby` prop — alternative to `aria-label` when a visible label exists
+- [ ] `aria-valuetext` prop — optional human-readable progress description (e.g., "Step 3 of 5")
+- [ ] `size` prop on `CircularProgress` — `small` (24dp) / `medium` (48dp, default) / `large` (72dp)
+- [ ] `fourColor` prop on `CircularProgress` — enables MD3 four-color indeterminate animation variant
+- [ ] `trackVisibility` prop on `LinearProgress` — `visible` (shows track, default) / `hidden` (indicator only)
+- [ ] Dark mode support via existing token system
+
+### Deliverables
+
+- [ ] `LinearProgress.tsx` — MD3 styled linear bar (`'use client'`, `forwardRef`, CVA)
+- [ ] `LinearProgressHeadless.tsx` — React Aria headless primitive
+- [ ] `CircularProgress.tsx` — MD3 styled SVG ring (`'use client'`, `forwardRef`, CVA)
+- [ ] `CircularProgressHeadless.tsx` — React Aria headless primitive
+- [ ] `Progress.variants.ts` — shared CVA variant definitions for both components
+- [ ] `Progress.types.ts` — shared TypeScript types extending React Aria `AriaProgressBarProps`
+- [ ] `Progress.test.tsx` — unit + accessibility tests for both components (≥ 85% coverage)
+- [ ] `Progress.stories.tsx` — Storybook stories for all variants, modes, and sizes
+- [ ] `index.ts` — named exports for both components, headless, variants, and types
+
+## Architecture
+
+This component follows the established **three-layer architecture** used by all TinyBigUI components:
+
+```
+Layer 3 — LinearProgress.tsx / CircularProgress.tsx    (MD3 styled, CVA variants, 'use client')
+Layer 2 — LinearProgressHeadless / CircularProgressHeadless  (React Aria: useProgressBar)
+Layer 1 — React Aria                                   (useProgressBar)
+```
+
+**React Aria hooks:**
+
+- `useProgressBar` — wires `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, `aria-valuetext`, `aria-label`/`aria-labelledby` on the container element; automatically omits `aria-valuenow` when `value` is not provided (indeterminate)
+
+**LinearProgress DOM structure:**
+
+```
+<div role="progressbar" aria-valuemin aria-valuemax [aria-valuenow]>
+  <div class="track">           ← full-width background
+    <div class="indicator" />   ← animated/sized foreground bar
+  </div>
+</div>
+```
+
+**CircularProgress DOM structure:**
+
+```
+<div role="progressbar" aria-valuemin aria-valuemax [aria-valuenow]>
+  <svg viewBox="...">
+    <circle class="track" />      ← background ring
+    <circle class="indicator" />  ← stroke-dashoffset-animated foreground
+  </svg>
+</div>
+```
+
+**CVA variants (LinearProgress):** `mode` (`determinate` | `indeterminate`), `trackVisibility` (`visible` | `hidden`)
+
+**CVA variants (CircularProgress):** `mode` (`determinate` | `indeterminate`), `size` (`small` | `medium` | `large`), `fourColor` (`true` | `false`)
+
+**Token usage (no arbitrary values):**
+
+- Track: `bg-surface-container-highest` (Linear), SVG `stroke` mapped from `--color-surface-container-highest` (Circular)
+- Indicator: `bg-primary` (Linear), SVG `stroke` mapped from `--color-primary` (Circular)
+- Four-color variant cycles: `primary`, `secondary`, `tertiary`, `error` strokes via CSS custom property animation
+- Indeterminate animation duration and easing: `--md-sys-motion-duration-long2` (500ms), `--md-sys-motion-easing-emphasized`
+- No hardcoded hex values in inline SVG stroke attributes; use `currentColor` with a Tailwind `text-primary` wrapper or CSS custom properties
+
+**SVG implementation note:** The `stroke-dasharray` and `stroke-dashoffset` for the determinate circular indicator must be computed from the circle's circumference (`2πr`). Expose `radius` as a constant derived from the `size` variant, not as an arbitrary inline value. The indeterminate animation is a CSS `@keyframes` animation defined in `tokens.css` or within the component's Tailwind layer.
+
+## Acceptance Criteria
+
+- [ ] `LinearProgress` renders a horizontal track with a foreground indicator bar
+- [ ] `CircularProgress` renders an SVG ring with a foreground stroke indicator
+- [ ] Determinate mode: `aria-valuenow` reflects the current `value`; indicator width/stroke-dashoffset updates smoothly via CSS transition using MD3 motion tokens
+- [ ] Indeterminate mode: `aria-valuenow` is omitted per ARIA spec; continuous animation plays using MD3 motion tokens; no inline `animation` or `transition` values
+- [ ] `aria-valuemin` and `aria-valuemax` always reflect `minValue` and `maxValue`
+- [ ] `aria-label` or `aria-labelledby` is required (TypeScript enforcement + dev-mode warning if absent)
+- [ ] `aria-valuetext` is passed through when provided
+- [ ] `CircularProgress` renders correctly at all three sizes (`small`, `medium`, `large`)
+- [ ] `fourColor` prop cycles through `primary`, `secondary`, `tertiary`, `error` strokes during indeterminate animation
+- [ ] `trackVisibility="hidden"` on `LinearProgress` hides the track background while keeping the indicator
+- [ ] Both components pass `axe` accessibility audit with zero violations
+- [ ] Test coverage ≥ 85% (unit + accessibility + determinate value update tests)
+- [ ] Storybook stories cover: Linear determinate (animated value change), Linear indeterminate, Circular determinate, Circular indeterminate, Circular four-color, all three sizes, hidden track
+- [ ] No hardcoded hex values, no arbitrary Tailwind classes, no inline `style` attribute for colors
+- [ ] SVG stroke uses `currentColor` or CSS custom properties — not inline hex
+- [ ] ESLint error-free and Prettier-formatted
+- [ ] Named exports only; `index.ts` re-exports all public API
+
+## Dependencies
+
+- `v0.2.0` released (AppBar, Tabs, Drawer, Bottom Navigation)
+- `@tinybigui/tokens` — existing MD3 token system (`packages/tokens/src/tokens.css`); indeterminate `@keyframes` animations may need to be added
+- No Phase 1 component dependencies (Progress Indicators are self-contained)
+
+## Out of Scope
+
+- **Skeleton loaders / shimmer effects** — a distinct pattern from Progress Indicators; tracked as a separate future component
+- **Buffer state for LinearProgress** — MD3 specifies a buffered variant (two-layer track); not included in the initial implementation
+- **Segmented progress** — step-based progress display; future enhancement
+- **Native `<progress>` element** — use a `<div role="progressbar">` for full styling control per MD3 spec; the native element has limited cross-browser styling support
+
+## Future Considerations
+
+> **LinearProgress buffer variant:** MD3 defines a "buffer" state for `LinearProgress` showing a filled buffer region and a separate indicator. This is documented here for awareness and should be tracked as a follow-up enhancement issue once the base `LinearProgress` is shipped.
+
+## Resources
+
+- [MD3 Progress Indicators Spec](https://m3.material.io/components/progress-indicators/specs)
+- [React Aria `useProgressBar`](https://react-spectrum.adobe.com/react-aria/useProgressBar.html)
+- [ARIA progressbar role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role)
+- [TinyBigUI Architecture Rule](.cursor/rules/architecture.mdc)
+- [TinyBigUI Code Style Rule](.cursor/rules/code-style.mdc)
+- [Existing reference: `Button` component](packages/react/src/components/Button/) (three-layer pattern)
+- [Existing reference: `Checkbox` component](packages/react/src/components/Checkbox/) (SVG + React Aria state pattern)

--- a/packages/react/src/components/NavigationBar/NavigationBar.stories.tsx
+++ b/packages/react/src/components/NavigationBar/NavigationBar.stories.tsx
@@ -271,8 +271,8 @@ export const Playground: Story = {
   render: (args) => (
     <PlaygroundExample
       items={args.items ?? fiveItems}
-      hideLabels={args.hideLabels}
-      disableRipple={args.disableRipple}
+      hideLabels={args.hideLabels ?? false}
+      disableRipple={args.disableRipple ?? false}
     />
   ),
   args: {

--- a/packages/react/src/components/NavigationBar/NavigationBar.stories.tsx
+++ b/packages/react/src/components/NavigationBar/NavigationBar.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { NavigationBar } from "./NavigationBar";
 import { NavigationBarItem } from "./NavigationBarItem";
 import { HeadlessNavigationBar, HeadlessNavigationBarItem } from "./NavigationBarHeadless";
-import type { NavigationBarItemConfig } from "./NavigationBar.types";
+import type { NavigationBarItemConfig, NavigationBarProps } from "./NavigationBar.types";
 import type { Key } from "react-aria";
 
 // ─── MD3 Material Icons (inline SVG) ─────────────────────────────────────────
@@ -250,7 +250,9 @@ function PlaygroundExample({
  * The current active destination is shown above the bar.
  */
 export const Controlled: Story = {
-  render: (args) => <ControlledExample items={args.items ?? fourItems} />,
+  render: (args: Partial<NavigationBarProps>) => (
+    <ControlledExample items={args.items ?? fourItems} />
+  ),
   args: {
     items: fourItems,
   },
@@ -268,7 +270,7 @@ export const Controlled: Story = {
  * Interactive playground: full control over all props.
  */
 export const Playground: Story = {
-  render: (args) => (
+  render: (args: Partial<NavigationBarProps>) => (
     <PlaygroundExample
       items={args.items ?? fiveItems}
       hideLabels={args.hideLabels ?? false}

--- a/packages/react/src/components/NavigationBar/NavigationBar.stories.tsx
+++ b/packages/react/src/components/NavigationBar/NavigationBar.stories.tsx
@@ -1,0 +1,398 @@
+import { useState, type CSSProperties, type JSX } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { NavigationBar } from "./NavigationBar";
+import { NavigationBarItem } from "./NavigationBarItem";
+import { HeadlessNavigationBar, HeadlessNavigationBarItem } from "./NavigationBarHeadless";
+import type { NavigationBarItemConfig } from "./NavigationBar.types";
+import type { Key } from "react-aria";
+
+// ─── MD3 Material Icons (inline SVG) ─────────────────────────────────────────
+
+const HomeIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+  </svg>
+);
+
+const SearchIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+  </svg>
+);
+
+const ProfileIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+  </svg>
+);
+
+const BookmarkIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z" />
+  </svg>
+);
+
+const SettingsIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.47.47 0 0 0-.59.22L2.74 8.87a.48.48 0 0 0 .12.61l2.03 1.58c-.05.3-.07.63-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.57 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32a.47.47 0 0 0-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
+  </svg>
+);
+
+// ─── Fixture data ─────────────────────────────────────────────────────────────
+
+const threeItems: NavigationBarItemConfig[] = [
+  { key: "home", icon: <HomeIcon />, label: "Home" },
+  { key: "search", icon: <SearchIcon />, label: "Search" },
+  { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+];
+
+const fourItems: NavigationBarItemConfig[] = [
+  { key: "home", icon: <HomeIcon />, label: "Home" },
+  { key: "search", icon: <SearchIcon />, label: "Search" },
+  { key: "bookmarks", icon: <BookmarkIcon />, label: "Saved" },
+  { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+];
+
+const fiveItems: NavigationBarItemConfig[] = [
+  { key: "home", icon: <HomeIcon />, label: "Home" },
+  { key: "search", icon: <SearchIcon />, label: "Search" },
+  { key: "bookmarks", icon: <BookmarkIcon />, label: "Saved" },
+  { key: "settings", icon: <SettingsIcon />, label: "Settings" },
+  { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+];
+
+// ─── Storybook Meta ────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof NavigationBar> = {
+  title: "Navigation/NavigationBar",
+  component: NavigationBar,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Material Design 3 Navigation Bar (Bottom Navigation). Renders a fixed bottom bar with 3–5 destination items. Supports animated active indicator pill, optional labels, badges, disabled items, and full keyboard navigation (Arrow Left/Right, Home, End).",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    hideLabels: {
+      control: "boolean",
+      description: "Hide labels on all items (icon-only mode)",
+    },
+    disableRipple: {
+      control: "boolean",
+      description: "Disable ripple effect on all items",
+    },
+    "aria-label": {
+      control: "text",
+      description: "Accessible label for the nav landmark (required)",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{ height: "300px", position: "relative", background: "var(--md-sys-color-surface)" }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof NavigationBar>;
+
+// ─── Stories ──────────────────────────────────────────────────────────────────
+
+/**
+ * Default: 3 items with labels (uncontrolled).
+ * Home is active on first render.
+ */
+export const Default: Story = {
+  args: {
+    items: threeItems,
+    defaultActiveKey: "home",
+    "aria-label": "Main navigation",
+  },
+};
+
+/**
+ * Four destination items.
+ */
+export const FourItems: Story = {
+  args: {
+    items: fourItems,
+    defaultActiveKey: "home",
+    "aria-label": "Main navigation",
+  },
+};
+
+/**
+ * Five destination items (maximum).
+ */
+export const FiveItems: Story = {
+  args: {
+    items: fiveItems,
+    defaultActiveKey: "home",
+    "aria-label": "Main navigation",
+  },
+};
+
+/**
+ * Icon-only mode: labels hidden globally via `hideLabels`.
+ * Each item must have an `aria-label` for accessibility.
+ */
+export const IconOnly: Story = {
+  args: {
+    items: [
+      { key: "home", icon: <HomeIcon />, label: "Home", "aria-label": "Home" },
+      { key: "search", icon: <SearchIcon />, label: "Search", "aria-label": "Search" },
+      { key: "bookmarks", icon: <BookmarkIcon />, label: "Saved", "aria-label": "Saved" },
+      { key: "profile", icon: <ProfileIcon />, label: "Profile", "aria-label": "Profile" },
+    ],
+    defaultActiveKey: "home",
+    "aria-label": "Main navigation",
+    hideLabels: true,
+  },
+};
+
+/**
+ * Badge examples: dot indicator, numeric count, "999+" truncation.
+ */
+export const WithBadges: Story = {
+  args: {
+    items: [
+      { key: "home", icon: <HomeIcon />, label: "Home" },
+      { key: "search", icon: <SearchIcon />, label: "Search", badge: true },
+      { key: "bookmarks", icon: <BookmarkIcon />, label: "Saved", badge: 5 },
+      { key: "profile", icon: <ProfileIcon />, label: "Profile", badge: 1234 },
+    ],
+    defaultActiveKey: "home",
+    "aria-label": "Main navigation",
+  },
+};
+
+/**
+ * Disabled item: the "Bookmarks" destination is not interactive.
+ */
+export const WithDisabledItem: Story = {
+  args: {
+    items: [
+      { key: "home", icon: <HomeIcon />, label: "Home" },
+      { key: "search", icon: <SearchIcon />, label: "Search" },
+      { key: "bookmarks", icon: <BookmarkIcon />, label: "Saved", isDisabled: true },
+      { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+    ],
+    defaultActiveKey: "home",
+    "aria-label": "Main navigation",
+  },
+};
+
+// ─── Component wrappers for controlled stories (hooks must be in components) ──
+
+interface ControlledExampleProps {
+  items: NavigationBarItemConfig[];
+}
+
+function ControlledExample({ items }: ControlledExampleProps): JSX.Element {
+  const [activeKey, setActiveKey] = useState<Key>("home");
+  return (
+    <div style={{ height: "300px", position: "relative" }}>
+      <p
+        style={{
+          padding: "16px",
+          fontFamily: "sans-serif",
+          color: "var(--md-sys-color-on-surface)",
+        }}
+      >
+        Active destination: <strong>{String(activeKey)}</strong>
+      </p>
+      <NavigationBar
+        items={items}
+        activeKey={activeKey}
+        onActiveChange={setActiveKey}
+        aria-label="Main navigation"
+      />
+    </div>
+  );
+}
+
+interface PlaygroundExampleProps {
+  items: NavigationBarItemConfig[];
+  hideLabels?: boolean;
+  disableRipple?: boolean;
+}
+
+function PlaygroundExample({
+  items,
+  hideLabels,
+  disableRipple,
+}: PlaygroundExampleProps): JSX.Element {
+  const [activeKey, setActiveKey] = useState<Key>("home");
+  return (
+    <div style={{ height: "300px", position: "relative" }}>
+      <NavigationBar
+        items={items}
+        activeKey={activeKey}
+        onActiveChange={setActiveKey}
+        aria-label="Main navigation"
+        {...(hideLabels !== undefined ? { hideLabels } : {})}
+        {...(disableRipple !== undefined ? { disableRipple } : {})}
+      />
+    </div>
+  );
+}
+
+/**
+ * Controlled: parent manages `activeKey` + `onActiveChange`.
+ * The current active destination is shown above the bar.
+ */
+export const Controlled: Story = {
+  render: (args) => <ControlledExample items={args.items ?? fourItems} />,
+  args: {
+    items: fourItems,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Controlled mode: pass `activeKey` and `onActiveChange` to manage the active destination from the parent.",
+      },
+    },
+  },
+};
+
+/**
+ * Interactive playground: full control over all props.
+ */
+export const Playground: Story = {
+  render: (args) => (
+    <PlaygroundExample
+      items={args.items ?? fiveItems}
+      hideLabels={args.hideLabels}
+      disableRipple={args.disableRipple}
+    />
+  ),
+  args: {
+    items: fiveItems,
+    hideLabels: false,
+    disableRipple: false,
+  },
+};
+
+// ─── NavigationBarItem (standalone) ──────────────────────────────────────────
+
+/**
+ * `NavigationBarItem` standalone (no tablist semantics).
+ * Demonstrates all visual states: active, inactive, badge, disabled.
+ */
+export const StandaloneItem: StoryObj<typeof NavigationBarItem> = {
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        gap: "8px",
+        padding: "16px",
+        background: "var(--md-sys-color-surface-container)",
+        alignItems: "center",
+      }}
+    >
+      <NavigationBarItem
+        itemKey="home"
+        icon={<HomeIcon />}
+        label="Home"
+        isActive
+        style={{ width: "80px", height: "80px" } as CSSProperties}
+      />
+      <NavigationBarItem
+        itemKey="search"
+        icon={<SearchIcon />}
+        label="Search"
+        badge={3}
+        style={{ width: "80px", height: "80px" } as CSSProperties}
+      />
+      <NavigationBarItem
+        itemKey="bookmarks"
+        icon={<BookmarkIcon />}
+        label="Saved"
+        badge
+        style={{ width: "80px", height: "80px" } as CSSProperties}
+      />
+      <NavigationBarItem
+        itemKey="profile"
+        icon={<ProfileIcon />}
+        label="Profile"
+        isDisabled
+        style={{ width: "80px", height: "80px" } as CSSProperties}
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Standalone `NavigationBarItem` renders visual states: active, badge (numeric), badge (dot), and disabled.",
+      },
+    },
+  },
+};
+
+// ─── HeadlessNavigationBar (advanced consumer) ────────────────────────────────
+
+/**
+ * Headless usage — advanced consumer with full visual control.
+ * Demonstrates composing `HeadlessNavigationBar` + `HeadlessNavigationBarItem`
+ * directly for custom styling.
+ */
+function HeadlessExample(): JSX.Element {
+  const [activeKey, setActiveKey] = useState<Key>("home");
+  return (
+    <HeadlessNavigationBar
+      items={threeItems}
+      selectedKey={activeKey}
+      onSelectionChange={setActiveKey}
+      aria-label="Custom navigation"
+      className="bg-tertiary-container fixed right-0 bottom-0 left-0 flex h-20"
+      renderItem={(config) => (
+        <HeadlessNavigationBarItem
+          key={config.key}
+          itemKey={config.key}
+          className="flex flex-1 cursor-pointer flex-col items-center justify-center gap-1 outline-none"
+        >
+          {({ isSelected }) => (
+            <>
+              <span
+                className={isSelected ? "text-on-tertiary-container" : "text-on-surface-variant"}
+              >
+                {config.icon}
+              </span>
+              {config.label && (
+                <span
+                  className={`text-xs font-medium ${
+                    isSelected ? "text-on-tertiary-container" : "text-on-surface-variant"
+                  }`}
+                >
+                  {config.label}
+                </span>
+              )}
+            </>
+          )}
+        </HeadlessNavigationBarItem>
+      )}
+    />
+  );
+}
+
+export const HeadlessUsage: StoryObj<typeof HeadlessNavigationBar> = {
+  render: () => <HeadlessExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Headless layer usage for advanced consumers. Custom styling using MD3 tertiary color scheme.",
+      },
+    },
+  },
+};

--- a/packages/react/src/components/NavigationBar/NavigationBar.test.tsx
+++ b/packages/react/src/components/NavigationBar/NavigationBar.test.tsx
@@ -1,0 +1,608 @@
+import React from "react";
+import { describe, test, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { NavigationBar } from "./NavigationBar";
+import { NavigationBarItem } from "./NavigationBarItem";
+import { HeadlessNavigationBar, HeadlessNavigationBarItem } from "./NavigationBarHeadless";
+import type { NavigationBarItemConfig } from "./NavigationBar.types";
+
+// ─── Test Icon Mocks ─────────────────────────────────────────────────────────
+
+const HomeIcon = () => <svg data-testid="home-icon" aria-hidden="true" />;
+const SearchIcon = () => <svg data-testid="search-icon" aria-hidden="true" />;
+const ProfileIcon = () => <svg data-testid="profile-icon" aria-hidden="true" />;
+const SettingsIcon = () => <svg data-testid="settings-icon" aria-hidden="true" />;
+const BookmarkIcon = () => <svg data-testid="bookmark-icon" aria-hidden="true" />;
+
+// ─── Fixture Items ────────────────────────────────────────────────────────────
+
+const threeItems: NavigationBarItemConfig[] = [
+  { key: "home", icon: <HomeIcon />, label: "Home" },
+  { key: "search", icon: <SearchIcon />, label: "Search" },
+  { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+];
+
+const fourItems: NavigationBarItemConfig[] = [
+  ...threeItems,
+  { key: "settings", icon: <SettingsIcon />, label: "Settings" },
+];
+
+const fiveItems: NavigationBarItemConfig[] = [
+  ...fourItems,
+  { key: "bookmarks", icon: <BookmarkIcon />, label: "Bookmarks" },
+];
+
+// ─── NavigationBar ────────────────────────────────────────────────────────────
+
+describe("NavigationBar", () => {
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  describe("Rendering", () => {
+    test("renders with 3 items", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs).toHaveLength(3);
+    });
+
+    test("renders with 4 items", () => {
+      render(
+        <NavigationBar items={fourItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      expect(screen.getAllByRole("tab")).toHaveLength(4);
+    });
+
+    test("renders with 5 items", () => {
+      render(
+        <NavigationBar items={fiveItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      expect(screen.getAllByRole("tab")).toHaveLength(5);
+    });
+
+    test("renders labels for each item by default", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      expect(screen.getByText("Home")).toBeInTheDocument();
+      expect(screen.getByText("Search")).toBeInTheDocument();
+      expect(screen.getByText("Profile")).toBeInTheDocument();
+    });
+
+    test("hides labels when hideLabels is true", () => {
+      render(
+        <NavigationBar
+          items={threeItems}
+          defaultActiveKey="home"
+          aria-label="Main navigation"
+          hideLabels
+        />
+      );
+      expect(screen.queryByText("Home")).not.toBeInTheDocument();
+      expect(screen.queryByText("Search")).not.toBeInTheDocument();
+      expect(screen.queryByText("Profile")).not.toBeInTheDocument();
+    });
+
+    test("renders icons for each item", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      expect(screen.getByTestId("home-icon")).toBeInTheDocument();
+      expect(screen.getByTestId("search-icon")).toBeInTheDocument();
+      expect(screen.getByTestId("profile-icon")).toBeInTheDocument();
+    });
+
+    test("applies custom className to the bar", () => {
+      render(
+        <NavigationBar
+          items={threeItems}
+          defaultActiveKey="home"
+          aria-label="Main navigation"
+          className="my-custom-class"
+        />
+      );
+      const nav = screen.getByRole("navigation");
+      expect(nav).toHaveClass("my-custom-class");
+    });
+
+    test("forwards ref to the nav element", () => {
+      const ref = React.createRef<HTMLElement>();
+      render(
+        <NavigationBar
+          ref={ref}
+          items={threeItems}
+          defaultActiveKey="home"
+          aria-label="Main navigation"
+        />
+      );
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+      expect(ref.current?.tagName).toBe("NAV");
+    });
+  });
+
+  // ── Active State ───────────────────────────────────────────────────────────
+
+  describe("Active state", () => {
+    test("activates the correct item via defaultActiveKey (uncontrolled)", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="search" aria-label="Main navigation" />
+      );
+      const searchTab = screen.getByRole("tab", { name: /search/i });
+      expect(searchTab).toHaveAttribute("aria-selected", "true");
+    });
+
+    test("all other items are not selected", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="search" aria-label="Main navigation" />
+      );
+      const homeTab = screen.getByRole("tab", { name: /home/i });
+      const profileTab = screen.getByRole("tab", { name: /profile/i });
+      expect(homeTab).toHaveAttribute("aria-selected", "false");
+      expect(profileTab).toHaveAttribute("aria-selected", "false");
+    });
+
+    test("activates the correct item via activeKey (controlled)", () => {
+      render(
+        <NavigationBar
+          items={threeItems}
+          activeKey="profile"
+          onActiveChange={() => {}}
+          aria-label="Main navigation"
+        />
+      );
+      expect(screen.getByRole("tab", { name: /profile/i })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      );
+    });
+
+    test("calls onActiveChange when a tab is clicked", async () => {
+      const user = userEvent.setup();
+      const onActiveChange = vi.fn();
+      render(
+        <NavigationBar
+          items={threeItems}
+          defaultActiveKey="home"
+          onActiveChange={onActiveChange}
+          aria-label="Main navigation"
+        />
+      );
+      await user.click(screen.getByRole("tab", { name: /search/i }));
+      expect(onActiveChange).toHaveBeenCalledWith("search");
+    });
+
+    test("switches active item on click (uncontrolled)", async () => {
+      const user = userEvent.setup();
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      await user.click(screen.getByRole("tab", { name: /search/i }));
+      expect(screen.getByRole("tab", { name: /search/i })).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByRole("tab", { name: /home/i })).toHaveAttribute("aria-selected", "false");
+    });
+
+    test("renders active indicator pill on the active item", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      const activeTab = screen.getByRole("tab", { name: /home/i });
+      const pill = activeTab.querySelector("[data-indicator-pill]");
+      expect(pill).toBeInTheDocument();
+      expect(pill).toHaveAttribute("data-active", "true");
+    });
+
+    test("active item has data-active attribute", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      const activeTab = screen.getByRole("tab", { name: /home/i });
+      expect(activeTab).toHaveAttribute("data-selected", "true");
+    });
+  });
+
+  // ── Badge ──────────────────────────────────────────────────────────────────
+
+  describe("Badge", () => {
+    test("renders dot badge when badge is true", () => {
+      const itemsWithDot: NavigationBarItemConfig[] = [
+        { key: "home", icon: <HomeIcon />, label: "Home", badge: true },
+        { key: "search", icon: <SearchIcon />, label: "Search" },
+        { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+      ];
+      render(
+        <NavigationBar items={itemsWithDot} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      const homeTab = screen.getByRole("tab", { name: /home/i });
+      const badge = homeTab.querySelector("[data-badge]");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveAttribute("data-badge-dot", "true");
+    });
+
+    test("renders numeric badge count", () => {
+      const itemsWithBadge: NavigationBarItemConfig[] = [
+        { key: "home", icon: <HomeIcon />, label: "Home", badge: 5 },
+        { key: "search", icon: <SearchIcon />, label: "Search" },
+        { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+      ];
+      render(
+        <NavigationBar
+          items={itemsWithBadge}
+          defaultActiveKey="home"
+          aria-label="Main navigation"
+        />
+      );
+      const homeTab = screen.getByRole("tab", { name: /home/i });
+      const badge = homeTab.querySelector("[data-badge]");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent("5");
+    });
+
+    test("truncates badge to 999+ when count exceeds 999", () => {
+      const itemsWithBigBadge: NavigationBarItemConfig[] = [
+        { key: "home", icon: <HomeIcon />, label: "Home", badge: 1000 },
+        { key: "search", icon: <SearchIcon />, label: "Search" },
+        { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+      ];
+      render(
+        <NavigationBar
+          items={itemsWithBigBadge}
+          defaultActiveKey="home"
+          aria-label="Main navigation"
+        />
+      );
+      const homeTab = screen.getByRole("tab", { name: /home/i });
+      expect(homeTab.querySelector("[data-badge]")).toHaveTextContent("999+");
+    });
+
+    test("hides badge when numeric value is 0", () => {
+      const itemsWithZero: NavigationBarItemConfig[] = [
+        { key: "home", icon: <HomeIcon />, label: "Home", badge: 0 },
+        { key: "search", icon: <SearchIcon />, label: "Search" },
+        { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+      ];
+      render(
+        <NavigationBar items={itemsWithZero} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      const homeTab = screen.getByRole("tab", { name: /home/i });
+      expect(homeTab.querySelector("[data-badge]")).not.toBeInTheDocument();
+    });
+
+    test("renders 999 as-is (not truncated)", () => {
+      const items999: NavigationBarItemConfig[] = [
+        { key: "home", icon: <HomeIcon />, label: "Home", badge: 999 },
+        { key: "search", icon: <SearchIcon />, label: "Search" },
+        { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+      ];
+      render(
+        <NavigationBar items={items999} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      const homeTab = screen.getByRole("tab", { name: /home/i });
+      expect(homeTab.querySelector("[data-badge]")).toHaveTextContent("999");
+    });
+  });
+
+  // ── Keyboard Navigation ────────────────────────────────────────────────────
+
+  describe("Keyboard navigation", () => {
+    test("navigates to the next item with ArrowRight", async () => {
+      const user = userEvent.setup();
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      screen.getByRole("tab", { name: /home/i }).focus();
+      await user.keyboard("{ArrowRight}");
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: /search/i }));
+    });
+
+    test("navigates to the previous item with ArrowLeft", async () => {
+      const user = userEvent.setup();
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="search" aria-label="Main navigation" />
+      );
+      screen.getByRole("tab", { name: /search/i }).focus();
+      await user.keyboard("{ArrowLeft}");
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: /home/i }));
+    });
+
+    test("navigates to the last item with End", async () => {
+      const user = userEvent.setup();
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      screen.getByRole("tab", { name: /home/i }).focus();
+      await user.keyboard("{End}");
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: /profile/i }));
+    });
+
+    test("navigates to the first item with Home", async () => {
+      const user = userEvent.setup();
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="profile" aria-label="Main navigation" />
+      );
+      screen.getByRole("tab", { name: /profile/i }).focus();
+      await user.keyboard("{Home}");
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: /home/i }));
+    });
+
+    test("wraps from last to first item with ArrowRight", async () => {
+      const user = userEvent.setup();
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="profile" aria-label="Main navigation" />
+      );
+      screen.getByRole("tab", { name: /profile/i }).focus();
+      await user.keyboard("{ArrowRight}");
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: /home/i }));
+    });
+  });
+
+  // ── Accessibility ──────────────────────────────────────────────────────────
+
+  describe("Accessibility", () => {
+    test("has no axe violations", async () => {
+      const { container } = render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("outer element has role='navigation'", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      expect(screen.getByRole("navigation")).toBeInTheDocument();
+    });
+
+    test("nav element has descriptive aria-label", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      const nav = screen.getByRole("navigation");
+      expect(nav).toHaveAttribute("aria-label", "Main navigation");
+    });
+
+    test("inner container has role='tablist'", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      expect(screen.getByRole("tablist")).toBeInTheDocument();
+    });
+
+    test("each item has role='tab'", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs).toHaveLength(3);
+    });
+
+    test("active item has aria-selected='true'", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="search" aria-label="Main navigation" />
+      );
+      expect(screen.getByRole("tab", { name: /search/i })).toHaveAttribute("aria-selected", "true");
+    });
+
+    test("inactive items have aria-selected='false'", () => {
+      render(
+        <NavigationBar items={threeItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      expect(screen.getByRole("tab", { name: /search/i })).toHaveAttribute(
+        "aria-selected",
+        "false"
+      );
+      expect(screen.getByRole("tab", { name: /profile/i })).toHaveAttribute(
+        "aria-selected",
+        "false"
+      );
+    });
+
+    test("icon-only items require aria-label for accessibility", () => {
+      const iconOnlyItems: NavigationBarItemConfig[] = [
+        { key: "home", icon: <HomeIcon />, "aria-label": "Home" },
+        { key: "search", icon: <SearchIcon />, "aria-label": "Search" },
+        { key: "profile", icon: <ProfileIcon />, "aria-label": "Profile" },
+      ];
+      render(
+        <NavigationBar
+          items={iconOnlyItems}
+          defaultActiveKey="home"
+          aria-label="Main navigation"
+          hideLabels
+        />
+      );
+      const tabs = screen.getAllByRole("tab");
+      tabs.forEach((tab) => {
+        expect(tab.getAttribute("aria-label") ?? tab.textContent).toBeTruthy();
+      });
+    });
+  });
+
+  // ── Disabled Items ─────────────────────────────────────────────────────────
+
+  describe("Disabled items", () => {
+    test("disabled item has aria-disabled attribute", () => {
+      const itemsWithDisabled: NavigationBarItemConfig[] = [
+        { key: "home", icon: <HomeIcon />, label: "Home" },
+        { key: "search", icon: <SearchIcon />, label: "Search", isDisabled: true },
+        { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+      ];
+      render(
+        <NavigationBar
+          items={itemsWithDisabled}
+          defaultActiveKey="home"
+          aria-label="Main navigation"
+        />
+      );
+      const disabledTab = screen.getByRole("tab", { name: /search/i });
+      expect(disabledTab).toHaveAttribute("aria-disabled", "true");
+    });
+
+    test("disabled item cannot be activated by click", async () => {
+      const user = userEvent.setup();
+      const onActiveChange = vi.fn();
+      const itemsWithDisabled: NavigationBarItemConfig[] = [
+        { key: "home", icon: <HomeIcon />, label: "Home" },
+        { key: "search", icon: <SearchIcon />, label: "Search", isDisabled: true },
+        { key: "profile", icon: <ProfileIcon />, label: "Profile" },
+      ];
+      render(
+        <NavigationBar
+          items={itemsWithDisabled}
+          defaultActiveKey="home"
+          onActiveChange={onActiveChange}
+          aria-label="Main navigation"
+        />
+      );
+      await user.click(screen.getByRole("tab", { name: /search/i }));
+      expect(onActiveChange).not.toHaveBeenCalledWith("search");
+      expect(screen.getByRole("tab", { name: /home/i })).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  // ── Item Count Constraint ──────────────────────────────────────────────────
+
+  describe("Item count constraint", () => {
+    test("emits console.warn in dev when fewer than 3 items are provided", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const twoItems: NavigationBarItemConfig[] = [
+        { key: "home", icon: <HomeIcon />, label: "Home" },
+        { key: "search", icon: <SearchIcon />, label: "Search" },
+      ];
+      render(
+        <NavigationBar items={twoItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("NavigationBar"));
+      warnSpy.mockRestore();
+    });
+
+    test("emits console.warn in dev when more than 5 items are provided", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sixItems: NavigationBarItemConfig[] = [
+        ...fiveItems,
+        { key: "extra", icon: <HomeIcon />, label: "Extra" },
+      ];
+      render(
+        <NavigationBar items={sixItems} defaultActiveKey="home" aria-label="Main navigation" />
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("NavigationBar"));
+      warnSpy.mockRestore();
+    });
+  });
+});
+
+// ─── NavigationBarItem (standalone) ──────────────────────────────────────────
+
+describe("NavigationBarItem", () => {
+  test("renders icon and label", () => {
+    render(<NavigationBarItem icon={<HomeIcon />} label="Home" itemKey="home" />);
+    expect(screen.getByTestId("home-icon")).toBeInTheDocument();
+    expect(screen.getByText("Home")).toBeInTheDocument();
+  });
+
+  test("hides label when hideLabels is true", () => {
+    render(<NavigationBarItem icon={<HomeIcon />} label="Home" itemKey="home" hideLabels />);
+    expect(screen.queryByText("Home")).not.toBeInTheDocument();
+  });
+
+  test("shows active indicator pill when isActive is true", () => {
+    render(<NavigationBarItem icon={<HomeIcon />} label="Home" itemKey="home" isActive />);
+    const item = screen.getByRole("button");
+    expect(item.querySelector("[data-indicator-pill]")).toHaveAttribute("data-active", "true");
+  });
+
+  test("applies custom className", () => {
+    render(
+      <NavigationBarItem icon={<HomeIcon />} label="Home" itemKey="home" className="custom" />
+    );
+    expect(screen.getByRole("button")).toHaveClass("custom");
+  });
+});
+
+// ─── HeadlessNavigationBar ────────────────────────────────────────────────────
+
+describe("HeadlessNavigationBar", () => {
+  test("renders a nav element with role='navigation'", () => {
+    render(
+      <HeadlessNavigationBar
+        items={threeItems}
+        defaultSelectedKey="home"
+        aria-label="Test navigation"
+        renderItem={(config) => (
+          <HeadlessNavigationBarItem key={config.key} itemKey={config.key}>
+            {config.label}
+          </HeadlessNavigationBarItem>
+        )}
+      />
+    );
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+  });
+
+  test("renders a div with role='tablist' inside nav", () => {
+    render(
+      <HeadlessNavigationBar
+        items={threeItems}
+        defaultSelectedKey="home"
+        aria-label="Test navigation"
+        renderItem={(config) => (
+          <HeadlessNavigationBarItem key={config.key} itemKey={config.key}>
+            {config.label}
+          </HeadlessNavigationBarItem>
+        )}
+      />
+    );
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+  });
+
+  test("applies aria-label to the nav element", () => {
+    render(
+      <HeadlessNavigationBar
+        items={threeItems}
+        defaultSelectedKey="home"
+        aria-label="Custom label"
+        renderItem={(config) => (
+          <HeadlessNavigationBarItem key={config.key} itemKey={config.key}>
+            {config.label}
+          </HeadlessNavigationBarItem>
+        )}
+      />
+    );
+    expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "Custom label");
+  });
+
+  test("renders without styles (no visual classes enforced)", () => {
+    render(
+      <HeadlessNavigationBar
+        items={threeItems}
+        defaultSelectedKey="home"
+        aria-label="Test navigation"
+        renderItem={(config) => (
+          <HeadlessNavigationBarItem key={config.key} itemKey={config.key}>
+            {config.label}
+          </HeadlessNavigationBarItem>
+        )}
+      />
+    );
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(3);
+  });
+
+  test("passes selectedKey correctly in controlled mode", () => {
+    render(
+      <HeadlessNavigationBar
+        items={threeItems}
+        selectedKey="profile"
+        onSelectionChange={() => {}}
+        aria-label="Test navigation"
+        renderItem={(config) => (
+          <HeadlessNavigationBarItem key={config.key} itemKey={config.key}>
+            {config.label}
+          </HeadlessNavigationBarItem>
+        )}
+      />
+    );
+    expect(screen.getByRole("tab", { name: /profile/i })).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/packages/react/src/components/NavigationBar/NavigationBar.tsx
+++ b/packages/react/src/components/NavigationBar/NavigationBar.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { forwardRef, type JSX } from "react";
+import { useRipple } from "../../hooks/useRipple";
+import { cn } from "../../utils/cn";
+import { HeadlessNavigationBar, HeadlessNavigationBarItem } from "./NavigationBarHeadless";
+import {
+  navigationBarVariants,
+  indicatorPillVariants,
+  badgeVariants,
+  iconWrapperVariants,
+  labelVariants,
+} from "./NavigationBar.variants";
+import type { NavigationBarProps, NavigationBarItemConfig } from "./NavigationBar.types";
+import type { Key } from "react-aria";
+
+// ─── Item count validation ────────────────────────────────────────────────────
+
+const MIN_ITEMS = 3;
+const MAX_ITEMS = 5;
+
+function validateItemCount(count: number): void {
+  if (process.env.NODE_ENV !== "production" && (count < MIN_ITEMS || count > MAX_ITEMS)) {
+    console.warn(
+      `[NavigationBar] MD3 Navigation Bar requires between ${MIN_ITEMS} and ${MAX_ITEMS} ` +
+        `destination items. Received ${count}. ` +
+        `See: https://m3.material.io/components/navigation-bar/overview`
+    );
+  }
+}
+
+// ─── Badge helpers ────────────────────────────────────────────────────────────
+
+function getBadgeText(badge: number | true | undefined): string | null {
+  if (badge === undefined || badge === 0) return null;
+  if (badge === true) return null; // dot — no text
+  if (badge > 999) return "999+";
+  return String(badge);
+}
+
+function isBadgeVisible(badge: number | true | undefined): boolean {
+  if (badge === undefined) return false;
+  if (badge === 0) return false;
+  return true;
+}
+
+// ─── Visual content ───────────────────────────────────────────────────────────
+
+/**
+ * Private — renders the visual content of a navigation bar item.
+ * Intentionally has NO button wrapper (the button is provided by
+ * `HeadlessNavigationBarItem` to avoid nested interactive elements).
+ */
+interface ItemVisualProps {
+  config: NavigationBarItemConfig;
+  isActive: boolean;
+  hideLabels: boolean;
+  disableRipple: boolean;
+}
+
+function ItemVisual({ config, isActive, hideLabels, disableRipple }: ItemVisualProps): JSX.Element {
+  const isItemDisabled = config.isDisabled === true;
+  const { onMouseDown, ripples } = useRipple({
+    ...(disableRipple || isItemDisabled ? { disabled: true } : {}),
+  });
+
+  const showBadge = isBadgeVisible(config.badge);
+  const isDot = config.badge === true;
+  const badgeText = getBadgeText(config.badge);
+
+  return (
+    // Overflow-hidden wrapper required for ripple containment.
+    // pointer-events-none is intentional: the parent <button> handles all interaction.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <span
+      onMouseDown={onMouseDown}
+      className="pointer-events-none relative flex h-full w-full flex-col items-center justify-center overflow-hidden"
+    >
+      {ripples}
+
+      {/* Active indicator pill */}
+      <span
+        data-indicator-pill
+        data-active={isActive}
+        aria-hidden="true"
+        className={cn(indicatorPillVariants({ isActive }))}
+      />
+
+      {/* Icon + Badge wrapper */}
+      <span
+        data-icon
+        className={cn(
+          iconWrapperVariants(),
+          isActive ? "text-on-secondary-container" : "text-on-surface-variant"
+        )}
+      >
+        <span className="relative z-10 flex h-6 w-6 items-center justify-center">
+          {config.icon}
+        </span>
+
+        {showBadge && (
+          <span
+            data-badge
+            data-badge-dot={isDot || undefined}
+            aria-label={
+              isDot ? "notification" : badgeText ? `${badgeText} notifications` : undefined
+            }
+            aria-live="polite"
+            className={cn(badgeVariants({ isDot }))}
+          >
+            {isDot ? null : badgeText}
+          </span>
+        )}
+      </span>
+
+      {/* Label */}
+      {!hideLabels && config.label && (
+        <span
+          data-label
+          className={cn(labelVariants(), isActive ? "text-on-surface" : "text-on-surface-variant")}
+        >
+          {config.label}
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ─── NavigationBar ────────────────────────────────────────────────────────────
+
+/**
+ * Material Design 3 Navigation Bar (Bottom Navigation) — Layer 3.
+ *
+ * Renders a fixed bottom navigation bar with 3–5 destination items, each with
+ * an icon, optional label, animated active indicator pill, and optional badge.
+ *
+ * **Architecture:**
+ * - Layer 3 (this file): MD3 styled, CVA variants, `'use client'`
+ * - Layer 2: `HeadlessNavigationBar` + `HeadlessNavigationBarItem` — React Aria
+ * - Layer 1: `useTabList`, `useTab`, `useFocusRing` — accessibility foundation
+ *
+ * **Key Features:**
+ * - 3–5 destination items (dev warning outside this range)
+ * - Animated indicator pill per MD3 motion tokens (scale + opacity)
+ * - Badge: dot, numeric count, "999+" truncation, hidden at 0
+ * - `hideLabels` for icon-only mode
+ * - Controlled (`activeKey` + `onActiveChange`) and uncontrolled (`defaultActiveKey`)
+ * - Full keyboard navigation: Arrow Left/Right, Home, End, roving `tabIndex`
+ * - WCAG 2.1 AA: `role="navigation"` + `aria-label`, `role="tablist"`,
+ *   `role="tab"` + `aria-selected`, visible focus ring
+ *
+ * **Future — Navigation Rail:**
+ * At wider viewports, a NavigationBar may transition to a Navigation Rail.
+ * This is a separate component tracked as a future Phase 5+ item.
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled
+ * <NavigationBar
+ *   items={[
+ *     { key: 'home', icon: <HomeIcon />, label: 'Home' },
+ *     { key: 'search', icon: <SearchIcon />, label: 'Search', badge: 3 },
+ *     { key: 'profile', icon: <ProfileIcon />, label: 'Profile' },
+ *   ]}
+ *   defaultActiveKey="home"
+ *   aria-label="Main navigation"
+ * />
+ *
+ * // Controlled
+ * <NavigationBar
+ *   items={items}
+ *   activeKey={activeKey}
+ *   onActiveChange={setActiveKey}
+ *   aria-label="Main navigation"
+ * />
+ *
+ * // Icon-only mode
+ * <NavigationBar
+ *   items={iconOnlyItems}
+ *   defaultActiveKey="home"
+ *   aria-label="Main navigation"
+ *   hideLabels
+ * />
+ * ```
+ *
+ * @see https://m3.material.io/components/navigation-bar/overview
+ * @see https://m3.material.io/components/navigation-bar/specs
+ */
+export const NavigationBar = forwardRef<HTMLElement, NavigationBarProps>(
+  (
+    {
+      items,
+      activeKey,
+      defaultActiveKey,
+      onActiveChange,
+      hideLabels = false,
+      "aria-label": ariaLabel,
+      disableRipple = false,
+      className,
+    },
+    ref
+  ) => {
+    validateItemCount(items.length);
+
+    return (
+      <HeadlessNavigationBar
+        ref={ref}
+        items={items}
+        {...(activeKey !== undefined ? { selectedKey: activeKey } : {})}
+        {...(defaultActiveKey !== undefined ? { defaultSelectedKey: defaultActiveKey } : {})}
+        {...(onActiveChange ? { onSelectionChange: onActiveChange as (key: Key) => void } : {})}
+        aria-label={ariaLabel}
+        className={cn(navigationBarVariants(), className)}
+        renderItem={(config: NavigationBarItemConfig) => (
+          // HeadlessNavigationBarItem renders the <button role="tab"> with all
+          // ARIA semantics. ItemVisual renders the icon/pill/badge/label inside
+          // — no nested <button> elements.
+          <HeadlessNavigationBarItem
+            key={config.key}
+            itemKey={config.key}
+            {...(config["aria-label"] !== undefined ? { "aria-label": config["aria-label"] } : {})}
+            className={cn(
+              "relative flex flex-1 flex-col items-center justify-center",
+              "cursor-pointer outline-none select-none",
+              "duration-short2 ease-standard transition-colors",
+              // State layer pseudo-element
+              "before:absolute before:inset-0 before:rounded-none",
+              "before:bg-on-surface-variant before:opacity-0",
+              "before:duration-short2 before:ease-standard before:transition-opacity",
+              "hover:before:opacity-8",
+              "active:before:opacity-12",
+              // Focus ring
+              "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
+              // Disabled styling
+              config.isDisabled && "pointer-events-none cursor-not-allowed opacity-38"
+            )}
+          >
+            {({ isSelected }: { isSelected: boolean }) => (
+              <ItemVisual
+                config={config}
+                isActive={isSelected}
+                hideLabels={hideLabels}
+                disableRipple={disableRipple}
+              />
+            )}
+          </HeadlessNavigationBarItem>
+        )}
+      />
+    );
+  }
+);
+
+NavigationBar.displayName = "NavigationBar";

--- a/packages/react/src/components/NavigationBar/NavigationBar.types.ts
+++ b/packages/react/src/components/NavigationBar/NavigationBar.types.ts
@@ -1,6 +1,5 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 import type { Key } from "react-aria";
-import type { TabListState } from "react-stately";
 
 /**
  * Badge value for a NavigationBarItem.
@@ -313,14 +312,4 @@ export interface HeadlessNavigationBarItemProps {
    * Applied as `aria-label` on the `<button>` element.
    */
   "aria-label"?: string;
-}
-
-/**
- * Context value shared between HeadlessNavigationBar and HeadlessNavigationBarItem.
- * @internal
- */
-export interface NavigationBarContextValue {
-  state: TabListState<object>;
-  hideLabels: boolean;
-  disableRipple: boolean;
 }

--- a/packages/react/src/components/NavigationBar/NavigationBar.types.ts
+++ b/packages/react/src/components/NavigationBar/NavigationBar.types.ts
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 import type { Key } from "react-aria";
-import type { TabListState } from "@react-stately/tabs";
+import type { TabListState } from "react-stately";
 
 /**
  * Badge value for a NavigationBarItem.
@@ -320,7 +320,7 @@ export interface HeadlessNavigationBarItemProps {
  * @internal
  */
 export interface NavigationBarContextValue {
-  state: TabListState<NavigationBarItemConfig>;
+  state: TabListState<object>;
   hideLabels: boolean;
   disableRipple: boolean;
 }

--- a/packages/react/src/components/NavigationBar/NavigationBar.types.ts
+++ b/packages/react/src/components/NavigationBar/NavigationBar.types.ts
@@ -1,0 +1,326 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import type { Key } from "react-aria";
+import type { TabListState } from "@react-stately/tabs";
+
+/**
+ * Badge value for a NavigationBarItem.
+ *
+ * - `true` — renders a dot indicator (no count)
+ * - `number` — renders the count; 0 hides the badge; values > 999 display "999+"
+ */
+export type NavigationBarBadge = number | true;
+
+/**
+ * Configuration for a single NavigationBar destination item.
+ *
+ * @example
+ * ```tsx
+ * const item: NavigationBarItemConfig = {
+ *   key: 'home',
+ *   icon: <HomeIcon />,
+ *   label: 'Home',
+ *   badge: 3,
+ * };
+ * ```
+ */
+export interface NavigationBarItemConfig {
+  /**
+   * Unique identifier for this destination (used as the selection key).
+   */
+  key: string;
+
+  /**
+   * Icon element displayed at 24dp. Always visible regardless of `hideLabels`.
+   */
+  icon: ReactNode;
+
+  /**
+   * Visible label beneath the icon.
+   * Required unless `aria-label` is provided (icon-only mode with `hideLabels`).
+   */
+  label?: string;
+
+  /**
+   * Badge displayed on the icon.
+   * - `true` renders a dot indicator.
+   * - `0` hides the badge.
+   * - `1–999` renders the count.
+   * - `> 999` renders "999+".
+   */
+  badge?: NavigationBarBadge;
+
+  /**
+   * When `true`, the item cannot be focused or activated.
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Accessible name used when labels are hidden (`hideLabels` mode).
+   * Required for icon-only items; enforced at runtime via dev warning.
+   */
+  "aria-label"?: string;
+}
+
+/**
+ * Material Design 3 Navigation Bar (Bottom Navigation) props.
+ *
+ * Accepts 3–5 destination items. Item count outside this range triggers a
+ * dev-only `console.warn`.
+ *
+ * **Controlled usage:**
+ * ```tsx
+ * <NavigationBar
+ *   items={items}
+ *   activeKey={activeKey}
+ *   onActiveChange={setActiveKey}
+ *   aria-label="Main navigation"
+ * />
+ * ```
+ *
+ * **Uncontrolled usage:**
+ * ```tsx
+ * <NavigationBar
+ *   items={items}
+ *   defaultActiveKey="home"
+ *   aria-label="Main navigation"
+ * />
+ * ```
+ *
+ * @see https://m3.material.io/components/navigation-bar/overview
+ */
+export interface NavigationBarProps {
+  /**
+   * Array of 3–5 destination items.
+   * Item count outside the 3–5 range triggers a dev warning.
+   */
+  items: NavigationBarItemConfig[];
+
+  /**
+   * Controlled active key. Pair with `onActiveChange`.
+   * Use `null` to explicitly deselect all items.
+   */
+  activeKey?: Key | null;
+
+  /**
+   * Default active key for uncontrolled usage.
+   */
+  defaultActiveKey?: Key;
+
+  /**
+   * Called when the active destination changes.
+   */
+  onActiveChange?: (key: Key) => void;
+
+  /**
+   * When `true`, hides labels on all items (icon-only mode).
+   * @default false
+   */
+  hideLabels?: boolean;
+
+  /**
+   * Accessible label for the `<nav>` landmark element. Required.
+   *
+   * @example "Main navigation"
+   */
+  "aria-label": string;
+
+  /**
+   * Disable ripple effect on all items.
+   * @default false
+   */
+  disableRipple?: boolean;
+
+  /**
+   * Additional CSS classes merged onto the `<nav>` element via `cn()`.
+   */
+  className?: string;
+}
+
+/**
+ * Standalone NavigationBarItem props.
+ *
+ * Used internally by `NavigationBar` and available for advanced consumers
+ * composing with `HeadlessNavigationBar`.
+ *
+ * Extends `ButtonHTMLAttributes` (minus `disabled`) so that tab props from
+ * `useTab` can be spread directly onto the rendered `<button>`.
+ */
+export interface NavigationBarItemProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "disabled"
+> {
+  /**
+   * The unique key for this item (passed to the headless layer).
+   */
+  itemKey: Key;
+
+  /**
+   * Icon element displayed at 24dp.
+   */
+  icon: ReactNode;
+
+  /**
+   * Visible label beneath the icon.
+   */
+  label?: string;
+
+  /**
+   * Badge value.
+   */
+  badge?: NavigationBarBadge;
+
+  /**
+   * Whether this item is the currently selected destination.
+   * @default false
+   */
+  isActive?: boolean;
+
+  /**
+   * When `true`, hides the label for this item.
+   * @default false
+   */
+  hideLabels?: boolean;
+
+  /**
+   * Whether this item is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Disable ripple effect on this item.
+   * @default false
+   */
+  disableRipple?: boolean;
+}
+
+/**
+ * HeadlessNavigationBar props.
+ *
+ * Provides the accessibility foundation (`role="navigation"`, `role="tablist"`,
+ * `useTabList`, `useTabListState`) without any visual styling.
+ * Intended for advanced consumers who need full visual control.
+ *
+ * @example
+ * ```tsx
+ * <HeadlessNavigationBar
+ *   items={items}
+ *   defaultSelectedKey="home"
+ *   aria-label="Main navigation"
+ *   renderItem={(config) => (
+ *     <HeadlessNavigationBarItem key={config.key} itemKey={config.key}>
+ *       {config.icon}
+ *       <span>{config.label}</span>
+ *     </HeadlessNavigationBarItem>
+ *   )}
+ * />
+ * ```
+ */
+export interface HeadlessNavigationBarProps {
+  /**
+   * Array of item configs used to build the React Aria collection.
+   */
+  items: NavigationBarItemConfig[];
+
+  /**
+   * Controlled selected key. Pair with `onSelectionChange`.
+   * Use `null` to explicitly deselect all items.
+   */
+  selectedKey?: Key | null;
+
+  /**
+   * Default selected key for uncontrolled usage.
+   */
+  defaultSelectedKey?: Key;
+
+  /**
+   * Called when the selected key changes.
+   */
+  onSelectionChange?: (key: Key) => void;
+
+  /**
+   * Accessible label for the `<nav>` landmark.
+   */
+  "aria-label": string;
+
+  /**
+   * Additional CSS classes for the inner `<div role="tablist">`.
+   */
+  className?: string;
+
+  /**
+   * Render function called for each item in the collection.
+   * Receives the item config; use `HeadlessNavigationBarItem` inside.
+   */
+  renderItem: (config: NavigationBarItemConfig) => ReactNode;
+}
+
+/**
+ * Render props passed to `HeadlessNavigationBarItem`'s children when used as
+ * a render function.
+ */
+export interface NavigationBarItemRenderProps {
+  /** Whether this item is the active destination. */
+  isSelected: boolean;
+  /** Whether the item has a visible keyboard focus ring. */
+  isFocusVisible: boolean;
+}
+
+/**
+ * HeadlessNavigationBarItem props.
+ *
+ * Renders a single tab-accessible button using `useTab` from React Aria.
+ * Must be rendered inside `HeadlessNavigationBar` (reads state from context).
+ *
+ * Accepts children as ReactNode or as a render function receiving state props.
+ *
+ * @example
+ * ```tsx
+ * // Static children
+ * <HeadlessNavigationBarItem itemKey="home">
+ *   Home
+ * </HeadlessNavigationBarItem>
+ *
+ * // Render function (access to isSelected / isFocusVisible)
+ * <HeadlessNavigationBarItem itemKey="home">
+ *   {({ isSelected }) => (
+ *     <span style={{ fontWeight: isSelected ? 'bold' : 'normal' }}>Home</span>
+ *   )}
+ * </HeadlessNavigationBarItem>
+ * ```
+ */
+export interface HeadlessNavigationBarItemProps {
+  /**
+   * The key matching `NavigationBarItemConfig.key`. Used to look up the
+   * item in the React Aria collection state.
+   */
+  itemKey: Key;
+
+  /**
+   * Content to render inside the button — either a ReactNode or a render
+   * function receiving `{ isSelected, isFocusVisible }`.
+   */
+  children: ReactNode | ((renderProps: NavigationBarItemRenderProps) => ReactNode);
+
+  /**
+   * Additional CSS classes merged onto the `<button>` element.
+   */
+  className?: string;
+
+  /**
+   * Accessible label for icon-only items (when no visible text label is present).
+   * Applied as `aria-label` on the `<button>` element.
+   */
+  "aria-label"?: string;
+}
+
+/**
+ * Context value shared between HeadlessNavigationBar and HeadlessNavigationBarItem.
+ * @internal
+ */
+export interface NavigationBarContextValue {
+  state: TabListState<NavigationBarItemConfig>;
+  hideLabels: boolean;
+  disableRipple: boolean;
+}

--- a/packages/react/src/components/NavigationBar/NavigationBar.variants.ts
+++ b/packages/react/src/components/NavigationBar/NavigationBar.variants.ts
@@ -1,0 +1,215 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Navigation Bar container variants (CVA).
+ *
+ * Bar surface: `bg-surface-container`
+ * Height: 80dp (`h-20`)
+ * Position: `fixed bottom-0` — full-width bottom bar
+ *
+ * @see https://m3.material.io/components/navigation-bar/specs
+ */
+export const navigationBarVariants = cva([
+  // Layout
+  "fixed bottom-0 left-0 right-0 z-10",
+  "w-full",
+  "flex flex-row items-stretch",
+  // MD3 surface
+  "bg-surface-container",
+  // MD3 height: 80dp
+  "h-20",
+  // Safe-area bottom (for mobile devices)
+  "pb-safe",
+]);
+
+/**
+ * Material Design 3 Navigation Bar item variants (CVA).
+ *
+ * Each item is a flex column that fills available horizontal space.
+ * Active/inactive colors follow MD3 color roles:
+ * - Active icon:   `text-on-secondary-container`
+ * - Inactive icon: `text-on-surface-variant`
+ * - Active label:  `text-on-surface`
+ * - Inactive label:`text-on-surface-variant`
+ *
+ * State layers use MD3 opacity values via `::before` pseudo-element.
+ *
+ * @see https://m3.material.io/components/navigation-bar/specs
+ */
+export const navigationBarItemVariants = cva(
+  [
+    // Layout
+    "relative flex flex-1 flex-col items-center justify-center",
+    "cursor-pointer select-none outline-none",
+    // State layer pseudo-element (covers the full item area)
+    "before:absolute before:inset-0 before:rounded-none before:transition-opacity before:duration-short2 before:ease-standard",
+    // Focus-visible ring
+    "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+    // Transition for color changes
+    "transition-colors duration-short2 ease-standard",
+  ],
+  {
+    variants: {
+      /**
+       * Whether this item is the currently selected destination.
+       * Controls icon and label colors per MD3 spec.
+       */
+      isActive: {
+        true: [
+          // Active icon color applied via text-color on the icon wrapper
+          "[&>[data-icon]]:text-on-secondary-container",
+          // Active label color
+          "[&>[data-label]]:text-on-surface",
+          // State layer color for active item
+          "before:bg-on-surface-variant",
+        ],
+        false: [
+          // Inactive icon color
+          "[&>[data-icon]]:text-on-surface-variant",
+          // Inactive label color
+          "[&>[data-label]]:text-on-surface-variant",
+          // State layer color for inactive item
+          "before:bg-on-surface-variant",
+        ],
+      },
+
+      /**
+       * Whether the item is disabled.
+       * Applies `opacity-38` per MD3 disabled state.
+       */
+      isDisabled: {
+        true: ["cursor-not-allowed opacity-38 pointer-events-none"],
+        false: [],
+      },
+
+      /**
+       * Hover and press state layer opacities.
+       * Applied via compound variants on hover/active pseudo-classes.
+       */
+      isHovered: {
+        true: ["before:opacity-8"],
+        false: ["before:opacity-0"],
+      },
+
+      isPressed: {
+        true: ["before:opacity-12"],
+        false: [],
+      },
+    },
+
+    compoundVariants: [
+      // When not hovered or pressed, state layer is invisible
+      {
+        isHovered: false,
+        isPressed: false,
+        className: "before:opacity-0",
+      },
+    ],
+
+    defaultVariants: {
+      isActive: false,
+      isDisabled: false,
+      isHovered: false,
+      isPressed: false,
+    },
+  }
+);
+
+/**
+ * Active indicator pill variants (CVA).
+ *
+ * The pill sits behind the icon, centered horizontally.
+ * MD3 spec: 64dp wide × 32dp tall, `rounded-full`, `bg-secondary-container`.
+ *
+ * Animation uses MD3 motion tokens:
+ * - Active:   `scale-x-100 opacity-100`
+ * - Inactive: `scale-x-0   opacity-0`
+ * - Duration: `duration-medium2` (300ms)
+ * - Easing:   `ease-emphasized`
+ */
+export const indicatorPillVariants = cva(
+  [
+    "absolute inset-x-0 mx-auto",
+    "w-16 h-8",
+    "rounded-full bg-secondary-container",
+    "transition-[transform,opacity] duration-medium2 ease-emphasized",
+    "origin-center",
+  ],
+  {
+    variants: {
+      isActive: {
+        true: ["scale-x-100 opacity-100"],
+        false: ["scale-x-0 opacity-0"],
+      },
+    },
+    defaultVariants: {
+      isActive: false,
+    },
+  }
+);
+
+/**
+ * Badge variants (CVA).
+ *
+ * Positioned at the top-right of the icon area.
+ * MD3 uses `error` color role for badges.
+ *
+ * - Dot:     small circle, no text
+ * - Numeric: rounded pill with count
+ */
+export const badgeVariants = cva(
+  [
+    "absolute",
+    "flex items-center justify-center",
+    "bg-error text-on-error",
+    "font-medium leading-none",
+    // MD3 label-small
+    "text-[0.6875rem]",
+  ],
+  {
+    variants: {
+      isDot: {
+        true: [
+          // Dot: 6dp diameter, top-right of icon
+          "top-0 right-3.5",
+          "w-1.5 h-1.5 min-w-0 rounded-full",
+        ],
+        false: [
+          // Numeric: pill shape, top-right of icon
+          "top-0 right-2",
+          "min-w-[1rem] h-4 px-1 rounded-full",
+        ],
+      },
+    },
+    defaultVariants: {
+      isDot: false,
+    },
+  }
+);
+
+/**
+ * Icon wrapper variants — controls size and positioning.
+ * The icon wrapper is `relative` to position the badge and indicator.
+ */
+export const iconWrapperVariants = cva([
+  "relative z-10 flex items-center justify-center",
+  "w-6 h-6",
+]);
+
+/**
+ * Label variants — `text-label-medium` per MD3 Navigation Bar spec.
+ * Transition mirrors the icon color transition.
+ */
+export const labelVariants = cva([
+  "mt-1 select-none",
+  "text-label-medium",
+  "transition-colors duration-short2 ease-standard",
+  "truncate max-w-full",
+]);
+
+// ─── Type exports ─────────────────────────────────────────────────────────────
+
+export type NavigationBarVariants = VariantProps<typeof navigationBarVariants>;
+export type NavigationBarItemVariants = VariantProps<typeof navigationBarItemVariants>;
+export type IndicatorPillVariants = VariantProps<typeof indicatorPillVariants>;
+export type BadgeVariants = VariantProps<typeof badgeVariants>;

--- a/packages/react/src/components/NavigationBar/NavigationBarHeadless.tsx
+++ b/packages/react/src/components/NavigationBar/NavigationBarHeadless.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { createContext, forwardRef, useContext, useRef } from "react";
+import { useTabList, useTab, useFocusRing } from "react-aria";
+import { useTabListState, Item } from "react-stately";
+import { mergeProps } from "@react-aria/utils";
+import type { TabListState } from "@react-stately/tabs";
+import type { NavigationBarContextValue, NavigationBarItemConfig } from "./NavigationBar.types";
+import type {
+  HeadlessNavigationBarProps,
+  HeadlessNavigationBarItemProps,
+} from "./NavigationBar.types";
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+/**
+ * Shared context between HeadlessNavigationBar and HeadlessNavigationBarItem.
+ * Provides the React Aria TabListState and bar-level configuration.
+ * @internal
+ */
+export const NavigationBarContext = createContext<NavigationBarContextValue | null>(null);
+
+/**
+ * Hook to read the NavigationBarContext inside HeadlessNavigationBarItem.
+ * Throws a descriptive error if used outside HeadlessNavigationBar.
+ * @internal
+ */
+function useNavigationBarContext(): NavigationBarContextValue {
+  const ctx = useContext(NavigationBarContext);
+  if (ctx === null) {
+    throw new Error("HeadlessNavigationBarItem must be rendered inside HeadlessNavigationBar.");
+  }
+  return ctx;
+}
+
+// ─── HeadlessNavigationBar ────────────────────────────────────────────────────
+
+/**
+ * Headless Navigation Bar (Layer 2).
+ *
+ * Renders an accessible `<nav role="navigation">` landmark wrapping a
+ * `<div role="tablist">`. Provides keyboard navigation (Arrow Left/Right,
+ * Home, End) and full ARIA semantics via React Aria's `useTabList`.
+ *
+ * All item accessibility is handled by `HeadlessNavigationBarItem`.
+ *
+ * Use this component when you need complete visual control beyond what the
+ * styled `NavigationBar` provides.
+ *
+ * @example
+ * ```tsx
+ * <HeadlessNavigationBar
+ *   items={items}
+ *   defaultSelectedKey="home"
+ *   aria-label="Main navigation"
+ *   renderItem={(config) => (
+ *     <HeadlessNavigationBarItem key={config.key} itemKey={config.key}>
+ *       {config.icon}
+ *       <span>{config.label}</span>
+ *     </HeadlessNavigationBarItem>
+ *   )}
+ * />
+ * ```
+ */
+export const HeadlessNavigationBar = forwardRef<HTMLElement, HeadlessNavigationBarProps>(
+  (
+    {
+      items,
+      selectedKey,
+      defaultSelectedKey,
+      onSelectionChange,
+      "aria-label": ariaLabel,
+      className,
+      renderItem,
+    },
+    ref
+  ) => {
+    // Build the React Aria collection from the items array.
+    // Item children (text content) are used as the `textValue` for type-ahead.
+    const collectionChildren = items.map((item) => (
+      <Item key={item.key} textValue={item.label ?? item["aria-label"] ?? item.key}>
+        {item.key}
+      </Item>
+    ));
+
+    const disabledKeys = items.filter((item) => item.isDisabled).map((item) => item.key);
+
+    // useTabListState manages selected key, keyboard navigation state, and
+    // the internal React Aria Collection.
+    // We conditionally spread optional props to satisfy exactOptionalPropertyTypes.
+    // The generic T is asserted as NavigationBarItemConfig because JSX children
+    // cause TypeScript to infer T=object (item data type isn't preserved via JSX).
+    const state = useTabListState({
+      children: collectionChildren,
+      ...(selectedKey !== undefined ? { selectedKey } : {}),
+      ...(defaultSelectedKey !== undefined ? { defaultSelectedKey } : {}),
+      ...(onSelectionChange ? { onSelectionChange } : {}),
+      disabledKeys,
+    });
+
+    const tabListRef = useRef<HTMLDivElement>(null);
+
+    // useTabList provides the ARIA props for the tablist container:
+    // role="tablist", keyboard event handlers (Arrow keys, Home, End).
+    const { tabListProps } = useTabList({ "aria-label": ariaLabel }, state, tabListRef);
+
+    return (
+      <nav
+        ref={ref as React.RefObject<HTMLElement>}
+        role="navigation"
+        aria-label={ariaLabel}
+        className={className}
+      >
+        <NavigationBarContext.Provider value={{ state, hideLabels: false, disableRipple: false }}>
+          {/* The tablist is a full-width flex row inside the nav */}
+          <div {...tabListProps} ref={tabListRef} className="flex h-full w-full items-stretch">
+            {[...state.collection].map((collectionItem) => {
+              const itemConfig = items.find((i) => String(i.key) === String(collectionItem.key));
+              if (!itemConfig) return null;
+              return renderItem(itemConfig);
+            })}
+          </div>
+        </NavigationBarContext.Provider>
+      </nav>
+    );
+  }
+);
+
+HeadlessNavigationBar.displayName = "HeadlessNavigationBar";
+
+// ─── HeadlessNavigationBarItem ────────────────────────────────────────────────
+
+/**
+ * Headless Navigation Bar Item (Layer 2).
+ *
+ * Renders an accessible `<button role="tab">` using React Aria's `useTab`.
+ * Provides `aria-selected`, `aria-disabled`, roving `tabIndex`, and
+ * focus management via `useFocusRing`.
+ *
+ * Must be rendered inside `HeadlessNavigationBar`.
+ *
+ * @example
+ * ```tsx
+ * <HeadlessNavigationBarItem itemKey="home" className="my-item">
+ *   <HomeIcon aria-hidden />
+ *   <span>Home</span>
+ * </HeadlessNavigationBarItem>
+ * ```
+ */
+export const HeadlessNavigationBarItem = forwardRef<
+  HTMLButtonElement,
+  HeadlessNavigationBarItemProps
+>(({ itemKey, children, className, "aria-label": ariaLabel }, ref) => {
+  const { state } = useNavigationBarContext();
+
+  const internalRef = useRef<HTMLButtonElement>(null);
+  const resolvedRef = (ref as React.RefObject<HTMLButtonElement>) ?? internalRef;
+
+  // useTab in @react-aria/tabs 3.x takes { key } (not { item }).
+  // It provides: role="tab", aria-selected, aria-disabled, tabIndex,
+  // and keyboard event handling (selection on Enter/Space).
+  const { tabProps, isSelected } = useTab({ key: itemKey }, state, resolvedRef);
+
+  // Navigation bar has no tab panels, so remove aria-controls to avoid ARIA
+  // validation errors (aria-controls must reference an existing element).
+  const { "aria-controls": _controls, ...tabPropsWithoutControls } = tabProps;
+
+  // useFocusRing provides isFocusVisible for focus ring management.
+  const { focusProps, isFocusVisible } = useFocusRing();
+
+  // Support both ReactNode children and render-function children.
+  const content =
+    typeof children === "function" ? children({ isSelected, isFocusVisible }) : children;
+
+  return (
+    <button
+      type="button"
+      {...mergeProps(tabPropsWithoutControls, focusProps)}
+      ref={resolvedRef}
+      className={className}
+      aria-label={ariaLabel}
+      data-focus-visible={isFocusVisible || undefined}
+      data-selected={isSelected}
+    >
+      {content}
+    </button>
+  );
+});
+
+HeadlessNavigationBarItem.displayName = "HeadlessNavigationBarItem";

--- a/packages/react/src/components/NavigationBar/NavigationBarHeadless.tsx
+++ b/packages/react/src/components/NavigationBar/NavigationBarHeadless.tsx
@@ -4,8 +4,7 @@ import { createContext, forwardRef, useContext, useRef } from "react";
 import { useTabList, useTab, useFocusRing } from "react-aria";
 import { useTabListState, Item } from "react-stately";
 import { mergeProps } from "@react-aria/utils";
-import type { TabListState } from "@react-stately/tabs";
-import type { NavigationBarContextValue, NavigationBarItemConfig } from "./NavigationBar.types";
+import type { NavigationBarContextValue } from "./NavigationBar.types";
 import type {
   HeadlessNavigationBarProps,
   HeadlessNavigationBarItemProps,

--- a/packages/react/src/components/NavigationBar/NavigationBarHeadless.tsx
+++ b/packages/react/src/components/NavigationBar/NavigationBarHeadless.tsx
@@ -2,15 +2,24 @@
 
 import { createContext, forwardRef, useContext, useRef } from "react";
 import { useTabList, useTab, useFocusRing } from "react-aria";
-import { useTabListState, Item } from "react-stately";
+import { useTabListState, Item, type TabListState } from "react-stately";
 import { mergeProps } from "@react-aria/utils";
-import type { NavigationBarContextValue } from "./NavigationBar.types";
 import type {
   HeadlessNavigationBarProps,
   HeadlessNavigationBarItemProps,
 } from "./NavigationBar.types";
 
 // ─── Context ──────────────────────────────────────────────────────────────────
+
+/**
+ * Context value shared between HeadlessNavigationBar and HeadlessNavigationBarItem.
+ * @internal
+ */
+export interface NavigationBarContextValue {
+  state: TabListState<object>;
+  hideLabels: boolean;
+  disableRipple: boolean;
+}
 
 /**
  * Shared context between HeadlessNavigationBar and HeadlessNavigationBarItem.

--- a/packages/react/src/components/NavigationBar/NavigationBarItem.tsx
+++ b/packages/react/src/components/NavigationBar/NavigationBarItem.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { forwardRef } from "react";
+import { useRipple } from "../../hooks/useRipple";
+import { cn } from "../../utils/cn";
+import {
+  navigationBarItemVariants,
+  indicatorPillVariants,
+  badgeVariants,
+  iconWrapperVariants,
+  labelVariants,
+} from "./NavigationBar.variants";
+import type { NavigationBarItemProps, NavigationBarBadge } from "./NavigationBar.types";
+
+// ─── Badge helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns the display string for a badge value.
+ * - `true`  → renders dot (no text)
+ * - `0`     → hidden
+ * - `1–999` → count as string
+ * - `> 999` → "999+"
+ */
+function getBadgeContent(badge: NavigationBarBadge): string | null {
+  if (badge === true) return null; // dot — no text
+  if (badge === 0) return ""; // hidden
+  if (badge > 999) return "999+";
+  return String(badge);
+}
+
+/**
+ * Whether a badge value should be rendered at all.
+ */
+function isBadgeVisible(badge: NavigationBarBadge | undefined): boolean {
+  if (badge === undefined) return false;
+  if (badge === 0) return false;
+  return true;
+}
+
+// ─── NavigationBarItem ────────────────────────────────────────────────────────
+
+/**
+ * Material Design 3 Navigation Bar Item (Layer 3).
+ *
+ * Renders a single destination item within a `NavigationBar`. Handles:
+ * - Active indicator pill (`rounded-full`, animated with MD3 motion tokens)
+ * - Icon slot (24dp, always visible)
+ * - Badge (dot, numeric count, 999+ truncation)
+ * - Label (hidden in `hideLabels` mode)
+ * - MD3 state layers (hover `opacity-8`, pressed `opacity-12`)
+ * - Ripple effect via `useRipple`
+ * - Focus ring via `data-focus-visible`
+ *
+ * Used internally by `NavigationBar`. Can also be composed with
+ * `HeadlessNavigationBarItem` for advanced customization.
+ *
+ * **Future — Navigation Rail:**
+ * At wider viewports, a NavigationBar may transition to a Navigation Rail.
+ * This is a separate component tracked as a future Phase 5+ item.
+ *
+ * @example
+ * ```tsx
+ * // Used standalone (advanced consumer with HeadlessNavigationBar)
+ * <NavigationBarItem
+ *   itemKey="home"
+ *   icon={<HomeIcon />}
+ *   label="Home"
+ *   isActive
+ * />
+ * ```
+ */
+export const NavigationBarItem = forwardRef<HTMLButtonElement, NavigationBarItemProps>(
+  (
+    {
+      itemKey: _itemKey,
+      icon,
+      label,
+      badge,
+      isActive = false,
+      hideLabels = false,
+      isDisabled = false,
+      disableRipple = false,
+      className,
+      "aria-label": ariaLabel,
+      // Spread remaining props (e.g. tabProps from useTab)
+      ...rest
+    },
+    ref
+  ) => {
+    const { onMouseDown, ripples } = useRipple({
+      ...(disableRipple || isDisabled ? { disabled: true } : {}),
+    });
+
+    const showBadge = isBadgeVisible(badge);
+    const isDot = badge === true;
+    const badgeContent = badge !== undefined ? getBadgeContent(badge) : null;
+
+    return (
+      <button
+        type="button"
+        ref={ref}
+        onMouseDown={onMouseDown}
+        disabled={isDisabled}
+        aria-label={ariaLabel}
+        className={cn(
+          navigationBarItemVariants({
+            isActive,
+            isDisabled,
+          }),
+          className
+        )}
+        {...rest}
+      >
+        {/* Overflow hidden container for ripple */}
+        <span className="relative flex h-full w-full flex-col items-center justify-center overflow-hidden rounded-none">
+          {/* Ripple nodes */}
+          {ripples}
+
+          {/* Active indicator pill — animates behind the icon */}
+          <span
+            data-indicator-pill
+            data-active={isActive}
+            className={cn(indicatorPillVariants({ isActive }))}
+            aria-hidden="true"
+          />
+
+          {/* Icon + Badge wrapper */}
+          <span data-icon className={cn(iconWrapperVariants())}>
+            {/* Icon (24dp, aria-hidden is set by the consumer on the SVG) */}
+            <span className="relative z-10 flex h-6 w-6 items-center justify-center">{icon}</span>
+
+            {/* Badge */}
+            {showBadge && (
+              <span
+                data-badge
+                data-badge-dot={isDot || undefined}
+                aria-label={
+                  isDot
+                    ? "notification"
+                    : badgeContent
+                      ? `${badgeContent} notifications`
+                      : undefined
+                }
+                aria-live="polite"
+                className={cn(badgeVariants({ isDot }))}
+              >
+                {isDot ? null : badgeContent}
+              </span>
+            )}
+          </span>
+
+          {/* Label */}
+          {!hideLabels && label && (
+            <span data-label className={cn(labelVariants())}>
+              {label}
+            </span>
+          )}
+        </span>
+      </button>
+    );
+  }
+);
+
+NavigationBarItem.displayName = "NavigationBarItem";

--- a/packages/react/src/components/NavigationBar/index.ts
+++ b/packages/react/src/components/NavigationBar/index.ts
@@ -7,6 +7,7 @@ export {
   HeadlessNavigationBar,
   HeadlessNavigationBarItem,
   NavigationBarContext,
+  type NavigationBarContextValue,
 } from "./NavigationBarHeadless";
 
 // CVA Variants (for external customization)
@@ -32,5 +33,4 @@ export type {
   HeadlessNavigationBarProps,
   HeadlessNavigationBarItemProps,
   NavigationBarItemRenderProps,
-  NavigationBarContextValue,
 } from "./NavigationBar.types";

--- a/packages/react/src/components/NavigationBar/index.ts
+++ b/packages/react/src/components/NavigationBar/index.ts
@@ -1,0 +1,36 @@
+// Layer 3: MD3 Styled Components (most users use these)
+export { NavigationBar } from "./NavigationBar";
+export { NavigationBarItem } from "./NavigationBarItem";
+
+// Layer 2: Headless Components (for advanced customization)
+export {
+  HeadlessNavigationBar,
+  HeadlessNavigationBarItem,
+  NavigationBarContext,
+} from "./NavigationBarHeadless";
+
+// CVA Variants (for external customization)
+export {
+  navigationBarVariants,
+  navigationBarItemVariants,
+  indicatorPillVariants,
+  badgeVariants,
+  iconWrapperVariants,
+  labelVariants,
+  type NavigationBarVariants,
+  type NavigationBarItemVariants,
+  type IndicatorPillVariants,
+  type BadgeVariants,
+} from "./NavigationBar.variants";
+
+// Types
+export type {
+  NavigationBarBadge,
+  NavigationBarItemConfig,
+  NavigationBarProps,
+  NavigationBarItemProps,
+  HeadlessNavigationBarProps,
+  HeadlessNavigationBarItemProps,
+  NavigationBarItemRenderProps,
+  NavigationBarContextValue,
+} from "./NavigationBar.types";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -28,3 +28,19 @@ export type {
   RadioHeadlessProps,
   RadioGroupHeadlessProps,
 } from "./Radio";
+
+export {
+  NavigationBar,
+  NavigationBarItem,
+  HeadlessNavigationBar,
+  HeadlessNavigationBarItem,
+} from "./NavigationBar";
+export type {
+  NavigationBarProps,
+  NavigationBarItemProps,
+  NavigationBarItemConfig,
+  NavigationBarBadge,
+  HeadlessNavigationBarProps,
+  HeadlessNavigationBarItemProps,
+  NavigationBarItemRenderProps,
+} from "./NavigationBar";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -72,3 +72,19 @@ export type {
   RadioHeadlessProps,
   RadioGroupHeadlessProps,
 } from "./components/Radio";
+
+export {
+  NavigationBar,
+  NavigationBarItem,
+  HeadlessNavigationBar,
+  HeadlessNavigationBarItem,
+} from "./components/NavigationBar";
+export type {
+  NavigationBarProps,
+  NavigationBarItemProps,
+  NavigationBarItemConfig,
+  NavigationBarBadge,
+  HeadlessNavigationBarProps,
+  HeadlessNavigationBarItemProps,
+  NavigationBarItemRenderProps,
+} from "./components/NavigationBar";


### PR DESCRIPTION
## Summary

- Implements the Material Design 3 **Navigation Bar** (Bottom Navigation) component as a fully accessible, three-layer architecture component
- Adds `NavigationBar` and `NavigationBarItem` (styled layer 3) + `HeadlessNavigationBar` and `HeadlessNavigationBarItem` (headless layer 2 using React Aria)
- 46 unit/integration/accessibility tests, all passing, including an axe audit

## Components

### `NavigationBar` (main styled component)
- Fixed bottom bar with 3–5 destination items
- Animated active **indicator pill** (`duration-medium2` + `ease-emphasized` MD3 motion tokens)
- **Badge** support: dot indicator, numeric count, "999+" truncation, hidden when count is 0
- `hideLabels` prop for icon-only mode (requires `aria-label` on each item for WCAG)
- Controlled (`activeKey` / `onActiveChange`) and uncontrolled (`defaultActiveKey`) usage
- Dev console warning for item count outside 3–5 range

### `HeadlessNavigationBar` / `HeadlessNavigationBarItem`
- Built on React Aria `useTabList` / `useTabListState` / `useTab` / `useFocusRing`
- Provides full keyboard navigation: Arrow Left/Right, Home, End, roving `tabIndex`
- ARIA: `role="navigation"` + `aria-label`, `role="tablist"`, `role="tab"` + `aria-selected`
- Removes `aria-controls` (no tab panels rendered) to prevent axe violations

### `NavigationBarItem` (standalone styled item)
- Standalone item with icon, label, badge, indicator pill, state layers, and ripple
- For use outside a tab-list context

## Architecture decisions
- Data-driven `items[]` API (not JSX children) for type safety
- `HeadlessNavigationBarItem` owns the `<button>` element; item visuals are rendered inside it via render prop to avoid nested buttons
- `TabListState<object>` cast to `TabListState<NavigationBarItemConfig>` (TypeScript limitation: generic inference breaks with JSX children)
- Conditional prop spreading throughout to satisfy `exactOptionalPropertyTypes: true`

## Test plan
- [x] All 46 tests pass: `pnpm vitest run`
- [x] TypeScript clean: `pnpm tsc --noEmit -p packages/react/tsconfig.json`
- [x] Lint clean: `pnpm eslint packages/react/src/components/NavigationBar/`
- [x] Visual review in Storybook: Default, Four Items, Five Items, Icon Only, With Badges, With Disabled Item, Controlled, Playground, Standalone Item, Headless Usage stories
- [x] Keyboard navigation: Tab to bar, Arrow Left/Right between items, Home/End
- [x] Screen reader: VoiceOver/NVDA reads item label + position (e.g. "Home, tab 1 of 3, selected")
