### PR TITLE
feat(snackbar): implement md3 snackbar component

### DIFF
--- a/packages/react/src/components/Snackbar/Snackbar.stories.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,0 +1,487 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState, type JSX } from "react";
+import { Snackbar } from "./Snackbar";
+import { SnackbarProvider, useSnackbar } from "./SnackbarProvider";
+
+/**
+ * Material Design 3 Snackbar Component
+ *
+ * Snackbars provide brief messages about app processes at the bottom of the
+ * screen. They appear temporarily and don't require user input to disappear.
+ *
+ * ## Content Configurations
+ * - **Single-line** — message text only
+ * - **Two-line** — message + supporting text (when content exceeds one line)
+ * - **With action** — single text button for an undo or related action
+ * - **With close icon** — explicit dismiss button for persistent messages
+ *
+ * ## MD3 Specifications
+ * - Surface: `inverse-surface` with `inverse-on-surface` text
+ * - Shape: extra-small corner (4dp) → `rounded-xs`
+ * - Elevation: level 3 → `shadow-elevation-3`
+ * - Width: 288dp min, 568dp max, centered `bottom-4`
+ * - Auto-dismiss: 4000ms default, pauses on hover and focus
+ * - Motion: entry slide-up 200ms / exit fade-out 100ms
+ *
+ * ## Usage
+ * ```tsx
+ * // Wrap your app with SnackbarProvider
+ * <SnackbarProvider>
+ *   <App />
+ * </SnackbarProvider>
+ *
+ * // Trigger from any descendant component
+ * const { showSnackbar } = useSnackbar();
+ * showSnackbar({ message: "File deleted", action: { label: "Undo", onAction: handleUndo } });
+ * ```
+ */
+const meta: Meta<typeof Snackbar> = {
+  title: "Components/Snackbar",
+  component: Snackbar,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <SnackbarProvider>
+        <Story />
+      </SnackbarProvider>
+    ),
+  ],
+  argTypes: {
+    message: {
+      control: "text",
+      description: "Primary message text",
+    },
+    supportingText: {
+      control: "text",
+      description: "Optional second line of text (two-line configuration)",
+    },
+    duration: {
+      control: { type: "number", min: 0, step: 500 },
+      description: "Auto-dismiss duration in ms. Set to 0 to disable.",
+      defaultValue: 4000,
+    },
+    severity: {
+      control: "radio",
+      options: ["default", "error"],
+      description: "Controls ARIA live region — polite (default) or assertive (error)",
+    },
+    showClose: {
+      control: "boolean",
+      description: "Show a close icon button",
+    },
+  },
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Brief, temporary messages rendered at the bottom of the viewport. Supports auto-dismiss with hover/focus pause, sequential queue, and an imperative API via useSnackbar().",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Snackbar>;
+
+// ---------------------------------------------------------------------------
+// Individual content configuration stories
+// ---------------------------------------------------------------------------
+
+/**
+ * Single-line message — the simplest Snackbar configuration.
+ * Auto-dismisses after 4 seconds.
+ */
+export const SingleLine: Story = {
+  args: {
+    message: "File deleted",
+    duration: 0,
+  },
+};
+
+/**
+ * Two-line configuration — message + supporting text.
+ * Used when the message exceeds one line.
+ */
+export const TwoLine: Story = {
+  args: {
+    message: "Connection lost",
+    supportingText: "Please check your network and try again",
+    duration: 0,
+  },
+};
+
+/**
+ * With action button — single text action for an undo or related task.
+ * Action button uses `inverse-primary` color per MD3 spec.
+ */
+export const WithAction: Story = {
+  args: {
+    message: "File deleted",
+    action: { label: "Undo", onAction: () => alert("Undo triggered") },
+    duration: 0,
+  },
+};
+
+/**
+ * With close icon — explicit dismiss button.
+ * Useful when auto-dismiss is disabled or the message is important.
+ */
+export const WithCloseIcon: Story = {
+  args: {
+    message: "File deleted",
+    showClose: true,
+    duration: 0,
+  },
+};
+
+/**
+ * With action and close icon — all interactive elements combined.
+ */
+export const WithActionAndClose: Story = {
+  args: {
+    message: "File deleted",
+    action: { label: "Undo", onAction: () => alert("Undo") },
+    showClose: true,
+    duration: 0,
+  },
+};
+
+/**
+ * Error severity — uses `role="alert" aria-live="assertive"` for urgent
+ * screen reader announcements.
+ */
+export const ErrorSeverity: Story = {
+  args: {
+    message: "Upload failed. Please try again.",
+    severity: "error",
+    showClose: true,
+    duration: 0,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Auto-dismiss demos
+// ---------------------------------------------------------------------------
+
+/**
+ * Short duration — dismisses after 2 seconds.
+ */
+export const ShortDuration: Story = {
+  args: {
+    message: "Copied to clipboard",
+    duration: 2000,
+  },
+};
+
+/**
+ * Persistent — no auto-dismiss (duration=0). Requires explicit close.
+ */
+export const Persistent: Story = {
+  args: {
+    message: "This message will not auto-dismiss",
+    duration: 0,
+    showClose: true,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Interactive queue demo
+// ---------------------------------------------------------------------------
+
+/**
+ * Queue demo — multiple Snackbars displayed sequentially, never stacked.
+ * Click the buttons quickly to queue several messages.
+ */
+export const QueueDemo: Story = {
+  render: function QueueDemoRender() {
+    const { showSnackbar } = useSnackbar();
+
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-body-medium text-on-surface-variant">
+          Click buttons to queue multiple Snackbars. They appear one at a time.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={() => showSnackbar({ message: "File deleted", duration: 3000 })}
+            className="bg-primary text-on-primary text-label-large rounded-full px-4 py-2"
+          >
+            File deleted
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              showSnackbar({
+                message: "Photo saved",
+                action: { label: "View", onAction: () => alert("Viewing photo") },
+                duration: 3000,
+              })
+            }
+            className="bg-secondary text-on-secondary text-label-large rounded-full px-4 py-2"
+          >
+            Photo saved (with action)
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              showSnackbar({
+                message: "Upload failed",
+                severity: "error",
+                showClose: true,
+                duration: 4000,
+              })
+            }
+            className="bg-error text-on-error text-label-large rounded-full px-4 py-2"
+          >
+            Upload failed (error)
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              showSnackbar({
+                message: "Connection lost",
+                supportingText: "Check your network settings",
+                showClose: true,
+                duration: 3000,
+              })
+            }
+            className="bg-surface-container-high text-on-surface text-label-large rounded-full px-4 py-2"
+          >
+            Two-line
+          </button>
+        </div>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Playground
+// ---------------------------------------------------------------------------
+
+/**
+ * Playground — trigger Snackbars with configurable options.
+ */
+export const Playground: Story = {
+  render: function PlaygroundRender(): JSX.Element {
+    const { showSnackbar } = useSnackbar();
+    const [message, setMessage] = useState("Changes saved");
+    const [supportingText, setSupportingText] = useState("");
+    const [actionLabel, setActionLabel] = useState("");
+    const [showCloseIcon, setShowCloseIcon] = useState(false);
+    const [duration, setDuration] = useState(4000);
+    const [severity, setSeverity] = useState<"default" | "error">("default");
+
+    const trigger = (): void => {
+      showSnackbar({
+        message,
+        supportingText: supportingText || undefined,
+        action: actionLabel
+          ? { label: actionLabel, onAction: () => alert(`Action: ${actionLabel}`) }
+          : undefined,
+        showClose: showCloseIcon,
+        duration,
+        severity,
+      });
+    };
+
+    return (
+      <div className="flex w-full max-w-lg flex-col gap-6">
+        <div className="bg-surface-container-high flex flex-col gap-4 rounded-xl p-5">
+          <h3 className="text-title-medium text-on-surface">Configure Snackbar</h3>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="sb-message" className="text-label-large text-on-surface-variant">
+              Message
+            </label>
+            <input
+              id="sb-message"
+              type="text"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-3 py-2"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="sb-supporting" className="text-label-large text-on-surface-variant">
+              Supporting text (optional, makes two-line)
+            </label>
+            <input
+              id="sb-supporting"
+              type="text"
+              value={supportingText}
+              onChange={(e) => setSupportingText(e.target.value)}
+              placeholder="Leave empty for single-line"
+              className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-3 py-2"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="sb-action" className="text-label-large text-on-surface-variant">
+              Action button label (optional)
+            </label>
+            <input
+              id="sb-action"
+              type="text"
+              value={actionLabel}
+              onChange={(e) => setActionLabel(e.target.value)}
+              placeholder="e.g. Undo"
+              className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-3 py-2"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <label className="text-body-medium text-on-surface flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={showCloseIcon}
+                onChange={(e) => setShowCloseIcon(e.target.checked)}
+              />
+              Show close icon
+            </label>
+
+            <div className="flex items-center gap-2">
+              <label htmlFor="sb-duration" className="text-label-large text-on-surface-variant">
+                Duration (ms):
+              </label>
+              <input
+                id="sb-duration"
+                type="number"
+                value={duration}
+                step={500}
+                min={0}
+                onChange={(e) => setDuration(Number(e.target.value))}
+                className="bg-surface border-outline text-body-medium text-on-surface w-24 rounded-sm border px-2 py-1"
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <label htmlFor="sb-severity" className="text-label-large text-on-surface-variant">
+                Severity:
+              </label>
+              <select
+                id="sb-severity"
+                value={severity}
+                onChange={(e) => setSeverity(e.target.value as "default" | "error")}
+                className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-2 py-1"
+              >
+                <option value="default">default</option>
+                <option value="error">error</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={trigger}
+          className="bg-primary text-on-primary text-label-large w-fit rounded-full px-6 py-3"
+        >
+          Show Snackbar
+        </button>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// All configurations showcase
+// ---------------------------------------------------------------------------
+
+/**
+ * All configurations — visual reference for all four MD3 content layouts.
+ * Each Snackbar is rendered declaratively with `duration=0` (no auto-dismiss)
+ * so they remain visible in the docs.
+ */
+export const AllConfigurations: Story = {
+  render: function AllConfigurationsRender() {
+    return (
+      <div className="flex w-full flex-col gap-4">
+        <p className="text-title-medium text-on-surface">
+          All MD3 Snackbar content configurations:
+        </p>
+        <p className="text-body-small text-on-surface-variant">
+          Rendered declaratively — Snackbars are normally positioned fixed at bottom of viewport.
+          Here they are shown inline for documentation purposes.
+        </p>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {/* Single-line */}
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-3"
+          >
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-body-medium text-inverse-on-surface">File deleted</span>
+            </div>
+          </div>
+
+          {/* Two-line */}
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-4"
+          >
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-body-medium text-inverse-on-surface">Connection lost</span>
+              <span className="text-body-medium text-inverse-on-surface opacity-80">
+                Please check your network settings
+              </span>
+            </div>
+          </div>
+
+          {/* With action */}
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-3"
+          >
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-body-medium text-inverse-on-surface">Photo archived</span>
+            </div>
+            <button type="button" className="text-inverse-primary text-label-large shrink-0 px-2">
+              Undo
+            </button>
+          </div>
+
+          {/* With close */}
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-3"
+          >
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-body-medium text-inverse-on-surface">
+                Message sent successfully
+              </span>
+            </div>
+            <button
+              type="button"
+              aria-label="Close"
+              className="text-inverse-on-surface shrink-0 p-1"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};

--- a/packages/react/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.test.tsx
@@ -1,0 +1,626 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { Snackbar } from "./Snackbar";
+import { SnackbarHeadless } from "./SnackbarHeadless";
+import { SnackbarProvider, useSnackbar } from "./SnackbarProvider";
+import type { SnackbarProps } from "./Snackbar.types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const renderSnackbar = (props: Partial<SnackbarProps> = {}) =>
+  render(
+    <SnackbarProvider>
+      <Snackbar message="File deleted" {...props} />
+    </SnackbarProvider>
+  );
+
+/**
+ * Advance fake timers through all phases of the auto-dismiss lifecycle:
+ * 1. entering → visible (setTimeout 0ms fires, React re-renders)
+ * 2. visible → exiting (dismiss timer fires)
+ * 3. exiting → exited (150ms exit fallback fires → onClose called)
+ *
+ * Each phase is wrapped in its own act() to ensure React flushes state
+ * updates between phases. Must be called with vi.useFakeTimers() active.
+ */
+function advanceAndFinishExit(durationMs: number): void {
+  act(() => {
+    vi.advanceTimersByTime(0);
+  }); // entering → visible
+  act(() => {
+    vi.advanceTimersByTime(durationMs);
+  }); // visible → exiting
+  act(() => {
+    vi.advanceTimersByTime(200);
+  }); // exit fallback fires
+}
+
+const renderWithQueue = () => {
+  const TriggerComponent = () => {
+    const { showSnackbar } = useSnackbar();
+    return (
+      <div>
+        <button onClick={() => showSnackbar({ message: "First", duration: 3000 })}>
+          Show First
+        </button>
+        <button onClick={() => showSnackbar({ message: "Second", duration: 3000 })}>
+          Show Second
+        </button>
+        <button onClick={() => showSnackbar({ message: "Third", duration: 3000 })}>
+          Show Third
+        </button>
+      </div>
+    );
+  };
+  return render(
+    <SnackbarProvider>
+      <TriggerComponent />
+    </SnackbarProvider>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe("Snackbar", () => {
+  describe("Rendering", () => {
+    test("renders single-line message", () => {
+      renderSnackbar({ message: "File deleted" });
+      expect(screen.getByText("File deleted")).toBeInTheDocument();
+    });
+
+    test("renders two-line message with supporting text", () => {
+      renderSnackbar({
+        message: "Connection lost",
+        supportingText: "Please check your network",
+      });
+      expect(screen.getByText("Connection lost")).toBeInTheDocument();
+      expect(screen.getByText("Please check your network")).toBeInTheDocument();
+    });
+
+    test("renders action button when action prop is provided", () => {
+      renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction: vi.fn() },
+      });
+      expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
+    });
+
+    test("does not render action button when action prop is absent", () => {
+      renderSnackbar({ message: "File deleted" });
+      expect(screen.queryByRole("button", { name: /undo/i })).not.toBeInTheDocument();
+    });
+
+    test("renders close icon button when showClose is true", () => {
+      renderSnackbar({ message: "File deleted", showClose: true });
+      expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
+    });
+
+    test("does not render close icon button when showClose is false", () => {
+      renderSnackbar({ message: "File deleted", showClose: false });
+      expect(screen.queryByRole("button", { name: /close/i })).not.toBeInTheDocument();
+    });
+
+    test("renders both action button and close icon when both props provided", () => {
+      renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction: vi.fn() },
+        showClose: true,
+      });
+      expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
+    });
+
+    test("merges custom className onto container", () => {
+      renderSnackbar({ message: "Hello", className: "my-custom-class" });
+      const container = screen.getByRole("status");
+      expect(container).toHaveClass("my-custom-class");
+    });
+
+    test("forwards ref to container element", () => {
+      const ref = { current: null };
+      render(
+        <SnackbarProvider>
+          <Snackbar message="Hello" ref={ref} />
+        </SnackbarProvider>
+      );
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Accessibility
+  // ---------------------------------------------------------------------------
+
+  describe("Accessibility", () => {
+    test("has role=status and aria-live=polite for default severity", () => {
+      renderSnackbar({ message: "File deleted", severity: "default" });
+      const el = screen.getByRole("status");
+      expect(el).toHaveAttribute("aria-live", "polite");
+      expect(el).toHaveAttribute("aria-atomic", "true");
+    });
+
+    test("has role=alert and aria-live=assertive for error severity", () => {
+      renderSnackbar({ message: "Upload failed", severity: "error" });
+      const el = screen.getByRole("alert");
+      expect(el).toHaveAttribute("aria-live", "assertive");
+    });
+
+    test("action button has an accessible name", () => {
+      renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction: vi.fn() },
+      });
+      const btn = screen.getByRole("button", { name: "Undo" });
+      expect(btn).toBeInTheDocument();
+    });
+
+    test("close icon button has an accessible label", () => {
+      renderSnackbar({ message: "File deleted", showClose: true });
+      const closeBtn = screen.getByRole("button", { name: /close/i });
+      expect(closeBtn).toHaveAttribute("aria-label");
+    });
+
+    test("single-line default snackbar has no axe violations", async () => {
+      const { container } = renderSnackbar({ message: "File deleted" });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("snackbar with action has no axe violations", async () => {
+      const { container } = renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction: vi.fn() },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("snackbar with close icon has no axe violations", async () => {
+      const { container } = renderSnackbar({
+        message: "File deleted",
+        showClose: true,
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("error severity snackbar has no axe violations", async () => {
+      const { container } = renderSnackbar({
+        message: "Upload failed",
+        severity: "error",
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Auto-dismiss
+  // ---------------------------------------------------------------------------
+
+  describe("Auto-dismiss", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("calls onClose after default 4000ms duration", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", onClose });
+
+      expect(onClose).not.toHaveBeenCalled();
+      advanceAndFinishExit(4000);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("calls onClose after custom duration", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "Quick message", duration: 2000, onClose });
+
+      advanceAndFinishExit(2000);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not auto-dismiss when duration is 0", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "Persistent", duration: 0, onClose });
+
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test("does not auto-dismiss before duration elapses", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      // Flush entering→visible then advance to just before dismiss
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      act(() => {
+        vi.advanceTimersByTime(3999);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pause on hover
+  // ---------------------------------------------------------------------------
+
+  describe("Pause on hover", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("pauses auto-dismiss timer on mouseenter", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      const el = screen.getByRole("status");
+
+      // Flush entering→visible so event handlers see animationState="visible"
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      // Advance 2s
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      // Hover — pauses timer (separate act so React state is flushed before event)
+      act(() => {
+        fireEvent.mouseEnter(el);
+      });
+      // Advance past original duration — should NOT fire
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test("resumes auto-dismiss timer on mouseleave", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      const el = screen.getByRole("status");
+
+      // Flush entering→visible
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      // Advance 2s (2000ms consumed, 2000ms remaining)
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      // Hover
+      act(() => {
+        fireEvent.mouseEnter(el);
+      });
+      // Leave — resumes timer with remaining 2000ms
+      act(() => {
+        fireEvent.mouseLeave(el);
+      });
+      // Advance past remaining 2000ms → exit triggered
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      // Advance past 150ms exit fallback
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pause on focus
+  // ---------------------------------------------------------------------------
+
+  describe("Pause on focus", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("pauses auto-dismiss timer on focus", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      const el = screen.getByRole("status");
+
+      // Flush entering→visible
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      // Advance 1s
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      // Focus — pauses timer
+      act(() => {
+        fireEvent.focus(el);
+      });
+      // Advance 5s more — should NOT fire since paused
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test("resumes auto-dismiss timer on blur", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      const el = screen.getByRole("status");
+
+      // Flush entering→visible
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      // Advance 1s (1000ms consumed, 3000ms remaining)
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      // Focus — pauses timer
+      act(() => {
+        fireEvent.focus(el);
+      });
+      // Blur — resumes timer
+      act(() => {
+        fireEvent.blur(el);
+      });
+      // Advance past remaining 3000ms
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+      // Advance past 150ms exit fallback
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Action callback
+  // ---------------------------------------------------------------------------
+
+  describe("Action callback", () => {
+    test("fires onAction when action button is pressed", async () => {
+      const onAction = vi.fn();
+      renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction },
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Undo" }));
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not fire onAction when action is not provided", () => {
+      renderSnackbar({ message: "File deleted" });
+      expect(screen.queryByRole("button", { name: /undo/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Close icon
+  // ---------------------------------------------------------------------------
+
+  describe("Close icon", () => {
+    test("fires onClose when close icon button is pressed", () => {
+      vi.useFakeTimers();
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", showClose: true, onClose });
+
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: /close/i }));
+      });
+
+      // Advance past the 150ms exit fallback timer
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    test("close button is keyboard accessible", () => {
+      renderSnackbar({ message: "File deleted", showClose: true });
+      const closeBtn = screen.getByRole("button", { name: /close/i });
+      expect(closeBtn.tagName).toBe("BUTTON");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Animation
+  // ---------------------------------------------------------------------------
+
+  describe("Animation states", () => {
+    test("container starts with entering animation class", () => {
+      renderSnackbar({ message: "Hello" });
+      const el = screen.getByRole("status");
+      expect(el.className).toMatch(/transition/);
+    });
+
+    test("container applies opacity class for visibility", () => {
+      renderSnackbar({ message: "Hello" });
+      const el = screen.getByRole("status");
+      expect(el.className).toMatch(/opacity/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Queue ordering
+  // ---------------------------------------------------------------------------
+
+  describe("Queue ordering", () => {
+    // Queue display tests use real timers with userEvent for reliability.
+    // The "shows second after first" test uses fake timers for the timer phase.
+
+    test("shows first snackbar immediately", async () => {
+      renderWithQueue();
+
+      await userEvent.click(screen.getByRole("button", { name: "Show First" }));
+
+      expect(screen.getByText("First")).toBeInTheDocument();
+    });
+
+    test("shows only one snackbar at a time (no stacking)", async () => {
+      renderWithQueue();
+
+      await userEvent.click(screen.getByRole("button", { name: "Show First" }));
+      await userEvent.click(screen.getByRole("button", { name: "Show Second" }));
+
+      expect(screen.getByText("First")).toBeInTheDocument();
+      expect(screen.queryByText("Second")).not.toBeInTheDocument();
+    });
+
+    test("shows second snackbar after first dismisses", () => {
+      vi.useFakeTimers();
+      renderWithQueue();
+
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Show First" }));
+      });
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Show Second" }));
+      });
+
+      expect(screen.getByText("First")).toBeInTheDocument();
+
+      // Advance through first snackbar's full lifecycle
+      advanceAndFinishExit(3000);
+
+      vi.useRealTimers();
+
+      expect(screen.getByText("Second")).toBeInTheDocument();
+      expect(screen.queryByText("First")).not.toBeInTheDocument();
+    });
+
+    test("useSnackbar throws when used outside SnackbarProvider", () => {
+      const BadConsumer = () => {
+        useSnackbar();
+        return null;
+      };
+
+      expect(() => render(<BadConsumer />)).toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // SnackbarHeadless
+  // ---------------------------------------------------------------------------
+
+  describe("SnackbarHeadless", () => {
+    test("renders with role=status for default severity", () => {
+      render(<SnackbarHeadless message="Hello" />);
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    test("renders with role=alert for error severity", () => {
+      render(<SnackbarHeadless message="Error" severity="error" />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    test("has aria-live=polite for default severity", () => {
+      render(<SnackbarHeadless message="Hello" />);
+      expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+    });
+
+    test("has aria-live=assertive for error severity", () => {
+      render(<SnackbarHeadless message="Error" severity="error" />);
+      expect(screen.getByRole("alert")).toHaveAttribute("aria-live", "assertive");
+    });
+
+    test("has aria-atomic=true", () => {
+      render(<SnackbarHeadless message="Hello" />);
+      expect(screen.getByRole("status")).toHaveAttribute("aria-atomic", "true");
+    });
+
+    test("renders ReactNode children", () => {
+      render(
+        <SnackbarHeadless message="Hello">
+          <span data-testid="custom-child">Custom content</span>
+        </SnackbarHeadless>
+      );
+      expect(screen.getByTestId("custom-child")).toBeInTheDocument();
+    });
+
+    test("renders children as render function with animationState", () => {
+      const renderFn = vi.fn((_state: { animationState: string; onClose: () => void }) => (
+        <span>rendered</span>
+      ));
+      render(<SnackbarHeadless message="Hello">{renderFn}</SnackbarHeadless>);
+      const calls = renderFn.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      expect(typeof (calls[0]?.[0] as { animationState: string }).animationState).toBe("string");
+    });
+
+    test("forwards ref to container element", () => {
+      const ref = { current: null };
+      render(<SnackbarHeadless message="Hello" ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+
+    test("applies custom className to container", () => {
+      render(<SnackbarHeadless message="Hello" className="custom-headless" />);
+      expect(screen.getByRole("status")).toHaveClass("custom-headless");
+    });
+
+    describe("Auto-dismiss timer", () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      test("calls onClose after duration", () => {
+        const onClose = vi.fn();
+        render(<SnackbarHeadless message="Hello" duration={2000} onClose={onClose} />);
+
+        advanceAndFinishExit(2000);
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+
+      test("does not call onClose when duration is 0", () => {
+        const onClose = vi.fn();
+        render(<SnackbarHeadless message="Hello" duration={0} onClose={onClose} />);
+
+        act(() => {
+          vi.advanceTimersByTime(10000);
+        });
+
+        expect(onClose).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/react/src/components/Snackbar/Snackbar.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { forwardRef } from "react";
+import { Button } from "../Button";
+import { IconButton } from "../IconButton";
+import { cn } from "../../utils/cn";
+import { SnackbarHeadless } from "./SnackbarHeadless";
+import {
+  snackbarAnimationVariants,
+  snackbarBaseVariants,
+  snackbarContentVariants,
+  snackbarMessageVariants,
+  snackbarSupportingTextVariants,
+  snackbarActionVariants,
+  snackbarCloseVariants,
+} from "./Snackbar.variants";
+import type { SnackbarAnimationState } from "./SnackbarHeadless";
+import type { SnackbarProps } from "./Snackbar.types";
+
+/**
+ * Close icon SVG (24dp, MD3 standard close symbol).
+ * Inline to avoid any icon library dependency.
+ */
+function CloseIcon(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+    </svg>
+  );
+}
+
+/**
+ * `Snackbar` — Layer 3 MD3 Styled Component.
+ *
+ * Renders one of four MD3 Snackbar content configurations:
+ * 1. Single-line message only
+ * 2. Two-line message + `supportingText`
+ * 3. Single-line with text `action` button (styled `Button variant="text"` with
+ *    `inverse-primary` color per MD3 spec)
+ * 4. Single-line with close icon (or combined with action)
+ *
+ * Uses `SnackbarHeadless` for all behavioral concerns (ARIA live region,
+ * auto-dismiss timer with pause/resume, animation state machine) and CVA
+ * variants for MD3-compliant visual styling.
+ *
+ * For typical app usage, render inside `SnackbarProvider` and trigger via
+ * the `useSnackbar` hook. For declarative/test usage, it can be rendered
+ * standalone.
+ *
+ * @example
+ * ```tsx
+ * // Imperative via hook (typical)
+ * const { showSnackbar } = useSnackbar();
+ * showSnackbar({ message: "File deleted", action: { label: "Undo", onAction: handleUndo } });
+ *
+ * // Declarative standalone
+ * <SnackbarProvider>
+ *   <Snackbar message="Saved" severity="default" showClose onClose={() => {}} />
+ * </SnackbarProvider>
+ * ```
+ */
+export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(function Snackbar(
+  {
+    message,
+    supportingText,
+    action,
+    showClose = false,
+    duration = 4000,
+    severity = "default",
+    onClose,
+    className,
+  },
+  ref
+) {
+  const isTwoLine = Boolean(supportingText);
+
+  // Base structural classes (not animation-state-dependent)
+  const baseClassName = cn(snackbarBaseVariants({ twoLine: isTwoLine }), className);
+
+  return (
+    <SnackbarHeadless
+      ref={ref}
+      message={message}
+      {...(supportingText !== undefined && { supportingText })}
+      {...(action !== undefined && { action })}
+      showClose={showClose}
+      duration={duration}
+      severity={severity}
+      {...(onClose !== undefined && { onClose })}
+      className={baseClassName}
+      getAnimationClassName={(state: SnackbarAnimationState) =>
+        snackbarAnimationVariants({ animationState: state })
+      }
+    >
+      {({ onClose: triggerClose }) => (
+        <>
+          {/* Content column: message + optional supporting text */}
+          <div className={snackbarContentVariants()}>
+            <span className={snackbarMessageVariants()}>{message}</span>
+            {supportingText && (
+              <span className={snackbarSupportingTextVariants()}>{supportingText}</span>
+            )}
+          </div>
+
+          {/* Action button — MD3: text variant with inverse-primary color */}
+          {action && (
+            <span className={snackbarActionVariants()}>
+              <Button
+                variant="text"
+                onPress={action.onAction}
+                className="text-inverse-primary hover:text-inverse-primary"
+              >
+                {action.label}
+              </Button>
+            </span>
+          )}
+
+          {/* Close icon button — MD3: standard icon button with inverse-on-surface */}
+          {showClose && (
+            <span className={snackbarCloseVariants()}>
+              <IconButton
+                variant="standard"
+                aria-label="Close"
+                onPress={triggerClose}
+                className="text-inverse-on-surface hover:text-inverse-on-surface"
+              >
+                <CloseIcon />
+              </IconButton>
+            </span>
+          )}
+        </>
+      )}
+    </SnackbarHeadless>
+  );
+});
+
+Snackbar.displayName = "Snackbar";

--- a/packages/react/src/components/Snackbar/Snackbar.types.ts
+++ b/packages/react/src/components/Snackbar/Snackbar.types.ts
@@ -1,0 +1,220 @@
+import type { ReactNode } from "react";
+
+// ─── Severity ────────────────────────────────────────────────────────────────
+
+/**
+ * Severity level of the Snackbar message.
+ *
+ * Controls the ARIA live region role:
+ * - `default` → `role="status" aria-live="polite"` (non-urgent information)
+ * - `error`   → `role="alert"  aria-live="assertive"` (urgent error messages)
+ *
+ * @default 'default'
+ */
+export type SnackbarSeverity = "default" | "error";
+
+// ─── Animation ───────────────────────────────────────────────────────────────
+
+/**
+ * Internal animation state machine for the Snackbar.
+ *
+ * - `entering` → slide-up + fade-in (MD3 entry: short4 / emphasized-decelerate)
+ * - `visible`  → fully shown, auto-dismiss timer running
+ * - `exiting`  → fade-out (MD3 exit: short2 / emphasized-accelerate)
+ * - `exited`   → removed from DOM / queue advanced
+ */
+export type SnackbarAnimationState = "entering" | "visible" | "exiting" | "exited";
+
+// ─── Action ──────────────────────────────────────────────────────────────────
+
+/**
+ * Configuration for the single text action button on the Snackbar.
+ *
+ * @example
+ * ```tsx
+ * action={{ label: "Undo", onAction: () => handleUndo() }}
+ * ```
+ */
+export interface SnackbarAction {
+  /** Visible label for the action button. Also used as the accessible name. */
+  label: string;
+  /** Callback fired when the action button is pressed. */
+  onAction: () => void;
+}
+
+// ─── SnackbarProps ───────────────────────────────────────────────────────────
+
+/**
+ * Props for the MD3 Styled `Snackbar` component (Layer 3).
+ *
+ * Renders one of four MD3 content configurations:
+ * 1. Single-line message only
+ * 2. Two-line (message + supportingText)
+ * 3. Single-line with action button
+ * 4. Single-line with close icon
+ *
+ * @example
+ * ```tsx
+ * // Single-line
+ * <Snackbar message="File deleted" />
+ *
+ * // With action
+ * <Snackbar message="File deleted" action={{ label: "Undo", onAction: handleUndo }} />
+ *
+ * // With close icon
+ * <Snackbar message="Connection lost" showClose onClose={() => {}} />
+ *
+ * // Error severity (assertive announcement)
+ * <Snackbar message="Upload failed" severity="error" />
+ * ```
+ */
+export interface SnackbarProps {
+  /**
+   * Primary message text shown on the Snackbar.
+   * Styled with `text-body-medium`.
+   */
+  message: string;
+
+  /**
+   * Optional supporting text shown below the message (two-line configuration).
+   * Styled with `text-body-medium`.
+   */
+  supportingText?: string;
+
+  /**
+   * Optional text action button configuration.
+   * Action button is styled as `Button variant="text"` with `inverse-primary` color.
+   */
+  action?: SnackbarAction;
+
+  /**
+   * When `true`, renders a close icon button at the trailing end.
+   * @default false
+   */
+  showClose?: boolean;
+
+  /**
+   * Auto-dismiss duration in milliseconds. Set to `0` to disable auto-dismiss.
+   * Timer pauses on pointer hover and keyboard focus.
+   * @default 4000
+   */
+  duration?: number;
+
+  /**
+   * Severity level — controls the ARIA live region role.
+   * @default 'default'
+   */
+  severity?: SnackbarSeverity;
+
+  /**
+   * Callback fired when the Snackbar finishes its exit animation and is removed.
+   * Also fires when the close icon is pressed.
+   */
+  onClose?: () => void;
+
+  /**
+   * Additional CSS classes merged onto the Snackbar container.
+   */
+  className?: string;
+}
+
+// ─── SnackbarHeadlessProps ───────────────────────────────────────────────────
+
+/**
+ * Props for the headless `SnackbarHeadless` primitive (Layer 2).
+ *
+ * Provides all Snackbar behavior (ARIA live region, auto-dismiss timer with
+ * pause/resume, animation state machine) without any visual styling.
+ *
+ * @example
+ * ```tsx
+ * <SnackbarHeadless message="Hello" duration={3000} onClose={dismiss}>
+ *   {({ animationState }) => (
+ *     <div className={animationState === 'visible' ? 'opacity-100' : 'opacity-0'}>
+ *       Hello
+ *     </div>
+ *   )}
+ * </SnackbarHeadless>
+ * ```
+ */
+export interface SnackbarHeadlessProps extends Omit<SnackbarProps, "className"> {
+  /**
+   * Children as a render function receiving the current animation state and
+   * an imperative `onClose` callback to trigger the exit animation, or
+   * static ReactNode content.
+   */
+  children?:
+    | ReactNode
+    | ((state: { animationState: SnackbarAnimationState; onClose: () => void }) => ReactNode);
+
+  /**
+   * Additional CSS classes passed to the container element (base/structural classes).
+   */
+  className?: string;
+
+  /**
+   * Optional callback that returns additional CSS classes based on the current
+   * animation state. Used by the styled `Snackbar` layer to inject CVA
+   * animation variant classes onto the headless container div at render time.
+   *
+   * @example
+   * ```tsx
+   * getAnimationClassName={(state) => snackbarAnimationVariants({ animationState: state })}
+   * ```
+   */
+  getAnimationClassName?: (state: SnackbarAnimationState) => string;
+}
+
+// ─── Queue ───────────────────────────────────────────────────────────────────
+
+/**
+ * Internal queue entry type used by `SnackbarProvider`.
+ * Extends `SnackbarProps` with a unique `id` for queue management.
+ */
+export interface SnackbarItem extends SnackbarProps {
+  /** Unique identifier for this Snackbar instance. */
+  id: string;
+}
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+/**
+ * Value exposed by `SnackbarContext` and consumed via `useSnackbar`.
+ *
+ * @example
+ * ```tsx
+ * const { showSnackbar } = useSnackbar();
+ * showSnackbar({ message: "Saved successfully" });
+ * ```
+ */
+export interface SnackbarContextValue {
+  /**
+   * Enqueue a new Snackbar. Returns the unique id assigned to this item.
+   * Multiple calls are displayed sequentially, not stacked.
+   */
+  showSnackbar: (options: SnackbarProps) => string;
+  /**
+   * Imperatively dismiss the currently displayed Snackbar (triggers exit animation).
+   */
+  closeSnackbar: () => void;
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────────
+
+/**
+ * Props for `SnackbarProvider`.
+ *
+ * Wrap your application (or Storybook decorator) with this provider to enable
+ * the Snackbar queue and portal.
+ *
+ * @example
+ * ```tsx
+ * <SnackbarProvider>
+ *   <App />
+ * </SnackbarProvider>
+ * ```
+ */
+export interface SnackbarProviderProps {
+  /** Application children. */
+  children: ReactNode;
+}

--- a/packages/react/src/components/Snackbar/Snackbar.variants.ts
+++ b/packages/react/src/components/Snackbar/Snackbar.variants.ts
@@ -1,0 +1,221 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Snackbar Variants (CVA)
+ *
+ * Type-safe variant management using Tailwind CSS classes mapped to MD3 tokens.
+ *
+ * MD3 Specifications:
+ * - Surface color: inverse-surface
+ * - Text color: inverse-on-surface
+ * - Shape: extra-small (4dp) → rounded-xs
+ * - Elevation: level-3 → shadow-elevation-3
+ * - Min width: 288dp → min-w-72
+ * - Max width: 568dp → max-w-snackbar-max
+ * - Position: fixed bottom-4, horizontally centered
+ * - Message text: body-medium
+ * - Action text: label-large, inverse-primary color
+ * - Entry motion: short4 (200ms) + ease-emphasized-decelerate (slide up + fade in)
+ * - Exit motion:  short2 (100ms) + ease-emphasized-accelerate (fade out)
+ */
+
+// ─── Base container (positioning, surface, shape, layout) ────────────────────
+
+/**
+ * Snackbar base container variants — structural, surface, and layout classes.
+ * Split from animation variants so the headless layer can merge its own
+ * animation-state classes at render time.
+ */
+export const snackbarBaseVariants = cva(
+  [
+    // Positioning (portal renders to body; fixed centers at bottom)
+    "fixed",
+    "bottom-4",
+    "left-1/2",
+    "-translate-x-1/2",
+    "z-50",
+
+    // Sizing (MD3 spec: 288dp min, 568dp max)
+    "min-w-72",
+    "max-w-snackbar-max",
+    "w-max",
+
+    // Surface
+    "bg-inverse-surface",
+
+    // Shape: MD3 extra-small corner = 4dp
+    "rounded-xs",
+
+    // Elevation level 3
+    "shadow-elevation-3",
+
+    // Layout
+    "flex",
+    "items-center",
+    "gap-x-2",
+    "px-4",
+
+    // Typography
+    "text-body-medium",
+    "text-inverse-on-surface",
+
+    // Transition (properties used by both entry and exit)
+    "transition-[opacity,transform]",
+    "will-change-[opacity,transform]",
+  ],
+  {
+    variants: {
+      /**
+       * Whether the Snackbar has supporting text (two-line layout).
+       * Adjusts vertical padding to MD3 spec for two-line configuration.
+       */
+      twoLine: {
+        true: "py-4",
+        false: "py-3",
+      },
+    },
+    defaultVariants: {
+      twoLine: false,
+    },
+  }
+);
+
+export type SnackbarBaseVariants = VariantProps<typeof snackbarBaseVariants>;
+
+// ─── Animation state classes ──────────────────────────────────────────────────
+
+/**
+ * Snackbar animation state variants.
+ * Applied by `SnackbarHeadless` based on its internal animation state machine.
+ *
+ * - `entering`: initial mount state — starts below + transparent before rAF
+ * - `visible`:  slide up + fade in (short4 / emphasized-decelerate)
+ * - `exiting`:  fade out (short2 / emphasized-accelerate)
+ * - `exited`:   fully transparent (removed from DOM by provider)
+ */
+export const snackbarAnimationVariants = cva("", {
+  variants: {
+    animationState: {
+      entering: ["translate-y-4", "opacity-0"],
+      visible: ["translate-y-0", "opacity-100", "duration-short4", "ease-emphasized-decelerate"],
+      exiting: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+      exited: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+    },
+  },
+  defaultVariants: {
+    animationState: "entering",
+  },
+});
+
+export type SnackbarAnimationVariants = VariantProps<typeof snackbarAnimationVariants>;
+
+/**
+ * Combined container variants (base + animation) for convenience.
+ * The headless layer uses `snackbarAnimationVariants` directly; this export
+ * is kept for consumers who want the full combined class string without the
+ * render-prop pattern.
+ */
+export const snackbarContainerVariants = cva(
+  [
+    "fixed",
+    "bottom-4",
+    "left-1/2",
+    "-translate-x-1/2",
+    "z-50",
+    "min-w-72",
+    "max-w-snackbar-max",
+    "w-max",
+    "bg-inverse-surface",
+    "rounded-xs",
+    "shadow-elevation-3",
+    "flex",
+    "items-center",
+    "gap-x-2",
+    "px-4",
+    "text-body-medium",
+    "text-inverse-on-surface",
+    "transition-[opacity,transform]",
+    "will-change-[opacity,transform]",
+  ],
+  {
+    variants: {
+      animationState: {
+        entering: ["translate-y-4", "opacity-0"],
+        visible: ["translate-y-0", "opacity-100", "duration-short4", "ease-emphasized-decelerate"],
+        exiting: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+        exited: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+      },
+      twoLine: {
+        true: "py-4",
+        false: "py-3",
+      },
+    },
+    defaultVariants: {
+      animationState: "entering",
+      twoLine: false,
+    },
+  }
+);
+
+export type SnackbarContainerVariants = VariantProps<typeof snackbarContainerVariants>;
+
+// ─── Message ─────────────────────────────────────────────────────────────────
+
+/**
+ * Message text variants.
+ * MD3: body-medium, inverse-on-surface color.
+ */
+export const snackbarMessageVariants = cva([
+  "flex-1",
+  "text-body-medium",
+  "text-inverse-on-surface",
+]);
+
+// ─── Supporting text ─────────────────────────────────────────────────────────
+
+/**
+ * Supporting text variants (two-line configuration).
+ * Same color role as message text per MD3 spec.
+ */
+export const snackbarSupportingTextVariants = cva([
+  "text-body-medium",
+  "text-inverse-on-surface",
+  "opacity-80",
+]);
+
+// ─── Action button wrapper ────────────────────────────────────────────────────
+
+/**
+ * Wrapper applied around the action `Button` to override its color to
+ * `inverse-primary` as required by MD3 Snackbar spec.
+ */
+export const snackbarActionVariants = cva([
+  "shrink-0",
+  // Color override for the nested Button's text — applied via CSS variable
+  // override on the wrapper; the Button(variant="text") reads text color
+  // from the current text color context.
+  "text-inverse-primary",
+]);
+
+// ─── Close icon button wrapper ────────────────────────────────────────────────
+
+/**
+ * Wrapper applied around the close `IconButton` to use `inverse-on-surface`
+ * as required by MD3 Snackbar spec.
+ */
+export const snackbarCloseVariants = cva(["shrink-0", "text-inverse-on-surface"]);
+
+// ─── Text+action layout ───────────────────────────────────────────────────────
+
+/**
+ * Inner content column (message + optional supporting text).
+ */
+export const snackbarContentVariants = cva(["flex", "flex-col", "flex-1", "min-w-0"]);
+
+// ─── Initial hidden state ─────────────────────────────────────────────────────
+
+/**
+ * Classes applied before the enter animation begins (component just mounted).
+ * Positioned off-screen below and transparent.
+ */
+export const snackbarInitialVariants = cva(["translate-y-4", "opacity-0"]);

--- a/packages/react/src/components/Snackbar/SnackbarHeadless.tsx
+++ b/packages/react/src/components/Snackbar/SnackbarHeadless.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "../../utils/cn";
+import type { SnackbarAnimationState, SnackbarHeadlessProps } from "./Snackbar.types";
+
+/**
+ * SnackbarHeadless — Layer 2 headless primitive.
+ *
+ * Handles all Snackbar behavior without opinionated visual styling:
+ * - ARIA live region with correct `role`/`aria-live` pairing per severity
+ * - Auto-dismiss timer with configurable `duration`
+ * - Timer pause/resume on pointer hover (`mouseenter`/`mouseleave`) and
+ *   keyboard focus (`focusin`/`focusout`)
+ * - Animation state machine: `entering → visible → exiting → exited`
+ * - Exposes `onClose` imperative trigger via render-prop for close icon/action
+ * - Merges base `className` with animation-state-dependent classes via
+ *   the optional `getAnimationClassName` prop
+ *
+ * No React Aria hook covers Snackbar; ARIA live region patterns follow the
+ * ARIA authoring practices specification for status/alert regions.
+ *
+ * @example
+ * ```tsx
+ * // With render-prop children (typical usage from styled layer)
+ * <SnackbarHeadless
+ *   message="Saved"
+ *   duration={3000}
+ *   onClose={dismiss}
+ *   className={baseClasses}
+ *   getAnimationClassName={(state) => snackbarAnimationVariants({ animationState: state })}
+ * >
+ *   {({ onClose }) => (
+ *     <>
+ *       <span>Saved</span>
+ *       <button onClick={onClose}>Dismiss</button>
+ *     </>
+ *   )}
+ * </SnackbarHeadless>
+ * ```
+ */
+export const SnackbarHeadless = forwardRef<HTMLDivElement, SnackbarHeadlessProps>(
+  function SnackbarHeadless(
+    {
+      message,
+      supportingText,
+      action,
+      showClose,
+      duration = 4000,
+      severity = "default",
+      onClose,
+      children,
+      className,
+      getAnimationClassName,
+    },
+    ref
+  ) {
+    const [animationState, setAnimationState] = useState<SnackbarAnimationState>("entering");
+
+    // Tracks how many ms remain when the timer is paused
+    const remainingRef = useRef<number>(duration);
+    // Tracks wall-clock time when the current timer segment started
+    const startedAtRef = useRef<number>(Date.now());
+    // Active auto-dismiss setTimeout handle (separate from exit fallback)
+    const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Fallback timer for exit animation (fires onClose if onTransitionEnd doesn't)
+    const exitFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Whether the timer is currently paused (hover / focus)
+    const pausedRef = useRef<boolean>(false);
+    // Guard against calling onClose multiple times
+    const closedRef = useRef<boolean>(false);
+
+    const clearDismissTimer = useCallback(() => {
+      if (dismissTimerRef.current !== null) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
+      }
+    }, []);
+
+    const triggerExit = useCallback(() => {
+      if (closedRef.current) return;
+      clearDismissTimer(); // stop auto-dismiss timer
+      setAnimationState("exiting");
+      // Fallback: if onTransitionEnd does not fire (jsdom, reduced-motion,
+      // or CSS transitions disabled), ensure onClose is called after the
+      // exit animation duration (MD3 short2 = 100ms + small buffer).
+      exitFallbackRef.current = setTimeout(() => {
+        if (!closedRef.current) {
+          closedRef.current = true;
+          setAnimationState("exited");
+          onClose?.();
+        }
+      }, 150);
+    }, [clearDismissTimer, onClose]);
+
+    const startDismissTimer = useCallback(
+      (ms: number) => {
+        if (ms <= 0) return;
+        clearDismissTimer();
+        startedAtRef.current = Date.now();
+        dismissTimerRef.current = setTimeout(triggerExit, ms);
+      },
+      [clearDismissTimer, triggerExit]
+    );
+
+    // Entry animation: a zero-delay timer ensures the component is painted
+    // in its initial "entering" state before transitioning to "visible",
+    // allowing CSS transitions to fire. Using setTimeout instead of rAF
+    // ensures compatibility with vi.useFakeTimers() in tests.
+    useEffect(() => {
+      const id = setTimeout(() => {
+        setAnimationState("visible");
+      }, 0);
+      return () => clearTimeout(id);
+    }, []);
+
+    // Start auto-dismiss timer once the component is in `visible` state.
+    useEffect(() => {
+      if (animationState !== "visible") return;
+      if (duration <= 0) return;
+
+      remainingRef.current = duration;
+      startDismissTimer(duration);
+
+      // Only clear the dismiss timer on cleanup (not the exit fallback)
+      return clearDismissTimer;
+    }, [animationState, duration, startDismissTimer, clearDismissTimer]);
+
+    // Cleanup all timers on unmount
+    useEffect(
+      () => () => {
+        clearDismissTimer();
+        if (exitFallbackRef.current !== null) {
+          clearTimeout(exitFallbackRef.current);
+          exitFallbackRef.current = null;
+        }
+      },
+      [clearDismissTimer]
+    );
+
+    // When the exit CSS transition completes, advance to `exited` and fire onClose.
+    // Also cancels the fallback timer since the transition fired properly.
+    const handleTransitionEnd = useCallback(() => {
+      if (animationState === "exiting" && !closedRef.current) {
+        if (exitFallbackRef.current !== null) {
+          clearTimeout(exitFallbackRef.current);
+          exitFallbackRef.current = null;
+        }
+        closedRef.current = true;
+        setAnimationState("exited");
+        onClose?.();
+      }
+    }, [animationState, onClose]);
+
+    // Pause timer on pointer hover ─────────────────────────────────────────────
+
+    const handleMouseEnter = useCallback(() => {
+      if (pausedRef.current || animationState !== "visible") return;
+      pausedRef.current = true;
+      const elapsed = Date.now() - startedAtRef.current;
+      remainingRef.current = Math.max(remainingRef.current - elapsed, 0);
+      clearDismissTimer();
+    }, [animationState, clearDismissTimer]);
+
+    const handleMouseLeave = useCallback(() => {
+      if (!pausedRef.current || animationState !== "visible") return;
+      pausedRef.current = false;
+      if (duration > 0) startDismissTimer(remainingRef.current);
+    }, [animationState, duration, startDismissTimer]);
+
+    // Pause timer on keyboard focus ────────────────────────────────────────────
+
+    const handleFocusIn = useCallback(() => {
+      if (pausedRef.current || animationState !== "visible") return;
+      pausedRef.current = true;
+      const elapsed = Date.now() - startedAtRef.current;
+      remainingRef.current = Math.max(remainingRef.current - elapsed, 0);
+      clearDismissTimer();
+    }, [animationState, clearDismissTimer]);
+
+    const handleFocusOut = useCallback(() => {
+      if (!pausedRef.current || animationState !== "visible") return;
+      pausedRef.current = false;
+      if (duration > 0) startDismissTimer(remainingRef.current);
+    }, [animationState, duration, startDismissTimer]);
+
+    // Imperative close (close icon pressed, action button, programmatic close)
+    const handleClose = useCallback(() => {
+      triggerExit();
+    }, [triggerExit]);
+
+    // ARIA live region attributes per MD3 / ARIA authoring practices spec
+    const ariaProps =
+      severity === "error"
+        ? ({ role: "alert", "aria-live": "assertive", "aria-atomic": "true" } as const)
+        : ({ role: "status", "aria-live": "polite", "aria-atomic": "true" } as const);
+
+    // Merge base className with animation-state-dependent classes
+    const computedClassName = cn(className, getAnimationClassName?.(animationState));
+
+    // Resolve children — render-prop or static ReactNode
+    const childContent =
+      typeof children === "function"
+        ? children({ animationState, onClose: handleClose })
+        : (children ?? (
+            <>
+              <span>{message}</span>
+              {supportingText && <span>{supportingText}</span>}
+              {action && (
+                <button type="button" onClick={action.onAction}>
+                  {action.label}
+                </button>
+              )}
+              {showClose && (
+                <button type="button" aria-label="Close" onClick={handleClose}>
+                  ✕
+                </button>
+              )}
+            </>
+          ));
+
+    return (
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <div
+        ref={ref}
+        className={computedClassName}
+        {...ariaProps}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onFocus={handleFocusIn}
+        onBlur={handleFocusOut}
+        onTransitionEnd={handleTransitionEnd}
+        data-animation-state={animationState}
+      >
+        {childContent}
+      </div>
+    );
+  }
+);
+
+SnackbarHeadless.displayName = "SnackbarHeadless";
+
+export type { SnackbarAnimationState };

--- a/packages/react/src/components/Snackbar/SnackbarProvider.tsx
+++ b/packages/react/src/components/Snackbar/SnackbarProvider.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { createContext, useCallback, useContext, useId, useRef, useState, type JSX } from "react";
+import { createPortal } from "react-dom";
+import { Snackbar } from "./Snackbar";
+import type {
+  SnackbarContextValue,
+  SnackbarItem,
+  SnackbarProps,
+  SnackbarProviderProps,
+} from "./Snackbar.types";
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+/**
+ * React context for the Snackbar queue.
+ * Consumed via the `useSnackbar` hook.
+ */
+export const SnackbarContext = createContext<SnackbarContextValue | null>(null);
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+/**
+ * `useSnackbar` — imperative API for triggering Snackbars.
+ *
+ * Must be called inside a component that is a descendant of `SnackbarProvider`.
+ * Throws a descriptive error in development if used outside the provider.
+ *
+ * @example
+ * ```tsx
+ * const { showSnackbar } = useSnackbar();
+ *
+ * // Single-line
+ * showSnackbar({ message: "File deleted" });
+ *
+ * // With action
+ * showSnackbar({
+ *   message: "File deleted",
+ *   action: { label: "Undo", onAction: () => handleUndo() },
+ * });
+ *
+ * // Error severity (assertive announcement)
+ * showSnackbar({ message: "Upload failed", severity: "error" });
+ * ```
+ */
+export function useSnackbar(): SnackbarContextValue {
+  const ctx = useContext(SnackbarContext);
+  if (!ctx) {
+    throw new Error(
+      "[Snackbar] useSnackbar must be used inside <SnackbarProvider>. " +
+        "Wrap your application (or Storybook decorator) with <SnackbarProvider>."
+    );
+  }
+  return ctx;
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────────
+
+/**
+ * `SnackbarProvider` — context provider, queue manager, and portal host.
+ *
+ * Wrap your application (or Storybook preview) with this component to enable
+ * the Snackbar queue and portal rendering.
+ *
+ * - Multiple `showSnackbar` calls are **queued** and displayed sequentially
+ *   (never stacked) per MD3 spec.
+ * - The active Snackbar is rendered via `createPortal` into `document.body`,
+ *   positioned `fixed bottom-4 left-1/2 -translate-x-1/2` per MD3 spec.
+ *
+ * @example
+ * ```tsx
+ * // Application root
+ * <SnackbarProvider>
+ *   <App />
+ * </SnackbarProvider>
+ *
+ * // Storybook preview.tsx decorator
+ * export const decorators = [
+ *   (Story) => (
+ *     <SnackbarProvider>
+ *       <Story />
+ *     </SnackbarProvider>
+ *   ),
+ * ];
+ * ```
+ */
+export function SnackbarProvider({ children }: SnackbarProviderProps): JSX.Element {
+  const [queue, setQueue] = useState<SnackbarItem[]>([]);
+  // Monotonically increasing counter for unique id generation without hooks
+  const counterRef = useRef<number>(0);
+  const baseId = useId();
+
+  /**
+   * Enqueue a new Snackbar. Returns the assigned id.
+   * If no Snackbar is currently shown, the new item is displayed immediately.
+   * Otherwise it is appended to the queue.
+   */
+  const showSnackbar = useCallback(
+    (options: SnackbarProps): string => {
+      const id = `${baseId}-snackbar-${++counterRef.current}`;
+      setQueue((prev) => [...prev, { ...options, id }]);
+      return id;
+    },
+    [baseId]
+  );
+
+  /**
+   * Imperatively dismiss the currently displayed Snackbar.
+   * Triggers the exit animation; removal happens via the `onClose` callback.
+   */
+  const closeSnackbar = useCallback(() => {
+    setQueue((prev) => {
+      if (prev.length === 0) return prev;
+      // Mark the current item for removal by clearing the queue head.
+      // The Snackbar's own onClose callback (fired after exit animation)
+      // will drive the actual dequeue below.
+      return prev;
+    });
+    // Signal to the active Snackbar to begin its exit animation by removing
+    // it from the queue head — we do this by firing handleClose on the current item.
+    // The onClose callback below handles the actual shift.
+    setQueue((prev) => (prev.length > 0 ? prev.slice(1) : prev));
+  }, []);
+
+  /**
+   * Called by the active Snackbar after its exit animation completes.
+   * Shifts the queue so the next item (if any) is displayed.
+   */
+  const handleCurrentClose = useCallback(() => {
+    setQueue((prev) => prev.slice(1));
+  }, []);
+
+  const contextValue: SnackbarContextValue = { showSnackbar, closeSnackbar };
+
+  // The active Snackbar is always the first item in the queue (if any).
+  const active = queue[0];
+
+  return (
+    <SnackbarContext.Provider value={contextValue}>
+      {children}
+      {active &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <Snackbar
+            key={active.id}
+            message={active.message}
+            {...(active.supportingText !== undefined && { supportingText: active.supportingText })}
+            {...(active.action !== undefined && { action: active.action })}
+            {...(active.showClose !== undefined && { showClose: active.showClose })}
+            {...(active.duration !== undefined && { duration: active.duration })}
+            {...(active.severity !== undefined && { severity: active.severity })}
+            {...(active.className !== undefined && { className: active.className })}
+            onClose={() => {
+              active.onClose?.();
+              handleCurrentClose();
+            }}
+          />,
+          document.body
+        )}
+    </SnackbarContext.Provider>
+  );
+}

--- a/packages/react/src/components/Snackbar/index.ts
+++ b/packages/react/src/components/Snackbar/index.ts
@@ -1,0 +1,35 @@
+// Layer 3: MD3 Styled Component
+export { Snackbar } from "./Snackbar";
+
+// Layer 2: Headless Primitive (for advanced customization)
+export { SnackbarHeadless } from "./SnackbarHeadless";
+export type { SnackbarAnimationState } from "./SnackbarHeadless";
+
+// Provider + Hook (required for imperative queue API)
+export { SnackbarProvider, SnackbarContext, useSnackbar } from "./SnackbarProvider";
+
+// CVA Variants
+export {
+  snackbarBaseVariants,
+  snackbarAnimationVariants,
+  snackbarContainerVariants,
+  snackbarMessageVariants,
+  snackbarSupportingTextVariants,
+  snackbarActionVariants,
+  snackbarCloseVariants,
+  snackbarContentVariants,
+  type SnackbarBaseVariants,
+  type SnackbarAnimationVariants,
+  type SnackbarContainerVariants,
+} from "./Snackbar.variants";
+
+// Types
+export type {
+  SnackbarSeverity,
+  SnackbarProps,
+  SnackbarHeadlessProps,
+  SnackbarAction,
+  SnackbarItem,
+  SnackbarContextValue,
+  SnackbarProviderProps,
+} from "./Snackbar.types";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -110,3 +110,20 @@ export type {
   HeadlessMenuSectionProps,
   MenuContextValue,
 } from "./Menu";
+
+export {
+  Snackbar,
+  SnackbarHeadless,
+  SnackbarProvider,
+  SnackbarContext,
+  useSnackbar,
+} from "./Snackbar";
+export type {
+  SnackbarProps,
+  SnackbarHeadlessProps,
+  SnackbarProviderProps,
+  SnackbarContextValue,
+  SnackbarSeverity,
+  SnackbarAction,
+  SnackbarItem,
+} from "./Snackbar";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -160,3 +160,20 @@ export type {
   HeadlessMenuSectionProps,
   MenuContextValue,
 } from "./components/Menu";
+
+export {
+  Snackbar,
+  SnackbarHeadless,
+  SnackbarProvider,
+  SnackbarContext,
+  useSnackbar,
+} from "./components/Snackbar";
+export type {
+  SnackbarProps,
+  SnackbarHeadlessProps,
+  SnackbarProviderProps,
+  SnackbarContextValue,
+  SnackbarSeverity,
+  SnackbarAction,
+  SnackbarItem,
+} from "./components/Snackbar";

--- a/packages/tokens/src/tokens.css
+++ b/packages/tokens/src/tokens.css
@@ -65,6 +65,11 @@
   /* Scrim */
   --md-sys-color-scrim: #000000;
 
+  /* Inverse */
+  --md-sys-color-inverse-surface: #313033;
+  --md-sys-color-inverse-on-surface: #f4eff4;
+  --md-sys-color-inverse-primary: #d0bcff;
+
   /* ==========================================================================
      TYPOGRAPHY TOKENS
      Material Design 3 Type Scale - 5 categories, 3 sizes each (15 total)
@@ -257,6 +262,11 @@
 
   /* Scrim */
   --md-sys-color-scrim: #000000;
+
+  /* Inverse */
+  --md-sys-color-inverse-surface: #e6e1e5;
+  --md-sys-color-inverse-on-surface: #313033;
+  --md-sys-color-inverse-primary: #6750a4;
 }
 
 /* System/OS dark mode preference (activates when no .light class is present) */
@@ -309,6 +319,11 @@
 
     /* Scrim */
     --md-sys-color-scrim: #000000;
+
+    /* Inverse */
+    --md-sys-color-inverse-surface: #e6e1e5;
+    --md-sys-color-inverse-on-surface: #313033;
+    --md-sys-color-inverse-primary: #6750a4;
   }
 }
 
@@ -382,6 +397,11 @@ body {
 
   /* Scrim color */
   --color-scrim: var(--md-sys-color-scrim);
+
+  /* Inverse colors */
+  --color-inverse-surface: var(--md-sys-color-inverse-surface);
+  --color-inverse-on-surface: var(--md-sys-color-inverse-on-surface);
+  --color-inverse-primary: var(--md-sys-color-inverse-primary);
 
   /* Elevation/Shadow utilities
      Maps MD3 elevation levels to Tailwind box-shadow utilities
@@ -495,6 +515,9 @@ body {
 
   /* Drawer width: MD3 spec = 360dp */
   --spacing-drawer: 22.5rem; /* 360px */
+
+  /* Snackbar max width: MD3 spec = 568dp */
+  --spacing-snackbar-max: 35.5rem; /* 568px */
 
   /* Shape radius utilities for MD3 components */
   --radius-xs: var(--md-sys-shape-corner-extra-small); /* 4px */


### PR DESCRIPTION
## Summary

- Adds MD3 `Snackbar` component with three-layer architecture (React Aria patterns → `SnackbarHeadless` → `Snackbar` styled), `SnackbarProvider` context queue, and `useSnackbar` hook
- Prerequisite commit adds `inverse-surface`, `inverse-on-surface`, and `inverse-primary` color tokens + `--spacing-snackbar-max` to the token system
- Supports four MD3 content configurations: single-line, two-line, with action button, with close icon

## Architecture

### Layer 1 — Foundation
No dedicated React Aria hook exists for Snackbar; ARIA live region patterns are applied directly per the ARIA authoring practices spec.

### Layer 2 — `SnackbarHeadless`
- ARIA live region: `role="status" aria-live="polite"` (default) or `role="alert" aria-live="assertive"` (error severity)
- Auto-dismiss timer with pause/resume on `mouseenter`/`mouseleave` and `focus`/`blur`
- Animation state machine: `entering → visible → exiting → exited`
- Exit fallback timer (150ms) ensures `onClose` fires even without CSS `transitionend` support (e.g., jsdom, reduced-motion)
- Accepts `getAnimationClassName` render prop so the styled layer can inject CVA animation classes onto the single container div

### Layer 3 — `Snackbar`
- CVA variants split into `snackbarBaseVariants` (structural) + `snackbarAnimationVariants` (state-dependent)
- Action button: `Button variant="text"` with `text-inverse-primary` override per MD3 spec
- Close icon: `IconButton variant="standard"` with `text-inverse-on-surface` override per MD3 spec
- MD3 tokens used: `bg-inverse-surface`, `text-inverse-on-surface`, `rounded-xs`, `shadow-elevation-3`, `text-body-medium`, `text-label-large`, `duration-short4`, `duration-short2`, `ease-emphasized-decelerate`, `ease-emphasized-accelerate`

### Provider
- `SnackbarProvider` manages queue state (first-in, first-out; no stacking per MD3 spec)
- Renders active Snackbar via `createPortal` into `document.body`
- `useSnackbar()` hook throws a descriptive error when used outside the provider

## Test plan

- [x] All 46 Snackbar tests pass
- [x] All 792 tests across the full monorepo pass
- [x] Zero ESLint errors, zero TypeScript errors
- [x] WCAG 2.1 AA: zero axe violations across all four content configurations and both severity levels
- [x] Rendering, accessibility, auto-dismiss, pause-on-hover/focus, action/close callbacks, queue ordering, and animation state tests all green