### PR TITLE
feat(dialog): implement MD3 dialog component

### DIFF
--- a/packages/react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/Dialog/Dialog.stories.tsx
@@ -1,0 +1,351 @@
+import { useState, type JSX } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Dialog } from "./Dialog";
+import { DialogHeadline } from "./DialogHeadline";
+import { DialogContent } from "./DialogContent";
+import { DialogActions } from "./DialogActions";
+import { DialogHeadless } from "./DialogHeadless";
+import { Button } from "../Button";
+import { IconButton } from "../IconButton";
+
+// ─── Inline SVG Icons ─────────────────────────────────────────────────────────
+
+const CloseIcon = (): JSX.Element => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+  </svg>
+);
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Material Design 3 Dialog component.
+ *
+ * Dialogs provide important prompts in a user flow. They can require an action,
+ * communicate information, or help users accomplish a task.
+ *
+ * ## Variants
+ *
+ * - **Basic** (default): A floating card dialog with headline, body text, and
+ *   action buttons. Supports scale + fade entry animation. Closes on scrim
+ *   click or Escape key. Min 280dp, max 560dp width.
+ *
+ * - **Full-screen**: Full viewport overlay suited for mobile and complex forms.
+ *   Replaces the headline with a top app bar row (close icon button + confirm
+ *   action). Slide-up entry animation. Does NOT close on scrim click.
+ *
+ * ## Accessibility
+ *
+ * - `role="dialog"` + `aria-modal="true"` (React Aria `useDialog`)
+ * - `aria-labelledby` → `DialogHeadline` id
+ * - `aria-describedby` → `DialogContent` id
+ * - Focus trap while open (`FocusScope`)
+ * - Focus restores to trigger on close
+ * - Body scroll locked while open (`usePreventScroll`)
+ * - Escape key always closes
+ *
+ * @see https://m3.material.io/components/dialogs/overview
+ */
+const meta: Meta<typeof Dialog> = {
+  title: "Feedback/Dialog",
+  component: Dialog,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Material Design 3 Dialog — provides important prompts requiring user action. Supports Basic and Full-screen variants with composable slot-based API.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["basic", "fullscreen"],
+      description: "Structural variant — Basic (floating card) or Full-screen (full viewport).",
+    },
+    open: {
+      control: "boolean",
+      description: "Controlled open state.",
+    },
+    defaultOpen: {
+      control: "boolean",
+      description: "Default open state for uncontrolled usage.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+// ─── Basic ────────────────────────────────────────────────────────────────────
+
+const BasicDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button variant="filled" onPress={() => setOpen(true)}>
+        Open dialog
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogHeadline>Permanently delete?</DialogHeadline>
+        <DialogContent>
+          Deleting the selected messages will also remove them from all your devices.
+        </DialogContent>
+        <DialogActions>
+          <Button variant="text" onPress={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="filled" onPress={() => setOpen(false)}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+/**
+ * The Basic dialog presents a simple prompt with a headline, body text, and
+ * two action buttons. The primary action uses `variant="filled"` and the
+ * secondary uses `variant="text"` per MD3 spec.
+ */
+export const Basic: Story = {
+  render: () => <BasicDemo />,
+};
+
+// ─── Scrollable content ───────────────────────────────────────────────────────
+
+const ScrollableContentDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button variant="filled" onPress={() => setOpen(true)}>
+        Open scrollable dialog
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogHeadline>Terms of service</DialogHeadline>
+        <DialogContent>
+          <p>
+            By using this service, you agree to these terms. Read them carefully. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua.
+          </p>
+          <p className="mt-4">
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+            commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+            dolore eu fugiat nulla pariatur.
+          </p>
+          <p className="mt-4">
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+            mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit
+            voluptatem accusantium doloremque.
+          </p>
+          <p className="mt-4">
+            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia
+            consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
+          </p>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="text" onPress={() => setOpen(false)}>
+            Decline
+          </Button>
+          <Button variant="filled" onPress={() => setOpen(false)}>
+            Accept
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates the scrollable body content behavior when content exceeds
+ * the available height.
+ */
+export const ScrollableContent: Story = {
+  render: () => <ScrollableContentDemo />,
+};
+
+// ─── Confirmation ─────────────────────────────────────────────────────────────
+
+const ConfirmationDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  const handleConfirm = (): void => {
+    setConfirmed(true);
+    setOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-8">
+      <Button variant="filled" onPress={() => setOpen(true)}>
+        Delete account
+      </Button>
+      {confirmed && <p className="text-body-medium text-on-surface-variant">Account deleted.</p>}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogHeadline>Delete account?</DialogHeadline>
+        <DialogContent>
+          Your account and all associated data will be permanently deleted. This action cannot be
+          undone.
+        </DialogContent>
+        <DialogActions>
+          <Button variant="text" onPress={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="filled" onPress={handleConfirm}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+/**
+ * A destructive action confirmation dialog. The primary action uses a
+ * standard filled button (MD3 does not use an error-colored button in dialogs).
+ */
+export const Confirmation: Story = {
+  render: () => <ConfirmationDemo />,
+};
+
+// ─── Full-screen ───────────────────────────────────────────────────────────────
+
+const FullscreenDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button variant="filled" onPress={() => setOpen(true)}>
+        Open full-screen dialog
+      </Button>
+      <Dialog variant="fullscreen" open={open} onOpenChange={setOpen}>
+        <DialogHeadline
+          closeButton={
+            <IconButton variant="standard" aria-label="Close" onPress={() => setOpen(false)}>
+              <CloseIcon />
+            </IconButton>
+          }
+          confirmButton={
+            <Button variant="text" onPress={() => setOpen(false)}>
+              Save
+            </Button>
+          }
+        >
+          New event
+        </DialogHeadline>
+        <DialogContent>
+          <div className="flex flex-col gap-4">
+            <p className="text-body-medium text-on-surface-variant">
+              Fill in the details for your new event. Use the Save button in the top bar to confirm,
+              or the close icon to discard changes.
+            </p>
+            <label className="flex flex-col gap-1">
+              <span className="text-label-medium text-on-surface">Event name</span>
+              <input
+                type="text"
+                placeholder="My event"
+                className="border-outline text-body-medium text-on-surface bg-surface-container focus:border-primary rounded-md border px-3 py-2 outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-label-medium text-on-surface">Description</span>
+              <textarea
+                rows={4}
+                placeholder="Add a description..."
+                className="border-outline text-body-medium text-on-surface bg-surface-container focus:border-primary resize-none rounded-md border px-3 py-2 outline-none"
+              />
+            </label>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+/**
+ * The Full-screen dialog covers the entire viewport and is suited for mobile
+ * layouts or complex form flows. The headline is replaced with a top app bar
+ * row containing a close icon button and a confirm action.
+ *
+ * Per MD3 spec, the Full-screen dialog does NOT close on scrim click —
+ * only via the close button or Escape key.
+ */
+export const Fullscreen: Story = {
+  render: () => <FullscreenDemo />,
+};
+
+// ─── Uncontrolled ─────────────────────────────────────────────────────────────
+
+/**
+ * Demonstrates the uncontrolled pattern using `defaultOpen`. Useful in
+ * simple scenarios where the dialog state does not need to be lifted up.
+ */
+export const Uncontrolled: Story = {
+  render: () => (
+    <div className="flex items-center justify-center p-8">
+      <Dialog defaultOpen>
+        <DialogHeadline>Uncontrolled dialog</DialogHeadline>
+        <DialogContent>
+          This dialog opens immediately without controlled state. Dismiss it by pressing Escape or
+          clicking the scrim.
+        </DialogContent>
+        <DialogActions>
+          <Button variant="filled">Got it</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  ),
+};
+
+// ─── Headless (advanced customization) ────────────────────────────────────────
+
+const HeadlessDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex items-center justify-center p-8">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="bg-secondary text-on-secondary text-label-large rounded-md px-4 py-2"
+      >
+        Open headless dialog
+      </button>
+      <DialogHeadless
+        open={open}
+        onOpenChange={setOpen}
+        aria-label="Custom headless dialog"
+        className="bg-surface-container-high shadow-elevation-3 w-full max-w-md rounded-2xl p-8"
+        scrimClassName="fixed inset-0 z-40 bg-scrim opacity-32"
+      >
+        <DialogHeadline>Custom styled dialog</DialogHeadline>
+        <DialogContent>
+          This dialog uses `DialogHeadless` for fully custom styling while retaining all React Aria
+          behavior and WCAG 2.1 AA compliance.
+        </DialogContent>
+        <DialogActions>
+          <Button variant="text" onPress={() => setOpen(false)}>
+            Close
+          </Button>
+        </DialogActions>
+      </DialogHeadless>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates the headless primitive for fully custom styling while
+ * retaining all MD3 behavior and accessibility semantics.
+ */
+export const Headless: Story = {
+  render: () => <HeadlessDemo />,
+};

--- a/packages/react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react/src/components/Dialog/Dialog.test.tsx
@@ -1,0 +1,519 @@
+import { useState, type ComponentProps } from "react";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { Dialog } from "./Dialog";
+import { DialogHeadline } from "./DialogHeadline";
+import { DialogContent } from "./DialogContent";
+import { DialogActions } from "./DialogActions";
+import { DialogHeadless } from "./DialogHeadless";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderBasicDialog(props: Partial<ComponentProps<typeof Dialog>> = {}) {
+  return render(
+    <Dialog open aria-label="Test dialog" {...props}>
+      <DialogHeadline>Dialog headline</DialogHeadline>
+      <DialogContent>Dialog body content.</DialogContent>
+      <DialogActions>
+        <button type="button">Cancel</button>
+        <button type="button">Confirm</button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+function renderFullscreenDialog(props: Partial<ComponentProps<typeof Dialog>> = {}) {
+  return render(
+    <Dialog variant="fullscreen" open aria-label="Fullscreen dialog" {...props}>
+      <DialogHeadline>Fullscreen headline</DialogHeadline>
+      <DialogContent>Fullscreen body content.</DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Controlled dialog wrapper for open/close interaction tests.
+ */
+function ControlledDialog({
+  onOpenChange,
+  variant,
+}: {
+  onOpenChange?: (open: boolean) => void;
+  variant?: "basic" | "fullscreen";
+}) {
+  const [open, setOpen] = useState(false);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open dialog
+      </button>
+      <Dialog variant={variant} open={open} onOpenChange={handleOpenChange}>
+        <DialogHeadline>Controlled dialog</DialogHeadline>
+        <DialogContent>Controlled content.</DialogContent>
+        <DialogActions>
+          <button type="button" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </button>
+          <button type="button" onClick={() => handleOpenChange(false)}>
+            Confirm
+          </button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+// ─── Advance animation timers ─────────────────────────────────────────────────
+
+function advanceToVisible(): void {
+  act(() => {
+    vi.advanceTimersByTime(0);
+  });
+}
+
+// ─── Dialog (Basic variant) ───────────────────────────────────────────────────
+
+describe("Dialog", () => {
+  // ── Rendering ───────────────────────────────────────────────────────────────
+
+  describe("Rendering", () => {
+    test("renders when open is true", () => {
+      renderBasicDialog({ open: true });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("does not render when open is false", () => {
+      renderBasicDialog({ open: false });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    test("renders headline content", () => {
+      renderBasicDialog();
+      expect(screen.getByText("Dialog headline")).toBeInTheDocument();
+    });
+
+    test("renders body content", () => {
+      renderBasicDialog();
+      expect(screen.getByText("Dialog body content.")).toBeInTheDocument();
+    });
+
+    test("renders action buttons", () => {
+      renderBasicDialog();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    });
+
+    test("defaults to basic variant", () => {
+      renderBasicDialog();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toBeInTheDocument();
+    });
+
+    test("renders scrim overlay when open", () => {
+      renderBasicDialog({ open: true });
+      expect(screen.getByTestId("dialog-scrim")).toBeInTheDocument();
+    });
+
+    test("does not render scrim when closed", () => {
+      renderBasicDialog({ open: false });
+      expect(screen.queryByTestId("dialog-scrim")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── ARIA / Accessibility ─────────────────────────────────────────────────────
+
+  describe("Accessibility", () => {
+    test("has role dialog", () => {
+      renderBasicDialog();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("has aria-modal true", () => {
+      renderBasicDialog();
+      expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+    });
+
+    test("aria-labelledby points to headline id", () => {
+      renderBasicDialog();
+      const dialog = screen.getByRole("dialog");
+      const labelledById = dialog.getAttribute("aria-labelledby");
+      expect(labelledById).toBeTruthy();
+      const headline = document.getElementById(labelledById!);
+      expect(headline).toBeInTheDocument();
+      expect(headline?.textContent).toBe("Dialog headline");
+    });
+
+    test("aria-describedby points to content id", () => {
+      renderBasicDialog();
+      const dialog = screen.getByRole("dialog");
+      const describedById = dialog.getAttribute("aria-describedby");
+      expect(describedById).toBeTruthy();
+      const content = document.getElementById(describedById!);
+      expect(content).toBeInTheDocument();
+      expect(content?.textContent).toBe("Dialog body content.");
+    });
+
+    test("passes axe accessibility audit (basic)", async () => {
+      const { container } = renderBasicDialog();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("passes axe accessibility audit (fullscreen)", async () => {
+      const { container } = renderFullscreenDialog();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("headline renders as h2", () => {
+      renderBasicDialog();
+      const headline = screen.getByRole("heading", { level: 2 });
+      expect(headline).toBeInTheDocument();
+      expect(headline.textContent).toBe("Dialog headline");
+    });
+  });
+
+  // ── Open/Close behavior ──────────────────────────────────────────────────────
+
+  describe("Open/Close behavior", () => {
+    test("controlled: renders when open prop is true", () => {
+      render(
+        <Dialog open onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("controlled: hides when open prop becomes false after exit animation", () => {
+      vi.useFakeTimers();
+      const { rerender } = render(
+        <Dialog open onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+      // Advance to visible state
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+      rerender(
+        <Dialog open={false} onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+      // Advance past exit animation fallback (150ms)
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      vi.useRealTimers();
+    });
+
+    test("uncontrolled: shows dialog when defaultOpen is true", () => {
+      render(
+        <Dialog defaultOpen>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("onOpenChange is called with false when dialog is dismissed", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(<ControlledDialog onOpenChange={onOpenChange} />);
+
+      await user.click(screen.getByRole("button", { name: "Open dialog" }));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // ── Keyboard interactions ────────────────────────────────────────────────────
+
+  describe("Keyboard interactions", () => {
+    test("Escape key closes the basic dialog", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog open onOpenChange={onOpenChange}>
+          <DialogContent>Content</DialogContent>
+          <DialogActions>
+            <button type="button">Cancel</button>
+          </DialogActions>
+        </Dialog>
+      );
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      await user.keyboard("{Escape}");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    test("Escape key closes the fullscreen dialog", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog variant="fullscreen" open onOpenChange={onOpenChange}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      await user.keyboard("{Escape}");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // ── Scrim behavior ───────────────────────────────────────────────────────────
+
+  describe("Scrim behavior", () => {
+    test("clicking scrim closes basic dialog", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog open onOpenChange={onOpenChange}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+
+      const scrim = screen.getByTestId("dialog-scrim");
+      await user.click(scrim);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    test("clicking scrim does NOT close fullscreen dialog", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog variant="fullscreen" open onOpenChange={onOpenChange}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+
+      const scrim = screen.getByTestId("dialog-scrim");
+      await user.click(scrim);
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Focus management ─────────────────────────────────────────────────────────
+
+  describe("Focus management", () => {
+    test("focus moves into dialog when opened", async () => {
+      const user = userEvent.setup();
+
+      render(<ControlledDialog />);
+
+      await user.click(screen.getByRole("button", { name: "Open dialog" }));
+
+      await waitFor(() => {
+        const dialog = screen.getByRole("dialog");
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
+    });
+
+    test("focus is trapped within dialog (Tab stays inside)", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Dialog open onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+          <DialogActions>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+          </DialogActions>
+        </Dialog>
+      );
+
+      const dialog = screen.getByRole("dialog");
+      const buttons = screen.getAllByRole("button");
+
+      // Tab through all buttons — focus should stay within dialog
+      for (const _btn of buttons) {
+        await user.tab();
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      }
+    });
+  });
+
+  // ── Action button callbacks ──────────────────────────────────────────────────
+
+  describe("Action button callbacks", () => {
+    test("action button press fires callback", async () => {
+      const handleConfirm = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog open onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+          <DialogActions>
+            <button type="button" onClick={handleConfirm}>
+              Confirm
+            </button>
+          </DialogActions>
+        </Dialog>
+      );
+
+      await user.click(screen.getByRole("button", { name: "Confirm" }));
+      expect(handleConfirm).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── Variant rendering ────────────────────────────────────────────────────────
+
+  describe("Variant rendering", () => {
+    test("basic variant renders dialog with correct data-variant", () => {
+      renderBasicDialog();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.closest("[data-variant='basic']")).toBeInTheDocument();
+    });
+
+    test("fullscreen variant renders dialog with correct data-variant", () => {
+      renderFullscreenDialog();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.closest("[data-variant='fullscreen']")).toBeInTheDocument();
+    });
+  });
+
+  // ── Animation states ─────────────────────────────────────────────────────────
+
+  describe("Animation states", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("dialog panel starts in entering state on mount", () => {
+      renderBasicDialog({ open: true });
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveAttribute("data-animation-state", "entering");
+    });
+
+    test("dialog panel transitions to visible after zero-delay timer", () => {
+      renderBasicDialog({ open: true });
+      advanceToVisible();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveAttribute("data-animation-state", "visible");
+    });
+  });
+
+  // ── Custom className ─────────────────────────────────────────────────────────
+
+  describe("Custom className", () => {
+    test("className is merged onto dialog panel", () => {
+      renderBasicDialog({ className: "custom-test-class" });
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveClass("custom-test-class");
+    });
+  });
+});
+
+// ─── DialogHeadless (Layer 2) ─────────────────────────────────────────────────
+
+describe("DialogHeadless", () => {
+  test("renders children when open", () => {
+    render(
+      <DialogHeadless open aria-label="Headless dialog">
+        <div>Headless content</div>
+      </DialogHeadless>
+    );
+    expect(screen.getByText("Headless content")).toBeInTheDocument();
+  });
+
+  test("does not render when closed", () => {
+    render(
+      <DialogHeadless open={false} aria-label="Headless dialog">
+        <div>Headless content</div>
+      </DialogHeadless>
+    );
+    expect(screen.queryByText("Headless content")).not.toBeInTheDocument();
+  });
+
+  test("has role dialog with aria-modal", () => {
+    render(
+      <DialogHeadless open aria-label="Headless dialog">
+        <div>Content</div>
+      </DialogHeadless>
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+});
+
+// ─── Sub-components standalone ────────────────────────────────────────────────
+
+describe("DialogHeadline", () => {
+  test("renders headline text", () => {
+    render(
+      <Dialog open>
+        <DialogHeadline>My Headline</DialogHeadline>
+      </Dialog>
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("My Headline");
+  });
+
+  test("headline has a stable id attribute", () => {
+    render(
+      <Dialog open>
+        <DialogHeadline>Headline</DialogHeadline>
+      </Dialog>
+    );
+    const headline = screen.getByRole("heading", { level: 2 });
+    expect(headline.id).toBeTruthy();
+  });
+});
+
+describe("DialogContent", () => {
+  test("renders content text", () => {
+    render(
+      <Dialog open>
+        <DialogContent>My content text</DialogContent>
+      </Dialog>
+    );
+    expect(screen.getByText("My content text")).toBeInTheDocument();
+  });
+
+  test("content has a stable id attribute", () => {
+    render(
+      <Dialog open>
+        <DialogContent>Content</DialogContent>
+      </Dialog>
+    );
+    const content = screen.getByText("Content");
+    expect(content.id).toBeTruthy();
+  });
+});
+
+describe("DialogActions", () => {
+  test("renders action children", () => {
+    render(
+      <Dialog open>
+        <DialogActions>
+          <button type="button">Action</button>
+        </DialogActions>
+      </Dialog>
+    );
+    expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import { DialogHeadless } from "./DialogHeadless";
+import {
+  dialogPanelVariants,
+  dialogScrimVariants,
+  dialogAnimationVariants,
+} from "./Dialog.variants";
+import type { DialogAnimationState } from "./Dialog.types";
+import type { DialogProps } from "./Dialog.types";
+
+/**
+ * `Dialog` — Layer 3 MD3 Styled Dialog Component.
+ *
+ * Supports two structural variants per MD3 spec, with a composable slot-based
+ * API via `DialogHeadline`, `DialogContent`, and `DialogActions`:
+ *
+ * **Basic** (default):
+ * - Floating card: `bg-surface-container-high`, `rounded-xl`, `shadow-elevation-3`
+ * - Centered in viewport (min 280dp, max 560dp width)
+ * - Scale + fade entry animation (`duration-medium4 / ease-emphasized-decelerate`)
+ * - Fade exit animation (`duration-short2 / ease-emphasized-accelerate`)
+ * - Closes on scrim click or Escape key
+ *
+ * **Full-screen**:
+ * - Full viewport coverage — suited for mobile and complex forms
+ * - No rounded corners, no elevation shadow
+ * - Slide-up entry / slide-down exit animation
+ * - Does NOT close on scrim click per MD3 spec (only via Escape or close button)
+ * - Headline replaced by top app bar row (close icon + confirm action)
+ *
+ * Both variants:
+ * - `role="dialog"` + `aria-modal="true"` (React Aria `useDialog`)
+ * - `aria-labelledby` pointing to `DialogHeadline` id
+ * - `aria-describedby` pointing to `DialogContent` id
+ * - Focus trap active while open (`FocusScope`)
+ * - Focus returns to trigger element on close (`FocusScope restoreFocus`)
+ * - Body scroll locked while open (`usePreventScroll`)
+ * - Escape key always closes the dialog
+ * - Portal rendered to `document.body`
+ *
+ * @example
+ * ```tsx
+ * // Basic dialog — controlled
+ * function DeleteDialog() {
+ *   const [open, setOpen] = useState(false);
+ *
+ *   return (
+ *     <>
+ *       <Button onPress={() => setOpen(true)}>Delete file</Button>
+ *       <Dialog open={open} onOpenChange={setOpen}>
+ *         <DialogHeadline>Permanently delete?</DialogHeadline>
+ *         <DialogContent>
+ *           This action cannot be undone. The file and all associated data
+ *           will be permanently removed.
+ *         </DialogContent>
+ *         <DialogActions>
+ *           <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *           <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *         </DialogActions>
+ *       </Dialog>
+ *     </>
+ *   );
+ * }
+ *
+ * // Full-screen dialog — mobile form flow
+ * function NewEventDialog() {
+ *   const [open, setOpen] = useState(false);
+ *
+ *   return (
+ *     <>
+ *       <Button onPress={() => setOpen(true)}>New event</Button>
+ *       <Dialog variant="fullscreen" open={open} onOpenChange={setOpen}>
+ *         <DialogHeadline
+ *           closeButton={
+ *             <IconButton aria-label="Close" onPress={() => setOpen(false)}>
+ *               <CloseIcon />
+ *             </IconButton>
+ *           }
+ *           confirmButton={
+ *             <Button variant="text" onPress={handleSave}>Save</Button>
+ *           }
+ *         >
+ *           New event
+ *         </DialogHeadline>
+ *         <DialogContent>
+ *           <TextField label="Event name" />
+ *           <TextField label="Date" type="date" />
+ *         </DialogContent>
+ *       </Dialog>
+ *     </>
+ *   );
+ * }
+ * ```
+ *
+ * @see https://m3.material.io/components/dialogs/overview
+ * @see https://m3.material.io/components/dialogs/specs
+ */
+export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
+  {
+    variant = "basic",
+    open,
+    defaultOpen = false,
+    onOpenChange,
+    "aria-label": ariaLabel,
+    children,
+    className,
+  },
+  _ref
+) {
+  // Build panel class: structural + visual styles from CVA
+  const panelClassName = cn(dialogPanelVariants({ variant }), className);
+
+  // Scrim class shared between variants
+  const scrimClass = dialogScrimVariants();
+
+  return (
+    <DialogHeadless
+      variant={variant}
+      {...(open !== undefined ? { open } : {})}
+      {...(defaultOpen !== undefined ? { defaultOpen } : {})}
+      {...(onOpenChange !== undefined ? { onOpenChange } : {})}
+      {...(ariaLabel ? { "aria-label": ariaLabel } : {})}
+      className={panelClassName}
+      scrimClassName={scrimClass}
+      getAnimationClassName={(state: DialogAnimationState) =>
+        dialogAnimationVariants({ animationState: state, variant })
+      }
+    >
+      {children}
+    </DialogHeadless>
+  );
+});
+
+Dialog.displayName = "Dialog";

--- a/packages/react/src/components/Dialog/Dialog.types.ts
+++ b/packages/react/src/components/Dialog/Dialog.types.ts
@@ -1,0 +1,320 @@
+import type { ReactNode } from "react";
+
+// ─── Variant ──────────────────────────────────────────────────────────────────
+
+/**
+ * Structural variant of the MD3 Dialog.
+ *
+ * - `basic` — Floating dialog with headline, body, and action buttons.
+ *   Supports scale + fade entry animation. Closes on scrim click or Escape.
+ *   Max width 560dp per MD3 spec.
+ *
+ * - `fullscreen` — Full viewport overlay suited for mobile and complex forms.
+ *   Replaces headline with a top app bar row (close icon + confirm action).
+ *   Slide-up entry animation. Does NOT close on scrim click per MD3 spec.
+ *
+ * @default 'basic'
+ */
+export type DialogVariant = "basic" | "fullscreen";
+
+// ─── Animation ────────────────────────────────────────────────────────────────
+
+/**
+ * Internal animation state machine for the Dialog.
+ *
+ * - `entering` — initial mount state before transition fires
+ * - `visible`  — fully shown, entry animation complete
+ * - `exiting`  — exit animation in progress
+ * - `exited`   — removed from DOM
+ */
+export type DialogAnimationState = "entering" | "visible" | "exiting" | "exited";
+
+// ─── DialogContextValue ───────────────────────────────────────────────────────
+
+/**
+ * Internal context shared between `DialogHeadless` and its slot sub-components
+ * (`DialogHeadline`, `DialogContent`, `DialogActions`).
+ *
+ * Coordinates auto-generated `id` values for `aria-labelledby` and
+ * `aria-describedby`, exposes the close callback, and propagates the variant.
+ *
+ * @internal
+ */
+export interface DialogContextValue {
+  /** Stable id for the headline element — used as `aria-labelledby` on the dialog panel. */
+  headlineId: string;
+  /** Stable id for the content element — used as `aria-describedby` on the dialog panel. */
+  contentId: string;
+  /** Callback to programmatically close the dialog (triggers exit animation). */
+  close: () => void;
+  /** Current structural variant, propagated to sub-components for variant-specific rendering. */
+  variant: DialogVariant;
+}
+
+// ─── DialogHeadlessProps ──────────────────────────────────────────────────────
+
+/**
+ * Props for the headless `DialogHeadless` primitive (Layer 2).
+ *
+ * Provides all Dialog behavior (ARIA roles, focus trap, scroll lock,
+ * portal rendering, animation state machine, open/close state) without
+ * any visual styling.
+ *
+ * @example
+ * ```tsx
+ * <DialogHeadless
+ *   variant="basic"
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   aria-label="Confirm action"
+ *   className="bg-surface-container-high rounded-xl shadow-elevation-3"
+ *   scrimClassName="fixed inset-0 z-40 bg-scrim opacity-32"
+ * >
+ *   <DialogHeadline>Confirm deletion?</DialogHeadline>
+ *   <DialogContent>This action cannot be undone.</DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *   </DialogActions>
+ * </DialogHeadless>
+ * ```
+ */
+export interface DialogHeadlessProps {
+  /**
+   * Structural variant — controls animation, scrim dismissal, and DOM structure.
+   * @default 'basic'
+   */
+  variant?: DialogVariant;
+
+  /**
+   * Controlled open state. Pair with `onOpenChange`.
+   */
+  open?: boolean;
+
+  /**
+   * Default open state for uncontrolled usage.
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Called when the open state changes (e.g. Escape key, scrim click, close button).
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Accessible label for the dialog. Used when no `DialogHeadline` is provided.
+   * When `DialogHeadline` is present, `aria-labelledby` is preferred automatically.
+   */
+  "aria-label"?: string;
+
+  /**
+   * Dialog slot content — typically `DialogHeadline`, `DialogContent`, `DialogActions`.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes applied to the dialog panel element.
+   */
+  className?: string;
+
+  /**
+   * Additional CSS classes applied to the scrim overlay element.
+   */
+  scrimClassName?: string;
+
+  /**
+   * Additional CSS classes injected based on the current animation state.
+   * Called at render time to merge CVA animation classes onto the panel.
+   *
+   * @example
+   * ```tsx
+   * getAnimationClassName={(state) => dialogAnimationVariants({ animationState: state, variant })}
+   * ```
+   */
+  getAnimationClassName?: (state: DialogAnimationState) => string;
+}
+
+// ─── DialogProps ──────────────────────────────────────────────────────────────
+
+/**
+ * Props for the MD3 Styled `Dialog` component (Layer 3).
+ *
+ * Supports two structural variants — Basic (floating dialog) and Full-screen
+ * (full viewport overlay for mobile / complex forms) — with a composable
+ * slot-based API via `DialogHeadline`, `DialogContent`, and `DialogActions`.
+ *
+ * Supports both controlled (`open` + `onOpenChange`) and uncontrolled
+ * (`defaultOpen`) usage patterns.
+ *
+ * @example
+ * ```tsx
+ * // Basic dialog (controlled)
+ * <Dialog open={open} onOpenChange={setOpen}>
+ *   <DialogHeadline>Delete file?</DialogHeadline>
+ *   <DialogContent>This action cannot be undone.</DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *   </DialogActions>
+ * </Dialog>
+ *
+ * // Full-screen dialog (controlled)
+ * <Dialog variant="fullscreen" open={open} onOpenChange={setOpen}>
+ *   <DialogHeadline
+ *     closeButton={<IconButton aria-label="Close" onPress={() => setOpen(false)}><CloseIcon /></IconButton>}
+ *     confirmButton={<Button variant="text" onPress={handleSave}>Save</Button>}
+ *   >
+ *     New event
+ *   </DialogHeadline>
+ *   <DialogContent>
+ *     <TextField label="Event name" />
+ *   </DialogContent>
+ * </Dialog>
+ * ```
+ */
+export interface DialogProps {
+  /**
+   * Structural variant — `basic` (default) or `fullscreen`.
+   * @default 'basic'
+   */
+  variant?: DialogVariant;
+
+  /**
+   * Controlled open state. Pair with `onOpenChange`.
+   */
+  open?: boolean;
+
+  /**
+   * Default open state for uncontrolled usage.
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Called when the open state changes.
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Accessible label for the dialog when no `DialogHeadline` is present.
+   */
+  "aria-label"?: string;
+
+  /**
+   * Dialog slot content — `DialogHeadline`, `DialogContent`, `DialogActions`.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes merged onto the dialog panel element.
+   */
+  className?: string;
+}
+
+// ─── DialogHeadlineProps ──────────────────────────────────────────────────────
+
+/**
+ * Props for the `DialogHeadline` slot sub-component.
+ *
+ * Renders as an `<h2>` element and provides its `id` to `DialogContext`
+ * so the parent dialog panel can reference it via `aria-labelledby`.
+ *
+ * For the `fullscreen` variant, accepts optional `closeButton` and
+ * `confirmButton` slots that are rendered in the top app bar row per MD3 spec.
+ *
+ * @example
+ * ```tsx
+ * // Basic variant
+ * <DialogHeadline>Confirm deletion?</DialogHeadline>
+ *
+ * // Full-screen variant
+ * <DialogHeadline
+ *   closeButton={<IconButton aria-label="Close" onPress={onClose}><CloseIcon /></IconButton>}
+ *   confirmButton={<Button variant="text" onPress={onSave}>Save</Button>}
+ * >
+ *   New event
+ * </DialogHeadline>
+ * ```
+ */
+export interface DialogHeadlineProps {
+  /**
+   * Headline text content.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes merged onto the headline element.
+   */
+  className?: string;
+
+  /**
+   * Close icon button slot — rendered leading in the top app bar row
+   * for the `fullscreen` variant only.
+   */
+  closeButton?: ReactNode;
+
+  /**
+   * Confirm action slot — rendered trailing in the top app bar row
+   * for the `fullscreen` variant only.
+   */
+  confirmButton?: ReactNode;
+}
+
+// ─── DialogContentProps ───────────────────────────────────────────────────────
+
+/**
+ * Props for the `DialogContent` slot sub-component.
+ *
+ * Renders as a scrollable `<div>` and provides its `id` to `DialogContext`
+ * so the parent dialog panel can reference it via `aria-describedby`.
+ *
+ * @example
+ * ```tsx
+ * <DialogContent>
+ *   <p>This action cannot be undone. All associated data will be permanently removed.</p>
+ * </DialogContent>
+ * ```
+ */
+export interface DialogContentProps {
+  /**
+   * Body content — can be any React node.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes merged onto the content element.
+   */
+  className?: string;
+}
+
+// ─── DialogActionsProps ───────────────────────────────────────────────────────
+
+/**
+ * Props for the `DialogActions` slot sub-component.
+ *
+ * Renders a right-aligned flex row of action buttons per MD3 spec.
+ * Typically contains `Button` components with `variant="text"` (secondary)
+ * and `variant="filled"` (primary action).
+ *
+ * Not used in the `fullscreen` variant (confirm action is in the headline row).
+ *
+ * @example
+ * ```tsx
+ * <DialogActions>
+ *   <Button variant="text" onPress={onCancel}>Cancel</Button>
+ *   <Button variant="filled" onPress={onConfirm}>Confirm</Button>
+ * </DialogActions>
+ * ```
+ */
+export interface DialogActionsProps {
+  /**
+   * Action button elements — typically `Button` components.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes merged onto the actions container.
+   */
+  className?: string;
+}

--- a/packages/react/src/components/Dialog/Dialog.variants.ts
+++ b/packages/react/src/components/Dialog/Dialog.variants.ts
@@ -1,0 +1,287 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Dialog Variants (CVA)
+ *
+ * Type-safe variant management using Tailwind CSS classes mapped to MD3 tokens.
+ *
+ * MD3 Specifications:
+ * - Basic surface: surface-container-high
+ * - Elevation: level-3 → shadow-elevation-3
+ * - Shape (Basic): extra-large (28dp) → rounded-xl
+ * - Min width (Basic): 280dp → min-w-70
+ * - Max width (Basic): 560dp → max-w-dialog
+ * - Scrim: bg-scrim at opacity-32
+ * - Headline: text-headline-small, text-on-surface
+ * - Body: text-body-medium, text-on-surface-variant
+ * - Action row: right-aligned, gap-2
+ * - Entry motion (Basic): scale + fade, medium4 (400ms) + ease-emphasized-decelerate
+ * - Exit motion (Basic): fade, short2 (100ms) + ease-emphasized-accelerate
+ * - Entry motion (Fullscreen): slide-up, medium4 (400ms) + ease-emphasized-decelerate
+ * - Exit motion (Fullscreen): slide-down, short2 (100ms) + ease-emphasized-accelerate
+ */
+
+// ─── Scrim overlay ─────────────────────────────────────────────────────────────
+
+/**
+ * Scrim overlay variants — matches MD3 spec and Drawer scrim pattern.
+ * Full-screen variant uses the same scrim but onClick is a no-op.
+ */
+export const dialogScrimVariants = cva([
+  "fixed",
+  "inset-0",
+  "z-40",
+  "bg-scrim",
+  "opacity-32",
+  "transition-opacity",
+  "duration-medium2",
+  "ease-standard",
+]);
+
+export type DialogScrimVariants = VariantProps<typeof dialogScrimVariants>;
+
+// ─── Panel container ────────────────────────────────────────────────────────────
+
+/**
+ * Dialog panel container variants.
+ *
+ * - `basic`: floating card with rounded corners, elevation, max-width constraint.
+ * - `fullscreen`: full viewport coverage, no corners, no max-width.
+ *
+ * Positioned and centered by the portal wrapper; `z-50` sits above the scrim.
+ */
+export const dialogPanelVariants = cva(
+  [
+    // Stacking above scrim
+    "z-50",
+
+    // Surface
+    "bg-surface-container-high",
+
+    // Flex column layout for slots
+    "flex",
+    "flex-col",
+
+    // Transition for animation state changes
+    "transition-[opacity,transform]",
+    "will-change-[opacity,transform]",
+  ],
+  {
+    variants: {
+      variant: {
+        basic: [
+          // Shape: MD3 extra-large = 28dp
+          "rounded-xl",
+          // Elevation level 3
+          "shadow-elevation-3",
+          // Width constraints per MD3 spec (280dp min, 560dp max)
+          "min-w-70",
+          "max-w-dialog-max",
+          "w-full",
+          // Internal spacing
+          "pt-6",
+          "pb-3",
+          "px-6",
+          // Positioned in viewport center
+          "relative",
+        ],
+        fullscreen: [
+          // Full viewport
+          "w-full",
+          "h-full",
+          // No rounded corners on fullscreen
+          "rounded-none",
+          // No elevation shadow on fullscreen
+          "shadow-none",
+          // Positioned to fill portal
+          "relative",
+        ],
+      },
+    },
+    defaultVariants: {
+      variant: "basic",
+    },
+  }
+);
+
+export type DialogPanelVariants = VariantProps<typeof dialogPanelVariants>;
+
+// ─── Portal wrapper ─────────────────────────────────────────────────────────────
+
+/**
+ * Wrapper that centers the basic dialog in the viewport.
+ * Not applied to the fullscreen variant (which fills the viewport directly).
+ */
+export const dialogWrapperVariants = cva([], {
+  variants: {
+    variant: {
+      basic: ["fixed", "inset-0", "z-50", "flex", "items-center", "justify-center", "px-4"],
+      fullscreen: ["fixed", "inset-0", "z-50"],
+    },
+  },
+  defaultVariants: {
+    variant: "basic",
+  },
+});
+
+export type DialogWrapperVariants = VariantProps<typeof dialogWrapperVariants>;
+
+// ─── Animation state classes ────────────────────────────────────────────────────
+
+/**
+ * Animation state variants — applied by `DialogHeadless` based on its
+ * internal animation state machine. Variant-specific to match MD3 motion spec:
+ *
+ * Basic: scale + fade (entry) / fade (exit)
+ * Fullscreen: slide-up (entry) / slide-down (exit)
+ */
+export const dialogAnimationVariants = cva("", {
+  variants: {
+    animationState: {
+      entering: [],
+      visible: [],
+      exiting: [],
+      exited: [],
+    },
+    variant: {
+      basic: [],
+      fullscreen: [],
+    },
+  },
+  compoundVariants: [
+    // Basic: entering — start scaled down + transparent
+    {
+      animationState: "entering",
+      variant: "basic",
+      className: ["scale-90", "opacity-0"],
+    },
+    // Basic: visible — scale to full + fade in
+    {
+      animationState: "visible",
+      variant: "basic",
+      className: ["scale-100", "opacity-100", "duration-medium4", "ease-emphasized-decelerate"],
+    },
+    // Basic: exiting — fade out (scale stays at 1)
+    {
+      animationState: "exiting",
+      variant: "basic",
+      className: ["scale-100", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+    },
+    // Basic: exited — fully transparent
+    {
+      animationState: "exited",
+      variant: "basic",
+      className: ["scale-100", "opacity-0"],
+    },
+    // Fullscreen: entering — start below viewport + transparent
+    {
+      animationState: "entering",
+      variant: "fullscreen",
+      className: ["translate-y-full", "opacity-0"],
+    },
+    // Fullscreen: visible — slide up + fade in
+    {
+      animationState: "visible",
+      variant: "fullscreen",
+      className: ["translate-y-0", "opacity-100", "duration-medium4", "ease-emphasized-decelerate"],
+    },
+    // Fullscreen: exiting — slide down + fade out
+    {
+      animationState: "exiting",
+      variant: "fullscreen",
+      className: ["translate-y-full", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+    },
+    // Fullscreen: exited — fully off-screen
+    {
+      animationState: "exited",
+      variant: "fullscreen",
+      className: ["translate-y-full", "opacity-0"],
+    },
+  ],
+  defaultVariants: {
+    animationState: "entering",
+    variant: "basic",
+  },
+});
+
+export type DialogAnimationVariants = VariantProps<typeof dialogAnimationVariants>;
+
+// ─── DialogHeadline ─────────────────────────────────────────────────────────────
+
+/**
+ * Headline element variants.
+ * MD3: text-headline-small, text-on-surface.
+ */
+export const dialogHeadlineVariants = cva(["text-headline-small", "text-on-surface"], {
+  variants: {
+    variant: {
+      basic: ["mb-4"],
+      fullscreen: [
+        // Top app bar row in fullscreen: flex, items-center, gap
+        "flex",
+        "items-center",
+        "gap-4",
+        "px-4",
+        "h-14",
+        "shrink-0",
+        "border-b",
+        "border-outline-variant",
+      ],
+    },
+  },
+  defaultVariants: {
+    variant: "basic",
+  },
+});
+
+export type DialogHeadlineVariants = VariantProps<typeof dialogHeadlineVariants>;
+
+/**
+ * Headline text inside the fullscreen top app bar row.
+ */
+export const dialogHeadlineTitleVariants = cva([
+  "flex-1",
+  "text-headline-small",
+  "text-on-surface",
+  "truncate",
+]);
+
+// ─── DialogContent ──────────────────────────────────────────────────────────────
+
+/**
+ * Scrollable body content variants.
+ * MD3: text-body-medium, text-on-surface-variant, scrollable.
+ */
+export const dialogContentVariants = cva(
+  ["text-body-medium", "text-on-surface-variant", "overflow-y-auto", "flex-1"],
+  {
+    variants: {
+      variant: {
+        basic: ["mb-6"],
+        fullscreen: ["px-6", "py-4"],
+      },
+    },
+    defaultVariants: {
+      variant: "basic",
+    },
+  }
+);
+
+export type DialogContentVariants = VariantProps<typeof dialogContentVariants>;
+
+// ─── DialogActions ──────────────────────────────────────────────────────────────
+
+/**
+ * Action button row variants.
+ * MD3: right-aligned flex row with gap-2, padding-top per spec.
+ */
+export const dialogActionsVariants = cva([
+  "flex",
+  "items-center",
+  "justify-end",
+  "gap-2",
+  "pt-3",
+  "shrink-0",
+]);
+
+export type DialogActionsVariants = VariantProps<typeof dialogActionsVariants>;

--- a/packages/react/src/components/Dialog/DialogActions.tsx
+++ b/packages/react/src/components/Dialog/DialogActions.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import { useDialogContext } from "./DialogHeadless";
+import { dialogActionsVariants } from "./Dialog.variants";
+import type { DialogActionsProps } from "./Dialog.types";
+
+/**
+ * `DialogActions` — Action button row slot sub-component (Layer 3).
+ *
+ * Renders a right-aligned flex row of action buttons per MD3 spec.
+ * Intended to contain `Button` components (typically `variant="text"` for
+ * secondary actions and `variant="filled"` for the primary action).
+ *
+ * Not used in the `fullscreen` variant — the confirm action is placed in the
+ * headline top app bar row via `DialogHeadline`'s `confirmButton` slot.
+ *
+ * Must be rendered inside a `<Dialog>` or `<DialogHeadless>` component.
+ *
+ * @example
+ * ```tsx
+ * <Dialog open onOpenChange={setOpen}>
+ *   <DialogHeadline>Discard changes?</DialogHeadline>
+ *   <DialogContent>Your unsaved changes will be lost.</DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDiscard}>Discard</Button>
+ *   </DialogActions>
+ * </Dialog>
+ * ```
+ */
+export const DialogActions = forwardRef<HTMLDivElement, DialogActionsProps>(function DialogActions(
+  { children, className },
+  ref
+) {
+  // Consume context to validate sub-component is used inside Dialog
+  useDialogContext();
+
+  return (
+    <div ref={ref} className={cn(dialogActionsVariants(), className)}>
+      {children}
+    </div>
+  );
+});
+
+DialogActions.displayName = "DialogActions";

--- a/packages/react/src/components/Dialog/DialogContent.tsx
+++ b/packages/react/src/components/Dialog/DialogContent.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import { useDialogContext } from "./DialogHeadless";
+import { dialogContentVariants } from "./Dialog.variants";
+import type { DialogContentProps } from "./Dialog.types";
+
+/**
+ * `DialogContent` — Scrollable body slot sub-component (Layer 3).
+ *
+ * Renders as a scrollable `<div>` and registers its `id` with the parent
+ * `DialogContext` so the dialog panel can wire `aria-describedby` correctly.
+ *
+ * Styled with `text-body-medium` and `text-on-surface-variant` per MD3 spec.
+ * Overflows vertically when content exceeds the available height.
+ *
+ * Must be rendered inside a `<Dialog>` or `<DialogHeadless>` component.
+ *
+ * @example
+ * ```tsx
+ * <Dialog open onOpenChange={setOpen}>
+ *   <DialogHeadline>Confirm deletion?</DialogHeadline>
+ *   <DialogContent>
+ *     <p>
+ *       This will permanently delete the file and all associated data.
+ *       This action cannot be undone.
+ *     </p>
+ *   </DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *   </DialogActions>
+ * </Dialog>
+ * ```
+ */
+export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(function DialogContent(
+  { children, className },
+  ref
+) {
+  const { contentId, variant } = useDialogContext();
+
+  return (
+    <div ref={ref} id={contentId} className={cn(dialogContentVariants({ variant }), className)}>
+      {children}
+    </div>
+  );
+});
+
+DialogContent.displayName = "DialogContent";

--- a/packages/react/src/components/Dialog/DialogHeadless.tsx
+++ b/packages/react/src/components/Dialog/DialogHeadless.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import type React from "react";
+import { useDialog, useOverlay, usePreventScroll, FocusScope } from "react-aria";
+import { useOverlayTriggerState } from "react-stately";
+import { mergeProps } from "@react-aria/utils";
+import { cn } from "../../utils/cn";
+import type {
+  DialogAnimationState,
+  DialogContextValue,
+  DialogHeadlessProps,
+  DialogVariant,
+} from "./Dialog.types";
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+/**
+ * Context shared between `DialogHeadless` and slot sub-components
+ * (`DialogHeadline`, `DialogContent`, `DialogActions`).
+ *
+ * Provides stable IDs for aria-labelledby / aria-describedby wiring,
+ * the close callback, and the active variant.
+ *
+ * @internal
+ */
+export const DialogContext = createContext<DialogContextValue | null>(null);
+
+/**
+ * Hook to consume `DialogContext` inside dialog slot sub-components.
+ * Throws a descriptive error if used outside a `DialogHeadless` tree.
+ *
+ * @internal
+ */
+export function useDialogContext(): DialogContextValue {
+  const ctx = useContext(DialogContext);
+  if (ctx === null) {
+    throw new Error(
+      "[Dialog] DialogHeadline, DialogContent, and DialogActions must be rendered " +
+        "inside a <Dialog> or <DialogHeadless> component."
+    );
+  }
+  return ctx;
+}
+
+// ─── DialogPanel (internal) ───────────────────────────────────────────────────
+
+/**
+ * Inner dialog panel — wires React Aria hooks (`useDialog`, `useOverlay`,
+ * `usePreventScroll`) and renders the accessible dialog element with the
+ * centering wrapper.
+ *
+ * DOM structure:
+ * ```
+ *   <div> (centering / positioning wrapper, z-50)
+ *     <div role="dialog" aria-modal> (panel — className, animation, data attrs)
+ *       {children}
+ *     </div>
+ *   </div>
+ * ```
+ *
+ * This allows `screen.getByRole("dialog")` to directly return the panel
+ * (with `data-animation-state` and `data-variant` for test assertions).
+ *
+ * @internal
+ */
+interface DialogPanelProps {
+  ariaLabel: string | undefined;
+  headlineId: string;
+  contentId: string;
+  onClose: () => void;
+  onTransitionEnd: () => void;
+  variant: DialogVariant;
+  isDismissable: boolean;
+  wrapperClassName: string;
+  className: string | undefined;
+  animationState: DialogAnimationState;
+  getAnimationClassName: ((state: DialogAnimationState) => string) | undefined;
+  children: React.ReactNode;
+}
+
+const DialogPanel = ({
+  ariaLabel,
+  headlineId,
+  contentId,
+  onClose,
+  onTransitionEnd,
+  variant,
+  isDismissable,
+  wrapperClassName,
+  className,
+  animationState,
+  getAnimationClassName,
+  children,
+}: DialogPanelProps): React.ReactElement => {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Lock body scroll while dialog is open
+  usePreventScroll();
+
+  // useDialog: applies role="dialog", aria-modal="true", aria-labelledby, aria-describedby
+  const { dialogProps } = useDialog(
+    {
+      ...(ariaLabel ? { "aria-label": ariaLabel } : {}),
+      "aria-labelledby": headlineId,
+      "aria-describedby": contentId,
+    },
+    panelRef
+  );
+
+  // useOverlay: handles Escape key dismissal and outside-click dismissal
+  const { overlayProps } = useOverlay(
+    {
+      isOpen: true,
+      onClose,
+      isDismissable,
+      shouldCloseOnBlur: false,
+    },
+    panelRef
+  );
+
+  // Merge animation classes onto the panel element
+  const panelClassName = cn(className, getAnimationClassName?.(animationState));
+
+  return (
+    // Centering/positioning wrapper — structural only, no ARIA role
+    <div className={wrapperClassName}>
+      {/* Panel: semantic dialog element with React Aria hooks, animation, data attrs */}
+      <div
+        {...mergeProps(overlayProps, dialogProps)}
+        ref={panelRef}
+        aria-modal="true"
+        className={panelClassName}
+        data-animation-state={animationState}
+        data-variant={variant}
+        onTransitionEnd={onTransitionEnd}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+DialogPanel.displayName = "DialogPanel";
+
+// ─── DialogHeadless ───────────────────────────────────────────────────────────
+
+/**
+ * `DialogHeadless` — Layer 2 headless primitive.
+ *
+ * Provides all MD3 Dialog behavior and ARIA semantics without any visual styling:
+ *
+ * - **Portal rendering**: dialog and scrim render in `document.body` via
+ *   `createPortal` to avoid stacking context issues.
+ * - **Open/close state**: via `useOverlayTriggerState` (supports controlled
+ *   `open` + `onOpenChange` and uncontrolled `defaultOpen`).
+ * - **Scroll lock**: `usePreventScroll` locks body scroll while open.
+ * - **Focus trap**: `FocusScope` with `contain`, `restoreFocus`, `autoFocus`.
+ * - **Dismiss behavior**: `useOverlay` handles Escape key and outside click.
+ *   Basic variant is dismissable (Escape + outside click);
+ *   Full-screen variant is Escape-dismissable only (no scrim click) per MD3 spec.
+ * - **Animation state machine**: `entering → visible → exiting → exited`
+ *   mirrors the Snackbar animation pattern.
+ * - **ARIA wiring**: `DialogContext` provides stable IDs for `aria-labelledby`
+ *   and `aria-describedby`, consumed by slot sub-components.
+ *
+ * React Aria hooks used:
+ * - `useDialog` — `role="dialog"`, `aria-modal`, `aria-labelledby`, `aria-describedby`
+ * - `useOverlay` — Escape key + outside-click dismissal
+ * - `usePreventScroll` — body scroll lock
+ * - `FocusScope` — focus trap + restoreFocus on close
+ * - `useOverlayTriggerState` — open/close state management
+ *
+ * @example
+ * ```tsx
+ * // Controlled basic dialog
+ * <DialogHeadless
+ *   variant="basic"
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   className={cn(dialogWrapperVariants({ variant: 'basic' }), dialogPanelVariants({ variant: 'basic' }))}
+ *   scrimClassName={dialogScrimVariants()}
+ *   getAnimationClassName={(state) =>
+ *     dialogAnimationVariants({ animationState: state, variant: 'basic' })
+ *   }
+ * >
+ *   <DialogHeadline>Confirm?</DialogHeadline>
+ *   <DialogContent>This action cannot be undone.</DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *   </DialogActions>
+ * </DialogHeadless>
+ * ```
+ */
+export const DialogHeadless = forwardRef<HTMLDivElement, DialogHeadlessProps>(
+  function DialogHeadless(
+    {
+      variant = "basic",
+      open,
+      defaultOpen = false,
+      onOpenChange,
+      "aria-label": ariaLabel,
+      children,
+      className,
+      scrimClassName,
+      getAnimationClassName,
+    },
+    _ref
+  ) {
+    // ── Open/close state ─────────────────────────────────────────────────────
+
+    const state = useOverlayTriggerState({
+      ...(open !== undefined ? { isOpen: open } : {}),
+      ...(defaultOpen !== undefined ? { defaultOpen } : {}),
+      ...(onOpenChange !== undefined ? { onOpenChange } : {}),
+    });
+
+    const isOpen = state.isOpen;
+
+    const close = useCallback(() => {
+      state.close();
+    }, [state]);
+
+    // ── Animation state machine ───────────────────────────────────────────────
+
+    const [animationState, setAnimationState] = useState<DialogAnimationState>("exited");
+    // Guard against calling state updates after unmount / multiple times
+    const closedRef = useRef<boolean>(false);
+    // Fallback timer for exit animation in case onTransitionEnd doesn't fire
+    const exitFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // When isOpen becomes true → start entry animation cycle
+    useEffect(() => {
+      if (!isOpen) return;
+
+      closedRef.current = false;
+      setAnimationState("entering");
+
+      // Zero-delay timer ensures "entering" state is rendered (allowing CSS
+      // transition initial values) before transitioning to "visible".
+      const id = setTimeout(() => {
+        setAnimationState("visible");
+      }, 0);
+
+      return () => clearTimeout(id);
+    }, [isOpen]);
+
+    // When isOpen becomes false while visible → start exit animation cycle
+    useEffect(() => {
+      if (isOpen) return;
+      if (animationState === "exited" || animationState === "entering") return;
+
+      if (animationState === "visible") {
+        setAnimationState("exiting");
+
+        // Fallback: advance to exited if CSS transition doesn't fire
+        exitFallbackRef.current = setTimeout(() => {
+          if (!closedRef.current) {
+            closedRef.current = true;
+            setAnimationState("exited");
+          }
+        }, 150);
+      }
+    }, [isOpen, animationState]);
+
+    // Cleanup on unmount
+    useEffect(
+      () => () => {
+        if (exitFallbackRef.current !== null) {
+          clearTimeout(exitFallbackRef.current);
+        }
+      },
+      []
+    );
+
+    const handleTransitionEnd = useCallback(() => {
+      if (animationState === "exiting" && !closedRef.current) {
+        if (exitFallbackRef.current !== null) {
+          clearTimeout(exitFallbackRef.current);
+          exitFallbackRef.current = null;
+        }
+        closedRef.current = true;
+        setAnimationState("exited");
+      }
+    }, [animationState]);
+
+    // ── ARIA ID coordination ──────────────────────────────────────────────────
+
+    const baseId = useId();
+    const headlineId = `${baseId}-dialog-headline`;
+    const contentId = `${baseId}-dialog-content`;
+
+    const contextValue: DialogContextValue = {
+      headlineId,
+      contentId,
+      close,
+      variant,
+    };
+
+    // ── Scrim dismissal ───────────────────────────────────────────────────────
+
+    // Basic variant: scrim click closes dialog. Full-screen: scrim is inert.
+    const handleScrimClick = useCallback(() => {
+      if (variant === "basic") {
+        close();
+      }
+    }, [variant, close]);
+
+    // ── Portal gate ───────────────────────────────────────────────────────────
+
+    // Do not render portal until open, and remove once animation is fully exited
+    if (!isOpen && animationState === "exited") {
+      return null;
+    }
+
+    // ── Portal content ────────────────────────────────────────────────────────
+
+    const content = (
+      <DialogContext.Provider value={contextValue}>
+        {/* Scrim overlay — click closes for basic, inert for fullscreen */}
+        <div
+          data-testid="dialog-scrim"
+          className={scrimClassName}
+          onClick={handleScrimClick}
+          aria-hidden="true"
+        />
+
+        {/* FocusScope: traps focus, restores focus to trigger on close, auto-focuses first element */}
+        <FocusScope contain restoreFocus autoFocus>
+          <DialogPanel
+            ariaLabel={ariaLabel}
+            headlineId={headlineId}
+            contentId={contentId}
+            onClose={close}
+            onTransitionEnd={handleTransitionEnd}
+            variant={variant}
+            isDismissable={variant === "basic"}
+            wrapperClassName={
+              variant === "basic"
+                ? "fixed inset-0 z-50 flex items-center justify-center px-4"
+                : "fixed inset-0 z-50"
+            }
+            className={className}
+            animationState={animationState}
+            getAnimationClassName={getAnimationClassName}
+          >
+            {children}
+          </DialogPanel>
+        </FocusScope>
+      </DialogContext.Provider>
+    );
+
+    if (typeof document === "undefined") return null;
+
+    return createPortal(content, document.body) as React.ReactElement;
+  }
+);
+
+DialogHeadless.displayName = "DialogHeadless";

--- a/packages/react/src/components/Dialog/DialogHeadline.tsx
+++ b/packages/react/src/components/Dialog/DialogHeadline.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import { useDialogContext } from "./DialogHeadless";
+import { dialogHeadlineVariants, dialogHeadlineTitleVariants } from "./Dialog.variants";
+import type { DialogHeadlineProps } from "./Dialog.types";
+
+/**
+ * `DialogHeadline` — Headline slot sub-component (Layer 3).
+ *
+ * Renders as an `<h2>` element and registers its `id` with the parent
+ * `DialogContext` so the dialog panel can wire `aria-labelledby` correctly.
+ *
+ * For the `fullscreen` variant, the headline renders as a top app bar row
+ * containing optional `closeButton` (leading icon button) and `confirmButton`
+ * (trailing text action) per MD3 Full-screen Dialog spec.
+ *
+ * Must be rendered inside a `<Dialog>` or `<DialogHeadless>` component.
+ *
+ * @example
+ * ```tsx
+ * // Basic variant
+ * <Dialog open onOpenChange={setOpen}>
+ *   <DialogHeadline>Delete file?</DialogHeadline>
+ *   ...
+ * </Dialog>
+ *
+ * // Full-screen variant with app bar controls
+ * <Dialog variant="fullscreen" open onOpenChange={setOpen}>
+ *   <DialogHeadline
+ *     closeButton={
+ *       <IconButton aria-label="Close" onPress={() => setOpen(false)}>
+ *         <CloseIcon />
+ *       </IconButton>
+ *     }
+ *     confirmButton={
+ *       <Button variant="text" onPress={handleSave}>Save</Button>
+ *     }
+ *   >
+ *     New event
+ *   </DialogHeadline>
+ *   ...
+ * </Dialog>
+ * ```
+ */
+export const DialogHeadline = forwardRef<HTMLHeadingElement, DialogHeadlineProps>(
+  function DialogHeadline({ children, className, closeButton, confirmButton }, ref) {
+    const { headlineId, variant } = useDialogContext();
+
+    if (variant === "fullscreen") {
+      return (
+        // Top app bar row for fullscreen variant
+        <div className={cn(dialogHeadlineVariants({ variant: "fullscreen" }), className)}>
+          {/* Leading close icon button */}
+          {closeButton}
+
+          {/* Headline text — grows to fill available space */}
+          <h2 id={headlineId} className={dialogHeadlineTitleVariants()}>
+            {children}
+          </h2>
+
+          {/* Trailing confirm action */}
+          {confirmButton}
+        </div>
+      );
+    }
+
+    return (
+      <h2
+        ref={ref}
+        id={headlineId}
+        className={cn(dialogHeadlineVariants({ variant: "basic" }), className)}
+      >
+        {children}
+      </h2>
+    );
+  }
+);
+
+DialogHeadline.displayName = "DialogHeadline";

--- a/packages/react/src/components/Dialog/index.ts
+++ b/packages/react/src/components/Dialog/index.ts
@@ -1,0 +1,39 @@
+// Layer 3: MD3 Styled Components (most users use these)
+export { Dialog } from "./Dialog";
+export { DialogHeadline } from "./DialogHeadline";
+export { DialogContent } from "./DialogContent";
+export { DialogActions } from "./DialogActions";
+
+// Layer 2: Headless Primitive (for advanced customization)
+export { DialogHeadless, DialogContext, useDialogContext } from "./DialogHeadless";
+
+// CVA Variants
+export {
+  dialogScrimVariants,
+  dialogPanelVariants,
+  dialogWrapperVariants,
+  dialogAnimationVariants,
+  dialogHeadlineVariants,
+  dialogHeadlineTitleVariants,
+  dialogContentVariants,
+  dialogActionsVariants,
+  type DialogScrimVariants,
+  type DialogPanelVariants,
+  type DialogWrapperVariants,
+  type DialogAnimationVariants,
+  type DialogHeadlineVariants,
+  type DialogContentVariants,
+  type DialogActionsVariants,
+} from "./Dialog.variants";
+
+// Types
+export type {
+  DialogVariant,
+  DialogAnimationState,
+  DialogProps,
+  DialogHeadlessProps,
+  DialogHeadlineProps,
+  DialogContentProps,
+  DialogActionsProps,
+  DialogContextValue,
+} from "./Dialog.types";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -127,3 +127,23 @@ export type {
   SnackbarAction,
   SnackbarItem,
 } from "./Snackbar";
+
+export {
+  Dialog,
+  DialogHeadline,
+  DialogContent,
+  DialogActions,
+  DialogHeadless,
+  DialogContext,
+  useDialogContext,
+} from "./Dialog";
+export type {
+  DialogVariant,
+  DialogAnimationState,
+  DialogProps,
+  DialogHeadlessProps,
+  DialogHeadlineProps,
+  DialogContentProps,
+  DialogActionsProps,
+  DialogContextValue,
+} from "./Dialog";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -177,3 +177,23 @@ export type {
   SnackbarAction,
   SnackbarItem,
 } from "./components/Snackbar";
+
+export {
+  Dialog,
+  DialogHeadline,
+  DialogContent,
+  DialogActions,
+  DialogHeadless,
+  DialogContext,
+  useDialogContext,
+} from "./components/Dialog";
+export type {
+  DialogVariant,
+  DialogAnimationState,
+  DialogProps,
+  DialogHeadlessProps,
+  DialogHeadlineProps,
+  DialogContentProps,
+  DialogActionsProps,
+  DialogContextValue,
+} from "./components/Dialog";

--- a/packages/tokens/src/tokens.css
+++ b/packages/tokens/src/tokens.css
@@ -519,6 +519,9 @@ body {
   /* Snackbar max width: MD3 spec = 568dp */
   --spacing-snackbar-max: 35.5rem; /* 568px */
 
+  /* Dialog max width: MD3 spec = 560dp */
+  --spacing-dialog-max: 35rem; /* 560px */
+
   /* Shape radius utilities for MD3 components */
   --radius-xs: var(--md-sys-shape-corner-extra-small); /* 4px */
   --radius-sm: var(--md-sys-shape-corner-small); /* 8px */


### PR DESCRIPTION
## What does this PR do?

Implements the Material Design 3 Dialog component for Phase 3 (v0.3.0), following the established three-layer architecture.

## Changes

- `Dialog.types.ts` — All TypeScript interfaces: `DialogVariant`, `DialogAnimationState`, `DialogContextValue`, `DialogHeadlessProps`, `DialogProps`, `DialogHeadlineProps`, `DialogContentProps`, `DialogActionsProps`
- `Dialog.variants.ts` — CVA variant definitions: scrim, panel (basic/fullscreen), animation state machine, headline, content, actions
- `DialogHeadless.tsx` — Layer 2 headless primitive with React Aria (`useDialog`, `useOverlay`, `usePreventScroll`, `FocusScope`, `useOverlayTriggerState`), portal rendering, animation state machine, `DialogContext`
- `Dialog.tsx` — Layer 3 styled component wrapping `DialogHeadless` with CVA variants
- `DialogHeadline.tsx` — Headline slot (`h2` / fullscreen top app bar row), wires `aria-labelledby`
- `DialogContent.tsx` — Scrollable body slot, wires `aria-describedby`
- `DialogActions.tsx` — Right-aligned action button row
- `Dialog.test.tsx` — 39 tests covering rendering, ARIA, open/close, keyboard Escape, focus trap, scrim behavior, variant rendering, animation states, axe audit
- `Dialog.stories.tsx` — Storybook stories: Basic, Scrollable, Confirmation, Fullscreen, Uncontrolled, Headless
- `index.ts` — Barrel exports (all three layers)
- `packages/tokens/src/tokens.css` — Added `--spacing-dialog-max: 35rem` (560dp per MD3 spec)
- Updated `components/index.ts` and `src/index.ts` with Dialog exports

## Testing

- 39 new tests, all passing
- Full test suite: 831 tests passing across 18 test files
- TypeScript strict mode: no errors
- ESLint: no errors

## Accessibility

- `role="dialog"` + `aria-modal="true"` via React Aria `useDialog`
- `aria-labelledby` → `DialogHeadline` id (auto-generated via `useId`)
- `aria-describedby` → `DialogContent` id (auto-generated via `useId`)
- Focus trap via `FocusScope` (contain + restoreFocus + autoFocus)
- Body scroll lock via `usePreventScroll`
- Escape key always closes (via `useOverlay`)
- Scrim click closes Basic; no-op for Full-screen (per MD3 spec)
- Portal rendering to `document.body` via `createPortal`
- axe audit passes for both variants

## MD3 Compliance

- Basic: `bg-surface-container-high`, `rounded-xl` (28dp), `shadow-elevation-3`, scale+fade animation
- Full-screen: full viewport, slide-up animation, top app bar row with close + confirm
- Scrim: `bg-scrim opacity-32` (matches Drawer scrim pattern)
- Motion: `duration-medium4` + `ease-emphasized-decelerate` entry, `duration-short2` + `ease-emphasized-accelerate` exit
- Typography: `text-headline-small` (headline), `text-body-medium` (content)

## Checklist

- [x] Tests added and passing (39 tests)
- [x] Linter passes
- [x] TypeScript strict mode passes
- [x] Storybook stories added
- [x] Three-layer architecture followed
- [x] React Aria used for accessibility
- [x] MD3 specification compliant
- [x] Portal rendering to document.body
- [x] Controlled and uncontrolled usage supported

## Related

Part of Phase 3 milestone (v0.3.0 — Feedback components: Dialog, Snackbar, Menu)