### PR TITLE
feat(drawer): implement MD3 Navigation Drawer component

### DIFF
--- a/packages/react/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react/src/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,466 @@
+import { useState, type JSX } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Drawer } from "./Drawer";
+import { DrawerItem } from "./DrawerItem";
+import { DrawerSection } from "./DrawerSection";
+import { HeadlessDrawer, HeadlessDrawerItem } from "./DrawerHeadless";
+
+// ─── Inline SVG Icons ─────────────────────────────────────────────────────────
+
+const HomeIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+  </svg>
+);
+
+const InboxIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 12h-4c0 1.66-1.34 3-3 3s-3-1.34-3-3H5V5h14v10z" />
+  </svg>
+);
+
+const StarredIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+  </svg>
+);
+
+const SnoozedIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67V7z" />
+  </svg>
+);
+
+const DraftsIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M21.99 8c0-.72-.37-1.35-.94-1.7L12 1 2.95 6.3C2.38 6.65 2 7.28 2 8v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2l-.01-12zM12 13 3.74 7.84 12 3l8.26 4.84L12 13z" />
+  </svg>
+);
+
+const SettingsIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.47.47 0 0 0-.59.22L2.74 8.87a.48.48 0 0 0 .12.61l2.03 1.58c-.05.3-.07.63-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.57 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32a.47.47 0 0 0-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
+  </svg>
+);
+
+const HelpIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z" />
+  </svg>
+);
+
+const MenuIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
+  </svg>
+);
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof Drawer> = {
+  title: "Navigation/Drawer",
+  component: Drawer,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Material Design 3 Navigation Drawer — provides access to destinations and app functionality. Supports Standard (inline) and Modal (overlay) variants.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["standard", "modal"],
+      description: "Structural variant — Standard renders inline, Modal renders as an overlay.",
+    },
+    open: {
+      control: "boolean",
+      description: "Controlled open state.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+// ─── Standard variant ─────────────────────────────────────────────────────────
+
+export const StandardOpen: Story = {
+  name: "Standard — Open",
+  render: () => (
+    <div className="bg-surface relative h-screen">
+      <Drawer variant="standard" open aria-label="App navigation">
+        <div className="px-4 pt-6 pb-4">
+          <span className="text-headline-small text-on-surface">Mail</span>
+        </div>
+        <DrawerItem
+          icon={<InboxIcon />}
+          label="Inbox"
+          isActive
+          badge={<span className="text-label-medium text-on-surface-variant">24</span>}
+        />
+        <DrawerItem icon={<StarredIcon />} label="Starred" />
+        <DrawerItem icon={<SnoozedIcon />} label="Snoozed" />
+        <DrawerItem
+          icon={<DraftsIcon />}
+          label="Drafts"
+          badge={<span className="text-label-medium text-on-surface-variant">3</span>}
+        />
+        <DrawerSection header="More" showDivider>
+          <DrawerItem icon={<SettingsIcon />} label="Settings" />
+          <DrawerItem icon={<HelpIcon />} label="Help & feedback" />
+        </DrawerSection>
+      </Drawer>
+    </div>
+  ),
+};
+
+export const StandardClosed: Story = {
+  name: "Standard — Closed",
+  render: () => (
+    <div className="bg-surface relative h-screen">
+      <Drawer variant="standard" open={false} aria-label="App navigation">
+        <DrawerItem icon={<InboxIcon />} label="Inbox" isActive />
+        <DrawerItem icon={<StarredIcon />} label="Starred" />
+      </Drawer>
+      <div className="p-8">
+        <p className="text-body-large text-on-surface">Drawer is closed (off-screen)</p>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Standard controlled ──────────────────────────────────────────────────────
+
+const StandardControlledDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(true);
+  const [activeItem, setActiveItem] = useState("inbox");
+
+  return (
+    <div className="bg-surface relative h-screen">
+      <div className="flex items-center gap-4 p-4">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="bg-surface-container-high text-on-surface flex items-center gap-2 rounded-full px-4 py-2"
+        >
+          <MenuIcon />
+          {open ? "Close Drawer" : "Open Drawer"}
+        </button>
+        <span className="text-body-medium text-on-surface-variant">Active: {activeItem}</span>
+      </div>
+
+      <Drawer variant="standard" open={open} onOpenChange={setOpen} aria-label="App navigation">
+        <div className="px-4 pt-6 pb-4">
+          <span className="text-headline-small text-on-surface">Mail</span>
+        </div>
+        <DrawerItem
+          icon={<InboxIcon />}
+          label="Inbox"
+          isActive={activeItem === "inbox"}
+          onPress={() => setActiveItem("inbox")}
+        />
+        <DrawerItem
+          icon={<StarredIcon />}
+          label="Starred"
+          isActive={activeItem === "starred"}
+          onPress={() => setActiveItem("starred")}
+        />
+        <DrawerItem
+          icon={<DraftsIcon />}
+          label="Drafts"
+          isActive={activeItem === "drafts"}
+          onPress={() => setActiveItem("drafts")}
+        />
+        <DrawerSection header="More" showDivider>
+          <DrawerItem
+            icon={<SettingsIcon />}
+            label="Settings"
+            isActive={activeItem === "settings"}
+            onPress={() => setActiveItem("settings")}
+          />
+        </DrawerSection>
+      </Drawer>
+    </div>
+  );
+};
+
+export const StandardControlled: Story = {
+  name: "Standard — Controlled toggle",
+  render: () => <StandardControlledDemo />,
+};
+
+// ─── Modal variant ────────────────────────────────────────────────────────────
+
+const ModalOpenDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(true);
+  const [activeItem, setActiveItem] = useState("inbox");
+
+  return (
+    <div className="bg-surface relative h-screen">
+      <div className="flex items-center gap-4 p-4">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="bg-surface-container-high text-on-surface flex items-center gap-2 rounded-full px-4 py-2"
+        >
+          <MenuIcon />
+          Open Modal Drawer
+        </button>
+        <span className="text-body-medium text-on-surface-variant">Active: {activeItem}</span>
+      </div>
+
+      <Drawer variant="modal" open={open} onOpenChange={setOpen} aria-label="App navigation">
+        <div className="px-4 pt-6 pb-4">
+          <span className="text-headline-small text-on-surface">Mail</span>
+        </div>
+        <DrawerItem
+          icon={<InboxIcon />}
+          label="Inbox"
+          isActive={activeItem === "inbox"}
+          badge={<span className="text-label-medium text-on-surface-variant">24</span>}
+          onPress={() => {
+            setActiveItem("inbox");
+            setOpen(false);
+          }}
+        />
+        <DrawerItem
+          icon={<StarredIcon />}
+          label="Starred"
+          isActive={activeItem === "starred"}
+          onPress={() => {
+            setActiveItem("starred");
+            setOpen(false);
+          }}
+        />
+        <DrawerItem
+          icon={<SnoozedIcon />}
+          label="Snoozed"
+          isActive={activeItem === "snoozed"}
+          onPress={() => {
+            setActiveItem("snoozed");
+            setOpen(false);
+          }}
+        />
+        <DrawerItem
+          icon={<DraftsIcon />}
+          label="Drafts"
+          isActive={activeItem === "drafts"}
+          badge={<span className="text-label-medium text-on-surface-variant">3</span>}
+          onPress={() => {
+            setActiveItem("drafts");
+            setOpen(false);
+          }}
+        />
+        <DrawerSection header="More" showDivider>
+          <DrawerItem
+            icon={<SettingsIcon />}
+            label="Settings"
+            isActive={activeItem === "settings"}
+            onPress={() => {
+              setActiveItem("settings");
+              setOpen(false);
+            }}
+          />
+          <DrawerItem icon={<HelpIcon />} label="Help & feedback" onPress={() => setOpen(false)} />
+        </DrawerSection>
+      </Drawer>
+    </div>
+  );
+};
+
+export const ModalOpen: Story = {
+  name: "Modal — Open",
+  render: () => <ModalOpenDemo />,
+};
+
+// ─── With link items ──────────────────────────────────────────────────────────
+
+export const WithLinkItems: Story = {
+  name: "Standard — Link-based items (href)",
+  render: () => (
+    <div className="bg-surface relative h-screen">
+      <Drawer variant="standard" open aria-label="App navigation">
+        <div className="px-4 pt-6 pb-4">
+          <span className="text-headline-small text-on-surface">Navigation</span>
+        </div>
+        <DrawerItem href="/" icon={<HomeIcon />} label="Home" isActive />
+        <DrawerItem href="/inbox" icon={<InboxIcon />} label="Inbox" />
+        <DrawerSection header="Account" showDivider>
+          <DrawerItem href="/settings" icon={<SettingsIcon />} label="Settings" />
+          <DrawerItem href="/help" icon={<HelpIcon />} label="Help" />
+        </DrawerSection>
+      </Drawer>
+    </div>
+  ),
+};
+
+// ─── Without icons ────────────────────────────────────────────────────────────
+
+export const WithoutIcons: Story = {
+  name: "Standard — Without icons",
+  render: () => (
+    <div className="bg-surface relative h-screen">
+      <Drawer variant="standard" open aria-label="App navigation">
+        <div className="px-4 pt-6 pb-4">
+          <span className="text-headline-small text-on-surface">Documents</span>
+        </div>
+        <DrawerItem label="Recent" isActive />
+        <DrawerItem label="Shared with me" />
+        <DrawerItem label="Starred" />
+        <DrawerSection header="Folders" showDivider>
+          <DrawerItem label="Work" />
+          <DrawerItem label="Personal" />
+          <DrawerItem label="Archive" />
+        </DrawerSection>
+      </Drawer>
+    </div>
+  ),
+};
+
+// ─── With secondary text ──────────────────────────────────────────────────────
+
+export const WithSecondaryText: Story = {
+  name: "Standard — Secondary text",
+  render: () => (
+    <div className="bg-surface relative h-screen">
+      <Drawer variant="standard" open aria-label="App navigation">
+        <div className="px-4 pt-6 pb-4">
+          <span className="text-headline-small text-on-surface">Mail</span>
+        </div>
+        <DrawerItem
+          icon={<InboxIcon />}
+          label="Inbox"
+          secondaryText="Your primary inbox"
+          isActive
+        />
+        <DrawerItem icon={<StarredIcon />} label="Starred" secondaryText="Saved for later" />
+        <DrawerItem icon={<DraftsIcon />} label="Drafts" secondaryText="3 unsent messages" />
+      </Drawer>
+    </div>
+  ),
+};
+
+// ─── Disabled items ───────────────────────────────────────────────────────────
+
+export const WithDisabledItems: Story = {
+  name: "Standard — Disabled items",
+  render: () => (
+    <div className="bg-surface relative h-screen">
+      <Drawer variant="standard" open aria-label="App navigation">
+        <div className="px-4 pt-6 pb-4">
+          <span className="text-headline-small text-on-surface">Mail</span>
+        </div>
+        <DrawerItem icon={<InboxIcon />} label="Inbox" isActive />
+        <DrawerItem icon={<StarredIcon />} label="Starred" isDisabled />
+        <DrawerItem icon={<DraftsIcon />} label="Drafts" />
+        <DrawerSection header="More" showDivider>
+          <DrawerItem icon={<SettingsIcon />} label="Settings" isDisabled />
+          <DrawerItem icon={<HelpIcon />} label="Help & feedback" />
+        </DrawerSection>
+      </Drawer>
+    </div>
+  ),
+};
+
+// ─── Multiple sections ────────────────────────────────────────────────────────
+
+export const MultipleSections: Story = {
+  name: "Standard — Multiple sections",
+  render: () => (
+    <div className="bg-surface relative h-screen">
+      <Drawer variant="standard" open aria-label="App navigation">
+        <div className="px-4 pt-6 pb-4">
+          <span className="text-headline-small text-on-surface">Mail</span>
+        </div>
+        <DrawerSection>
+          <DrawerItem
+            icon={<InboxIcon />}
+            label="Inbox"
+            isActive
+            badge={<span className="text-label-medium text-on-surface-variant">24</span>}
+          />
+          <DrawerItem icon={<StarredIcon />} label="Starred" />
+          <DrawerItem icon={<SnoozedIcon />} label="Snoozed" />
+          <DrawerItem
+            icon={<DraftsIcon />}
+            label="Drafts"
+            badge={<span className="text-label-medium text-on-surface-variant">3</span>}
+          />
+        </DrawerSection>
+        <DrawerSection header="Labels" showDivider>
+          <DrawerItem label="Work" />
+          <DrawerItem label="Travel" />
+          <DrawerItem label="Finance" />
+        </DrawerSection>
+        <DrawerSection header="More" showDivider>
+          <DrawerItem icon={<SettingsIcon />} label="Settings" />
+          <DrawerItem icon={<HelpIcon />} label="Help & feedback" />
+        </DrawerSection>
+      </Drawer>
+    </div>
+  ),
+};
+
+// ─── Headless primitives ──────────────────────────────────────────────────────
+
+export const HeadlessPrimitive: Story = {
+  name: "Headless — Custom styling",
+  render: () => (
+    <div className="bg-surface relative h-screen">
+      <HeadlessDrawer
+        variant="standard"
+        open
+        aria-label="Custom navigation"
+        className="bg-surface-container-low fixed top-0 left-0 flex h-full w-64 flex-col gap-1 rounded-r-xl p-4"
+      >
+        <div className="pb-4">
+          <span className="text-headline-small text-on-surface font-medium">Custom Drawer</span>
+        </div>
+        <HeadlessDrawerItem
+          className="bg-secondary-container text-on-secondary-container text-label-large flex h-14 items-center gap-3 rounded-full px-4"
+          isActive
+        >
+          <HomeIcon />
+          Home
+        </HeadlessDrawerItem>
+        <HeadlessDrawerItem className="text-on-surface-variant text-label-large hover:bg-on-surface-variant/8 flex h-14 items-center gap-3 rounded-full px-4">
+          <InboxIcon />
+          Inbox
+        </HeadlessDrawerItem>
+      </HeadlessDrawer>
+    </div>
+  ),
+};
+
+// ─── Dark mode ────────────────────────────────────────────────────────────────
+
+export const DarkMode: Story = {
+  name: "Standard — Dark mode",
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  render: () => (
+    <div className="dark bg-surface relative h-screen">
+      <Drawer variant="standard" open aria-label="App navigation">
+        <div className="px-4 pt-6 pb-4">
+          <span className="text-headline-small text-on-surface">Mail</span>
+        </div>
+        <DrawerItem
+          icon={<InboxIcon />}
+          label="Inbox"
+          isActive
+          badge={<span className="text-label-medium text-on-surface-variant">24</span>}
+        />
+        <DrawerItem icon={<StarredIcon />} label="Starred" />
+        <DrawerItem icon={<DraftsIcon />} label="Drafts" />
+        <DrawerSection header="More" showDivider>
+          <DrawerItem icon={<SettingsIcon />} label="Settings" />
+        </DrawerSection>
+      </Drawer>
+    </div>
+  ),
+};

--- a/packages/react/src/components/Drawer/Drawer.test.tsx
+++ b/packages/react/src/components/Drawer/Drawer.test.tsx
@@ -1,0 +1,535 @@
+import React from "react";
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { Drawer } from "./Drawer";
+import { DrawerItem } from "./DrawerItem";
+import { DrawerSection } from "./DrawerSection";
+import { HeadlessDrawer, HeadlessDrawerItem } from "./DrawerHeadless";
+
+// ─── Test Icon Mocks ───────────────────────────────────────────────────────────
+
+const HomeIcon = () => <svg data-testid="home-icon" aria-hidden="true" />;
+const SettingsIcon = () => <svg data-testid="settings-icon" aria-hidden="true" />;
+const InboxIcon = () => <svg data-testid="inbox-icon" aria-hidden="true" />;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderStandardDrawer(props: Partial<React.ComponentProps<typeof Drawer>> = {}) {
+  return render(
+    <Drawer variant="standard" open aria-label="App navigation" {...props}>
+      <DrawerItem label="Home" isActive />
+      <DrawerItem label="Settings" />
+    </Drawer>
+  );
+}
+
+function renderModalDrawer(props: Partial<React.ComponentProps<typeof Drawer>> = {}) {
+  return render(
+    <Drawer variant="modal" open aria-label="App navigation" {...props}>
+      <DrawerItem label="Home" isActive />
+      <DrawerItem label="Settings" />
+    </Drawer>
+  );
+}
+
+// ─── Drawer ────────────────────────────────────────────────────────────────────
+
+describe("Drawer", () => {
+  // ── Standard Variant ────────────────────────────────────────────────────────
+
+  describe("Standard variant", () => {
+    test("renders as nav landmark", () => {
+      renderStandardDrawer();
+      expect(screen.getByRole("navigation")).toBeInTheDocument();
+    });
+
+    test("has correct aria-label", () => {
+      renderStandardDrawer();
+      expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "App navigation");
+    });
+
+    test("renders children", () => {
+      renderStandardDrawer();
+      expect(screen.getByText("Home")).toBeInTheDocument();
+      expect(screen.getByText("Settings")).toBeInTheDocument();
+    });
+
+    test("does NOT render a dialog role", () => {
+      renderStandardDrawer();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    test("does NOT render a scrim when open", () => {
+      renderStandardDrawer();
+      expect(screen.queryByTestId("drawer-scrim")).not.toBeInTheDocument();
+    });
+
+    test("is hidden (off-screen) when open=false", () => {
+      renderStandardDrawer({ open: false });
+      const nav = screen.getByRole("navigation");
+      expect(nav.className).toContain("-translate-x-full");
+    });
+
+    test("is visible when open=true", () => {
+      renderStandardDrawer({ open: true });
+      const nav = screen.getByRole("navigation");
+      expect(nav.className).not.toContain("-translate-x-full");
+    });
+
+    test("calls onOpenChange when standard drawer is toggled programmatically", () => {
+      const onOpenChange = vi.fn();
+      renderStandardDrawer({ onOpenChange });
+      // onOpenChange should not be called on initial render
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    test("accepts custom className", () => {
+      renderStandardDrawer({ className: "custom-nav-class" });
+      expect(screen.getByRole("navigation")).toHaveClass("custom-nav-class");
+    });
+  });
+
+  // ── Modal Variant ────────────────────────────────────────────────────────────
+
+  describe("Modal variant", () => {
+    test("renders dialog with role='dialog'", () => {
+      renderModalDrawer();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("has aria-modal='true'", () => {
+      renderModalDrawer();
+      expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+    });
+
+    test("has correct aria-label on dialog", () => {
+      renderModalDrawer();
+      expect(screen.getByRole("dialog")).toHaveAttribute("aria-label", "App navigation");
+    });
+
+    test("renders scrim when open", () => {
+      renderModalDrawer();
+      expect(screen.getByTestId("drawer-scrim")).toBeInTheDocument();
+    });
+
+    test("does NOT render scrim when closed", () => {
+      renderModalDrawer({ open: false });
+      expect(screen.queryByTestId("drawer-scrim")).not.toBeInTheDocument();
+    });
+
+    test("calls onOpenChange(false) when scrim is clicked", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      renderModalDrawer({ onOpenChange });
+      await user.click(screen.getByTestId("drawer-scrim"));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    test("calls onOpenChange(false) when Escape is pressed", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      renderModalDrawer({ onOpenChange });
+      await user.keyboard("{Escape}");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    test("renders nav landmark wrapping the dialog", () => {
+      renderModalDrawer();
+      expect(screen.getByRole("navigation")).toBeInTheDocument();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("renders children inside dialog", () => {
+      renderModalDrawer();
+      expect(screen.getByText("Home")).toBeInTheDocument();
+    });
+  });
+
+  // ── Accessibility ─────────────────────────────────────────────────────────────
+
+  describe("Accessibility (axe)", () => {
+    test("standard variant passes axe audit", async () => {
+      const { container } = renderStandardDrawer();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("modal variant passes axe audit when open", async () => {
+      const { container } = renderModalDrawer();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("modal variant passes axe audit when closed", async () => {
+      const { container } = renderModalDrawer({ open: false });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});
+
+// ─── DrawerItem ───────────────────────────────────────────────────────────────
+
+describe("DrawerItem", () => {
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  describe("Rendering", () => {
+    test("renders label text", () => {
+      render(<DrawerItem label="Home" />);
+      expect(screen.getByText("Home")).toBeInTheDocument();
+    });
+
+    test("renders as <button> when no href", () => {
+      render(<DrawerItem label="Home" />);
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    test("renders as <a> when href is provided", () => {
+      render(<DrawerItem label="Home" href="/home" />);
+      expect(screen.getByRole("link")).toBeInTheDocument();
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/home");
+    });
+
+    test("renders icon when provided", () => {
+      render(<DrawerItem label="Home" icon={<HomeIcon />} />);
+      expect(screen.getByTestId("home-icon")).toBeInTheDocument();
+    });
+
+    test("renders badge content when provided", () => {
+      render(<DrawerItem label="Inbox" badge={<span data-testid="badge">3</span>} />);
+      expect(screen.getByTestId("badge")).toBeInTheDocument();
+    });
+
+    test("renders secondary text when provided", () => {
+      render(<DrawerItem label="Profile" secondaryText="Edit your profile" />);
+      expect(screen.getByText("Edit your profile")).toBeInTheDocument();
+    });
+
+    test("accepts custom className", () => {
+      render(<DrawerItem label="Home" className="custom-item" />);
+      expect(screen.getByRole("button")).toHaveClass("custom-item");
+    });
+  });
+
+  // ── Active State ───────────────────────────────────────────────────────────
+
+  describe("Active state", () => {
+    test("has aria-current='page' when isActive=true", () => {
+      render(<DrawerItem label="Home" isActive />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-current", "page");
+    });
+
+    test("does NOT have aria-current when isActive=false", () => {
+      render(<DrawerItem label="Home" />);
+      expect(screen.getByRole("button")).not.toHaveAttribute("aria-current");
+    });
+  });
+
+  // ── Disabled State ─────────────────────────────────────────────────────────
+
+  describe("Disabled state", () => {
+    test("is not clickable when disabled", async () => {
+      const user = userEvent.setup();
+      const onPress = vi.fn();
+      render(<DrawerItem label="Home" isDisabled onPress={onPress} />);
+      const item = screen.getByRole("button");
+      await user.click(item);
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    test("is not accessible when disabled", () => {
+      render(<DrawerItem label="Home" isDisabled />);
+      // React Aria sets the native `disabled` attribute on <button> elements
+      // (or aria-disabled for non-button elements)
+      const item = screen.getByRole("button");
+      expect(item).toBeDisabled();
+    });
+  });
+
+  // ── Interactions ───────────────────────────────────────────────────────────
+
+  describe("Interactions", () => {
+    test("calls onPress when clicked", async () => {
+      const user = userEvent.setup();
+      const onPress = vi.fn();
+      render(<DrawerItem label="Home" onPress={onPress} />);
+      await user.click(screen.getByRole("button"));
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    test("calls onPress when Enter is pressed", async () => {
+      const user = userEvent.setup();
+      const onPress = vi.fn();
+      render(<DrawerItem label="Home" onPress={onPress} />);
+      screen.getByRole("button").focus();
+      await user.keyboard("{Enter}");
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    test("calls onPress when Space is pressed", async () => {
+      const user = userEvent.setup();
+      const onPress = vi.fn();
+      render(<DrawerItem label="Home" onPress={onPress} />);
+      screen.getByRole("button").focus();
+      await user.keyboard(" ");
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Accessibility ──────────────────────────────────────────────────────────
+
+  describe("Accessibility (axe)", () => {
+    test("button item passes axe audit", async () => {
+      const { container } = render(<DrawerItem label="Home" icon={<HomeIcon />} />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("link item passes axe audit", async () => {
+      const { container } = render(<DrawerItem label="Settings" href="/settings" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("active item passes axe audit", async () => {
+      const { container } = render(<DrawerItem label="Home" isActive />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("disabled item passes axe audit", async () => {
+      const { container } = render(<DrawerItem label="Home" isDisabled />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});
+
+// ─── DrawerSection ────────────────────────────────────────────────────────────
+
+describe("DrawerSection", () => {
+  test("renders children", () => {
+    render(
+      <DrawerSection>
+        <DrawerItem label="Profile" />
+      </DrawerSection>
+    );
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+  });
+
+  test("renders header when provided", () => {
+    render(
+      <DrawerSection header="Account">
+        <DrawerItem label="Profile" />
+      </DrawerSection>
+    );
+    expect(screen.getByText("Account")).toBeInTheDocument();
+  });
+
+  test("does NOT render header when not provided", () => {
+    render(
+      <DrawerSection>
+        <DrawerItem label="Profile" />
+      </DrawerSection>
+    );
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+  });
+
+  test("renders divider when showDivider=true", () => {
+    render(
+      <DrawerSection showDivider>
+        <DrawerItem label="Profile" />
+      </DrawerSection>
+    );
+    // The <hr> has aria-hidden="true" so we need to query with hidden: true
+    expect(screen.getByRole("separator", { hidden: true })).toBeInTheDocument();
+  });
+
+  test("does NOT render divider when showDivider=false", () => {
+    render(
+      <DrawerSection>
+        <DrawerItem label="Profile" />
+      </DrawerSection>
+    );
+    expect(screen.queryByRole("separator", { hidden: true })).not.toBeInTheDocument();
+  });
+
+  test("passes axe audit", async () => {
+    const { container } = render(
+      <nav aria-label="test">
+        <DrawerSection header="Account" showDivider>
+          <DrawerItem label="Profile" />
+          <DrawerItem label="Logout" />
+        </DrawerSection>
+      </nav>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+// ─── Full Drawer Composition ──────────────────────────────────────────────────
+
+describe("Drawer composition", () => {
+  test("renders standard drawer with sections and items", () => {
+    render(
+      <Drawer variant="standard" open aria-label="App navigation">
+        <DrawerItem icon={<HomeIcon />} label="Home" isActive />
+        <DrawerSection header="Account" showDivider>
+          <DrawerItem icon={<SettingsIcon />} label="Settings" />
+        </DrawerSection>
+      </Drawer>
+    );
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("Account")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  test("standard drawer with sections passes axe audit", async () => {
+    const { container } = render(
+      <Drawer variant="standard" open aria-label="App navigation">
+        <DrawerItem icon={<HomeIcon />} label="Home" isActive />
+        <DrawerSection header="Account" showDivider>
+          <DrawerItem icon={<SettingsIcon />} label="Settings" />
+        </DrawerSection>
+      </Drawer>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("renders modal drawer with sections and items", () => {
+    render(
+      <Drawer variant="modal" open aria-label="App navigation">
+        <DrawerItem icon={<HomeIcon />} label="Home" isActive />
+        <DrawerSection header="More" showDivider>
+          <DrawerItem icon={<InboxIcon />} label="Inbox" badge={<span>5</span>} />
+        </DrawerSection>
+      </Drawer>
+    );
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("More")).toBeInTheDocument();
+    expect(screen.getByText("Inbox")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  test("controlled modal drawer toggles correctly", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <Drawer variant="modal" open onOpenChange={onOpenChange} aria-label="App navigation">
+        <DrawerItem label="Home" />
+      </Drawer>
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("drawer-scrim"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    rerender(
+      <Drawer variant="modal" open={false} onOpenChange={onOpenChange} aria-label="App navigation">
+        <DrawerItem label="Home" />
+      </Drawer>
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+// ─── Headless Primitives ──────────────────────────────────────────────────────
+
+describe("HeadlessDrawer", () => {
+  test("renders standard variant as nav landmark", () => {
+    render(
+      <HeadlessDrawer variant="standard" open aria-label="Headless nav">
+        <div>Content</div>
+      </HeadlessDrawer>
+    );
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+  });
+
+  test("renders modal variant as dialog", () => {
+    render(
+      <HeadlessDrawer variant="modal" open aria-label="Headless nav">
+        <div>Content</div>
+      </HeadlessDrawer>
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});
+
+describe("HeadlessDrawerItem", () => {
+  test("renders as button by default", () => {
+    render(<HeadlessDrawerItem>Click me</HeadlessDrawerItem>);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  test("renders as link when href is provided", () => {
+    render(<HeadlessDrawerItem href="/home">Home</HeadlessDrawerItem>);
+    expect(screen.getByRole("link")).toBeInTheDocument();
+  });
+
+  test("sets aria-current='page' when isActive=true", () => {
+    render(<HeadlessDrawerItem isActive>Home</HeadlessDrawerItem>);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-current", "page");
+  });
+
+  test("passes axe audit", async () => {
+    const { container } = render(
+      <nav aria-label="test">
+        <HeadlessDrawerItem>Home</HeadlessDrawerItem>
+        <HeadlessDrawerItem href="/settings">Settings</HeadlessDrawerItem>
+        <HeadlessDrawerItem isActive>Active</HeadlessDrawerItem>
+      </nav>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+// ─── Focus Management (Modal) ─────────────────────────────────────────────────
+
+describe("Modal drawer focus management", () => {
+  test("focus returns to trigger after modal closes via Escape", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const TriggerTest = () => {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open Drawer</button>
+          <Drawer
+            variant="modal"
+            open={open}
+            onOpenChange={(val) => {
+              setOpen(val);
+              onOpenChange(val);
+            }}
+            aria-label="App navigation"
+          >
+            <DrawerItem label="Home" />
+          </Drawer>
+        </>
+      );
+    };
+
+    render(<TriggerTest />);
+
+    const trigger = screen.getByText("Open Drawer");
+    await user.click(trigger);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/react/src/components/Drawer/Drawer.tsx
+++ b/packages/react/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { forwardRef } from "react";
+import { HeadlessDrawer } from "./DrawerHeadless";
+import { drawerVariants, scrimVariants } from "./Drawer.variants";
+import { cn } from "../../utils/cn";
+import type { DrawerProps } from "./Drawer.types";
+
+/**
+ * Material Design 3 Navigation Drawer (Layer 3: Styled).
+ *
+ * Supports two structural variants driven by the `variant` prop:
+ *
+ * - **`standard`** — Inline `<nav>` landmark. Permanently visible or
+ *   collapsible via controlled `open` prop. No overlay or focus trap.
+ *   Surface: `bg-surface-container-low`.
+ *
+ * - **`modal`** — Overlay dialog with scrim backdrop, slide-in animation,
+ *   focus trap, and `Escape` to close.
+ *   Surface: `bg-surface-container`, `shadow-elevation-1`.
+ *
+ * Both variants:
+ * - `role="navigation"` on the outer wrapper
+ * - `rounded-r-xl` (28px per MD3 shape extra-large on right side only)
+ * - Slide-in animation: `translate-x` driven by MD3 motion tokens
+ * - `w-drawer` (360dp per MD3 spec)
+ *
+ * Modal-only:
+ * - `role="dialog"` + `aria-modal="true"` on the panel
+ * - `FocusScope` containing focus + restoring on close
+ * - `usePreventScroll` to lock body scroll
+ * - Scrim: `bg-scrim opacity-32` — click closes drawer
+ * - `Escape` key closes drawer
+ *
+ * @example
+ * ```tsx
+ * // Standard variant (collapsible sidebar)
+ * <Drawer
+ *   variant="standard"
+ *   open={sidebarOpen}
+ *   onOpenChange={setSidebarOpen}
+ *   aria-label="App navigation"
+ * >
+ *   <DrawerItem icon={<HomeIcon />} label="Home" isActive />
+ *   <DrawerSection header="Settings" showDivider>
+ *     <DrawerItem icon={<SettingsIcon />} label="Preferences" />
+ *   </DrawerSection>
+ * </Drawer>
+ *
+ * // Modal variant (overlay)
+ * <Drawer
+ *   variant="modal"
+ *   open={drawerOpen}
+ *   onOpenChange={setDrawerOpen}
+ *   aria-label="App navigation"
+ * >
+ *   <DrawerItem label="Home" isActive />
+ *   <DrawerItem label="Inbox" badge={<span>5</span>} />
+ * </Drawer>
+ * ```
+ *
+ * @see https://m3.material.io/components/navigation-drawer/overview
+ */
+export const Drawer = forwardRef<HTMLElement, DrawerProps>(
+  (
+    {
+      variant = "standard",
+      open,
+      defaultOpen = false,
+      onOpenChange,
+      "aria-label": ariaLabel,
+      children,
+      className,
+      disableRipple = false,
+      ...restProps
+    },
+    ref
+  ) => {
+    const isOpen = open ?? defaultOpen;
+
+    const drawerPanelClass = cn(
+      drawerVariants({
+        variant,
+        open: isOpen,
+      }),
+      className
+    );
+
+    const scrimClass = scrimVariants();
+
+    return (
+      <HeadlessDrawer
+        ref={ref}
+        variant={variant}
+        {...(open !== undefined ? { open } : {})}
+        {...(defaultOpen !== undefined ? { defaultOpen } : {})}
+        {...(onOpenChange !== undefined ? { onOpenChange } : {})}
+        aria-label={ariaLabel}
+        className={drawerPanelClass}
+        scrimClassName={scrimClass}
+        disableRipple={disableRipple}
+        {...restProps}
+      >
+        {children}
+      </HeadlessDrawer>
+    );
+  }
+);
+
+Drawer.displayName = "Drawer";

--- a/packages/react/src/components/Drawer/Drawer.types.ts
+++ b/packages/react/src/components/Drawer/Drawer.types.ts
@@ -1,0 +1,290 @@
+import type { ReactNode } from "react";
+import type { AriaButtonProps, AriaDialogProps, AriaLinkOptions } from "react-aria";
+
+/**
+ * Structural variant of the Navigation Drawer.
+ *
+ * - `standard` — inline `<nav>` landmark; no overlay or focus trap; supports
+ *   controlled `open` prop for collapsible layouts.
+ * - `modal` — overlay dialog with scrim backdrop, slide-in animation,
+ *   focus trap, and `Escape` to close.
+ */
+export type DrawerVariant = "standard" | "modal";
+
+/**
+ * Material Design 3 Navigation Drawer props.
+ *
+ * Supports two structural variants — Standard (inline, permanently visible or
+ * togglable) and Modal (overlay with scrim and focus trap).
+ *
+ * @example
+ * ```tsx
+ * // Standard variant
+ * <Drawer variant="standard" open={open} onOpenChange={setOpen} aria-label="App navigation">
+ *   <DrawerItem label="Home" isActive />
+ *   <DrawerItem label="Settings" />
+ * </Drawer>
+ *
+ * // Modal variant with trigger
+ * <Drawer variant="modal" open={open} onOpenChange={setOpen} aria-label="App navigation">
+ *   <DrawerItem label="Home" isActive />
+ *   <DrawerSection header="Account">
+ *     <DrawerItem label="Profile" />
+ *   </DrawerSection>
+ * </Drawer>
+ * ```
+ */
+export interface DrawerProps extends AriaDialogProps {
+  /**
+   * Structural variant — drives which React Aria hooks and DOM structure are used.
+   * @default 'standard'
+   */
+  variant?: DrawerVariant;
+
+  /**
+   * Controlled open state. Pair with `onOpenChange`.
+   */
+  open?: boolean;
+
+  /**
+   * Default open state for uncontrolled usage.
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Called when the open state changes (e.g. Escape key, scrim click).
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Accessible label for the drawer landmark/dialog. Required.
+   *
+   * @example "App navigation"
+   */
+  "aria-label": string;
+
+  /**
+   * Drawer content — typically `DrawerItem` and `DrawerSection` elements.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes merged onto the drawer panel element.
+   */
+  className?: string;
+
+  /**
+   * Disable ripple effect on all items within the drawer.
+   * @default false
+   */
+  disableRipple?: boolean;
+}
+
+/**
+ * Material Design 3 Navigation Drawer Item props.
+ *
+ * Renders as `<a>` when `href` is provided (using `useLink`), or as `<button>`
+ * when no `href` is provided (using `useButton`).
+ *
+ * @example
+ * ```tsx
+ * // Button-based item (no href)
+ * <DrawerItem
+ *   icon={<HomeIcon />}
+ *   label="Home"
+ *   isActive
+ *   onPress={() => setPage('home')}
+ * />
+ *
+ * // Link-based item (with href)
+ * <DrawerItem href="/settings" icon={<SettingsIcon />} label="Settings" />
+ *
+ * // With badge
+ * <DrawerItem label="Inbox" badge={<span>3</span>} />
+ *
+ * // Disabled
+ * <DrawerItem label="Disabled" isDisabled />
+ * ```
+ */
+export interface DrawerItemProps extends AriaButtonProps, Pick<AriaLinkOptions, "href"> {
+  /**
+   * Optional URL — when provided, renders the item as `<a>` using `useLink`.
+   * When absent, renders as `<button>` using `useButton`.
+   */
+  href?: string;
+
+  /**
+   * Optional leading icon (24dp).
+   */
+  icon?: ReactNode;
+
+  /**
+   * Visible label text. Required.
+   */
+  label: string;
+
+  /**
+   * Optional trailing badge or secondary indicator element.
+   */
+  badge?: ReactNode;
+
+  /**
+   * Optional secondary descriptive text rendered below the label.
+   */
+  secondaryText?: string;
+
+  /**
+   * When `true`, marks this item as the active destination.
+   * Applies `aria-current="page"`, active indicator background, and
+   * `text-on-secondary-container`.
+   * @default false
+   */
+  isActive?: boolean;
+
+  /**
+   * Disable ripple effect on this specific item.
+   * @default false
+   */
+  disableRipple?: boolean;
+
+  /**
+   * Additional CSS classes merged via `cn()`.
+   */
+  className?: string;
+}
+
+/**
+ * Material Design 3 Navigation Drawer Section props.
+ *
+ * Groups related `DrawerItem` elements with an optional header label and
+ * a preceding divider (except the first section).
+ *
+ * @example
+ * ```tsx
+ * <DrawerSection header="Account">
+ *   <DrawerItem label="Profile" />
+ *   <DrawerItem label="Logout" />
+ * </DrawerSection>
+ * ```
+ */
+export interface DrawerSectionProps {
+  /**
+   * Optional section header label rendered in `text-title-small`.
+   */
+  header?: string;
+
+  /**
+   * Section content — typically `DrawerItem` elements.
+   */
+  children: ReactNode;
+
+  /**
+   * When `true`, renders a top divider line above the section.
+   * @default false
+   */
+  showDivider?: boolean;
+
+  /**
+   * Additional CSS classes merged via `cn()`.
+   */
+  className?: string;
+}
+
+/**
+ * Props for the headless Drawer primitive (Layer 2).
+ * Provides behavior and ARIA semantics without visual styling.
+ */
+export interface HeadlessDrawerProps {
+  /**
+   * Structural variant — drives which React Aria hooks are used.
+   * @default 'standard'
+   */
+  variant?: DrawerVariant;
+
+  /**
+   * Controlled open state.
+   */
+  open?: boolean;
+
+  /**
+   * Default open state for uncontrolled usage.
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Called when the open state changes.
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Accessible label. Required.
+   */
+  "aria-label": string;
+
+  /**
+   * Drawer content.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes for the drawer panel element.
+   */
+  className?: string;
+
+  /**
+   * Additional CSS classes for the scrim element (modal variant only).
+   */
+  scrimClassName?: string;
+
+  /**
+   * Disable ripple on all items.
+   * @default false
+   */
+  disableRipple?: boolean;
+}
+
+/**
+ * Props for the headless DrawerItem primitive (Layer 2).
+ */
+export interface HeadlessDrawerItemProps extends AriaButtonProps, Pick<AriaLinkOptions, "href"> {
+  /**
+   * Optional URL — determines `<a>` vs `<button>` rendering.
+   */
+  href?: string;
+
+  /**
+   * Whether this item is active (`aria-current="page"`).
+   * @default false
+   */
+  isActive?: boolean;
+
+  /**
+   * Item content.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes.
+   */
+  className?: string;
+
+  /**
+   * Mouse down handler (for ripple effect).
+   */
+  onMouseDown?: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+/**
+ * Context value shared between HeadlessDrawer and its children.
+ * @internal
+ */
+export interface DrawerContextValue {
+  /** Whether the drawer is currently open. */
+  isOpen: boolean;
+  /** Callback to close the drawer. */
+  close: () => void;
+  /** Whether ripple is disabled for all items. */
+  disableRipple: boolean;
+}

--- a/packages/react/src/components/Drawer/Drawer.variants.ts
+++ b/packages/react/src/components/Drawer/Drawer.variants.ts
@@ -1,0 +1,167 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Navigation Drawer container variants (CVA).
+ *
+ * Width: 360dp (`w-drawer`)
+ * Shape: `rounded-r-xl` (28px right-side radius per MD3 shape extra-large)
+ *
+ * Slide-in animation is driven by MD3 motion tokens:
+ * - Enter: `duration-medium4` (400ms), `ease-emphasized-decelerate`
+ * - Exit:  `duration-medium2` (300ms), `ease-emphasized-accelerate`
+ *
+ * @see https://m3.material.io/components/navigation-drawer/specs
+ */
+export const drawerVariants = cva(
+  [
+    // Layout
+    "fixed top-0 left-0 h-full w-drawer",
+    "flex flex-col overflow-y-auto",
+    // Stacking and shape
+    "z-50",
+    "rounded-r-xl",
+    // Slide animation (transition applies to all open/closed state changes)
+    "transition-transform duration-medium4 ease-emphasized-decelerate",
+    // Focus outline removal (focus management handled by FocusScope / React Aria)
+    "outline-none",
+  ],
+  {
+    variants: {
+      /**
+       * Structural variant — drives surface color and elevation.
+       * - `standard`: inline nav panel, lower-elevation surface
+       * - `modal`: overlay dialog with elevation shadow
+       */
+      variant: {
+        standard: ["bg-surface-container-low"],
+        modal: ["bg-surface-container", "shadow-elevation-1"],
+      },
+
+      /**
+       * Open/closed state — drives translation.
+       * - `true`:  drawer visible (`translate-x-0`)
+       * - `false`: drawer off-screen (`-translate-x-full`)
+       */
+      open: {
+        true: ["translate-x-0"],
+        false: ["-translate-x-full"],
+      },
+    },
+
+    defaultVariants: {
+      variant: "standard",
+      open: false,
+    },
+  }
+);
+
+/**
+ * Material Design 3 Navigation Drawer item variants (CVA).
+ *
+ * Each item is a full-width flex row with a pill-shaped active indicator.
+ *
+ * Active item: `bg-secondary-container` / `text-on-secondary-container`
+ * Inactive item: `text-on-surface-variant`
+ * State layers: `opacity-8` hover, `opacity-12` pressed
+ *
+ * @see https://m3.material.io/components/navigation-drawer/specs
+ */
+export const drawerItemVariants = cva(
+  [
+    // Layout
+    "relative flex w-full items-center gap-3",
+    "h-14 px-4",
+    "rounded-full",
+    // Typography
+    "text-label-large",
+    // Interaction
+    "cursor-pointer select-none outline-none",
+    // State layer pseudo-element
+    "before:absolute before:inset-0 before:rounded-full",
+    "before:transition-opacity before:duration-short2 before:ease-standard",
+    "before:opacity-0",
+    // Hover and focus visible state layers
+    "hover:before:opacity-8",
+    "focus-visible:before:opacity-12",
+    // Active pressed state
+    "active:before:opacity-12",
+    // Transition for color changes
+    "transition-colors duration-short2 ease-standard",
+  ],
+  {
+    variants: {
+      /**
+       * Whether this item is the currently active destination.
+       * Controls background, text color, and icon color per MD3 spec.
+       */
+      isActive: {
+        true: [
+          "bg-secondary-container",
+          "text-on-secondary-container",
+          "before:bg-on-secondary-container",
+        ],
+        false: ["bg-transparent", "text-on-surface-variant", "before:bg-on-surface-variant"],
+      },
+
+      /**
+       * Whether the item is disabled.
+       * Applies `opacity-38` per MD3 disabled state spec.
+       */
+      isDisabled: {
+        true: ["opacity-38 cursor-not-allowed pointer-events-none"],
+        false: [],
+      },
+    },
+
+    defaultVariants: {
+      isActive: false,
+      isDisabled: false,
+    },
+  }
+);
+
+/**
+ * Modal scrim overlay variants (CVA).
+ *
+ * Covers the full viewport behind the modal drawer.
+ * Clicking the scrim closes the drawer.
+ *
+ * Color: `bg-scrim` at `opacity-32` per MD3 spec.
+ */
+export const scrimVariants = cva([
+  "fixed inset-0 z-40",
+  "bg-scrim opacity-32",
+  "transition-opacity duration-medium2 ease-standard",
+]);
+
+/**
+ * Drawer section container variants (CVA).
+ *
+ * Groups related items with an optional header label and divider.
+ */
+export const drawerSectionVariants = cva(["flex flex-col w-full"]);
+
+/**
+ * Drawer section header variants (CVA).
+ *
+ * Header text: `text-title-small text-on-surface-variant` per MD3 spec.
+ */
+export const drawerSectionHeaderVariants = cva([
+  "px-7 pt-4 pb-2",
+  "text-title-small text-on-surface-variant",
+  "select-none",
+]);
+
+/**
+ * Drawer section divider variants (CVA).
+ *
+ * Horizontal rule using `border-outline-variant`.
+ */
+export const drawerDividerVariants = cva(["border-t border-outline-variant", "mx-4 my-2"]);
+
+// ─── Type exports ─────────────────────────────────────────────────────────────
+
+export type DrawerVariants = VariantProps<typeof drawerVariants>;
+export type DrawerItemVariants = VariantProps<typeof drawerItemVariants>;
+export type ScrimVariants = VariantProps<typeof scrimVariants>;
+export type DrawerSectionVariants = VariantProps<typeof drawerSectionVariants>;

--- a/packages/react/src/components/Drawer/DrawerHeadless.tsx
+++ b/packages/react/src/components/Drawer/DrawerHeadless.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { createContext, forwardRef, useContext, useRef, useCallback } from "react";
+import type React from "react";
+import {
+  useDialog,
+  useOverlay,
+  usePreventScroll,
+  useFocusRing,
+  useButton,
+  useLink,
+  FocusScope,
+} from "react-aria";
+import { useOverlayTriggerState } from "react-stately";
+import { mergeProps } from "@react-aria/utils";
+import type {
+  HeadlessDrawerProps,
+  HeadlessDrawerItemProps,
+  DrawerContextValue,
+} from "./Drawer.types";
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+/**
+ * Context shared between HeadlessDrawer and its children.
+ * @internal
+ */
+export const DrawerContext = createContext<DrawerContextValue | null>(null);
+
+/**
+ * Hook to access DrawerContext inside drawer children.
+ * @internal
+ */
+function useDrawerContext(): DrawerContextValue {
+  const ctx = useContext(DrawerContext);
+  if (ctx === null) {
+    throw new Error("DrawerItem must be rendered inside a Drawer component.");
+  }
+  return ctx;
+}
+
+// ─── HeadlessDrawer ───────────────────────────────────────────────────────────
+
+/**
+ * Headless Navigation Drawer (Layer 2).
+ *
+ * Provides all behavior and ARIA semantics without any visual styling.
+ * Renders two distinct DOM structures based on the `variant` prop:
+ *
+ * - **`standard`**: `<nav role="navigation">` — no overlay, no focus trap
+ * - **`modal`**: `<nav role="navigation">` containing a `FocusScope`-wrapped
+ *   `<div role="dialog" aria-modal="true">` with scrim overlay
+ *
+ * React Aria hooks used:
+ * - `useDialog` — `role="dialog"`, `aria-modal`, `aria-label` on modal panel
+ * - `useOverlay` — dismiss on Escape key and outside click (modal)
+ * - `usePreventScroll` — locks body scroll when modal is open
+ * - `FocusScope` — focus trap + restoreFocus when modal closes
+ * - `useOverlayTriggerState` — open/close state management
+ *
+ * @example
+ * ```tsx
+ * <HeadlessDrawer variant="modal" open aria-label="Navigation">
+ *   <HeadlessDrawerItem onPress={() => {}}>Home</HeadlessDrawerItem>
+ * </HeadlessDrawer>
+ * ```
+ */
+export const HeadlessDrawer = forwardRef<HTMLElement, HeadlessDrawerProps>(
+  (
+    {
+      variant = "standard",
+      open,
+      defaultOpen = false,
+      onOpenChange,
+      "aria-label": ariaLabel,
+      children,
+      className,
+      scrimClassName,
+      disableRipple = false,
+    },
+    ref
+  ) => {
+    // Manage open/close state with react-stately
+    // Use conditional spreading to satisfy exactOptionalPropertyTypes
+    const state = useOverlayTriggerState({
+      ...(open !== undefined ? { isOpen: open } : {}),
+      ...(defaultOpen !== undefined ? { defaultOpen } : {}),
+      ...(onOpenChange !== undefined ? { onOpenChange } : {}),
+    });
+
+    const isOpen = state.isOpen;
+
+    const close = useCallback(() => {
+      state.close();
+    }, [state]);
+
+    const contextValue: DrawerContextValue = {
+      isOpen,
+      close,
+      disableRipple,
+    };
+
+    if (variant === "modal") {
+      return (
+        <DrawerContext.Provider value={contextValue}>
+          <nav ref={ref as React.RefObject<HTMLElement>} role="navigation" aria-label={ariaLabel}>
+            {isOpen && (
+              <>
+                {/* Scrim overlay — clicking it closes the drawer */}
+                <div
+                  data-testid="drawer-scrim"
+                  className={scrimClassName}
+                  onClick={() => state.close()}
+                  aria-hidden="true"
+                />
+                {/* FocusScope: traps focus and restores it to trigger on close */}
+                <FocusScope contain restoreFocus autoFocus>
+                  <ModalDrawerPanel
+                    ariaLabel={ariaLabel}
+                    onClose={() => state.close()}
+                    className={className}
+                  >
+                    {children}
+                  </ModalDrawerPanel>
+                </FocusScope>
+              </>
+            )}
+          </nav>
+        </DrawerContext.Provider>
+      );
+    }
+
+    // Standard variant — inline nav, no overlay
+    return (
+      <DrawerContext.Provider value={contextValue}>
+        <nav
+          ref={ref as React.RefObject<HTMLElement>}
+          role="navigation"
+          aria-label={ariaLabel}
+          className={className}
+        >
+          {children}
+        </nav>
+      </DrawerContext.Provider>
+    );
+  }
+);
+
+HeadlessDrawer.displayName = "HeadlessDrawer";
+
+// ─── ModalDrawerPanel ─────────────────────────────────────────────────────────
+
+/**
+ * Inner dialog panel for the modal drawer variant.
+ * Applies `useDialog`, `useOverlay`, and `usePreventScroll`.
+ * @internal
+ */
+interface ModalDrawerPanelProps {
+  ariaLabel: string;
+  onClose: () => void;
+  className: string | undefined;
+  children: React.ReactNode;
+}
+
+const ModalDrawerPanel = ({
+  ariaLabel,
+  onClose,
+  className,
+  children,
+}: ModalDrawerPanelProps): React.ReactElement => {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // usePreventScroll locks the body scroll while the modal is open
+  usePreventScroll();
+
+  // useDialog provides role="dialog", aria-modal="true", and aria-label
+  const { dialogProps } = useDialog({ "aria-label": ariaLabel }, panelRef);
+
+  // useOverlay handles Escape key and outside-click dismissal
+  const { overlayProps } = useOverlay(
+    {
+      isOpen: true,
+      onClose,
+      isDismissable: true,
+      shouldCloseOnBlur: false,
+    },
+    panelRef
+  );
+
+  return (
+    <div
+      {...mergeProps(overlayProps, dialogProps)}
+      ref={panelRef}
+      className={className}
+      aria-modal="true"
+    >
+      {children}
+    </div>
+  );
+};
+
+ModalDrawerPanel.displayName = "ModalDrawerPanel";
+
+// ─── HeadlessDrawerItem ────────────────────────────────────────────────────────
+
+/**
+ * Headless Navigation Drawer Item (Layer 2).
+ *
+ * Renders as:
+ * - `<a>` using `useLink` when `href` is provided
+ * - `<button>` using `useButton` when no `href`
+ *
+ * Applies `aria-current="page"` when `isActive` is true.
+ * Uses `useFocusRing` for visible keyboard focus.
+ *
+ * @example
+ * ```tsx
+ * // Button-based item
+ * <HeadlessDrawerItem onPress={() => navigate('home')} isActive>
+ *   Home
+ * </HeadlessDrawerItem>
+ *
+ * // Link-based item
+ * <HeadlessDrawerItem href="/settings">
+ *   Settings
+ * </HeadlessDrawerItem>
+ * ```
+ */
+export const HeadlessDrawerItem = forwardRef<HTMLElement, HeadlessDrawerItemProps>(
+  (
+    {
+      href,
+      isActive = false,
+      children,
+      className,
+      isDisabled,
+      onMouseDown,
+      onPress,
+      onPressStart,
+      onPressEnd,
+      onPressChange,
+      onPressUp,
+      ...restProps
+    },
+    forwardedRef
+  ) => {
+    const internalRef = useRef<HTMLElement>(null);
+    const { isFocusVisible, focusProps } = useFocusRing();
+
+    if (href) {
+      // ── Link variant ──────────────────────────────────────────────────────
+      const linkRef = (forwardedRef ?? internalRef) as React.RefObject<HTMLAnchorElement>;
+
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const { linkProps } = useLink(
+        {
+          href,
+          ...(isDisabled !== undefined ? { isDisabled } : {}),
+          ...(onPress !== undefined ? { onPress } : {}),
+        },
+        linkRef
+      );
+
+      return (
+        <a
+          {...mergeProps(linkProps, focusProps, { onMouseDown })}
+          ref={linkRef}
+          href={href}
+          className={className}
+          aria-current={isActive ? "page" : undefined}
+          data-focus-visible={isFocusVisible || undefined}
+          data-active={isActive || undefined}
+        >
+          {children}
+        </a>
+      );
+    }
+
+    // ── Button variant ────────────────────────────────────────────────────────
+    const buttonRef = (forwardedRef ?? internalRef) as React.RefObject<HTMLButtonElement>;
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { buttonProps } = useButton(
+      {
+        ...restProps,
+        ...(isDisabled !== undefined ? { isDisabled } : {}),
+        ...(onPress !== undefined ? { onPress } : {}),
+        ...(onPressStart !== undefined ? { onPressStart } : {}),
+        ...(onPressEnd !== undefined ? { onPressEnd } : {}),
+        ...(onPressChange !== undefined ? { onPressChange } : {}),
+        ...(onPressUp !== undefined ? { onPressUp } : {}),
+        elementType: "button",
+      },
+      buttonRef
+    );
+
+    return (
+      <button
+        type="button"
+        {...mergeProps(buttonProps, focusProps, { onMouseDown })}
+        ref={buttonRef}
+        className={className}
+        aria-current={isActive ? "page" : undefined}
+        data-focus-visible={isFocusVisible || undefined}
+        data-active={isActive || undefined}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+HeadlessDrawerItem.displayName = "HeadlessDrawerItem";
+
+// ─── Re-export context hook for styled layer ──────────────────────────────────
+
+export { useDrawerContext };

--- a/packages/react/src/components/Drawer/DrawerItem.tsx
+++ b/packages/react/src/components/Drawer/DrawerItem.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { forwardRef } from "react";
+import { HeadlessDrawerItem } from "./DrawerHeadless";
+import { drawerItemVariants } from "./Drawer.variants";
+import { cn } from "../../utils/cn";
+import { useRipple } from "../../hooks/useRipple";
+import type { DrawerItemProps } from "./Drawer.types";
+
+/**
+ * Material Design 3 Navigation Drawer Item (Layer 3: Styled).
+ *
+ * Renders a navigation destination row following MD3 Navigation Drawer specs.
+ * Uses `HeadlessDrawerItem` for behavior and accessibility, CVA for variants.
+ *
+ * Renders as `<a>` when `href` is provided, `<button>` otherwise.
+ *
+ * Features:
+ * - Active indicator: `bg-secondary-container` / `text-on-secondary-container`
+ * - `aria-current="page"` on active item
+ * - Ripple effect on interaction
+ * - Hover/focus/pressed state layers (MD3 spec: 8% / 12%)
+ * - Optional leading icon (24dp slot)
+ * - Optional trailing badge or secondary text
+ * - Disabled state: `opacity-38`, non-interactive
+ *
+ * @example
+ * ```tsx
+ * // Active item with icon
+ * <DrawerItem icon={<HomeIcon />} label="Home" isActive onPress={() => navigate('/')} />
+ *
+ * // Link item
+ * <DrawerItem href="/settings" icon={<SettingsIcon />} label="Settings" />
+ *
+ * // Item with badge
+ * <DrawerItem label="Inbox" badge={<span>3</span>} />
+ *
+ * // Disabled
+ * <DrawerItem label="Disabled Feature" isDisabled />
+ * ```
+ *
+ * @see https://m3.material.io/components/navigation-drawer/specs
+ */
+export const DrawerItem = forwardRef<HTMLElement, DrawerItemProps>(
+  (
+    {
+      href,
+      icon,
+      label,
+      badge,
+      secondaryText,
+      isActive = false,
+      isDisabled = false,
+      disableRipple = false,
+      className,
+      onPress,
+      onPressStart,
+      onPressEnd,
+      onPressChange,
+      onPressUp,
+      ...restProps
+    },
+    ref
+  ) => {
+    const isItemDisabled = isDisabled;
+
+    const { onMouseDown: handleRipple, ripples } = useRipple({
+      disabled: isItemDisabled || disableRipple,
+    });
+
+    return (
+      <HeadlessDrawerItem
+        {...restProps}
+        ref={ref}
+        {...(href !== undefined ? { href } : {})}
+        isActive={isActive}
+        {...(isItemDisabled !== undefined ? { isDisabled: isItemDisabled } : {})}
+        {...(onPress !== undefined ? { onPress } : {})}
+        {...(onPressStart !== undefined ? { onPressStart } : {})}
+        {...(onPressEnd !== undefined ? { onPressEnd } : {})}
+        {...(onPressChange !== undefined ? { onPressChange } : {})}
+        {...(onPressUp !== undefined ? { onPressUp } : {})}
+        onMouseDown={handleRipple}
+        className={cn(
+          drawerItemVariants({
+            isActive,
+            isDisabled: isItemDisabled,
+          }),
+          className
+        )}
+      >
+        {/* Ripple effect */}
+        {ripples}
+
+        {/* Leading icon slot (24dp) */}
+        {icon && (
+          <span
+            className="relative z-10 flex shrink-0 items-center justify-center"
+            aria-hidden="true"
+          >
+            {icon}
+          </span>
+        )}
+
+        {/* Label and optional secondary text */}
+        <span className="relative z-10 flex min-w-0 flex-1 flex-col">
+          <span className="truncate">{label}</span>
+          {secondaryText && (
+            <span className="text-body-small truncate opacity-70">{secondaryText}</span>
+          )}
+        </span>
+
+        {/* Trailing badge */}
+        {badge && (
+          <span className="relative z-10 ml-auto flex shrink-0 items-center" aria-hidden="true">
+            {badge}
+          </span>
+        )}
+      </HeadlessDrawerItem>
+    );
+  }
+);
+
+DrawerItem.displayName = "DrawerItem";

--- a/packages/react/src/components/Drawer/DrawerSection.tsx
+++ b/packages/react/src/components/Drawer/DrawerSection.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { forwardRef } from "react";
+import {
+  drawerSectionVariants,
+  drawerSectionHeaderVariants,
+  drawerDividerVariants,
+} from "./Drawer.variants";
+import { cn } from "../../utils/cn";
+import type { DrawerSectionProps } from "./Drawer.types";
+
+/**
+ * Material Design 3 Navigation Drawer Section (Layer 3: Styled).
+ *
+ * Groups related `DrawerItem` elements with an optional header label and
+ * a horizontal divider. Follows MD3 Navigation Drawer spec for section
+ * grouping and typography.
+ *
+ * Features:
+ * - Optional header label: `text-title-small text-on-surface-variant`
+ * - Optional top divider: `border-outline-variant`
+ * - Semantic `<hr role="separator">` for the divider
+ *
+ * @example
+ * ```tsx
+ * // Section with header and divider
+ * <DrawerSection header="Account" showDivider>
+ *   <DrawerItem icon={<ProfileIcon />} label="Profile" />
+ *   <DrawerItem icon={<LogoutIcon />} label="Logout" />
+ * </DrawerSection>
+ *
+ * // Section without header (just a visual group)
+ * <DrawerSection showDivider>
+ *   <DrawerItem label="Help" />
+ * </DrawerSection>
+ * ```
+ *
+ * @see https://m3.material.io/components/navigation-drawer/specs
+ */
+export const DrawerSection = forwardRef<HTMLDivElement, DrawerSectionProps>(
+  ({ header, children, showDivider = false, className }, ref) => {
+    return (
+      <div ref={ref} className={cn(drawerSectionVariants(), className)}>
+        {/* Divider above the section */}
+        {showDivider && (
+          <hr role="separator" aria-hidden="true" className={drawerDividerVariants()} />
+        )}
+
+        {/* Section header label */}
+        {header && <span className={drawerSectionHeaderVariants()}>{header}</span>}
+
+        {/* Section items */}
+        {children}
+      </div>
+    );
+  }
+);
+
+DrawerSection.displayName = "DrawerSection";

--- a/packages/react/src/components/Drawer/index.ts
+++ b/packages/react/src/components/Drawer/index.ts
@@ -1,0 +1,32 @@
+// Layer 3: MD3 Styled Components (most users use these)
+export { Drawer } from "./Drawer";
+export { DrawerItem } from "./DrawerItem";
+export { DrawerSection } from "./DrawerSection";
+
+// Layer 2: Headless Primitives (for advanced customization)
+export { HeadlessDrawer, HeadlessDrawerItem, DrawerContext } from "./DrawerHeadless";
+
+// CVA Variants
+export {
+  drawerVariants,
+  drawerItemVariants,
+  scrimVariants,
+  drawerSectionVariants,
+  drawerSectionHeaderVariants,
+  drawerDividerVariants,
+  type DrawerVariants,
+  type DrawerItemVariants,
+  type ScrimVariants,
+  type DrawerSectionVariants,
+} from "./Drawer.variants";
+
+// Types
+export type {
+  DrawerVariant,
+  DrawerProps,
+  DrawerItemProps,
+  DrawerSectionProps,
+  HeadlessDrawerProps,
+  HeadlessDrawerItemProps,
+  DrawerContextValue,
+} from "./Drawer.types";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -68,3 +68,14 @@ export type {
   HeadlessTabProps,
   HeadlessTabPanelProps,
 } from "./Tabs";
+
+export { Drawer, DrawerItem, DrawerSection, HeadlessDrawer, HeadlessDrawerItem } from "./Drawer";
+export type {
+  DrawerProps,
+  DrawerItemProps,
+  DrawerSectionProps,
+  DrawerVariant,
+  HeadlessDrawerProps,
+  HeadlessDrawerItemProps,
+  DrawerContextValue,
+} from "./Drawer";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -112,3 +112,20 @@ export type {
   HeadlessNavigationBarItemProps,
   NavigationBarItemRenderProps,
 } from "./components/NavigationBar";
+
+export {
+  Drawer,
+  DrawerItem,
+  DrawerSection,
+  HeadlessDrawer,
+  HeadlessDrawerItem,
+} from "./components/Drawer";
+export type {
+  DrawerProps,
+  DrawerItemProps,
+  DrawerSectionProps,
+  DrawerVariant,
+  HeadlessDrawerProps,
+  HeadlessDrawerItemProps,
+  DrawerContextValue,
+} from "./components/Drawer";

--- a/packages/tokens/src/tokens.css
+++ b/packages/tokens/src/tokens.css
@@ -62,6 +62,9 @@
   --md-sys-color-background: #fffbfe;
   --md-sys-color-on-background: #1c1b1f;
 
+  /* Scrim */
+  --md-sys-color-scrim: #000000;
+
   /* ==========================================================================
      TYPOGRAPHY TOKENS
      Material Design 3 Type Scale - 5 categories, 3 sizes each (15 total)
@@ -251,6 +254,9 @@
   /* Background */
   --md-sys-color-background: #1c1b1f;
   --md-sys-color-on-background: #e6e1e5;
+
+  /* Scrim */
+  --md-sys-color-scrim: #000000;
 }
 
 /* System/OS dark mode preference (activates when no .light class is present) */
@@ -300,6 +306,9 @@
     /* Background */
     --md-sys-color-background: #1c1b1f;
     --md-sys-color-on-background: #e6e1e5;
+
+    /* Scrim */
+    --md-sys-color-scrim: #000000;
   }
 }
 
@@ -371,6 +380,9 @@ body {
   --color-background: var(--md-sys-color-background);
   --color-on-background: var(--md-sys-color-on-background);
 
+  /* Scrim color */
+  --color-scrim: var(--md-sys-color-scrim);
+
   /* Elevation/Shadow utilities
      Maps MD3 elevation levels to Tailwind box-shadow utilities
      Usage: shadow-elevation-1, shadow-elevation-2, etc. */
@@ -403,6 +415,7 @@ body {
   /* Opacity values for MD3 state layers */
   --opacity-8: 0.08;
   --opacity-12: 0.12;
+  --opacity-32: 0.32;
   --opacity-38: 0.38;
 
   /* Typography utilities
@@ -479,4 +492,15 @@ body {
   --spacing-appbar-small: 4rem; /* 64px */
   --spacing-appbar-medium: 7rem; /* 112px */
   --spacing-appbar-large: 9.5rem; /* 152px */
+
+  /* Drawer width: MD3 spec = 360dp */
+  --spacing-drawer: 22.5rem; /* 360px */
+
+  /* Shape radius utilities for MD3 components */
+  --radius-xs: var(--md-sys-shape-corner-extra-small); /* 4px */
+  --radius-sm: var(--md-sys-shape-corner-small); /* 8px */
+  --radius-md: var(--md-sys-shape-corner-medium); /* 12px */
+  --radius-lg: var(--md-sys-shape-corner-large); /* 16px */
+  --radius-xl: var(--md-sys-shape-corner-extra-large); /* 28px */
+  --radius-full: var(--md-sys-shape-corner-full);
 }


### PR DESCRIPTION
## Summary

Implements the Material Design 3 Navigation Drawer component for `@tinybigui/react` as part of the Phase 2 Navigation milestone. Closes #27.

- **Standard variant** — inline `<nav>` landmark with controlled `open` prop; no overlay or focus trap; `bg-surface-container-low`
- **Modal variant** — overlay dialog with scrim, slide-in animation, `FocusScope` focus trap, `Escape` to close; `bg-surface-container` + `shadow-elevation-1`
- **`DrawerItem`** — navigation row with optional icon, label, badge, secondary text, active indicator (`bg-secondary-container`), ripple effect, and state layers
- **`DrawerSection`** — groups items with optional header (`text-title-small`) and divider (`border-outline-variant`)
- **`HeadlessDrawer` / `HeadlessDrawerItem`** — React Aria primitives for advanced consumers

## Architecture

Three-layer architecture following project conventions:

```
Layer 3 — Drawer.tsx / DrawerItem.tsx / DrawerSection.tsx   (MD3 styled, CVA variants, 'use client')
Layer 2 — DrawerHeadless.tsx                                (React Aria: useDialog, useOverlay, FocusScope)
Layer 1 — React Aria                                        (useDialog, useOverlay, usePreventScroll, FocusScope, useLink, useButton)
```

## Files changed

| File | Description |
|------|-------------|
| `packages/tokens/src/tokens.css` | Added `--color-scrim`, `--opacity-32`, `--spacing-drawer`, shape radius utilities |
| `Drawer.types.ts` | TypeScript interfaces for all public props |
| `Drawer.variants.ts` | CVA definitions (drawer, item, scrim, section, divider) |
| `DrawerHeadless.tsx` | React Aria headless layer (standard + modal branches) |
| `DrawerItem.tsx` | Styled navigation item |
| `DrawerSection.tsx` | Styled section header + divider |
| `Drawer.tsx` | MD3 styled main component |
| `Drawer.test.tsx` | 56 tests — TDD first (rendering, a11y, keyboard, focus trap, interactions) |
| `Drawer.stories.tsx` | Storybook stories (11 stories: both variants, active, sections, disabled, links, dark mode) |
| `index.ts` | Named exports for all public components and types |
| `components/index.ts`, `src/index.ts` | Barrel exports updated |

## Quality gates

- **Tests:** 633/633 passing (56 new Drawer tests, all axe audits pass)
- **TypeScript:** zero errors (`pnpm typecheck`)
- **ESLint:** zero errors (`pnpm eslint`)
- **WCAG 2.1 AA:** `role="navigation"`, `aria-label`, `role="dialog"` + `aria-modal="true"`, `aria-current="page"` on active item, `Escape` closes modal, `FocusScope` traps focus, focus restores to trigger

## Test plan

- [ ] Open Storybook and verify Standard variant renders inline with correct token-based styling
- [ ] Open Storybook and verify Modal variant renders with scrim overlay and slide-in animation
- [ ] Verify `Escape` closes the modal drawer
- [ ] Verify clicking the scrim closes the modal drawer
- [ ] Verify focus is trapped in modal and returns to trigger on close
- [ ] Verify active item shows `bg-secondary-container` indicator
- [ ] Verify disabled items are not interactive
- [ ] Verify link items (`href`) render as `<a>` elements
- [ ] Verify dark mode styling works correctly
