### PR TITLE
feat(tabs): implement MD3 Tabs component

### DIFF
--- a/packages/react/src/components/Tabs/Tab.tsx
+++ b/packages/react/src/components/Tabs/Tab.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { forwardRef, useRef, useCallback } from "react";
+import type React from "react";
+import { useTab, useFocusRing } from "react-aria";
+import { mergeProps } from "@react-aria/utils";
+import { cn } from "../../utils/cn";
+import { useRipple } from "../../hooks/useRipple";
+import { useHeadlessTabsContext } from "./TabsHeadless";
+import { useTabsContext } from "./Tabs";
+import { tabVariants, tabIconVariants, tabBadgeVariants } from "./Tabs.variants";
+import type { TabProps, TabBadgeValue } from "./Tabs.types";
+
+type TabElement = HTMLButtonElement;
+
+/**
+ * Resolves a badge value to a displayable string or null
+ */
+function resolveBadgeDisplay(badge: TabBadgeValue | undefined): string | null {
+  if (badge === undefined || badge === false) return null;
+  if (badge === true) return "dot";
+  if (typeof badge === "number") {
+    if (badge === 0) return null;
+    return badge > 999 ? "999+" : String(badge);
+  }
+  return null;
+}
+
+/**
+ * Material Design 3 Tab Component (Layer 3: Styled)
+ *
+ * Renders a single tab item inside a TabList.
+ * Supports three content modes: icon-only, label-only, icon + label (stacked).
+ *
+ * Features:
+ * - ✅ Icon-only, label-only, icon + label (stacked) content modes
+ * - ✅ Ripple effect (Material Design)
+ * - ✅ MD3 state layers (hover 8%, pressed 12%)
+ * - ✅ Badge support (numeric, dot, 999+)
+ * - ✅ Disabled state (opacity-38, not focusable)
+ * - ✅ Full keyboard accessibility (via React Aria)
+ * - ✅ Primary/secondary variant colors
+ *
+ * MD3 Specifications:
+ * - Minimum height: 48dp
+ * - Minimum width: 90dp
+ * - Typography: Title Small (14px, weight 500, tracking 0.1px)
+ * - Icon: 24x24dp
+ * - Active indicator: 3dp primary / 2dp secondary
+ * - State layers: 8% hover, 12% pressed/focus
+ *
+ * @example
+ * ```tsx
+ * // Label only
+ * <Tab id="overview" label="Overview" />
+ *
+ * // Icon + label
+ * <Tab id="media" icon={<PhotoIcon />} label="Media" />
+ *
+ * // With numeric badge
+ * <Tab id="messages" label="Messages" badge={5} />
+ *
+ * // With dot badge
+ * <Tab id="notifications" label="Notifications" badge={true} />
+ *
+ * // Disabled
+ * <Tab id="archived" label="Archived" isDisabled />
+ * ```
+ */
+export const Tab = forwardRef<TabElement, TabProps>(
+  (
+    { id, icon, label, badge, isDisabled = false, disableRipple = false, className, ...htmlProps },
+    forwardedRef
+  ) => {
+    const { state } = useHeadlessTabsContext("Tab");
+    const { variant, layout } = useTabsContext();
+
+    const internalRef = useRef<TabElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<TabElement>;
+
+    // React Aria: provides tabProps (role, aria-selected, aria-controls, tabIndex, keyboard events).
+    // HTMLButtonElement is structurally compatible with FocusableElement (@react-aria/focus),
+    // which is not exported. Casting through HTMLElement satisfies the ref parameter type.
+    const {
+      tabProps,
+      isSelected,
+      isDisabled: ariaIsDisabled,
+    } = useTab({ key: id, isDisabled }, state, ref as React.RefObject<HTMLElement>);
+
+    // Focus ring for keyboard focus indicator
+    const { isFocusVisible, focusProps } = useFocusRing();
+
+    const finalIsDisabled = isDisabled || ariaIsDisabled;
+
+    // Ripple effect
+    const { onMouseDown: handleRipple, ripples } = useRipple({
+      disabled: finalIsDisabled || disableRipple,
+    });
+
+    // Direct selection handler — ensures click works reliably across all environments.
+    // React Aria's useTab uses shouldSelectOnPressUp which depends on pointerup events.
+    // In some environments (jsdom), pointer capture can interfere with pointerup dispatch.
+    // Adding a direct onClick fallback ensures selection always works on user click.
+    const handleClick = useCallback(() => {
+      if (!finalIsDisabled) {
+        state.setSelectedKey(id);
+      }
+    }, [state, id, finalIsDisabled]);
+
+    // Direct focus handler — ensures focusedKey is always in sync with DOM focus.
+    // React Aria uses focusedKey to determine keyboard delegate's starting position.
+    // Without this, focusedKey may be null after programmatic DOM focus, breaking Arrow navigation.
+    const handleFocus = useCallback(() => {
+      if (!finalIsDisabled) {
+        state.selectionManager.setFocusedKey(id);
+      }
+    }, [state.selectionManager, id, finalIsDisabled]);
+
+    // Merge all event handlers — tabProps includes ARIA attrs and keyboard handlers from React Aria.
+    // Keyboard navigation (ArrowRight/ArrowLeft/Home/End) is handled at the TabList level,
+    // not here, so we don't add an onKeyDown. Events bubble naturally from Tab → TabList.
+    const mergedProps = mergeProps(tabProps, focusProps, {
+      onMouseDown: disableRipple ? undefined : handleRipple,
+      onClick: handleClick,
+      onFocus: handleFocus,
+    });
+
+    // Badge display
+    const badgeDisplay = resolveBadgeDisplay(badge);
+    const isDotBadge = badgeDisplay === "dot";
+    const hasIcon = Boolean(icon);
+    const hasLabel = Boolean(label);
+
+    // Use button for native click handling. role="tab" from tabProps overrides default button role.
+    // tabIndex: use isSelected (not isFocused from React Aria) so the selected tab is always reachable
+    // via Tab key, regardless of whether React Aria has initialized its internal focusedKey.
+    return (
+      <button
+        {...mergedProps}
+        ref={ref}
+        type="button"
+        // Ensure data-key is set so React Aria's keyboard delegate can find this element by key
+        data-key={String(id)}
+        // Override React Aria's isFocused-based tabIndex with selection-based roving tabIndex
+        tabIndex={finalIsDisabled ? -1 : isSelected ? 0 : -1}
+        className={cn(
+          tabVariants({
+            variant,
+            selected: isSelected,
+            disabled: finalIsDisabled,
+            layout,
+          }),
+          isFocusVisible && "outline-primary outline outline-2 outline-offset-2",
+          className
+        )}
+        {...htmlProps}
+      >
+        {/* Ripple effect */}
+        {!disableRipple && ripples}
+
+        {/* Icon with optional badge */}
+        {hasIcon && (
+          <span className={cn(tabIconVariants({ hasLabel }))}>
+            {icon}
+            {/* Badge on icon — aria-hidden to keep tab's accessible name clean */}
+            {badgeDisplay && (
+              <span
+                data-badge-type={isDotBadge ? "dot" : "count"}
+                aria-hidden="true"
+                className={cn(tabBadgeVariants({ type: isDotBadge ? "dot" : "count" }))}
+              >
+                {!isDotBadge && badgeDisplay}
+              </span>
+            )}
+          </span>
+        )}
+
+        {/* Label */}
+        {hasLabel && (
+          <span className="relative z-10 truncate">
+            {label}
+            {/* Badge next to label — aria-hidden keeps accessible name clean */}
+            {!hasIcon && badgeDisplay && (
+              <span
+                data-badge-type={isDotBadge ? "dot" : "count"}
+                aria-hidden="true"
+                className={cn(
+                  "relative ml-1",
+                  tabBadgeVariants({ type: isDotBadge ? "dot" : "count" })
+                )}
+              >
+                {!isDotBadge && badgeDisplay}
+              </span>
+            )}
+          </span>
+        )}
+      </button>
+    );
+  }
+);
+
+Tab.displayName = "Tab";

--- a/packages/react/src/components/Tabs/TabList.tsx
+++ b/packages/react/src/components/Tabs/TabList.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { forwardRef, useRef, useLayoutEffect, useState, useCallback } from "react";
+import type React from "react";
+import { useTabList } from "react-aria";
+import { cn } from "../../utils/cn";
+import { useHeadlessTabsContext } from "./TabsHeadless";
+import { useTabsContext } from "./Tabs";
+import { tabListVariants, tabIndicatorVariants } from "./Tabs.variants";
+import type { TabListProps } from "./Tabs.types";
+
+/**
+ * Indicator position and width state for the animated sliding underline
+ */
+interface IndicatorStyle {
+  left: number;
+  width: number;
+}
+
+/**
+ * Material Design 3 TabList Component (Layer 3: Styled)
+ *
+ * Renders the tab row container with an animated active indicator.
+ * Uses React Aria's useTabList for role="tablist", keyboard navigation,
+ * and accessibility attributes.
+ *
+ * The active indicator slides to the selected tab using CSS transitions
+ * with MD3 motion tokens (medium2 duration, emphasized easing).
+ *
+ * MD3 Specifications:
+ * - Container background: bg-surface
+ * - Container height: 48dp
+ * - Bottom border: 1dp, outline-variant color
+ * - Fixed layout: tabs fill width equally
+ * - Scrollable layout: overflow-x, no wrapping
+ *
+ * @example
+ * ```tsx
+ * <Tabs aria-label="Settings" defaultSelectedKey="general">
+ *   <TabList>
+ *     <Tab id="general" label="General" />
+ *     <Tab id="privacy" label="Privacy" />
+ *   </TabList>
+ *   ...
+ * </Tabs>
+ * ```
+ */
+export const TabList = forwardRef<HTMLDivElement, TabListProps>(
+  ({ children, className }, forwardedRef) => {
+    const { state } = useHeadlessTabsContext("TabList");
+    const {
+      variant,
+      layout,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
+    } = useTabsContext();
+
+    const internalRef = useRef<HTMLDivElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
+
+    // React Aria provides role="tablist", aria-label, and keyboard navigation.
+    // Conditionally spread ARIA props to satisfy exactOptionalPropertyTypes:
+    // passing undefined values explicitly would violate the strict optional type constraint.
+    const { tabListProps } = useTabList(
+      {
+        ...(ariaLabel !== undefined && { "aria-label": ariaLabel }),
+        ...(ariaLabelledBy !== undefined && { "aria-labelledby": ariaLabelledBy }),
+      },
+      state,
+      ref
+    );
+
+    // ── Keyboard navigation ────────────────────────────────────────────────
+    /**
+     * Custom keyboard handler that reads from document.activeElement rather than
+     * state.focusedKey. This is critical for test reliability: when a tab is focused
+     * via element.focus() outside React's act() boundary, the setFocusedKey state
+     * update is deferred and state.focusedKey may still be null when the keydown fires.
+     * Reading from the DOM directly avoids this race condition entirely.
+     */
+    const handleNavKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (!["ArrowRight", "ArrowLeft", "Home", "End"].includes(e.key)) return;
+
+        const container = ref.current;
+        if (!container) return;
+
+        const focusedEl = document.activeElement as HTMLElement | null;
+        const currentKey = focusedEl?.dataset?.key;
+        if (!currentKey) return;
+
+        // Read the ordered tab keys and disabled state directly from the DOM.
+        // This is more reliable than state.collection.getKeys() because React Stately 3.x
+        // builds its collection through a virtual rendering context; when we compute
+        // <Item> elements programmatically inside Tabs.tsx, that context is never entered
+        // and state.collection remains empty. DOM attributes are always authoritative.
+        const allTabEls = [...container.querySelectorAll<HTMLElement>("[data-key]")];
+        const allKeys = allTabEls.map((el) => el.dataset.key!).filter(Boolean);
+        const enabledKeys = allKeys.filter(
+          (k) =>
+            allTabEls.find((el) => el.dataset.key === k)?.getAttribute("aria-disabled") !== "true"
+        );
+
+        const currentIndex = enabledKeys.indexOf(currentKey);
+        if (currentIndex === -1) return;
+
+        let nextKey: string | null = null;
+        switch (e.key) {
+          case "ArrowRight":
+            nextKey = enabledKeys[(currentIndex + 1) % enabledKeys.length] ?? null;
+            break;
+          case "ArrowLeft":
+            nextKey =
+              enabledKeys[(currentIndex - 1 + enabledKeys.length) % enabledKeys.length] ?? null;
+            break;
+          case "Home":
+            nextKey = enabledKeys[0] ?? null;
+            break;
+          case "End":
+            nextKey = enabledKeys[enabledKeys.length - 1] ?? null;
+            break;
+        }
+
+        if (nextKey != null) {
+          e.preventDefault();
+          state.setSelectedKey(nextKey);
+          const nextEl = container.querySelector<HTMLElement>(
+            `[data-key="${CSS.escape(nextKey)}"]`
+          );
+          nextEl?.focus();
+        }
+      },
+      [state, ref]
+    );
+
+    // Destructure onKeyDown so it can be used as a stable useCallback dependency.
+    const { onKeyDown: tabListKeyDown } = tabListProps;
+
+    /**
+     * Combined keyboard handler: our DOM-based navigation runs first for arrow/home/end.
+     * If we call e.preventDefault() (signalling we handled it), React Aria's handler is
+     * skipped for that key. Other keys (Enter, Space, Tab) pass through to React Aria.
+     */
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        handleNavKeyDown(e);
+        if (!e.defaultPrevented) {
+          tabListKeyDown?.(e);
+        }
+      },
+      [handleNavKeyDown, tabListKeyDown]
+    );
+
+    // ── Active indicator animation ─────────────────────────────────────────
+    const [indicatorStyle, setIndicatorStyle] = useState<IndicatorStyle>({ left: 0, width: 0 });
+    const [indicatorReady, setIndicatorReady] = useState(false);
+
+    /**
+     * Recalculates indicator position/width from the selected tab's DOM rect.
+     * Uses the [aria-selected="true"] element as the target.
+     * Only calls setState if values changed to prevent infinite update loops.
+     */
+    const updateIndicator = useCallback(() => {
+      const container = ref.current;
+      if (!container) return;
+
+      const selectedTab = container.querySelector<HTMLElement>('[aria-selected="true"]');
+      if (!selectedTab) return;
+
+      const containerRect = container.getBoundingClientRect();
+      const tabRect = selectedTab.getBoundingClientRect();
+
+      const newLeft = tabRect.left - containerRect.left + container.scrollLeft;
+      const newWidth = tabRect.width;
+
+      // Use functional update to avoid stale closure and prevent needless re-renders
+      setIndicatorStyle((prev) => {
+        if (prev.left === newLeft && prev.width === newWidth) return prev;
+        return { left: newLeft, width: newWidth };
+      });
+      setIndicatorReady(true);
+    }, [ref]);
+
+    // Only re-run when the selected key changes (not every render)
+    useLayoutEffect(() => {
+      updateIndicator();
+    }, [state.selectedKey, updateIndicator]);
+
+    // ── Render ──────────────────────────────────────────────────────────────
+    // Merge handleKeyDown into tabListProps so jsx-a11y can't flag a "static" div with
+    // an explicit onKeyDown. The role="tablist" (from tabListProps) makes it interactive,
+    // but ESLint can't trace roles through spread operators — this avoids the false positive.
+    const mergedTabListProps = { ...tabListProps, onKeyDown: handleKeyDown };
+
+    return (
+      <div {...mergedTabListProps} ref={ref} className={cn(tabListVariants({ layout }), className)}>
+        {children}
+
+        {/* Animated active indicator (sliding underline) */}
+        <span
+          data-tab-indicator
+          aria-hidden="true"
+          className={cn(
+            tabIndicatorVariants({ variant }),
+            // Hide until first position is calculated to avoid flash
+            !indicatorReady && "opacity-0"
+          )}
+          style={{
+            // Dynamic left/width values from DOM measurements
+            left: `${indicatorStyle.left}px`,
+            width: `${indicatorStyle.width}px`,
+          }}
+        />
+      </div>
+    );
+  }
+);
+
+TabList.displayName = "TabList";

--- a/packages/react/src/components/Tabs/TabPanel.tsx
+++ b/packages/react/src/components/Tabs/TabPanel.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { forwardRef, useRef } from "react";
+import type React from "react";
+import { useTabPanel } from "react-aria";
+import { cn } from "../../utils/cn";
+import { useHeadlessTabsContext } from "./TabsHeadless";
+import { useTabsContext } from "./Tabs";
+import { tabPanelVariants } from "./Tabs.variants";
+import type { TabPanelProps } from "./Tabs.types";
+
+/**
+ * Material Design 3 TabPanel Component (Layer 3: Styled)
+ *
+ * Renders the content area associated with a tab.
+ * Only the selected tab's panel content is shown.
+ *
+ * Provides full accessibility:
+ * - role="tabpanel"
+ * - aria-labelledby (pointing to the associated tab)
+ * - Focus management for panels without focusable children (tabIndex=-1)
+ *
+ * MD3 Specifications:
+ * - No specific container styling mandated by MD3 for the panel itself
+ * - The panel should be keyboard-reachable per WCAG requirements
+ *
+ * @example
+ * ```tsx
+ * <TabPanel id="overview">
+ *   <h2>Overview</h2>
+ *   <p>Content here...</p>
+ * </TabPanel>
+ * ```
+ */
+export const TabPanel = forwardRef<HTMLDivElement, TabPanelProps>(
+  ({ id, children, className }, forwardedRef) => {
+    const { state } = useHeadlessTabsContext("TabPanel");
+    useTabsContext(); // consume context to validate component is inside Tabs
+
+    const internalRef = useRef<HTMLDivElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
+
+    // React Aria: provides role="tabpanel", aria-labelledby, tabIndex
+    const { tabPanelProps } = useTabPanel({}, state, ref);
+
+    // Only render the selected panel
+    if (state.selectedKey !== id) {
+      return null;
+    }
+
+    return (
+      <div {...tabPanelProps} ref={ref} className={cn(tabPanelVariants(), className)}>
+        {children}
+      </div>
+    );
+  }
+);
+
+TabPanel.displayName = "TabPanel";

--- a/packages/react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,728 @@
+import { useState } from "react";
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Tabs } from "./Tabs";
+import { TabList } from "./TabList";
+import { Tab } from "./Tab";
+import { TabPanel } from "./TabPanel";
+
+// ─── Sample icons ─────────────────────────────────────────────────────────────
+
+const IconPhoto = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z" />
+  </svg>
+);
+
+const IconMusic = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+  </svg>
+);
+
+const IconVideo = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z" />
+  </svg>
+);
+
+const IconFavorite = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+  </svg>
+);
+
+const IconSettings = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
+  </svg>
+);
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof Tabs> = {
+  title: "Components/Tabs",
+  component: Tabs,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Material Design 3 Tabs component. Supports primary and secondary variants, fixed and scrollable layouts, icon-only, label-only, and icon+label content modes, badges, disabled tabs, and full keyboard navigation.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "secondary"],
+      description: "Active indicator and label color variant",
+    },
+    layout: {
+      control: "select",
+      options: ["fixed", "scrollable"],
+      description: "Tab row layout mode",
+    },
+    defaultSelectedKey: {
+      control: "text",
+      description: "Default selected tab key (uncontrolled)",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+// ─── Default ──────────────────────────────────────────────────────────────────
+
+export const Default: Story = {
+  render: (args) => (
+    <Tabs {...args} aria-label="Default tabs" defaultSelectedKey="photos">
+      <TabList>
+        <Tab id="photos" label="Photos" />
+        <Tab id="music" label="Music" />
+        <Tab id="videos" label="Videos" />
+      </TabList>
+      <TabPanel id="photos">
+        <p className="p-4">Photos tab content</p>
+      </TabPanel>
+      <TabPanel id="music">
+        <p className="p-4">Music tab content</p>
+      </TabPanel>
+      <TabPanel id="videos">
+        <p className="p-4">Videos tab content</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Default tabs with primary variant and fixed layout. Click or use arrow keys to switch tabs.",
+      },
+    },
+  },
+};
+
+// ─── Variants ─────────────────────────────────────────────────────────────────
+
+export const PrimaryVariant: Story = {
+  render: () => (
+    <Tabs aria-label="Primary tabs" defaultSelectedKey="photos" variant="primary">
+      <TabList>
+        <Tab id="photos" label="Photos" />
+        <Tab id="music" label="Music" />
+        <Tab id="videos" label="Videos" />
+      </TabList>
+      <TabPanel id="photos">
+        <p className="p-4">Photos content</p>
+      </TabPanel>
+      <TabPanel id="music">
+        <p className="p-4">Music content</p>
+      </TabPanel>
+      <TabPanel id="videos">
+        <p className="p-4">Videos content</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Primary variant: active indicator is `bg-primary`, active label is `text-primary`. Default variant for top-level navigation.",
+      },
+    },
+  },
+};
+
+export const SecondaryVariant: Story = {
+  render: () => (
+    <Tabs aria-label="Secondary tabs" defaultSelectedKey="photos" variant="secondary">
+      <TabList>
+        <Tab id="photos" label="Photos" />
+        <Tab id="music" label="Music" />
+        <Tab id="videos" label="Videos" />
+      </TabList>
+      <TabPanel id="photos">
+        <p className="p-4">Photos content</p>
+      </TabPanel>
+      <TabPanel id="music">
+        <p className="p-4">Music content</p>
+      </TabPanel>
+      <TabPanel id="videos">
+        <p className="p-4">Videos content</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Secondary variant: active indicator is `bg-on-surface-variant`, active label is `text-on-surface`. Used for sub-navigation inside a page.",
+      },
+    },
+  },
+};
+
+export const BothVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <div>
+        <p className="text-on-surface-variant mb-2 text-sm font-medium">Primary</p>
+        <Tabs aria-label="Primary tabs" defaultSelectedKey="tab1" variant="primary">
+          <TabList>
+            <Tab id="tab1" label="Overview" />
+            <Tab id="tab2" label="Details" />
+            <Tab id="tab3" label="Reviews" />
+          </TabList>
+          <TabPanel id="tab1">
+            <p className="p-4">Overview content</p>
+          </TabPanel>
+          <TabPanel id="tab2">
+            <p className="p-4">Details content</p>
+          </TabPanel>
+          <TabPanel id="tab3">
+            <p className="p-4">Reviews content</p>
+          </TabPanel>
+        </Tabs>
+      </div>
+      <div>
+        <p className="text-on-surface-variant mb-2 text-sm font-medium">Secondary</p>
+        <Tabs aria-label="Secondary tabs" defaultSelectedKey="tab1" variant="secondary">
+          <TabList>
+            <Tab id="tab1" label="Overview" />
+            <Tab id="tab2" label="Details" />
+            <Tab id="tab3" label="Reviews" />
+          </TabList>
+          <TabPanel id="tab1">
+            <p className="p-4">Overview content</p>
+          </TabPanel>
+          <TabPanel id="tab2">
+            <p className="p-4">Details content</p>
+          </TabPanel>
+          <TabPanel id="tab3">
+            <p className="p-4">Reviews content</p>
+          </TabPanel>
+        </Tabs>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Layouts ──────────────────────────────────────────────────────────────────
+
+export const FixedLayout: Story = {
+  render: () => (
+    <Tabs aria-label="Fixed layout tabs" defaultSelectedKey="photos" layout="fixed">
+      <TabList>
+        <Tab id="photos" label="Photos" />
+        <Tab id="music" label="Music" />
+        <Tab id="videos" label="Videos" />
+      </TabList>
+      <TabPanel id="photos">
+        <p className="p-4">Photos content</p>
+      </TabPanel>
+      <TabPanel id="music">
+        <p className="p-4">Music content</p>
+      </TabPanel>
+      <TabPanel id="videos">
+        <p className="p-4">Videos content</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Fixed layout: all tabs share the full container width equally (`flex-1`). Best for 2–5 tabs.",
+      },
+    },
+  },
+};
+
+export const ScrollableLayout: Story = {
+  render: () => (
+    <div className="w-72">
+      <Tabs aria-label="Scrollable layout tabs" defaultSelectedKey="tab1" layout="scrollable">
+        <TabList>
+          <Tab id="tab1" label="Photos" />
+          <Tab id="tab2" label="Music" />
+          <Tab id="tab3" label="Videos" />
+          <Tab id="tab4" label="Favorites" />
+          <Tab id="tab5" label="Settings" />
+          <Tab id="tab6" label="Profile" />
+        </TabList>
+        <TabPanel id="tab1">
+          <p className="p-4">Photos content</p>
+        </TabPanel>
+        <TabPanel id="tab2">
+          <p className="p-4">Music content</p>
+        </TabPanel>
+        <TabPanel id="tab3">
+          <p className="p-4">Videos content</p>
+        </TabPanel>
+        <TabPanel id="tab4">
+          <p className="p-4">Favorites content</p>
+        </TabPanel>
+        <TabPanel id="tab5">
+          <p className="p-4">Settings content</p>
+        </TabPanel>
+        <TabPanel id="tab6">
+          <p className="p-4">Profile content</p>
+        </TabPanel>
+      </Tabs>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Scrollable layout: tabs overflow horizontally with minimum width. Ideal for 5+ tabs or narrow containers. Scroll horizontally to see all tabs.",
+      },
+    },
+  },
+};
+
+// ─── Content Modes ────────────────────────────────────────────────────────────
+
+export const LabelOnly: Story = {
+  render: () => (
+    <Tabs aria-label="Label only tabs" defaultSelectedKey="photos">
+      <TabList>
+        <Tab id="photos" label="Photos" />
+        <Tab id="music" label="Music" />
+        <Tab id="videos" label="Videos" />
+      </TabList>
+      <TabPanel id="photos">
+        <p className="p-4">Photos content</p>
+      </TabPanel>
+      <TabPanel id="music">
+        <p className="p-4">Music content</p>
+      </TabPanel>
+      <TabPanel id="videos">
+        <p className="p-4">Videos content</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Label-only content mode. Each tab has a text label with no icon.",
+      },
+    },
+  },
+};
+
+export const IconOnly: Story = {
+  render: () => (
+    <Tabs aria-label="Icon only tabs" defaultSelectedKey="photos">
+      <TabList>
+        <Tab id="photos" icon={<IconPhoto />} aria-label="Photos" />
+        <Tab id="music" icon={<IconMusic />} aria-label="Music" />
+        <Tab id="videos" icon={<IconVideo />} aria-label="Videos" />
+      </TabList>
+      <TabPanel id="photos">
+        <p className="p-4">Photos content</p>
+      </TabPanel>
+      <TabPanel id="music">
+        <p className="p-4">Music content</p>
+      </TabPanel>
+      <TabPanel id="videos">
+        <p className="p-4">Videos content</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Icon-only content mode. Provide `aria-label` on each Tab for screen reader accessibility.",
+      },
+    },
+  },
+};
+
+export const IconAndLabel: Story = {
+  render: () => (
+    <Tabs aria-label="Icon and label tabs" defaultSelectedKey="photos">
+      <TabList>
+        <Tab id="photos" icon={<IconPhoto />} label="Photos" />
+        <Tab id="music" icon={<IconMusic />} label="Music" />
+        <Tab id="videos" icon={<IconVideo />} label="Videos" />
+      </TabList>
+      <TabPanel id="photos">
+        <p className="p-4">Photos content</p>
+      </TabPanel>
+      <TabPanel id="music">
+        <p className="p-4">Music content</p>
+      </TabPanel>
+      <TabPanel id="videos">
+        <p className="p-4">Videos content</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Icon + label content mode. Icon is stacked above the label per MD3 specification.",
+      },
+    },
+  },
+};
+
+export const AllContentModes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <div>
+        <p className="text-on-surface-variant mb-2 text-sm font-medium">Label only</p>
+        <Tabs aria-label="Label only" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" label="Photos" />
+            <Tab id="b" label="Music" />
+            <Tab id="c" label="Videos" />
+          </TabList>
+          <TabPanel id="a">
+            <p className="p-4">Content</p>
+          </TabPanel>
+          <TabPanel id="b">
+            <p className="p-4">Content</p>
+          </TabPanel>
+          <TabPanel id="c">
+            <p className="p-4">Content</p>
+          </TabPanel>
+        </Tabs>
+      </div>
+      <div>
+        <p className="text-on-surface-variant mb-2 text-sm font-medium">Icon only</p>
+        <Tabs aria-label="Icon only" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" icon={<IconPhoto />} aria-label="Photos" />
+            <Tab id="b" icon={<IconMusic />} aria-label="Music" />
+            <Tab id="c" icon={<IconVideo />} aria-label="Videos" />
+          </TabList>
+          <TabPanel id="a">
+            <p className="p-4">Content</p>
+          </TabPanel>
+          <TabPanel id="b">
+            <p className="p-4">Content</p>
+          </TabPanel>
+          <TabPanel id="c">
+            <p className="p-4">Content</p>
+          </TabPanel>
+        </Tabs>
+      </div>
+      <div>
+        <p className="text-on-surface-variant mb-2 text-sm font-medium">Icon + label</p>
+        <Tabs aria-label="Icon and label" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" icon={<IconPhoto />} label="Photos" />
+            <Tab id="b" icon={<IconMusic />} label="Music" />
+            <Tab id="c" icon={<IconVideo />} label="Videos" />
+          </TabList>
+          <TabPanel id="a">
+            <p className="p-4">Content</p>
+          </TabPanel>
+          <TabPanel id="b">
+            <p className="p-4">Content</p>
+          </TabPanel>
+          <TabPanel id="c">
+            <p className="p-4">Content</p>
+          </TabPanel>
+        </Tabs>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Badges ───────────────────────────────────────────────────────────────────
+
+export const NumericBadge: Story = {
+  render: () => (
+    <Tabs aria-label="Badge tabs" defaultSelectedKey="messages">
+      <TabList>
+        <Tab id="messages" label="Messages" badge={5} />
+        <Tab id="notifications" label="Alerts" badge={23} />
+        <Tab id="overflow" label="Overflow" badge={1234} />
+        <Tab id="none" label="Empty" badge={0} />
+      </TabList>
+      <TabPanel id="messages">
+        <p className="p-4">5 unread messages</p>
+      </TabPanel>
+      <TabPanel id="notifications">
+        <p className="p-4">23 alerts</p>
+      </TabPanel>
+      <TabPanel id="overflow">
+        <p className="p-4">999+ items (1234 actual)</p>
+      </TabPanel>
+      <TabPanel id="none">
+        <p className="p-4">No items</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Numeric badge. Values > 999 display as `999+`. Badge is `aria-hidden` to keep the tab's accessible name clean.",
+      },
+    },
+  },
+};
+
+export const DotBadge: Story = {
+  render: () => (
+    <Tabs aria-label="Dot badge tabs" defaultSelectedKey="updates">
+      <TabList>
+        <Tab id="updates" label="Updates" badge={true} />
+        <Tab id="messages" label="Messages" badge={true} />
+        <Tab id="settings" label="Settings" />
+      </TabList>
+      <TabPanel id="updates">
+        <p className="p-4">New updates available</p>
+      </TabPanel>
+      <TabPanel id="messages">
+        <p className="p-4">New messages</p>
+      </TabPanel>
+      <TabPanel id="settings">
+        <p className="p-4">Settings content</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Dot badge (`badge={true}`): a small indicator that something is new, without showing a count.",
+      },
+    },
+  },
+};
+
+export const BadgeWithIcons: Story = {
+  render: () => (
+    <Tabs aria-label="Badge with icons tabs" defaultSelectedKey="photos">
+      <TabList>
+        <Tab id="photos" icon={<IconPhoto />} label="Photos" badge={3} />
+        <Tab id="favorites" icon={<IconFavorite />} label="Favorites" badge={true} />
+        <Tab id="settings" icon={<IconSettings />} label="Settings" />
+      </TabList>
+      <TabPanel id="photos">
+        <p className="p-4">3 new photos</p>
+      </TabPanel>
+      <TabPanel id="favorites">
+        <p className="p-4">New favorites</p>
+      </TabPanel>
+      <TabPanel id="settings">
+        <p className="p-4">Settings</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Badges with icon+label content mode. Badge appears on the icon.",
+      },
+    },
+  },
+};
+
+// ─── Disabled ─────────────────────────────────────────────────────────────────
+
+export const DisabledTab: Story = {
+  render: () => (
+    <Tabs aria-label="Tabs with disabled" defaultSelectedKey="photos">
+      <TabList>
+        <Tab id="photos" label="Photos" />
+        <Tab id="music" label="Music" isDisabled />
+        <Tab id="videos" label="Videos" />
+      </TabList>
+      <TabPanel id="photos">
+        <p className="p-4">Photos content</p>
+      </TabPanel>
+      <TabPanel id="music">
+        <p className="p-4">Music content (disabled)</p>
+      </TabPanel>
+      <TabPanel id="videos">
+        <p className="p-4">Videos content</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Disabled tabs are visually de-emphasized (opacity-38), not focusable, and skipped during keyboard navigation.",
+      },
+    },
+  },
+};
+
+// ─── Controlled ───────────────────────────────────────────────────────────────
+
+const ControlledExample = (): React.ReactElement => {
+  const [selected, setSelected] = useState<React.Key>("photos");
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        <span className="text-on-surface-variant text-sm">Selected (from state):</span>
+        <code className="text-primary font-mono text-sm">{String(selected)}</code>
+      </div>
+      <Tabs aria-label="Controlled tabs" selectedKey={selected} onSelectionChange={setSelected}>
+        <TabList>
+          <Tab id="photos" label="Photos" />
+          <Tab id="music" label="Music" />
+          <Tab id="videos" label="Videos" />
+        </TabList>
+        <TabPanel id="photos">
+          <p className="p-4">Photos content</p>
+        </TabPanel>
+        <TabPanel id="music">
+          <p className="p-4">Music content</p>
+        </TabPanel>
+        <TabPanel id="videos">
+          <p className="p-4">Videos content</p>
+        </TabPanel>
+      </Tabs>
+      <div className="flex gap-2">
+        {["photos", "music", "videos"].map((key) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setSelected(key)}
+            className="rounded border px-3 py-1 text-sm capitalize"
+          >
+            Select {key}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const Controlled: Story = {
+  render: () => <ControlledExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Controlled mode: `selectedKey` and `onSelectionChange` are managed by the parent. Use the buttons below to change the selection externally.",
+      },
+    },
+  },
+};
+
+// ─── Kitchen sink ─────────────────────────────────────────────────────────────
+
+export const KitchenSink: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <div>
+        <p className="text-on-surface-variant mb-1 text-sm font-medium">
+          Primary · Fixed · Icon+Label · Badges
+        </p>
+        <Tabs
+          aria-label="Kitchen sink primary"
+          defaultSelectedKey="photos"
+          variant="primary"
+          layout="fixed"
+        >
+          <TabList>
+            <Tab id="photos" icon={<IconPhoto />} label="Photos" badge={3} />
+            <Tab id="music" icon={<IconMusic />} label="Music" badge={true} />
+            <Tab id="videos" icon={<IconVideo />} label="Videos" isDisabled />
+            <Tab id="favorites" icon={<IconFavorite />} label="Favorites" />
+          </TabList>
+          <TabPanel id="photos">
+            <p className="p-4">3 new photos</p>
+          </TabPanel>
+          <TabPanel id="music">
+            <p className="p-4">New music</p>
+          </TabPanel>
+          <TabPanel id="videos">
+            <p className="p-4">Videos (disabled)</p>
+          </TabPanel>
+          <TabPanel id="favorites">
+            <p className="p-4">Favorites</p>
+          </TabPanel>
+        </Tabs>
+      </div>
+      <div>
+        <p className="text-on-surface-variant mb-1 text-sm font-medium">
+          Secondary · Scrollable · Label only
+        </p>
+        <div className="w-72">
+          <Tabs
+            aria-label="Kitchen sink secondary"
+            defaultSelectedKey="a"
+            variant="secondary"
+            layout="scrollable"
+          >
+            <TabList>
+              <Tab id="a" label="Overview" />
+              <Tab id="b" label="Details" />
+              <Tab id="c" label="Reviews" badge={12} />
+              <Tab id="d" label="Related" />
+              <Tab id="e" label="Questions" badge={5} />
+              <Tab id="f" label="Share" />
+            </TabList>
+            <TabPanel id="a">
+              <p className="p-4">Overview</p>
+            </TabPanel>
+            <TabPanel id="b">
+              <p className="p-4">Details</p>
+            </TabPanel>
+            <TabPanel id="c">
+              <p className="p-4">12 Reviews</p>
+            </TabPanel>
+            <TabPanel id="d">
+              <p className="p-4">Related items</p>
+            </TabPanel>
+            <TabPanel id="e">
+              <p className="p-4">5 Questions</p>
+            </TabPanel>
+            <TabPanel id="f">
+              <p className="p-4">Share</p>
+            </TabPanel>
+          </Tabs>
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Playground ───────────────────────────────────────────────────────────────
+
+export const Playground: Story = {
+  render: (args) => (
+    <Tabs {...args} aria-label="Playground tabs" defaultSelectedKey="tab1">
+      <TabList>
+        <Tab id="tab1" icon={<IconPhoto />} label="Tab One" />
+        <Tab id="tab2" icon={<IconMusic />} label="Tab Two" />
+        <Tab id="tab3" icon={<IconVideo />} label="Tab Three" />
+      </TabList>
+      <TabPanel id="tab1">
+        <p className="p-4">Content for Tab One</p>
+      </TabPanel>
+      <TabPanel id="tab2">
+        <p className="p-4">Content for Tab Two</p>
+      </TabPanel>
+      <TabPanel id="tab3">
+        <p className="p-4">Content for Tab Three</p>
+      </TabPanel>
+    </Tabs>
+  ),
+  args: {
+    variant: "primary",
+    layout: "fixed",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Interactive playground — use the controls to switch between variant and layout options.",
+      },
+    },
+  },
+};

--- a/packages/react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/react/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,741 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import type React from "react";
+import { Tabs } from "./Tabs";
+import { TabList } from "./TabList";
+import { Tab } from "./Tab";
+import { TabPanel } from "./TabPanel";
+import {
+  HeadlessTabList,
+  HeadlessTab,
+  HeadlessTabPanel,
+  HeadlessTabsContext,
+} from "./TabsHeadless";
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+const PhotoIcon = () => <svg aria-hidden="true" data-testid="photo-icon" />;
+const MusicIcon = () => <svg aria-hidden="true" data-testid="music-icon" />;
+
+function BasicTabs({
+  selectedKey,
+  defaultSelectedKey,
+  onSelectionChange,
+  variant,
+  layout,
+}: {
+  selectedKey?: string;
+  defaultSelectedKey?: string;
+  onSelectionChange?: (key: React.Key) => void;
+  variant?: "primary" | "secondary";
+  layout?: "fixed" | "scrollable";
+}) {
+  return (
+    <Tabs
+      aria-label="Test tabs"
+      selectedKey={selectedKey}
+      defaultSelectedKey={defaultSelectedKey}
+      onSelectionChange={onSelectionChange}
+      variant={variant}
+      layout={layout}
+    >
+      <TabList>
+        <Tab id="photos" label="Photos" />
+        <Tab id="music" label="Music" />
+        <Tab id="videos" label="Videos" />
+      </TabList>
+      <TabPanel id="photos">Photos content</TabPanel>
+      <TabPanel id="music">Music content</TabPanel>
+      <TabPanel id="videos">Videos content</TabPanel>
+    </Tabs>
+  );
+}
+
+// ─── Rendering ───────────────────────────────────────────────────────────────
+
+describe("Tabs", () => {
+  describe("Rendering", () => {
+    test("renders a tablist with role='tablist'", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      expect(screen.getByRole("tablist")).toBeInTheDocument();
+    });
+
+    test("renders tabs with role='tab'", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs).toHaveLength(3);
+    });
+
+    test("renders tab panels with role='tabpanel'", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      // Only the selected panel should be visible; others may be hidden
+      const panel = screen.getByRole("tabpanel");
+      expect(panel).toBeInTheDocument();
+    });
+
+    test("renders tab labels", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      expect(screen.getByRole("tab", { name: "Photos" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Music" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Videos" })).toBeInTheDocument();
+    });
+
+    test("renders icon-only tab", () => {
+      render(
+        <Tabs aria-label="Icon tabs" defaultSelectedKey="photos">
+          <TabList>
+            <Tab id="photos" icon={<PhotoIcon />} aria-label="Photos" />
+            <Tab id="music" icon={<MusicIcon />} aria-label="Music" />
+          </TabList>
+          <TabPanel id="photos">Photos</TabPanel>
+          <TabPanel id="music">Music</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByTestId("photo-icon")).toBeInTheDocument();
+      expect(screen.getByTestId("music-icon")).toBeInTheDocument();
+    });
+
+    test("renders icon + label tab", () => {
+      render(
+        <Tabs aria-label="Icon label tabs" defaultSelectedKey="photos">
+          <TabList>
+            <Tab id="photos" icon={<PhotoIcon />} label="Photos" />
+          </TabList>
+          <TabPanel id="photos">Photos</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByTestId("photo-icon")).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Photos" })).toBeInTheDocument();
+    });
+
+    test("applies custom className to tabs wrapper", () => {
+      const { container } = render(
+        <Tabs aria-label="Test" defaultSelectedKey="a" className="custom-tabs">
+          <TabList>
+            <Tab id="a" label="A" />
+          </TabList>
+          <TabPanel id="a">A</TabPanel>
+        </Tabs>
+      );
+      expect(container.firstChild).toHaveClass("custom-tabs");
+    });
+
+    test("applies custom className to TabList", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="a">
+          <TabList className="custom-tablist">
+            <Tab id="a" label="A" />
+          </TabList>
+          <TabPanel id="a">A</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByRole("tablist")).toHaveClass("custom-tablist");
+    });
+
+    test("applies custom className to Tab", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" label="A" className="custom-tab" />
+          </TabList>
+          <TabPanel id="a">A</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByRole("tab", { name: "A" })).toHaveClass("custom-tab");
+    });
+
+    test("applies custom className to TabPanel", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" label="A" />
+          </TabList>
+          <TabPanel id="a" className="custom-panel">
+            A
+          </TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByRole("tabpanel")).toHaveClass("custom-panel");
+    });
+  });
+
+  // ─── Selection State ───────────────────────────────────────────────────────
+
+  describe("Selection", () => {
+    test("shows first tab panel by default when defaultSelectedKey is set", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      expect(screen.getByRole("tabpanel")).toHaveTextContent("Photos content");
+    });
+
+    test("selected tab has aria-selected='true'", () => {
+      render(<BasicTabs defaultSelectedKey="music" />);
+      expect(screen.getByRole("tab", { name: "Music" })).toHaveAttribute("aria-selected", "true");
+    });
+
+    test("non-selected tabs have aria-selected='false'", () => {
+      render(<BasicTabs defaultSelectedKey="music" />);
+      expect(screen.getByRole("tab", { name: "Photos" })).toHaveAttribute("aria-selected", "false");
+      expect(screen.getByRole("tab", { name: "Videos" })).toHaveAttribute("aria-selected", "false");
+    });
+
+    test("clicking a tab changes selection (uncontrolled)", async () => {
+      const user = userEvent.setup();
+      render(<BasicTabs defaultSelectedKey="photos" />);
+
+      await user.click(screen.getByRole("tab", { name: "Music" }));
+
+      expect(screen.getByRole("tab", { name: "Music" })).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByRole("tabpanel")).toHaveTextContent("Music content");
+    });
+
+    test("calls onSelectionChange when tab is clicked", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<BasicTabs defaultSelectedKey="photos" onSelectionChange={handleChange} />);
+
+      await user.click(screen.getByRole("tab", { name: "Videos" }));
+
+      expect(handleChange).toHaveBeenCalledWith("videos");
+    });
+
+    test("controlled: respects selectedKey prop", () => {
+      render(<BasicTabs selectedKey="videos" />);
+      expect(screen.getByRole("tab", { name: "Videos" })).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByRole("tabpanel")).toHaveTextContent("Videos content");
+    });
+
+    test("controlled: does not change selection without onSelectionChange updating prop", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<BasicTabs selectedKey="photos" onSelectionChange={handleChange} />);
+
+      await user.click(screen.getByRole("tab", { name: "Music" }));
+
+      // Since controlled, the selection stays unless prop is updated
+      expect(handleChange).toHaveBeenCalledWith("music");
+      // But the visual selection is still 'photos' (controlled, not updated)
+      expect(screen.getByRole("tab", { name: "Photos" })).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  // ─── Keyboard Navigation ──────────────────────────────────────────────────
+
+  describe("Keyboard navigation", () => {
+    test("ArrowRight moves focus to next tab", async () => {
+      const user = userEvent.setup();
+      render(<BasicTabs defaultSelectedKey="photos" />);
+
+      const photosTab = screen.getByRole("tab", { name: "Photos" });
+      photosTab.focus();
+      await user.keyboard("{ArrowRight}");
+
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Music" }));
+    });
+
+    test("ArrowLeft moves focus to previous tab", async () => {
+      const user = userEvent.setup();
+      render(<BasicTabs defaultSelectedKey="music" />);
+
+      const musicTab = screen.getByRole("tab", { name: "Music" });
+      musicTab.focus();
+      await user.keyboard("{ArrowLeft}");
+
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Photos" }));
+    });
+
+    test("ArrowRight wraps from last to first tab", async () => {
+      const user = userEvent.setup();
+      render(<BasicTabs defaultSelectedKey="videos" />);
+
+      const videosTab = screen.getByRole("tab", { name: "Videos" });
+      videosTab.focus();
+      await user.keyboard("{ArrowRight}");
+
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Photos" }));
+    });
+
+    test("ArrowLeft wraps from first to last tab", async () => {
+      const user = userEvent.setup();
+      render(<BasicTabs defaultSelectedKey="photos" />);
+
+      const photosTab = screen.getByRole("tab", { name: "Photos" });
+      photosTab.focus();
+      await user.keyboard("{ArrowLeft}");
+
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Videos" }));
+    });
+
+    test("Home key moves focus to first tab", async () => {
+      const user = userEvent.setup();
+      render(<BasicTabs defaultSelectedKey="videos" />);
+
+      const videosTab = screen.getByRole("tab", { name: "Videos" });
+      videosTab.focus();
+      await user.keyboard("{Home}");
+
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Photos" }));
+    });
+
+    test("End key moves focus to last tab", async () => {
+      const user = userEvent.setup();
+      render(<BasicTabs defaultSelectedKey="photos" />);
+
+      const photosTab = screen.getByRole("tab", { name: "Photos" });
+      photosTab.focus();
+      await user.keyboard("{End}");
+
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Videos" }));
+    });
+
+    test("Enter key selects focused tab", async () => {
+      const user = userEvent.setup();
+      render(<BasicTabs defaultSelectedKey="photos" />);
+
+      const photosTab = screen.getByRole("tab", { name: "Photos" });
+      photosTab.focus();
+      await user.keyboard("{ArrowRight}{Enter}");
+
+      expect(screen.getByRole("tab", { name: "Music" })).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  // ─── Accessibility ─────────────────────────────────────────────────────────
+
+  describe("Accessibility", () => {
+    test("tab has aria-controls pointing to its panel", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      const photosTab = screen.getByRole("tab", { name: "Photos" });
+      const ariaControls = photosTab.getAttribute("aria-controls");
+      expect(ariaControls).toBeTruthy();
+
+      const panel = document.getElementById(ariaControls!);
+      expect(panel).toBeInTheDocument();
+      expect(panel).toHaveTextContent("Photos content");
+    });
+
+    test("panel has aria-labelledby pointing to its tab", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      const panel = screen.getByRole("tabpanel");
+      const ariaLabelledBy = panel.getAttribute("aria-labelledby");
+      expect(ariaLabelledBy).toBeTruthy();
+
+      const tab = document.getElementById(ariaLabelledBy!);
+      expect(tab).toBeInTheDocument();
+      expect(tab).toHaveTextContent("Photos");
+    });
+
+    test("tablist has accessible label from aria-label", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      expect(screen.getByRole("tablist", { name: "Test tabs" })).toBeInTheDocument();
+    });
+
+    test("tablist has accessible label from aria-labelledby", () => {
+      render(
+        <div>
+          <h2 id="tabs-heading">My Tabs</h2>
+          <Tabs aria-labelledby="tabs-heading" defaultSelectedKey="photos">
+            <TabList>
+              <Tab id="photos" label="Photos" />
+            </TabList>
+            <TabPanel id="photos">Photos</TabPanel>
+          </Tabs>
+        </div>
+      );
+      expect(screen.getByRole("tablist", { name: "My Tabs" })).toBeInTheDocument();
+    });
+
+    test("passes axe accessibility audit (primary)", async () => {
+      const { container } = render(<BasicTabs defaultSelectedKey="photos" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("passes axe accessibility audit (secondary)", async () => {
+      const { container } = render(<BasicTabs defaultSelectedKey="photos" variant="secondary" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("passes axe accessibility audit (scrollable)", async () => {
+      const { container } = render(<BasicTabs defaultSelectedKey="photos" layout="scrollable" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("selected tab has tabindex='0', others have tabindex='-1' (roving tabIndex)", () => {
+      render(<BasicTabs defaultSelectedKey="music" />);
+      expect(screen.getByRole("tab", { name: "Music" })).toHaveAttribute("tabindex", "0");
+      expect(screen.getByRole("tab", { name: "Photos" })).toHaveAttribute("tabindex", "-1");
+      expect(screen.getByRole("tab", { name: "Videos" })).toHaveAttribute("tabindex", "-1");
+    });
+  });
+
+  // ─── Variants ─────────────────────────────────────────────────────────────
+
+  describe("Variants", () => {
+    test("primary variant: selected tab has text-primary class", () => {
+      render(<BasicTabs defaultSelectedKey="photos" variant="primary" />);
+      expect(screen.getByRole("tab", { name: "Photos" })).toHaveClass("text-primary");
+    });
+
+    test("secondary variant: selected tab has text-on-surface class", () => {
+      render(<BasicTabs defaultSelectedKey="photos" variant="secondary" />);
+      expect(screen.getByRole("tab", { name: "Photos" })).toHaveClass("text-on-surface");
+    });
+
+    test("unselected tab has text-on-surface-variant class for both variants", () => {
+      const { rerender } = render(<BasicTabs defaultSelectedKey="photos" variant="primary" />);
+      expect(screen.getByRole("tab", { name: "Music" })).toHaveClass("text-on-surface-variant");
+
+      rerender(
+        <Tabs aria-label="Test tabs" defaultSelectedKey="photos" variant="secondary">
+          <TabList>
+            <Tab id="photos" label="Photos" />
+            <Tab id="music" label="Music" />
+            <Tab id="videos" label="Videos" />
+          </TabList>
+          <TabPanel id="photos">Photos content</TabPanel>
+          <TabPanel id="music">Music content</TabPanel>
+          <TabPanel id="videos">Videos content</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByRole("tab", { name: "Music" })).toHaveClass("text-on-surface-variant");
+    });
+  });
+
+  // ─── Layout ───────────────────────────────────────────────────────────────
+
+  describe("Layout", () => {
+    test("fixed layout: tabs have flex-1 class", () => {
+      render(<BasicTabs defaultSelectedKey="photos" layout="fixed" />);
+      const tabs = screen.getAllByRole("tab");
+      tabs.forEach((tab) => {
+        expect(tab).toHaveClass("flex-1");
+      });
+    });
+
+    test("scrollable layout: tablist has overflow-x-auto class", () => {
+      render(<BasicTabs defaultSelectedKey="photos" layout="scrollable" />);
+      expect(screen.getByRole("tablist")).toHaveClass("overflow-x-auto");
+    });
+
+    test("scrollable layout: tabs have min-w and shrink-0 classes", () => {
+      render(<BasicTabs defaultSelectedKey="photos" layout="scrollable" />);
+      const tabs = screen.getAllByRole("tab");
+      tabs.forEach((tab) => {
+        expect(tab).toHaveClass("shrink-0");
+      });
+    });
+  });
+
+  // ─── Disabled State ───────────────────────────────────────────────────────
+
+  describe("Disabled", () => {
+    test("disabled tab has aria-disabled='true'", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="photos">
+          <TabList>
+            <Tab id="photos" label="Photos" />
+            <Tab id="music" label="Music" isDisabled />
+          </TabList>
+          <TabPanel id="photos">Photos</TabPanel>
+          <TabPanel id="music">Music</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByRole("tab", { name: "Music" })).toHaveAttribute("aria-disabled", "true");
+    });
+
+    test("disabled tab cannot be selected by clicking", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="photos" onSelectionChange={handleChange}>
+          <TabList>
+            <Tab id="photos" label="Photos" />
+            <Tab id="music" label="Music" isDisabled />
+          </TabList>
+          <TabPanel id="photos">Photos</TabPanel>
+          <TabPanel id="music">Music</TabPanel>
+        </Tabs>
+      );
+
+      await user.click(screen.getByRole("tab", { name: "Music" }));
+      expect(handleChange).not.toHaveBeenCalledWith("music");
+    });
+
+    test("disabled tab is skipped by keyboard navigation", async () => {
+      const user = userEvent.setup();
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="photos">
+          <TabList>
+            <Tab id="photos" label="Photos" />
+            <Tab id="music" label="Music" isDisabled />
+            <Tab id="videos" label="Videos" />
+          </TabList>
+          <TabPanel id="photos">Photos</TabPanel>
+          <TabPanel id="music">Music</TabPanel>
+          <TabPanel id="videos">Videos</TabPanel>
+        </Tabs>
+      );
+
+      const photosTab = screen.getByRole("tab", { name: "Photos" });
+      photosTab.focus();
+      await user.keyboard("{ArrowRight}");
+
+      // Should skip the disabled Music tab and land on Videos
+      expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Videos" }));
+    });
+
+    test("disabled tab has opacity-38 class", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="photos">
+          <TabList>
+            <Tab id="photos" label="Photos" />
+            <Tab id="music" label="Music" isDisabled />
+          </TabList>
+          <TabPanel id="photos">Photos</TabPanel>
+          <TabPanel id="music">Music</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByRole("tab", { name: "Music" })).toHaveClass("opacity-38");
+    });
+  });
+
+  // ─── Badge ────────────────────────────────────────────────────────────────
+
+  describe("Badge", () => {
+    test("renders numeric badge on tab", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" label="Messages" badge={5} />
+          </TabList>
+          <TabPanel id="a">Messages</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByText("5")).toBeInTheDocument();
+    });
+
+    test("truncates badge count > 999 to '999+'", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" label="Notifications" badge={1234} />
+          </TabList>
+          <TabPanel id="a">Notifications</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByText("999+")).toBeInTheDocument();
+    });
+
+    test("does not render badge when count is 0", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" label="Messages" badge={0} />
+          </TabList>
+          <TabPanel id="a">Messages</TabPanel>
+        </Tabs>
+      );
+      // No badge element should be visible
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    test("renders dot badge when badge=true", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" label="Updates" badge={true} data-testid="dot-badge-tab" />
+          </TabList>
+          <TabPanel id="a">Updates</TabPanel>
+        </Tabs>
+      );
+      // Dot badge should be present (no text)
+      const tab = screen.getByRole("tab", { name: "Updates" });
+      const dotBadge = tab.querySelector("[data-badge-type='dot']");
+      expect(dotBadge).toBeInTheDocument();
+    });
+  });
+
+  // ─── Ripple ───────────────────────────────────────────────────────────────
+
+  describe("Ripple", () => {
+    test("renders ripple container on tab items", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      const tabs = screen.getAllByRole("tab");
+      tabs.forEach((tab) => {
+        expect(tab.querySelector("[data-ripple-container]")).toBeInTheDocument();
+      });
+    });
+
+    test("does not render ripple when disableRipple is true", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" label="A" disableRipple />
+          </TabList>
+          <TabPanel id="a">A</TabPanel>
+        </Tabs>
+      );
+      const tab = screen.getByRole("tab", { name: "A" });
+      expect(tab.querySelector("[data-ripple-container]")).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Active Indicator ─────────────────────────────────────────────────────
+
+  describe("Active indicator", () => {
+    test("renders an active indicator element inside the tablist", () => {
+      render(<BasicTabs defaultSelectedKey="photos" />);
+      const tablist = screen.getByRole("tablist");
+      const indicator = tablist.querySelector("[data-tab-indicator]");
+      expect(indicator).toBeInTheDocument();
+    });
+
+    test("primary indicator has bg-primary class", () => {
+      render(<BasicTabs defaultSelectedKey="photos" variant="primary" />);
+      const tablist = screen.getByRole("tablist");
+      const indicator = tablist.querySelector("[data-tab-indicator]");
+      expect(indicator).toHaveClass("bg-primary");
+    });
+
+    test("secondary indicator has bg-on-surface-variant class", () => {
+      render(<BasicTabs defaultSelectedKey="photos" variant="secondary" />);
+      const tablist = screen.getByRole("tablist");
+      const indicator = tablist.querySelector("[data-tab-indicator]");
+      expect(indicator).toHaveClass("bg-on-surface-variant");
+    });
+  });
+
+  // ─── Headless Primitives ──────────────────────────────────────────────────
+
+  describe("Headless primitives", () => {
+    test("HeadlessTabList renders with role='tablist'", () => {
+      // This test verifies the headless layer is exposed for advanced consumers.
+      // We use a minimal render to check the API surface.
+      const { container } = render(
+        <Tabs aria-label="Test" defaultSelectedKey="a">
+          <TabList>
+            <Tab id="a" label="A" />
+          </TabList>
+          <TabPanel id="a">A</TabPanel>
+        </Tabs>
+      );
+      expect(container.querySelector('[role="tablist"]')).toBeInTheDocument();
+    });
+
+    test("HeadlessTabsContext is exported", () => {
+      expect(HeadlessTabsContext).toBeDefined();
+    });
+
+    test("HeadlessTabList is exported and usable", () => {
+      expect(HeadlessTabList).toBeDefined();
+    });
+
+    test("HeadlessTab is exported and usable", () => {
+      expect(HeadlessTab).toBeDefined();
+    });
+
+    test("HeadlessTabPanel is exported and usable", () => {
+      expect(HeadlessTabPanel).toBeDefined();
+    });
+
+    test("HeadlessTabList renders a tablist with tabs inside Tabs wrapper", () => {
+      render(
+        <Tabs aria-label="Headless test" defaultSelectedKey="x">
+          <HeadlessTabList>
+            <HeadlessTab item={{ key: "x", id: "x" }}>
+              {({ isSelected }) => <span>{isSelected ? "X (selected)" : "X"}</span>}
+            </HeadlessTab>
+            <HeadlessTab item={{ key: "y", id: "y" }}>
+              {({ isSelected }) => <span>{isSelected ? "Y (selected)" : "Y"}</span>}
+            </HeadlessTab>
+          </HeadlessTabList>
+          <HeadlessTabPanel>Panel content</HeadlessTabPanel>
+        </Tabs>
+      );
+      expect(screen.getByRole("tablist")).toBeInTheDocument();
+      expect(screen.getAllByRole("tab")).toHaveLength(2);
+      expect(screen.getByRole("tabpanel")).toBeInTheDocument();
+    });
+
+    test("HeadlessTab selected state is reflected in aria-selected", () => {
+      render(
+        <Tabs aria-label="Headless test" defaultSelectedKey="x">
+          <HeadlessTabList>
+            <HeadlessTab item={{ key: "x", id: "x" }}>X</HeadlessTab>
+            <HeadlessTab item={{ key: "y", id: "y" }}>Y</HeadlessTab>
+          </HeadlessTabList>
+          <HeadlessTabPanel>Content</HeadlessTabPanel>
+        </Tabs>
+      );
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+      expect(tabs[1]).toHaveAttribute("aria-selected", "false");
+    });
+  });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────────
+
+  // ─── Error handling ───────────────────────────────────────────────────────
+
+  describe("Error handling", () => {
+    test("Tab throws when used outside Tabs context", () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      expect(() => {
+        render(<Tab id="test" label="Test" />);
+      }).toThrow();
+      consoleError.mockRestore();
+    });
+
+    test("TabList throws when used outside Tabs context", () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      expect(() => {
+        render(
+          <TabList>
+            <Tab id="a" label="A" />
+          </TabList>
+        );
+      }).toThrow();
+      consoleError.mockRestore();
+    });
+  });
+
+  describe("Edge cases", () => {
+    test("renders single tab correctly", () => {
+      render(
+        <Tabs aria-label="Test" defaultSelectedKey="only">
+          <TabList>
+            <Tab id="only" label="Only" />
+          </TabList>
+          <TabPanel id="only">Content</TabPanel>
+        </Tabs>
+      );
+      expect(screen.getByRole("tab", { name: "Only" })).toHaveAttribute("aria-selected", "true");
+    });
+
+    test("renders many tabs without error", () => {
+      const tabItems = Array.from({ length: 10 }, (_, i) => ({
+        id: `tab-${i}`,
+        label: `Tab ${i + 1}`,
+      }));
+      render(
+        <Tabs aria-label="Many tabs" defaultSelectedKey="tab-0">
+          <TabList>
+            {tabItems.map((t) => (
+              <Tab key={t.id} id={t.id} label={t.label} />
+            ))}
+          </TabList>
+          {tabItems.map((t) => (
+            <TabPanel key={t.id} id={t.id}>
+              Content {t.id}
+            </TabPanel>
+          ))}
+        </Tabs>
+      );
+      expect(screen.getAllByRole("tab")).toHaveLength(10);
+    });
+  });
+});

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { createContext, forwardRef, useContext, useMemo, Children, isValidElement } from "react";
+import type React from "react";
+import { Item } from "react-stately";
+import { useTabListState } from "react-stately";
+import { cn } from "../../utils/cn";
+import { HeadlessTabsContext } from "./TabsHeadless";
+import type {
+  TabsProps,
+  TabsContextValue,
+  TabVariant,
+  TabLayout,
+  TabProps,
+  TabItem,
+} from "./Tabs.types";
+import type { Key } from "react-stately";
+
+/**
+ * Context providing MD3 styling context (variant, layout) to Tab, TabList, TabPanel
+ */
+export const TabsContext = createContext<TabsContextValue | null>(null);
+
+/**
+ * Hook to consume the tabs styling context
+ * @internal
+ */
+export function useTabsContext(): TabsContextValue {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error("Component must be used within a Tabs component");
+  }
+  return context;
+}
+
+/**
+ * Resolves a React component's display name safely.
+ * Handles both regular function components and exotic components (forwardRef, memo, etc.)
+ * where `typeof component` is "object", not "function".
+ */
+function getComponentName(type: unknown): string {
+  if (typeof type === "string") return type;
+  // forwardRef / memo return exotic objects — check displayName/name on the object itself
+  const exotic = type as { displayName?: string; name?: string };
+  return exotic.displayName ?? exotic.name ?? "";
+}
+
+/**
+ * Extracts Tab props from the children tree (TabList > Tab children)
+ * Used to build the React Aria collection for state management
+ */
+function extractTabItemsFromChildren(children: React.ReactNode): Array<{
+  key: Key;
+  label?: string;
+  icon?: React.ReactNode;
+  isDisabled?: boolean;
+  "aria-label"?: string;
+}> {
+  const items: Array<{
+    key: Key;
+    label?: string;
+    icon?: React.ReactNode;
+    isDisabled?: boolean;
+    "aria-label"?: string;
+  }> = [];
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+
+    if (getComponentName(child.type) === "TabList") {
+      // Extract Tab children from the TabList
+      const tabListProps = child.props as { children?: React.ReactNode };
+      Children.forEach(tabListProps.children, (tabChild) => {
+        if (!isValidElement(tabChild)) return;
+
+        if (getComponentName(tabChild.type) === "Tab") {
+          const tabProps = tabChild.props as TabProps & { "aria-label"?: string };
+          // Conditionally include optional properties to satisfy exactOptionalPropertyTypes.
+          // Passing undefined explicitly would violate the strict optional type constraint.
+          items.push({
+            key: tabProps.id,
+            ...(tabProps.label !== undefined && { label: tabProps.label }),
+            ...(tabProps.icon !== undefined && { icon: tabProps.icon }),
+            ...(tabProps.isDisabled !== undefined && { isDisabled: tabProps.isDisabled }),
+            ...(tabProps["aria-label"] !== undefined && { "aria-label": tabProps["aria-label"] }),
+          });
+        }
+      });
+    }
+  });
+
+  return items;
+}
+
+/**
+ * Material Design 3 Tabs Component (Layer 3: Styled Wrapper)
+ *
+ * The Tabs component manages shared selected state via useTabListState (React Aria + Stately),
+ * and provides this state to all child TabList, Tab, and TabPanel components via context.
+ *
+ * Architecture:
+ * 1. Extracts Tab metadata from children to build the React Aria collection
+ * 2. Creates tab list state with useTabListState
+ * 3. Provides React Aria state via HeadlessTabsContext
+ * 4. Provides MD3 styling context via TabsContext
+ *
+ * Features:
+ * - ✅ Controlled and uncontrolled selection
+ * - ✅ Primary and secondary variants
+ * - ✅ Fixed and scrollable layouts
+ * - ✅ Full keyboard navigation (via React Aria)
+ * - ✅ WCAG 2.1 AA compliant
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled
+ * <Tabs defaultSelectedKey="tab1" aria-label="Settings">
+ *   <TabList>
+ *     <Tab id="tab1" label="General" />
+ *     <Tab id="tab2" label="Privacy" />
+ *   </TabList>
+ *   <TabPanel id="tab1">General content</TabPanel>
+ *   <TabPanel id="tab2">Privacy content</TabPanel>
+ * </Tabs>
+ *
+ * // Controlled
+ * <Tabs selectedKey={tab} onSelectionChange={setTab} aria-label="App">
+ *   <TabList variant="secondary">
+ *     <Tab id="overview" label="Overview" />
+ *     <Tab id="details" label="Details" />
+ *   </TabList>
+ *   <TabPanel id="overview">Overview</TabPanel>
+ *   <TabPanel id="details">Details</TabPanel>
+ * </Tabs>
+ * ```
+ */
+export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
+  (
+    {
+      selectedKey,
+      defaultSelectedKey,
+      onSelectionChange,
+      variant = "primary",
+      layout = "fixed",
+      children,
+      className,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
+    },
+    ref
+  ) => {
+    // Extract tab items from children tree to build the React Aria collection
+    const tabItems = useMemo(() => extractTabItemsFromChildren(children), [children]);
+
+    // Create React Aria tab list state with Item-based collection.
+    // ARIA label props (aria-label / aria-labelledby) are NOT part of TabListStateOptions —
+    // they belong to useTabList (the React Aria hook in TabList.tsx).
+    // Conditionally spread optional props to satisfy exactOptionalPropertyTypes: passing
+    // undefined explicitly would violate the strict optional type constraint.
+    const state = useTabListState<TabItem>({
+      ...(selectedKey !== undefined && { selectedKey }),
+      ...(defaultSelectedKey !== undefined && { defaultSelectedKey }),
+      ...(onSelectionChange !== undefined && { onSelectionChange }),
+      disabledKeys: tabItems.filter((t) => t.isDisabled).map((t) => t.key),
+      children: tabItems.map((item) => (
+        <Item key={item.key} textValue={item.label ?? item["aria-label"] ?? String(item.key)}>
+          {item.label ?? item["aria-label"] ?? ""}
+        </Item>
+      )),
+    });
+
+    // MD3 styling context — conditionally include ARIA label props (exactOptionalPropertyTypes)
+    const tabsContextValue = useMemo<TabsContextValue>(
+      () => ({
+        selectedKey: state.selectedKey,
+        variant,
+        layout,
+        disabledKeys: tabItems.filter((t) => t.isDisabled).map((t) => t.key),
+        ...(ariaLabel !== undefined && { "aria-label": ariaLabel }),
+        ...(ariaLabelledBy !== undefined && { "aria-labelledby": ariaLabelledBy }),
+      }),
+      [state.selectedKey, variant, layout, tabItems, ariaLabel, ariaLabelledBy]
+    );
+
+    // Headless context providing React Aria state
+    const headlessContextValue = useMemo(() => ({ state }), [state]);
+
+    return (
+      <HeadlessTabsContext.Provider value={headlessContextValue}>
+        <TabsContext.Provider value={tabsContextValue}>
+          <div ref={ref} className={cn("flex flex-col", className)}>
+            {children}
+          </div>
+        </TabsContext.Provider>
+      </HeadlessTabsContext.Provider>
+    );
+  }
+);
+
+Tabs.displayName = "Tabs";
+
+// Export context helpers for use by child components
+export type { TabVariant, TabLayout };

--- a/packages/react/src/components/Tabs/Tabs.types.ts
+++ b/packages/react/src/components/Tabs/Tabs.types.ts
@@ -1,0 +1,360 @@
+import type React from "react";
+import type { AriaTabListProps, AriaTabProps, AriaTabPanelProps } from "react-aria";
+import type { Key, TabListState } from "react-stately";
+
+/**
+ * Tab variant following MD3 spec
+ * - primary: active indicator uses bg-primary; active text: text-primary
+ * - secondary: active indicator uses bg-on-surface-variant; active text: text-on-surface
+ */
+export type TabVariant = "primary" | "secondary";
+
+/**
+ * Tab layout mode
+ * - fixed: tabs fill available width equally
+ * - scrollable: tabs overflow horizontally with no wrapping
+ */
+export type TabLayout = "fixed" | "scrollable";
+
+/**
+ * Tab content mode (inferred from icon/label presence)
+ * - icon: icon prop only
+ * - label: label prop only
+ * - icon-label: both icon and label stacked
+ */
+export type TabContentMode = "icon" | "label" | "icon-label";
+
+/**
+ * Badge value for a tab item
+ * - number: displays count (999+ for values > 999, hidden for 0)
+ * - true: displays a dot indicator
+ * - false/undefined: no badge
+ */
+export type TabBadgeValue = number | boolean;
+
+/**
+ * Material Design 3 Tabs Wrapper Props
+ *
+ * The Tabs component manages shared state (selected key) and provides
+ * context to TabList and TabPanel children.
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled
+ * <Tabs defaultSelectedKey="tab1" aria-label="Settings tabs">
+ *   <TabList>
+ *     <Tab id="tab1" label="General" />
+ *     <Tab id="tab2" label="Privacy" />
+ *   </TabList>
+ *   <TabPanel id="tab1">General content</TabPanel>
+ *   <TabPanel id="tab2">Privacy content</TabPanel>
+ * </Tabs>
+ *
+ * // Controlled
+ * <Tabs selectedKey={selected} onSelectionChange={setSelected} aria-label="App tabs">
+ *   <TabList variant="secondary">
+ *     <Tab id="a" label="Overview" />
+ *     <Tab id="b" label="Details" />
+ *   </TabList>
+ *   <TabPanel id="a">Overview content</TabPanel>
+ *   <TabPanel id="b">Details content</TabPanel>
+ * </Tabs>
+ * ```
+ */
+export interface TabsProps {
+  /**
+   * Controlled selected tab key
+   */
+  selectedKey?: Key;
+
+  /**
+   * Default selected key for uncontrolled usage
+   */
+  defaultSelectedKey?: Key;
+
+  /**
+   * Callback when selected tab changes
+   */
+  onSelectionChange?: (key: Key) => void;
+
+  /**
+   * Tab variant — affects active indicator and label color
+   * @default 'primary'
+   */
+  variant?: TabVariant;
+
+  /**
+   * Layout mode
+   * @default 'fixed'
+   */
+  layout?: TabLayout;
+
+  /**
+   * TabList and TabPanel children
+   */
+  children: React.ReactNode;
+
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+
+  /**
+   * Accessible label for the tabs widget
+   */
+  "aria-label"?: string;
+
+  /**
+   * Accessible labelledby reference
+   */
+  "aria-labelledby"?: string;
+}
+
+/**
+ * Material Design 3 TabList Props
+ *
+ * Renders the tab row container with the active indicator.
+ * Must be a child of Tabs.
+ *
+ * @example
+ * ```tsx
+ * <TabList>
+ *   <Tab id="overview" label="Overview" />
+ *   <Tab id="activity" label="Activity" icon={<ActivityIcon />} />
+ * </TabList>
+ * ```
+ */
+export interface TabListProps {
+  /**
+   * Tab child elements
+   */
+  children: React.ReactNode;
+
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Material Design 3 Tab Props
+ *
+ * Represents a single tab item inside a TabList.
+ * Supports icon-only, label-only, and icon+label content modes.
+ *
+ * @example
+ * ```tsx
+ * // Label only
+ * <Tab id="overview" label="Overview" />
+ *
+ * // Icon + label
+ * <Tab id="media" icon={<PhotoIcon />} label="Media" />
+ *
+ * // With badge
+ * <Tab id="messages" label="Messages" badge={5} />
+ *
+ * // Dot badge
+ * <Tab id="notifications" label="Notifications" badge={true} />
+ *
+ * // Disabled
+ * <Tab id="archived" label="Archived" isDisabled />
+ * ```
+ */
+export interface TabProps {
+  /**
+   * Unique key identifying this tab (used to match with TabPanel)
+   */
+  id: Key;
+
+  /**
+   * Icon element displayed above or instead of the label
+   * Should be 24x24dp per MD3 Tabs spec
+   */
+  icon?: React.ReactNode;
+
+  /**
+   * Text label for the tab
+   */
+  label?: string;
+
+  /**
+   * Badge value
+   * - number: shows count (999+ for values > 999, hidden for 0)
+   * - true: shows dot indicator
+   */
+  badge?: TabBadgeValue;
+
+  /**
+   * Disables the tab (not focusable, not selectable)
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Disables ripple effect
+   * @default false
+   */
+  disableRipple?: boolean;
+
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Material Design 3 TabPanel Props
+ *
+ * Content area associated with a tab. Only the selected tab's panel is visible.
+ * The `id` must match the corresponding Tab's `id`.
+ *
+ * @example
+ * ```tsx
+ * <TabPanel id="overview">
+ *   <p>Overview content here</p>
+ * </TabPanel>
+ * ```
+ */
+export interface TabPanelProps {
+  /**
+   * Key matching the associated Tab's `id`
+   */
+  id: Key;
+
+  /**
+   * Panel content
+   */
+  children: React.ReactNode;
+
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Context value shared between Tabs, TabList, Tab, and TabPanel
+ */
+export interface TabsContextValue {
+  /**
+   * Currently selected tab key
+   */
+  selectedKey: Key | null;
+
+  /**
+   * Tab variant for styling
+   */
+  variant: TabVariant;
+
+  /**
+   * Layout mode
+   */
+  layout: TabLayout;
+
+  /**
+   * Disabled keys set
+   */
+  disabledKeys?: Iterable<Key>;
+
+  /**
+   * Accessible label for the tab list (aria-label)
+   */
+  "aria-label"?: string;
+
+  /**
+   * Accessible labelledby reference
+   */
+  "aria-labelledby"?: string;
+}
+
+// ============================================================
+// Headless Types
+// ============================================================
+
+/**
+ * Props for HeadlessTabList
+ * Extends AriaTabListProps for full React Aria accessibility support
+ */
+export interface HeadlessTabListProps extends Omit<AriaTabListProps<TabItem>, "children"> {
+  /**
+   * Tab item data for the collection
+   */
+  items: TabItem[];
+
+  /**
+   * Render function for each tab item
+   */
+  renderTab: (item: TabItem) => React.ReactNode;
+
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Internal tab item representation for React Aria collection
+ */
+export interface TabItem {
+  key: Key;
+  id: Key;
+  label?: string;
+  icon?: React.ReactNode;
+  badge?: TabBadgeValue;
+  isDisabled?: boolean;
+  textValue?: string;
+}
+
+/**
+ * Props for HeadlessTab
+ * Extends AriaTabProps for full React Aria accessibility support
+ */
+export interface HeadlessTabProps extends AriaTabProps {
+  /**
+   * Tab item from the collection
+   */
+  item: TabItem;
+
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+
+  /**
+   * Mouse down handler (for ripple effect)
+   */
+  onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+
+  /**
+   * Render function receiving interaction states
+   */
+  children?: (state: {
+    isSelected: boolean;
+    isDisabled: boolean;
+    isFocusVisible: boolean;
+    isPressed: boolean;
+  }) => React.ReactNode;
+}
+
+/**
+ * Props for HeadlessTabPanel
+ * Extends AriaTabPanelProps for full React Aria accessibility support
+ */
+export interface HeadlessTabPanelProps extends AriaTabPanelProps {
+  /**
+   * Panel content
+   */
+  children: React.ReactNode;
+
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Context value for headless tabs (React Aria state)
+ */
+export interface HeadlessTabsContextValue {
+  state: TabListState<TabItem>;
+}

--- a/packages/react/src/components/Tabs/Tabs.variants.ts
+++ b/packages/react/src/components/Tabs/Tabs.variants.ts
@@ -1,0 +1,244 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 TabList Variants (CVA)
+ *
+ * MD3 Specifications:
+ * - Container background: bg-surface
+ * - Container height: 48dp (fixed height tabs)
+ * - Bottom border: outline-variant color, 1dp
+ * - Fixed layout: tabs fill width equally
+ * - Scrollable layout: tabs overflow horizontally, no wrapping
+ */
+export const tabListVariants = cva(
+  [
+    // Base classes
+    "relative flex",
+    "bg-surface",
+    // Bottom divider line (MD3 spec)
+    "border-b border-outline-variant",
+  ],
+  {
+    variants: {
+      layout: {
+        fixed: "w-full",
+        scrollable: "overflow-x-auto scrollbar-none",
+      },
+    },
+    defaultVariants: {
+      layout: "fixed",
+    },
+  }
+);
+
+/**
+ * Material Design 3 Tab Item Variants (CVA)
+ *
+ * MD3 Specifications:
+ * - Minimum height: 48dp
+ * - Minimum width: 90dp (fixed), flexible (scrollable)
+ * - Typography: Title Small (14px, weight 500, tracking 0.1px)
+ * - State layers: 8% hover, 12% pressed/focus
+ * - Disabled: 38% opacity
+ * - Touch target: full tab area
+ */
+export const tabVariants = cva(
+  [
+    // Base layout
+    "relative flex flex-col items-center justify-center",
+    "min-h-12 px-4",
+    "cursor-pointer select-none",
+    "overflow-hidden",
+    // Typography: MD3 Title Small
+    "text-sm font-medium tracking-[0.1px]",
+    // Transition
+    "transition-colors duration-200",
+    // Focus visible
+    "focus-visible:outline-none",
+    // State layer via before pseudo-element
+    "before:absolute before:inset-0 before:transition-opacity before:duration-200",
+    "before:bg-current before:opacity-0",
+    "hover:before:opacity-8",
+    "active:before:opacity-12",
+    "focus-visible:before:opacity-12",
+  ],
+  {
+    variants: {
+      /**
+       * Tab variant (Primary or Secondary)
+       */
+      variant: {
+        primary: "",
+        secondary: "",
+      },
+
+      /**
+       * Selected state
+       */
+      selected: {
+        true: "",
+        false: "",
+      },
+
+      /**
+       * Disabled state
+       */
+      disabled: {
+        true: "opacity-38 cursor-not-allowed pointer-events-none",
+        false: "",
+      },
+
+      /**
+       * Layout determines min-width behavior
+       */
+      layout: {
+        fixed: "flex-1",
+        scrollable: "min-w-[90px] shrink-0",
+      },
+    },
+
+    compoundVariants: [
+      // Primary + selected
+      {
+        variant: "primary",
+        selected: true,
+        disabled: false,
+        className: "text-primary",
+      },
+      // Primary + unselected
+      {
+        variant: "primary",
+        selected: false,
+        disabled: false,
+        className: "text-on-surface-variant",
+      },
+      // Secondary + selected
+      {
+        variant: "secondary",
+        selected: true,
+        disabled: false,
+        className: "text-on-surface",
+      },
+      // Secondary + unselected
+      {
+        variant: "secondary",
+        selected: false,
+        disabled: false,
+        className: "text-on-surface-variant",
+      },
+    ],
+
+    defaultVariants: {
+      variant: "primary",
+      selected: false,
+      disabled: false,
+      layout: "fixed",
+    },
+  }
+);
+
+/**
+ * Active indicator variants (the sliding underline)
+ *
+ * MD3 Specifications:
+ * - Primary: 3dp height, bg-primary, rounded-full corners
+ * - Secondary: 2dp height, bg-on-surface-variant, no rounding
+ * - Absolutely positioned at bottom of tab list
+ * - Slides to selected tab using CSS transform
+ */
+export const tabIndicatorVariants = cva(
+  [
+    // Base: absolutely positioned at bottom
+    "absolute bottom-0 left-0",
+    "pointer-events-none",
+    // Transition using MD3 motion tokens (medium2 duration, emphasized easing)
+    "transition-[left,width]",
+    "duration-medium2",
+    "ease-emphasized",
+  ],
+  {
+    variants: {
+      variant: {
+        primary: ["h-[3px]", "bg-primary", "rounded-t-sm"],
+        secondary: ["h-[2px]", "bg-on-surface-variant"],
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+    },
+  }
+);
+
+/**
+ * Tab panel variants
+ *
+ * MD3 Specifications:
+ * - No specific container styling mandated
+ * - Focus management: panel receives focus if no focusable children
+ */
+export const tabPanelVariants = cva(
+  [
+    // Base panel styles
+    "outline-none",
+    "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+  ],
+  {
+    variants: {},
+    defaultVariants: {},
+  }
+);
+
+/**
+ * Tab badge variants
+ *
+ * Inline badge displayed in the upper-right area of the tab icon/label.
+ * MD3 badge spec: small indicator for notification count or status.
+ */
+export const tabBadgeVariants = cva(
+  [
+    // Base badge
+    "absolute",
+    "inline-flex items-center justify-center",
+    "bg-error text-on-error",
+    "font-medium leading-none",
+    "pointer-events-none",
+  ],
+  {
+    variants: {
+      type: {
+        dot: ["top-1 right-1", "w-1.5 h-1.5", "rounded-full"],
+        count: ["-top-1 -right-1", "min-w-[16px] h-4", "px-1", "rounded-full", "text-[11px]"],
+      },
+    },
+    defaultVariants: {
+      type: "count",
+    },
+  }
+);
+
+/**
+ * Tab icon wrapper variants
+ * Positions icon relative to the badge
+ */
+export const tabIconVariants = cva(
+  ["relative", "inline-flex items-center justify-center", "w-6 h-6"],
+  {
+    variants: {
+      hasLabel: {
+        true: "mb-1",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      hasLabel: false,
+    },
+  }
+);
+
+// Export variant prop types
+export type TabListVariants = VariantProps<typeof tabListVariants>;
+export type TabVariants = VariantProps<typeof tabVariants>;
+export type TabIndicatorVariants = VariantProps<typeof tabIndicatorVariants>;
+export type TabPanelVariants = VariantProps<typeof tabPanelVariants>;
+export type TabBadgeVariants = VariantProps<typeof tabBadgeVariants>;
+export type TabIconVariants = VariantProps<typeof tabIconVariants>;

--- a/packages/react/src/components/Tabs/TabsHeadless.tsx
+++ b/packages/react/src/components/Tabs/TabsHeadless.tsx
@@ -1,0 +1,173 @@
+import { createContext, forwardRef, useContext, useRef } from "react";
+import { useTab, useTabList, useTabPanel, useFocusRing } from "react-aria";
+import { mergeProps } from "@react-aria/utils";
+import type { TabListState } from "react-stately";
+import type {
+  HeadlessTabProps,
+  HeadlessTabPanelProps,
+  TabItem,
+  HeadlessTabsContextValue,
+} from "./Tabs.types";
+
+/**
+ * Context providing React Aria tab state to all headless primitives.
+ * State is created in the Tabs wrapper and shared here.
+ */
+export const HeadlessTabsContext = createContext<HeadlessTabsContextValue | null>(null);
+
+/**
+ * Hook to consume the headless tabs context
+ * @internal
+ */
+export function useHeadlessTabsContext(componentName: string): HeadlessTabsContextValue {
+  const context = useContext(HeadlessTabsContext);
+  if (!context) {
+    throw new Error(`${componentName} must be used within a Tabs component`);
+  }
+  return context;
+}
+
+/**
+ * Props for the HeadlessTabList container.
+ * State is injected from HeadlessTabsContext (created in Tabs wrapper).
+ */
+export interface HeadlessTabListContainerProps {
+  /** Children are Tab elements */
+  children: React.ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Headless TabList Component (Layer 2)
+ *
+ * Unstyled tab list container. Applies useTabList to the container element
+ * which wires up role="tablist", aria-label, and keyboard navigation.
+ * State must be provided via HeadlessTabsContext (from the Tabs wrapper).
+ *
+ * @example
+ * ```tsx
+ * // Advanced usage via headless primitives
+ * // State is provided by the Tabs wrapper above in the tree
+ * <HeadlessTabList className="my-tablist">
+ *   {items.map(item => <HeadlessTab key={item.key} item={item} />)}
+ * </HeadlessTabList>
+ * ```
+ */
+export const HeadlessTabList = forwardRef<HTMLDivElement, HeadlessTabListContainerProps>(
+  ({ children, className }, forwardedRef) => {
+    const { state } = useHeadlessTabsContext("HeadlessTabList");
+
+    const internalRef = useRef<HTMLDivElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
+
+    const { tabListProps } = useTabList({}, state, ref);
+
+    return (
+      <div {...tabListProps} ref={ref} className={className}>
+        {children}
+      </div>
+    );
+  }
+);
+
+HeadlessTabList.displayName = "HeadlessTabList";
+
+/**
+ * Headless Tab Component (Layer 2)
+ *
+ * Unstyled individual tab item. Provides full React Aria accessibility:
+ * - role="tab"
+ * - aria-selected
+ * - aria-controls (pointing to panel)
+ * - roving tabIndex
+ * - keyboard activation
+ *
+ * Must be used within HeadlessTabsContext.
+ *
+ * @example
+ * ```tsx
+ * <HeadlessTab item={item}>
+ *   {({ isSelected, isFocusVisible }) => (
+ *     <span className={isSelected ? 'font-bold' : ''}>
+ *       {item.label}
+ *     </span>
+ *   )}
+ * </HeadlessTab>
+ * ```
+ */
+export const HeadlessTab = forwardRef<HTMLButtonElement, HeadlessTabProps>(
+  ({ item, className, onMouseDown, children, ...props }, forwardedRef) => {
+    const { state } = useHeadlessTabsContext("HeadlessTab");
+
+    const internalRef = useRef<HTMLButtonElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLButtonElement>;
+
+    const { tabProps, isSelected, isDisabled, isPressed } = useTab(
+      {
+        key: item.key,
+        ...(item.isDisabled !== undefined && { isDisabled: item.isDisabled }),
+      },
+      state,
+      ref as React.RefObject<HTMLElement>
+    );
+
+    const { isFocusVisible, focusProps } = useFocusRing();
+
+    const mergedProps = mergeProps(tabProps, focusProps, {
+      className,
+      onMouseDown,
+    });
+
+    return (
+      <button {...mergedProps} ref={ref} type="button" data-key={String(item.key)} {...props}>
+        {typeof children === "function"
+          ? children({ isSelected, isDisabled, isFocusVisible, isPressed })
+          : children}
+      </button>
+    );
+  }
+);
+
+HeadlessTab.displayName = "HeadlessTab";
+
+/**
+ * Headless TabPanel Component (Layer 2)
+ *
+ * Unstyled tab panel. Provides:
+ * - role="tabpanel"
+ * - aria-labelledby (pointing to its tab)
+ * - Focus management for panels without focusable children
+ *
+ * Must be used within HeadlessTabsContext.
+ *
+ * @example
+ * ```tsx
+ * <HeadlessTabPanel>
+ *   <p>Panel content here</p>
+ * </HeadlessTabPanel>
+ * ```
+ */
+export const HeadlessTabPanel = forwardRef<HTMLDivElement, HeadlessTabPanelProps>(
+  ({ children, className, ...props }, forwardedRef) => {
+    const { state } = useHeadlessTabsContext("HeadlessTabPanel");
+
+    const internalRef = useRef<HTMLDivElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
+
+    const { tabPanelProps } = useTabPanel(props, state, ref);
+
+    return (
+      <div {...tabPanelProps} ref={ref} className={className}>
+        {children}
+      </div>
+    );
+  }
+);
+
+HeadlessTabPanel.displayName = "HeadlessTabPanel";
+
+/**
+ * Expose TabListState type for advanced consumers
+ */
+export type { TabListState, TabItem };

--- a/packages/react/src/components/Tabs/index.ts
+++ b/packages/react/src/components/Tabs/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Material Design 3 Tabs Component Exports
+ *
+ * Three-layer architecture:
+ * - Layer 1: React Aria Foundation (useTabList, useTab, useTabPanel, useTabListState)
+ * - Layer 2: Headless Primitives (HeadlessTabList, HeadlessTab, HeadlessTabPanel)
+ * - Layer 3: Styled Components (Tabs, TabList, Tab, TabPanel)
+ */
+
+// Styled components (Layer 3) — Most users will use these
+export { Tabs } from "./Tabs";
+export { TabList } from "./TabList";
+export { Tab } from "./Tab";
+export { TabPanel } from "./TabPanel";
+
+// Headless components (Layer 2) — For advanced customization
+export {
+  HeadlessTabList,
+  HeadlessTab,
+  HeadlessTabPanel,
+  HeadlessTabsContext,
+} from "./TabsHeadless";
+
+// Contexts — For advanced use cases
+export { TabsContext } from "./Tabs";
+
+// Types
+export type {
+  TabsProps,
+  TabListProps,
+  TabProps,
+  TabPanelProps,
+  TabVariant,
+  TabLayout,
+  TabContentMode,
+  TabBadgeValue,
+  TabsContextValue,
+  TabItem,
+  HeadlessTabListProps,
+  HeadlessTabProps,
+  HeadlessTabPanelProps,
+  HeadlessTabsContextValue,
+} from "./Tabs.types";
+
+// Variants — For external customization
+export {
+  tabListVariants,
+  tabVariants,
+  tabIndicatorVariants,
+  tabPanelVariants,
+  tabBadgeVariants,
+  tabIconVariants,
+} from "./Tabs.variants";
+
+export type {
+  TabListVariants,
+  TabVariants,
+  TabIndicatorVariants,
+  TabPanelVariants,
+  TabBadgeVariants,
+  TabIconVariants,
+} from "./Tabs.variants";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -47,3 +47,24 @@ export type {
   HeadlessNavigationBarItemProps,
   NavigationBarItemRenderProps,
 } from "./NavigationBar";
+
+export {
+  Tabs,
+  TabList,
+  Tab,
+  TabPanel,
+  HeadlessTabList,
+  HeadlessTab,
+  HeadlessTabPanel,
+} from "./Tabs";
+export type {
+  TabsProps,
+  TabListProps,
+  TabProps,
+  TabPanelProps,
+  TabVariant,
+  TabLayout,
+  TabItem,
+  HeadlessTabProps,
+  HeadlessTabPanelProps,
+} from "./Tabs";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -77,6 +77,27 @@ export type {
 } from "./components/Radio";
 
 export {
+  Tabs,
+  TabList,
+  Tab,
+  TabPanel,
+  HeadlessTabList,
+  HeadlessTab,
+  HeadlessTabPanel,
+} from "./components/Tabs";
+export type {
+  TabsProps,
+  TabListProps,
+  TabProps,
+  TabPanelProps,
+  TabVariant,
+  TabLayout,
+  TabItem,
+  HeadlessTabProps,
+  HeadlessTabPanelProps,
+} from "./components/Tabs";
+
+export {
   NavigationBar,
   NavigationBarItem,
   HeadlessNavigationBar,


### PR DESCRIPTION
## Summary

Closes #26

Implements the Material Design 3 Tabs component for `@tinybigui/react`, following the project's three-layer architecture and all TinyBigUI code standards.

### What's included

**Architecture (3 layers)**
- **Layer 1**: React Aria hooks (`useTabList`, `useTab`, `useTabPanel`, `useTabListState`)
- **Layer 2**: Headless primitives — `HeadlessTabList`, `HeadlessTab`, `HeadlessTabPanel`
- **Layer 3**: MD3 styled components — `Tabs`, `TabList`, `Tab`, `TabPanel`

**MD3 features**
- `primary` and `secondary` variants with animated active indicator
- `fixed` and `scrollable` layouts
- Content modes: `label-only`, `icon-only`, `icon-label` (stacked)
- Badge support: numeric (999+ truncation), dot, badge-with-icon
- Disabled tabs — skipped by keyboard navigation, `aria-disabled="true"`
- MD3 ripple effect and state layers (hover 8%, pressed 12%, focus 12%)
- Animated indicator using `useLayoutEffect` for synchronous DOM measurement

**Accessibility (WCAG 2.1 AA)**
- `role="tablist"` / `role="tab"` / `role="tabpanel"` ARIA roles
- Full keyboard navigation: `ArrowRight`, `ArrowLeft`, `Home`, `End`
- Roving tabIndex — selected tab is `0`, others are `-1`
- `aria-selected`, `aria-controls`, `aria-labelledby` wiring
- `axe` audit passes across all variants

**Tests & quality**
- 62 tests — 93.56% statement / 97.76% line coverage
- TypeScript strict mode + `exactOptionalPropertyTypes` — zero errors
- ESLint `--max-warnings=0` — clean
- Storybook stories covering all variants, layouts, content modes, badges, and controlled usage

### Technical notes

Keyboard navigation in `TabList.tsx` reads `document.activeElement.dataset.key` directly from the DOM rather than `state.collection.getKeys()`. React Stately 3.x populates its collection through a virtual rendering context that programmatically-constructed `<Item>` elements (used by `extractTabItemsFromChildren`) never enter, so the collection is always empty. The DOM approach is simpler, more reliable in jsdom tests, and keeps navigation independent of React Stately's internal timing.

`extractTabItemsFromChildren` uses a `getComponentName()` helper that checks `displayName` to correctly identify `forwardRef`-wrapped components (their `typeof` is `"object"`, not `"function"`).

## Test plan

- [ ] Run `pnpm test --filter @tinybigui/react` — all 62 tests pass
- [ ] Run `pnpm tsc --noEmit` — zero TypeScript errors
- [ ] Run `pnpm lint` — zero ESLint errors/warnings
- [ ] Launch Storybook and verify all Tabs stories render correctly (primary, secondary, fixed, scrollable, icon-only, label-only, icon+label, badges, disabled, controlled)
- [ ] Verify keyboard navigation: `Tab` focuses the tab list, `ArrowRight`/`ArrowLeft` moves focus, `Home`/`End` jump to first/last enabled tab
- [ ] Verify disabled tabs are skipped in keyboard navigation
- [ ] Verify ripple triggers on click

Made with [Cursor](https://cursor.com)