### PR TITLE
feat(menu): context menu, submenus, menu gap, and headless exports

### DIFF
--- a/.changeset/menu-triggers-layout.md
+++ b/.changeset/menu-triggers-layout.md
@@ -1,0 +1,5 @@
+---
+"@tinybigui/react": minor
+---
+
+Add `ContextMenuTrigger`, `SubmenuTrigger`, and `MenuGap`; expand headless menu primitives and types; update menu styles and stories.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@material/material-color-utilities": "^0.3.0",
+    "@react-aria/collections": "^3.0.1",
     "@react-aria/live-announcer": "^3.4.4",
     "@react-aria/utils": "^3.32.0",
     "class-variance-authority": "^0.7.1",

--- a/packages/react/src/components/Menu/ContextMenuTrigger.tsx
+++ b/packages/react/src/components/Menu/ContextMenuTrigger.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { type JSX } from "react";
+import { HeadlessContextMenuTrigger } from "./MenuHeadless";
+import type { ContextMenuTriggerProps } from "./Menu.types";
+
+/**
+ * MD3 styled ContextMenuTrigger component (Layer 3).
+ *
+ * Wraps arbitrary content and opens a menu on right-click or two-finger tap.
+ * The menu is positioned at the pointer coordinates.
+ *
+ * Keyboard: `Escape` closes the menu.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuTrigger>
+ *   <div>Right-click me</div>
+ *   <MenuTrigger.Menu aria-label="Context actions">
+ *     <MenuItem id="copy">Copy</MenuItem>
+ *     <MenuItem id="paste">Paste</MenuItem>
+ *   </MenuTrigger.Menu>
+ * </ContextMenuTrigger>
+ * ```
+ */
+export function ContextMenuTrigger({
+  children,
+  isOpen,
+  onOpenChange,
+}: ContextMenuTriggerProps): JSX.Element {
+  return (
+    <HeadlessContextMenuTrigger
+      {...(isOpen !== undefined ? { isOpen } : {})}
+      {...(onOpenChange !== undefined ? { onOpenChange } : {})}
+    >
+      {children}
+    </HeadlessContextMenuTrigger>
+  );
+}

--- a/packages/react/src/components/Menu/Menu.stories.tsx
+++ b/packages/react/src/components/Menu/Menu.stories.tsx
@@ -4,6 +4,9 @@ import { MenuTrigger } from "./Menu";
 import { MenuItem } from "./MenuItem";
 import { MenuSection } from "./MenuSection";
 import { MenuDivider } from "./MenuDivider";
+import { MenuGap } from "./MenuGap";
+import { SubmenuTrigger } from "./SubmenuTrigger";
+import { ContextMenuTrigger } from "./ContextMenuTrigger";
 import { HeadlessMenuTrigger, HeadlessMenuItem } from "./MenuHeadless";
 import { menuContainerVariants, menuItemVariants } from "./Menu.variants";
 import { cn } from "../../utils/cn";
@@ -46,11 +49,49 @@ const ListIcon = (): JSX.Element => (
   </svg>
 );
 
+const CardViewIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M4 4h7v5H4V4zm0 7h7v9H4v-9zm9-7h7v9h-7V4zm0 11h7v5h-7v-5z" />
+  </svg>
+);
+
 const MoreVertIcon = (): JSX.Element => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
   </svg>
 );
+
+const StarIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+  </svg>
+);
+
+const ShareIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
+  </svg>
+);
+
+const DeleteIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+  </svg>
+);
+
+const InfoIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+  </svg>
+);
+
+// ─── Shared trigger button styles ─────────────────────────────────────────────
+
+const primaryBtn = "bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5";
+const secondaryBtn =
+  "bg-secondary-container text-on-secondary-container text-label-large rounded-full px-6 py-2.5";
+const tertiaryBtn =
+  "bg-tertiary-container text-on-tertiary-container text-label-large rounded-full px-6 py-2.5";
 
 // ─── Meta ─────────────────────────────────────────────────────────────────────
 
@@ -61,8 +102,16 @@ const meta: Meta<typeof MenuTrigger> = {
     layout: "centered",
     docs: {
       description: {
-        component:
-          "Material Design 3 Menu — a contextual popup list anchored to a trigger element. Supports leading/trailing icons, keyboard shortcuts, section grouping with dividers, disabled items, and select variants.",
+        component: [
+          "Material Design 3 Menu — a contextual popup list anchored to a trigger element.",
+          "",
+          "Supports both **Baseline** (standard 4dp corners) and **Expressive Vertical** (16dp corners) styles,",
+          "two color schemes (**standard** surface-based and **vibrant** tertiary-based),",
+          "leading/trailing icons, keyboard shortcuts, supporting text, badges,",
+          "section grouping with dividers and gap separators, density control,",
+          "single/multiple selection with automatic checkmarks,",
+          "nested submenus, and right-click context menus.",
+        ].join("\n"),
       },
     },
   },
@@ -78,10 +127,7 @@ export const Basic: Story = {
   name: "Basic Menu",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Open Menu
       </button>
       <MenuTrigger.Menu aria-label="Edit actions">
@@ -100,10 +146,7 @@ export const WithLeadingIcons: Story = {
   name: "With Leading Icons",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Edit
       </button>
       <MenuTrigger.Menu aria-label="Edit">
@@ -127,10 +170,7 @@ export const WithKeyboardShortcuts: Story = {
   name: "With Keyboard Shortcuts",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Edit
       </button>
       <MenuTrigger.Menu aria-label="Edit">
@@ -148,16 +188,97 @@ export const WithKeyboardShortcuts: Story = {
   ),
 };
 
+// ─── Supporting Text ─────────────────────────────────────────────────────────
+
+export const WithSupportingText: Story = {
+  name: "With Supporting Text",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use the `description` prop to add a secondary line of supporting text below the item label. Per MD3 anatomy item 8.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        Share
+      </button>
+      <MenuTrigger.Menu aria-label="Share via">
+        <MenuItem
+          id="email"
+          leadingIcon={<CopyIcon />}
+          description="Send to anyone with an email address"
+        >
+          Email
+        </MenuItem>
+        <MenuItem id="link" leadingIcon={<ShareIcon />} description="Anyone with the link can view">
+          Copy link
+        </MenuItem>
+        <MenuItem
+          id="message"
+          leadingIcon={<InfoIcon />}
+          description="Send via SMS to a phone number"
+        >
+          Text message
+        </MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── With Badge ───────────────────────────────────────────────────────────────
+
+export const WithBadge: Story = {
+  name: "With Badge",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use the `badge` prop to render a small badge between the label and trailing content. Per MD3 anatomy item 5.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        Notifications
+      </button>
+      <MenuTrigger.Menu aria-label="Notification settings">
+        <MenuItem
+          id="all"
+          badge={
+            <span className="text-label-small bg-error text-on-error flex h-4 min-w-4 items-center justify-center rounded-full px-1">
+              12
+            </span>
+          }
+        >
+          All notifications
+        </MenuItem>
+        <MenuItem
+          id="mentions"
+          badge={
+            <span className="text-label-small bg-tertiary text-on-tertiary flex h-4 min-w-4 items-center justify-center rounded-full px-1">
+              3
+            </span>
+          }
+        >
+          Mentions only
+        </MenuItem>
+        <MenuItem id="none">None</MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
 // ─── With Sections ────────────────────────────────────────────────────────────
 
 export const WithSections: Story = {
   name: "With Sections and Dividers",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Edit
       </button>
       <MenuTrigger.Menu aria-label="Edit actions">
@@ -188,10 +309,7 @@ export const WithStandaloneDivider: Story = {
   name: "With Standalone MenuDivider",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Actions
       </button>
       <MenuTrigger.Menu aria-label="Actions">
@@ -212,10 +330,7 @@ export const WithDisabledItems: Story = {
   name: "With Disabled Items",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Edit
       </button>
       <MenuTrigger.Menu aria-label="Edit">
@@ -236,22 +351,54 @@ export const WithDisabledItems: Story = {
   ),
 };
 
-// ─── Select Variant — Single ──────────────────────────────────────────────────
+// ─── Density ──────────────────────────────────────────────────────────────────
+
+export const DensityLevels: Story = {
+  name: "Density Levels",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "MD3 web-only density prop controls item height: `0`=48dp (default), `-1`=44dp, `-2`=40dp, `-3`=36dp.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-start gap-4">
+      {([-0, -1, -2, -3] as const).map((density) => (
+        <MenuTrigger key={density}>
+          <button type="button" className={primaryBtn}>
+            density={density}
+          </button>
+          <MenuTrigger.Menu aria-label={`Density ${density}`} density={density}>
+            <MenuItem id="cut" leadingIcon={<CutIcon />}>
+              Cut
+            </MenuItem>
+            <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+              Copy
+            </MenuItem>
+            <MenuItem id="paste" leadingIcon={<PasteIcon />}>
+              Paste
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      ))}
+    </div>
+  ),
+};
+
+// ─── Selection — Single ───────────────────────────────────────────────────────
 
 const SelectSingleDemo = (): JSX.Element => {
   const [selected, setSelected] = useState<string>("list");
   return (
     <div className="flex flex-col items-center gap-4">
       <MenuTrigger>
-        <button
-          type="button"
-          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-        >
+        <button type="button" className={primaryBtn}>
           View: {selected}
         </button>
         <MenuTrigger.Menu
           aria-label="View options"
-          variant="select"
           selectionMode="single"
           selectedKeys={new Set([selected])}
           onSelectionChange={(keys) => {
@@ -265,6 +412,9 @@ const SelectSingleDemo = (): JSX.Element => {
           <MenuItem id="list" leadingIcon={<ListIcon />}>
             List view
           </MenuItem>
+          <MenuItem id="card" leadingIcon={<CardViewIcon />}>
+            Card view
+          </MenuItem>
         </MenuTrigger.Menu>
       </MenuTrigger>
       <p className="text-body-medium text-on-surface-variant">Selected: {selected}</p>
@@ -273,26 +423,30 @@ const SelectSingleDemo = (): JSX.Element => {
 };
 
 export const SelectSingle: Story = {
-  name: "Select Variant — Single Selection",
+  name: "Selection — Single",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Single-selection menus automatically render a leading checkmark on the selected item. Checkmark does not appear when a `leadingIcon` is already provided.",
+      },
+    },
+  },
   render: () => <SelectSingleDemo />,
 };
 
-// ─── Select Variant — Multiple ────────────────────────────────────────────────
+// ─── Selection — Multiple ─────────────────────────────────────────────────────
 
 const SelectMultipleDemo = (): JSX.Element => {
   const [selected, setSelected] = useState<Set<string>>(new Set(["bold"]));
   return (
     <div className="flex flex-col items-center gap-4">
       <MenuTrigger>
-        <button
-          type="button"
-          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-        >
+        <button type="button" className={primaryBtn}>
           Formatting
         </button>
         <MenuTrigger.Menu
           aria-label="Text formatting"
-          variant="select"
           selectionMode="multiple"
           selectedKeys={selected}
           onSelectionChange={(keys) => setSelected(new Set([...(keys as Set<string>)]))}
@@ -311,8 +465,319 @@ const SelectMultipleDemo = (): JSX.Element => {
 };
 
 export const SelectMultiple: Story = {
-  name: "Select Variant — Multiple Selection",
+  name: "Selection — Multiple",
   render: () => <SelectMultipleDemo />,
+};
+
+// ─── Vibrant Color Scheme ─────────────────────────────────────────────────────
+
+export const VibrantColorScheme: Story = {
+  name: "Vibrant Color Scheme",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `vibrant` color scheme uses the **tertiary container** background (vs. surface-container in standard). Designed for expressive vertical menus where stronger visual identity is desired.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-start gap-4">
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Standard</span>
+        <MenuTrigger>
+          <button type="button" className={secondaryBtn}>
+            Standard
+          </button>
+          <MenuTrigger.Menu aria-label="Standard" colorScheme="standard" menuStyle="vertical">
+            <MenuItem id="star" leadingIcon={<StarIcon />}>
+              Add to favourites
+            </MenuItem>
+            <MenuItem id="share" leadingIcon={<ShareIcon />}>
+              Share
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+              Delete
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Vibrant</span>
+        <MenuTrigger>
+          <button type="button" className={tertiaryBtn}>
+            Vibrant
+          </button>
+          <MenuTrigger.Menu aria-label="Vibrant" colorScheme="vibrant" menuStyle="vertical">
+            <MenuItem id="star" leadingIcon={<StarIcon />}>
+              Add to favourites
+            </MenuItem>
+            <MenuItem id="share" leadingIcon={<ShareIcon />}>
+              Share
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+              Delete
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Expressive Vertical Menu ─────────────────────────────────────────────────
+
+export const VerticalMenuStyle: Story = {
+  name: "Expressive Vertical Menu",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `vertical` menu style uses **16dp rounded corners** (vs 4dp in baseline) and supports `MenuGap` — a visual spacing element (not a separator) that groups items without a visible divider line.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        More actions
+      </button>
+      <MenuTrigger.Menu aria-label="More actions" menuStyle="vertical" colorScheme="vibrant">
+        <MenuItem id="star" leadingIcon={<StarIcon />}>
+          Add to favourites
+        </MenuItem>
+        <MenuItem id="share" leadingIcon={<ShareIcon />}>
+          Share
+        </MenuItem>
+        <MenuGap />
+        <MenuItem id="rename">Rename</MenuItem>
+        <MenuItem id="duplicate">Duplicate</MenuItem>
+        <MenuGap />
+        <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+          Delete
+        </MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── Gap vs Divider ───────────────────────────────────────────────────────────
+
+export const GapVsDivider: Story = {
+  name: "Gap vs Divider (Vertical)",
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          "Side-by-side comparison of the two MD3 vertical-menu separator styles.",
+          "",
+          "- **With gap** (left): A purely visual blank space (`MenuGap`) separates item groups. No visible line — the gap is hidden from the accessibility tree.",
+          "- **With divider** (right): A thin horizontal rule (`MenuDivider`) drawn with `outline-variant` colour separates groups.",
+        ].join("\n"),
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-start gap-8">
+      {/* ── With gap ── */}
+      <div className="flex flex-col items-center gap-2">
+        <MenuTrigger defaultOpen>
+          <button type="button" className={primaryBtn}>
+            With gap
+          </button>
+          <MenuTrigger.Menu aria-label="With gap" menuStyle="vertical">
+            <MenuItem id="item1" leadingIcon={<InfoIcon />}>
+              Item 1
+            </MenuItem>
+            <MenuItem id="item2" leadingIcon={<CopyIcon />} trailingText="⌘C">
+              Item 2
+            </MenuItem>
+            <MenuItem id="item3" leadingIcon={<CutIcon />}>
+              Item 3
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="item4" leadingIcon={<StarIcon />} trailingIcon={<span>▸</span>}>
+              Item 4
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+
+      {/* ── With divider ── */}
+      <div className="flex flex-col items-center gap-2">
+        <MenuTrigger defaultOpen>
+          <button type="button" className={primaryBtn}>
+            With divider
+          </button>
+          <MenuTrigger.Menu aria-label="With divider" menuStyle="vertical">
+            <MenuItem id="d-item1" leadingIcon={<InfoIcon />}>
+              Item 1
+            </MenuItem>
+            <MenuItem id="d-item2" leadingIcon={<CopyIcon />} trailingText="⌘C">
+              Item 2
+            </MenuItem>
+            <MenuItem id="d-item3" leadingIcon={<CutIcon />}>
+              Item 3
+            </MenuItem>
+            <MenuDivider />
+            <MenuItem id="d-item4" leadingIcon={<StarIcon />} trailingIcon={<span>▸</span>}>
+              Item 4
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Submenu ──────────────────────────────────────────────────────────────────
+
+export const WithSubmenu: Story = {
+  name: "With Submenu",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use `SubmenuTrigger` to nest a second menu inside a `MenuItem`. A trailing chevron is automatically appended. Keyboard: `ArrowRight` opens, `ArrowLeft` / `Escape` closes and returns focus to the parent item.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        Actions
+      </button>
+      <MenuTrigger.Menu aria-label="Actions">
+        <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+          Copy
+        </MenuItem>
+        <SubmenuTrigger>
+          <MenuItem id="share" leadingIcon={<ShareIcon />}>
+            Share
+          </MenuItem>
+          <MenuTrigger.Menu aria-label="Share via">
+            <MenuItem id="email">Email</MenuItem>
+            <MenuItem id="sms">SMS</MenuItem>
+            <MenuItem id="link" trailingText="⌘L">
+              Copy link
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </SubmenuTrigger>
+        <MenuDivider />
+        <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+          Delete
+        </MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── Context Menu ─────────────────────────────────────────────────────────────
+
+const ContextMenuDemo = (): JSX.Element => {
+  const [lastAction, setLastAction] = useState<string>("(none)");
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <ContextMenuTrigger>
+        <div className="border-outline text-on-surface-variant text-body-medium flex h-32 w-64 items-center justify-center rounded-lg border-dashed select-none">
+          Right-click anywhere here
+        </div>
+        <MenuTrigger.Menu
+          aria-label="Context actions"
+          onAction={(key) => setLastAction(String(key))}
+        >
+          <MenuItem id="cut" leadingIcon={<CutIcon />} trailingText="⌘X">
+            Cut
+          </MenuItem>
+          <MenuItem id="copy" leadingIcon={<CopyIcon />} trailingText="⌘C">
+            Copy
+          </MenuItem>
+          <MenuItem id="paste" leadingIcon={<PasteIcon />} trailingText="⌘V">
+            Paste
+          </MenuItem>
+          <MenuDivider />
+          <MenuItem id="select-all" trailingText="⌘A">
+            Select all
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </ContextMenuTrigger>
+      <p className="text-body-medium text-on-surface-variant">Last action: {lastAction}</p>
+    </div>
+  );
+};
+
+export const ContextMenu: Story = {
+  name: "Context Menu (Right-click)",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Wrap any content with `ContextMenuTrigger` to open a menu on right-click or two-finger tap. The menu is positioned at the pointer coordinates.",
+      },
+    },
+  },
+  render: () => <ContextMenuDemo />,
+};
+
+// ─── Scrollable ───────────────────────────────────────────────────────────────
+
+export const Scrollable: Story = {
+  name: "Scrollable Menu",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When menu content exceeds the available viewport height the menu becomes scrollable. Max height is `calc(100vh - 2rem)` by default.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        Select country
+      </button>
+      <MenuTrigger.Menu aria-label="Countries">
+        {[
+          "Argentina",
+          "Australia",
+          "Brazil",
+          "Canada",
+          "China",
+          "Denmark",
+          "Egypt",
+          "Finland",
+          "France",
+          "Germany",
+          "India",
+          "Indonesia",
+          "Italy",
+          "Japan",
+          "Mexico",
+          "Netherlands",
+          "New Zealand",
+          "Nigeria",
+          "Norway",
+          "Poland",
+          "Portugal",
+          "South Africa",
+          "South Korea",
+          "Spain",
+          "Sweden",
+          "Switzerland",
+          "Turkey",
+          "United Kingdom",
+          "United States",
+          "Vietnam",
+        ].map((country) => (
+          <MenuItem key={country} id={country.toLowerCase().replace(/ /g, "-")}>
+            {country}
+          </MenuItem>
+        ))}
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
 };
 
 // ─── Controlled Open ──────────────────────────────────────────────────────────
@@ -323,11 +788,7 @@ const ControlledOpenDemo = (): JSX.Element => {
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="flex gap-3">
-        <button
-          type="button"
-          onClick={() => setIsOpen(true)}
-          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-        >
+        <button type="button" onClick={() => setIsOpen(true)} className={primaryBtn}>
           Open
         </button>
         <button
@@ -368,10 +829,10 @@ export const ControlledOpen: Story = {
   render: () => <ControlledOpenDemo />,
 };
 
-// ─── Context Menu (IconButton trigger) ───────────────────────────────────────
+// ─── Icon Button Trigger ──────────────────────────────────────────────────────
 
 export const IconButtonTrigger: Story = {
-  name: "With IconButton Trigger",
+  name: "With Icon Button Trigger",
   render: () => (
     <MenuTrigger>
       <button
@@ -384,55 +845,35 @@ export const IconButtonTrigger: Story = {
       <MenuTrigger.Menu aria-label="More options">
         <MenuItem id="rename">Rename</MenuItem>
         <MenuItem id="duplicate">Duplicate</MenuItem>
-        <MenuItem id="share">Share</MenuItem>
+        <MenuItem id="share" leadingIcon={<ShareIcon />}>
+          Share
+        </MenuItem>
         <MenuDivider />
-        <MenuItem id="delete">Delete</MenuItem>
+        <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+          Delete
+        </MenuItem>
       </MenuTrigger.Menu>
     </MenuTrigger>
   ),
 };
 
-// ─── Headless Primitive ───────────────────────────────────────────────────────
-
-export const HeadlessPrimitive: Story = {
-  name: "Headless — Custom Styling",
-  render: () => (
-    <HeadlessMenuTrigger>
-      <button
-        type="button"
-        className="bg-tertiary text-on-tertiary text-label-large rounded-full px-6 py-2.5"
-      >
-        Custom Styled Menu
-      </button>
-      <HeadlessMenuTrigger.Menu
-        aria-label="Custom"
-        className={cn(menuContainerVariants({ open: true }), "border-outline-variant border")}
-      >
-        <HeadlessMenuItem id="option-a" className={cn(menuItemVariants(), "text-secondary")}>
-          Option A (custom)
-        </HeadlessMenuItem>
-        <HeadlessMenuItem id="option-b" className={cn(menuItemVariants())}>
-          Option B
-        </HeadlessMenuItem>
-      </HeadlessMenuTrigger.Menu>
-    </HeadlessMenuTrigger>
-  ),
-};
-
-// ─── Dark Mode ────────────────────────────────────────────────────────────────
+// ─── Dark Mode — Standard ─────────────────────────────────────────────────────
 
 export const DarkMode: Story = {
-  name: "Dark Mode",
+  name: "Dark Mode — Standard",
   parameters: {
     backgrounds: { default: "dark" },
+    docs: {
+      description: {
+        story:
+          "Standard color scheme in dark mode. Tokens automatically adapt via CSS `@media (prefers-color-scheme: dark)` or `.dark` class.",
+      },
+    },
   },
   render: () => (
     <div className="dark">
       <MenuTrigger>
-        <button
-          type="button"
-          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-        >
+        <button type="button" className={primaryBtn}>
           Open Menu
         </button>
         <MenuTrigger.Menu aria-label="Edit">
@@ -450,5 +891,73 @@ export const DarkMode: Story = {
         </MenuTrigger.Menu>
       </MenuTrigger>
     </div>
+  ),
+};
+
+// ─── Dark Mode — Vibrant ──────────────────────────────────────────────────────
+
+export const DarkModeVibrant: Story = {
+  name: "Dark Mode — Vibrant Vertical",
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  render: () => (
+    <div className="dark">
+      <MenuTrigger>
+        <button type="button" className={tertiaryBtn}>
+          More actions
+        </button>
+        <MenuTrigger.Menu aria-label="More actions" menuStyle="vertical" colorScheme="vibrant">
+          <MenuItem id="star" leadingIcon={<StarIcon />}>
+            Add to favourites
+          </MenuItem>
+          <MenuItem id="share" leadingIcon={<ShareIcon />}>
+            Share
+          </MenuItem>
+          <MenuGap />
+          <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+            Delete
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    </div>
+  ),
+};
+
+// ─── Headless Primitive ───────────────────────────────────────────────────────
+
+export const HeadlessPrimitive: Story = {
+  name: "Headless — Custom Styling",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Layer 2 headless primitives expose the full RAC API without any MD3 styles applied. Use these as a foundation for fully custom styling.",
+      },
+    },
+  },
+  render: () => (
+    <HeadlessMenuTrigger>
+      <button
+        type="button"
+        className="bg-tertiary text-on-tertiary text-label-large rounded-full px-6 py-2.5"
+      >
+        Custom Styled Menu
+      </button>
+      <HeadlessMenuTrigger.Menu
+        aria-label="Custom"
+        className={cn(
+          menuContainerVariants({ menuStyle: "baseline" }),
+          "border-outline-variant border"
+        )}
+      >
+        <HeadlessMenuItem id="option-a" className={cn(menuItemVariants(), "text-secondary")}>
+          Option A (custom)
+        </HeadlessMenuItem>
+        <HeadlessMenuItem id="option-b" className={cn(menuItemVariants())}>
+          Option B
+        </HeadlessMenuItem>
+      </HeadlessMenuTrigger.Menu>
+    </HeadlessMenuTrigger>
   ),
 };

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -6,7 +6,11 @@ import { MenuTrigger } from "./Menu";
 import { MenuItem } from "./MenuItem";
 import { MenuSection } from "./MenuSection";
 import { MenuDivider } from "./MenuDivider";
+import { MenuGap } from "./MenuGap";
+import { SubmenuTrigger } from "./SubmenuTrigger";
+import { ContextMenuTrigger } from "./ContextMenuTrigger";
 import { HeadlessMenuTrigger } from "./MenuHeadless";
+import { menuContainerVariants, menuItemVariants } from "./Menu.variants";
 
 // ─── Test Icon Mocks ───────────────────────────────────────────────────────────
 
@@ -52,9 +56,6 @@ describe("MenuTrigger", () => {
 
     test("trigger has aria-haspopup='menu'", () => {
       renderBasicMenu();
-      // React Aria's useOverlayTrigger sets aria-haspopup: true (boolean) for
-      // type='menu', which React serializes to "true" in the DOM. This is
-      // equivalent to "menu" per the WAI-ARIA spec.
       const trigger = screen.getByRole("button", { name: "Open Menu" });
       expect(trigger).toHaveAttribute("aria-haspopup");
     });
@@ -70,7 +71,11 @@ describe("MenuTrigger", () => {
     test("trigger has aria-expanded='true' when open", async () => {
       renderBasicMenu();
       await openMenu();
-      expect(screen.getByRole("button", { name: "Open Menu" })).toHaveAttribute(
+      // When the menu is open the Popover uses modal overlay behavior — RAC's
+      // ariaHideOutside hides everything outside the popover from the a11y tree,
+      // including the trigger. We use { hidden: true } to assert the attribute
+      // on the DOM node directly while it is aria-hidden.
+      expect(screen.getByRole("button", { name: "Open Menu", hidden: true })).toHaveAttribute(
         "aria-expanded",
         "true"
       );
@@ -116,7 +121,7 @@ describe("MenuTrigger", () => {
     test("clicking outside menu closes it", async () => {
       render(
         <div>
-          <div data-testid="outside">Outside</div>
+          <div data-testid="outside">Outside element</div>
           <MenuTrigger>
             <button type="button">Open Menu</button>
             <MenuTrigger.Menu aria-label="Actions">
@@ -125,12 +130,12 @@ describe("MenuTrigger", () => {
           </MenuTrigger>
         </div>
       );
-      await openMenu();
-      expect(screen.getByRole("menu")).toBeInTheDocument();
       const user = userEvent.setup();
-      // Close via Escape — JSDOM portals have limited pointer-event bubbling for
-      // "interact outside" detection, so Escape is the reliable cross-env close.
-      await user.keyboard("{Escape}");
+      await user.click(screen.getByRole("button", { name: "Open Menu" }));
+      await waitFor(() => {
+        expect(screen.getByRole("menu")).toBeInTheDocument();
+      });
+      await user.click(screen.getByTestId("outside"));
       await waitFor(() => {
         expect(screen.queryByRole("menu")).not.toBeInTheDocument();
       });
@@ -179,6 +184,19 @@ describe("MenuTrigger", () => {
       );
       expect(screen.getByRole("menu")).toBeInTheDocument();
     });
+
+    test("shouldFlip prop passes through to trigger", () => {
+      // shouldFlip defaults to true; test it can be set
+      render(
+        <MenuTrigger shouldFlip={false}>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      expect(screen.getByRole("button", { name: "Open Menu" })).toBeInTheDocument();
+    });
   });
 });
 
@@ -211,6 +229,32 @@ describe("Menu", () => {
       await openMenu();
       expect(screen.getByRole("menu")).toHaveClass("custom-menu");
     });
+
+    test("uses standard colorScheme by default", async () => {
+      renderBasicMenu();
+      await openMenu();
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bg-surface-container");
+    });
+
+    test("vibrant colorScheme applies tertiary container background", async () => {
+      renderBasicMenu({ colorScheme: "vibrant", menuStyle: "vertical" });
+      await openMenu();
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bg-tertiary-container");
+    });
+
+    test("baseline menuStyle uses extra-small corner radius", async () => {
+      renderBasicMenu({ menuStyle: "baseline" });
+      await openMenu();
+      expect(screen.getByRole("menu")).toHaveClass("rounded-xs");
+    });
+
+    test("vertical menuStyle uses large corner radius", async () => {
+      renderBasicMenu({ menuStyle: "vertical" });
+      await openMenu();
+      expect(screen.getByRole("menu")).toHaveClass("rounded-lg");
+    });
   });
 
   describe("Portal", () => {
@@ -218,7 +262,6 @@ describe("Menu", () => {
       renderBasicMenu();
       await openMenu();
       const menu = screen.getByRole("menu");
-      // The menu should be a descendant of body but not of the component's wrapper
       expect(document.body.contains(menu)).toBe(true);
     });
   });
@@ -240,6 +283,13 @@ describe("MenuItem", () => {
       expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
     });
 
+    test("uses body-large typography for label text", async () => {
+      renderBasicMenu();
+      await openMenu();
+      const item = screen.getByRole("menuitem", { name: "Cut" });
+      expect(item).toHaveClass("text-body-large");
+    });
+
     test("renders leading icon when provided", async () => {
       render(
         <MenuTrigger>
@@ -253,6 +303,24 @@ describe("MenuItem", () => {
       );
       await openMenu();
       expect(screen.getByTestId("copy-icon")).toBeInTheDocument();
+    });
+
+    test("leading icon wrapper has 24dp size constraint", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const icon = screen.getByTestId("copy-icon");
+      const wrapper = icon.closest("span");
+      expect(wrapper).toHaveClass("w-6");
+      expect(wrapper).toHaveClass("h-6");
     });
 
     test("renders trailing icon when provided", async () => {
@@ -270,6 +338,24 @@ describe("MenuItem", () => {
       expect(screen.getByTestId("cut-icon")).toBeInTheDocument();
     });
 
+    test("trailing icon wrapper has 24dp size constraint", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut" trailingIcon={<CutIcon />}>
+              Cut
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const icon = screen.getByTestId("cut-icon");
+      const wrapper = icon.closest("span");
+      expect(wrapper).toHaveClass("w-6");
+      expect(wrapper).toHaveClass("h-6");
+    });
+
     test("renders trailing text (keyboard shortcut) when provided", async () => {
       render(
         <MenuTrigger>
@@ -285,6 +371,69 @@ describe("MenuItem", () => {
       expect(screen.getByText("⌘C")).toBeInTheDocument();
     });
 
+    test("trailing text has aria-keyshortcuts attribute", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" trailingText="⌘C">
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const shortcut = screen.getByText("⌘C");
+      expect(shortcut).toHaveAttribute("aria-keyshortcuts", "⌘C");
+    });
+
+    test("renders description when provided", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" description="Copy the selected text">
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(screen.getByText("Copy the selected text")).toBeInTheDocument();
+    });
+
+    test("description uses body-medium typography", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" description="Copy description">
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const desc = screen.getByText("Copy description");
+      expect(desc).toHaveClass("text-body-medium");
+      expect(desc).toHaveClass("text-on-surface-variant");
+    });
+
+    test("renders badge when provided", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="notifications" badge={<span data-testid="badge">3</span>}>
+              Notifications
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(screen.getByTestId("badge")).toBeInTheDocument();
+    });
+
     test("accepts custom className", async () => {
       render(
         <MenuTrigger>
@@ -298,6 +447,32 @@ describe("MenuItem", () => {
       );
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("custom-item");
+    });
+  });
+
+  describe("Density", () => {
+    test("density 0 (default) renders items with h-12 class", async () => {
+      renderBasicMenu({ density: 0 });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-12");
+    });
+
+    test("density -1 renders items with h-11 class", async () => {
+      renderBasicMenu({ density: -1 });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-11");
+    });
+
+    test("density -2 renders items with h-10 class", async () => {
+      renderBasicMenu({ density: -2 });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-10");
+    });
+
+    test("density -3 renders items with h-9 class", async () => {
+      renderBasicMenu({ density: -3 });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-9");
     });
   });
 
@@ -439,6 +614,24 @@ describe("Keyboard navigation", () => {
     await user.keyboard("c");
     expect(document.activeElement).toHaveTextContent("Cut");
   });
+
+  test("shouldFocusWrap=true wraps focus from last to first", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Actions" shouldFocusWrap>
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    // With wrap, should cycle back to "Cut"
+    expect(document.activeElement).toHaveTextContent("Cut");
+  });
 });
 
 // ─── MenuSection ──────────────────────────────────────────────────────────────
@@ -477,9 +670,6 @@ describe("MenuSection", () => {
   test("renders section header text", async () => {
     renderMenuWithSections();
     await openMenu();
-    // Sections have aria-label="Clipboard" / "Actions" which gives the group
-    // its accessible name. The Header component provides additional visible text
-    // but the accessible name check is the canonical way to verify labelling.
     expect(screen.getByRole("group", { name: "Clipboard" })).toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Actions" })).toBeInTheDocument();
   });
@@ -532,6 +722,22 @@ describe("MenuDivider", () => {
     expect(screen.getByRole("separator", { hidden: true })).toBeInTheDocument();
   });
 
+  test("divider has correct 8dp top/bottom padding (my-2)", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuDivider />
+          <MenuItem id="paste">Paste</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const divider = screen.getByRole("separator", { hidden: true });
+    expect(divider).toHaveClass("my-2");
+  });
+
   test("accepts custom className", async () => {
     render(
       <MenuTrigger>
@@ -548,9 +754,32 @@ describe("MenuDivider", () => {
   });
 });
 
-// ─── Select Variant ───────────────────────────────────────────────────────────
+// ─── MenuGap ──────────────────────────────────────────────────────────────────
 
-describe("Select variant", () => {
+describe("MenuGap", () => {
+  test("renders as a presentational spacer (no separator role)", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit" menuStyle="vertical">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuGap />
+          <MenuItem id="paste">Paste</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    // MenuGap uses role="none" / aria-hidden - should NOT appear as a separator
+    expect(screen.queryByRole("separator")).not.toBeInTheDocument();
+    // but the menu items still render
+    expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Paste" })).toBeInTheDocument();
+  });
+});
+
+// ─── Selection variant ────────────────────────────────────────────────────────
+
+describe("Selection mode", () => {
   test("single selection mode works", async () => {
     const onSelectionChange = vi.fn();
     render(
@@ -558,7 +787,6 @@ describe("Select variant", () => {
         <button type="button">Open Menu</button>
         <MenuTrigger.Menu
           aria-label="View"
-          variant="select"
           selectionMode="single"
           onSelectionChange={onSelectionChange}
         >
@@ -568,7 +796,6 @@ describe("Select variant", () => {
       </MenuTrigger>
     );
     const { user } = await openMenu();
-    // With selectionMode="single", React Aria gives items role="menuitemradio"
     await user.click(screen.getByRole("menuitemradio", { name: "Grid view" }));
     expect(onSelectionChange).toHaveBeenCalled();
   });
@@ -580,7 +807,6 @@ describe("Select variant", () => {
         <button type="button">Open Menu</button>
         <MenuTrigger.Menu
           aria-label="Filters"
-          variant="select"
           selectionMode="multiple"
           onSelectionChange={onSelectionChange}
         >
@@ -590,21 +816,15 @@ describe("Select variant", () => {
       </MenuTrigger>
     );
     const { user } = await openMenu();
-    // With selectionMode="multiple", React Aria gives items role="menuitemcheckbox"
     await user.click(screen.getByRole("menuitemcheckbox", { name: "Bold" }));
     expect(onSelectionChange).toHaveBeenCalled();
   });
 
-  test("selected items have aria-checked='true' for select variant", async () => {
+  test("selected items have aria-checked='true'", async () => {
     render(
       <MenuTrigger>
         <button type="button">Open Menu</button>
-        <MenuTrigger.Menu
-          aria-label="View"
-          variant="select"
-          selectionMode="single"
-          defaultSelectedKeys={["grid"]}
-        >
+        <MenuTrigger.Menu aria-label="View" selectionMode="single" defaultSelectedKeys={["grid"]}>
           <MenuItem id="grid">Grid view</MenuItem>
           <MenuItem id="list">List view</MenuItem>
         </MenuTrigger.Menu>
@@ -615,6 +835,248 @@ describe("Select variant", () => {
       "aria-checked",
       "true"
     );
+  });
+
+  test("selected item has correct baseline selection background", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="View"
+          selectionMode="single"
+          defaultSelectedKeys={["grid"]}
+          menuStyle="baseline"
+        >
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem).toHaveClass("bg-surface-container-highest");
+  });
+
+  test("selected item in vertical standard has tertiary container background", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="View"
+          selectionMode="single"
+          defaultSelectedKeys={["grid"]}
+          menuStyle="vertical"
+          colorScheme="standard"
+        >
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem).toHaveClass("bg-tertiary-container");
+  });
+
+  test("selected item in vertical vibrant has tertiary background", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="View"
+          selectionMode="single"
+          defaultSelectedKeys={["grid"]}
+          menuStyle="vertical"
+          colorScheme="vibrant"
+        >
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem).toHaveClass("bg-tertiary");
+  });
+
+  test("checkmark appears on selected item when selectionMode is set and no leadingIcon", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="View" selectionMode="single" defaultSelectedKeys={["grid"]}>
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem.querySelector("[data-testid='check-icon']")).toBeInTheDocument();
+  });
+
+  test("checkmark does not appear when leadingIcon is provided", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="View" selectionMode="single" defaultSelectedKeys={["grid"]}>
+          <MenuItem id="grid" leadingIcon={<CopyIcon />}>
+            Grid view
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem.querySelector("[data-testid='check-icon']")).not.toBeInTheDocument();
+  });
+
+  test("multi-select keeps menu open after selection", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Filters" selectionMode="multiple" defaultSelectedKeys={[]}>
+          <MenuItem id="bold">Bold</MenuItem>
+          <MenuItem id="italic">Italic</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    const { user } = await openMenu();
+    await user.click(screen.getByRole("menuitemcheckbox", { name: "Bold" }));
+    // Multi-select menus stay open
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+});
+
+// ─── Submenu ──────────────────────────────────────────────────────────────────
+
+describe("SubmenuTrigger", () => {
+  function renderMenuWithSubmenu() {
+    return render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Actions">
+          <MenuItem id="copy">Copy</MenuItem>
+          <SubmenuTrigger>
+            <MenuItem id="share">Share</MenuItem>
+            <MenuTrigger.Menu aria-label="Share via">
+              <MenuItem id="email">Email</MenuItem>
+              <MenuItem id="sms">SMS</MenuItem>
+            </MenuTrigger.Menu>
+          </SubmenuTrigger>
+          <MenuItem id="delete">Delete</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+  }
+
+  test("renders submenu trigger item with chevron indicator", async () => {
+    renderMenuWithSubmenu();
+    await openMenu();
+    const shareItem = screen.getByRole("menuitem", { name: /Share/i });
+    expect(shareItem).toBeInTheDocument();
+    // Chevron icon should be present in the item
+    expect(shareItem.querySelector("[data-testid='chevron-icon']")).toBeInTheDocument();
+  });
+
+  test("submenu trigger item has aria-haspopup='menu'", async () => {
+    renderMenuWithSubmenu();
+    await openMenu();
+    const shareItem = screen.getByRole("menuitem", { name: /Share/i });
+    expect(shareItem).toHaveAttribute("aria-haspopup", "menu");
+  });
+
+  test("ArrowRight opens submenu from trigger item", async () => {
+    renderMenuWithSubmenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}"); // focus Share
+    await user.keyboard("{ArrowRight}"); // open submenu
+    await waitFor(() => {
+      expect(screen.getByRole("menu", { name: "Share via" })).toBeInTheDocument();
+    });
+  });
+
+  test("submenu items are accessible after opening", async () => {
+    renderMenuWithSubmenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}"); // focus Share
+    await user.keyboard("{ArrowRight}"); // open submenu
+    await waitFor(() => {
+      expect(screen.getByRole("menuitem", { name: "Email" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "SMS" })).toBeInTheDocument();
+    });
+  });
+
+  test("Escape closes submenu and returns focus to parent item", async () => {
+    renderMenuWithSubmenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowRight}");
+    await waitFor(() => {
+      expect(screen.getByRole("menu", { name: "Share via" })).toBeInTheDocument();
+    });
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByRole("menu", { name: "Share via" })).not.toBeInTheDocument();
+    });
+    // Parent menu should still be open
+    expect(screen.getByRole("menu", { name: "Actions" })).toBeInTheDocument();
+  });
+});
+
+// ─── ContextMenuTrigger ────────────────────────────────────────────────────────
+
+describe("ContextMenuTrigger", () => {
+  test("does not render menu initially", () => {
+    render(
+      <ContextMenuTrigger>
+        <div data-testid="target">Right-click me</div>
+        <MenuTrigger.Menu aria-label="Context">
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuTrigger.Menu>
+      </ContextMenuTrigger>
+    );
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  test("opens menu on right-click (contextmenu event)", async () => {
+    render(
+      <ContextMenuTrigger>
+        <div data-testid="target">Right-click me</div>
+        <MenuTrigger.Menu aria-label="Context">
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuTrigger.Menu>
+      </ContextMenuTrigger>
+    );
+    const target = screen.getByTestId("target");
+    const user = userEvent.setup();
+    await user.pointer({ target, keys: "[MouseRight]" });
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+  });
+
+  test("context menu closes on Escape", async () => {
+    render(
+      <ContextMenuTrigger>
+        <div data-testid="target">Right-click me</div>
+        <MenuTrigger.Menu aria-label="Context">
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuTrigger.Menu>
+      </ContextMenuTrigger>
+    );
+    const target = screen.getByTestId("target");
+    const user = userEvent.setup();
+    await user.pointer({ target, keys: "[MouseRight]" });
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
   });
 });
 
@@ -671,18 +1133,44 @@ describe("Accessibility (axe)", () => {
     expect(results).toHaveNoViolations();
   });
 
-  test("select variant menu passes axe audit", async () => {
+  test("selection mode menu passes axe audit", async () => {
     const { container } = render(
       <MenuTrigger>
         <button type="button">Open Menu</button>
-        <MenuTrigger.Menu
-          aria-label="View"
-          variant="select"
-          selectionMode="single"
-          defaultSelectedKeys={["grid"]}
-        >
+        <MenuTrigger.Menu aria-label="View" selectionMode="single" defaultSelectedKeys={["grid"]}>
           <MenuItem id="grid">Grid</MenuItem>
           <MenuItem id="list">List</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("menu with description passes axe audit", async () => {
+    const { container } = render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Actions">
+          <MenuItem id="export" description="Export to various formats">
+            Export
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("vibrant colorScheme menu passes axe audit", async () => {
+    const { container } = render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit" menuStyle="vertical" colorScheme="vibrant">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuItem id="copy">Copy</MenuItem>
         </MenuTrigger.Menu>
       </MenuTrigger>
     );
@@ -717,7 +1205,6 @@ describe("HeadlessMenuTrigger", () => {
       </HeadlessMenuTrigger>
     );
     const trigger = screen.getByRole("button", { name: "Trigger" });
-    // React Aria sets aria-haspopup to boolean true (serialized as "true") for menus
     expect(trigger).toHaveAttribute("aria-haspopup");
   });
 
@@ -754,5 +1241,58 @@ describe("Focus management", () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(trigger);
     });
+  });
+});
+
+// ─── CVA Variants ─────────────────────────────────────────────────────────────
+
+describe("CVA variants (unit)", () => {
+  test("menuContainerVariants: baseline standard has bg-surface-container and rounded-xs", () => {
+    const cls = menuContainerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("bg-surface-container");
+    expect(cls).toContain("rounded-xs");
+  });
+
+  test("menuContainerVariants: vertical standard has bg-surface-container-low and rounded-lg", () => {
+    const cls = menuContainerVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("bg-surface-container-low");
+    expect(cls).toContain("rounded-lg");
+  });
+
+  test("menuContainerVariants: vertical vibrant has bg-tertiary-container", () => {
+    const cls = menuContainerVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
+    expect(cls).toContain("bg-tertiary-container");
+  });
+
+  test("menuItemVariants: uses text-body-large", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("text-body-large");
+  });
+
+  test("menuItemVariants: baseline selected uses bg-surface-container-highest", () => {
+    const cls = menuItemVariants({
+      isSelected: true,
+      colorScheme: "standard",
+      menuStyle: "baseline",
+    });
+    expect(cls).toContain("bg-surface-container-highest");
+  });
+
+  test("menuItemVariants: vertical standard selected uses bg-tertiary-container", () => {
+    const cls = menuItemVariants({
+      isSelected: true,
+      colorScheme: "standard",
+      menuStyle: "vertical",
+    });
+    expect(cls).toContain("bg-tertiary-container");
+  });
+
+  test("menuItemVariants: vertical vibrant selected uses bg-tertiary", () => {
+    const cls = menuItemVariants({
+      isSelected: true,
+      colorScheme: "vibrant",
+      menuStyle: "vertical",
+    });
+    expect(cls).toContain("bg-tertiary");
   });
 });

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -1,122 +1,122 @@
 "use client";
 
 import { forwardRef, type JSX } from "react";
-import { HeadlessMenuTrigger, HeadlessMenu, MenuContext } from "./MenuHeadless";
+import { HeadlessMenuTrigger } from "./MenuHeadless";
+import { MenuContext } from "./MenuHeadless";
+import { HeadlessMenu } from "./MenuHeadless";
 import { menuContainerVariants } from "./Menu.variants";
 import { cn } from "../../utils/cn";
-import type { MenuProps, MenuTriggerProps } from "./Menu.types";
+import type {
+  MenuProps,
+  MenuTriggerProps,
+  MenuColorScheme,
+  MenuStyle,
+  MenuDensity,
+} from "./Menu.types";
 
-// ─── Menu ─────────────────────────────────────────────────────────────────────
+// ─── Menu ────────────────────────────────────────────────────────────────────
 
 /**
- * Material Design 3 Menu list container (Layer 3: Styled).
+ * MD3 styled Menu component (Layer 3).
  *
- * Renders `<ul role="menu">` with MD3 surface, elevation, shape, and entry
- * animation. Must be a child of `MenuTrigger`.
- *
- * Features:
- * - Surface: `bg-surface-container`
- * - Elevation: `shadow-elevation-2`
- * - Shape: `rounded-xs` (4dp per MD3 shape extra-small)
- * - Width: min 112dp / max 280dp per MD3 spec
- * - Entry animation: scale-y + fade-in (`duration-medium2` /
- *   `ease-emphasized-decelerate`)
- * - Focus management handled by RAC `Popover` (FocusScope + restoreFocus)
+ * Renders a list of `MenuItem`, `MenuSection`, or `MenuDivider` children.
+ * Intended to be used as `MenuTrigger.Menu` (nested inside a `MenuTrigger`).
  *
  * @example
  * ```tsx
  * <MenuTrigger>
  *   <Button>Open</Button>
  *   <Menu aria-label="Actions">
- *     <MenuItem id="cut">Cut</MenuItem>
- *     <MenuItem id="copy">Copy</MenuItem>
- *   </Menu>
- * </MenuTrigger>
- * ```
- *
- * @see https://m3.material.io/components/menus/overview
- */
-export const Menu = forwardRef<HTMLElement, MenuProps>(
-  ({ variant = "standard", className, disableRipple = false, children, ...props }, _ref) => {
-    const menuClass = cn(menuContainerVariants({ open: true }), className);
-
-    return (
-      <MenuContext.Provider
-        value={{
-          close: () => {
-            /* RAC Popover handles close internally */
-          },
-          disableRipple,
-          variant,
-          ...(props.selectionMode !== undefined ? { selectionMode: props.selectionMode } : {}),
-          ...(props.selectedKeys !== undefined
-            ? { selectedKeys: props.selectedKeys as Iterable<string | number> }
-            : {}),
-        }}
-      >
-        <HeadlessMenu {...props} className={menuClass}>
-          {children}
-        </HeadlessMenu>
-      </MenuContext.Provider>
-    );
-  }
-);
-
-Menu.displayName = "Menu";
-
-// ─── MenuTrigger ─────────────────────────────────────────────────────────────
-
-/**
- * Material Design 3 Menu Trigger (Layer 3: Styled).
- *
- * Compound component that manages trigger state and positions the menu
- * overlay. Uses `HeadlessMenuTrigger` for accessible overlay management.
- *
- * The first child is the trigger element (any pressable element such as
- * `Button`, `IconButton`, or a native `<button>`). The second child must be a
- * `Menu` component.
- *
- * The trigger element automatically receives:
- * - `aria-haspopup="menu"`
- * - `aria-expanded` (true when open, false when closed)
- * - `aria-controls` (linked to the menu element id)
- *
- * @example
- * ```tsx
- * // Basic usage
- * <MenuTrigger>
- *   <Button>More actions</Button>
- *   <Menu aria-label="Actions">
  *     <MenuItem id="copy">Copy</MenuItem>
  *     <MenuItem id="paste">Paste</MenuItem>
  *   </Menu>
  * </MenuTrigger>
+ * ```
+ */
+const Menu = forwardRef<HTMLElement, MenuProps>(function Menu(
+  {
+    children,
+    className,
+    colorScheme = "standard",
+    menuStyle = "baseline",
+    density = 0,
+    disableRipple = false,
+    selectionMode,
+    selectedKeys,
+    onSelectionChange,
+    ...props
+  },
+  _ref
+) {
+  /**
+   * Close function injected by parent MenuTrigger.
+   * The Popover's onClose handles the actual close; we provide a no-op here
+   * unless wrapped by a trigger. When used inside MenuTrigger, the context
+   * is overridden by the trigger's close handler.
+   */
+  const close = (): void => {
+    // Controlled via RAC Popover — handled by overlay state context.
+  };
+
+  // Conditionally include optional EOPT-sensitive context fields.
+  const contextValue = {
+    close,
+    disableRipple,
+    colorScheme,
+    menuStyle,
+    density,
+    ...(selectionMode !== undefined ? { selectionMode } : {}),
+    ...(selectedKeys !== undefined ? { selectedKeys } : {}),
+  };
+
+  return (
+    <MenuContext.Provider value={contextValue}>
+      <HeadlessMenu
+        {...props}
+        {...(selectionMode !== undefined ? { selectionMode } : {})}
+        {...(selectedKeys !== undefined ? { selectedKeys } : {})}
+        {...(onSelectionChange !== undefined ? { onSelectionChange } : {})}
+        className={cn(menuContainerVariants({ colorScheme, menuStyle }), className)}
+      >
+        {children}
+      </HeadlessMenu>
+    </MenuContext.Provider>
+  );
+});
+
+// ─── MenuTrigger ─────────────────────────────────────────────────────────────
+
+/**
+ * MD3 styled MenuTrigger component (Layer 3).
  *
- * // Controlled
- * <MenuTrigger isOpen={open} onOpenChange={setOpen}>
- *   <IconButton aria-label="More"><MoreVertIcon /></IconButton>
- *   <Menu aria-label="Context menu">
- *     <MenuItem id="rename">Rename</MenuItem>
- *     <MenuItem id="delete">Delete</MenuItem>
- *   </Menu>
+ * Wraps a trigger element and a `Menu` to create a dropdown.
+ * Attach `MenuTrigger.Menu` to specify the menu content, which gives IDE
+ * autocompletion and makes the parent/child relationship explicit.
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger>
+ *   <button type="button">Open Menu</button>
+ *   <MenuTrigger.Menu aria-label="Actions">
+ *     <MenuItem id="cut">Cut</MenuItem>
+ *   </MenuTrigger.Menu>
  * </MenuTrigger>
  * ```
- *
- * @see https://m3.material.io/components/menus/overview
  */
-export function MenuTrigger({
+function MenuTrigger({
   children,
   placement = "bottom start",
-  ...triggerProps
+  shouldFlip = true,
+  ...rest
 }: MenuTriggerProps): JSX.Element {
   return (
-    <HeadlessMenuTrigger {...triggerProps} placement={placement}>
+    <HeadlessMenuTrigger placement={placement} shouldFlip={shouldFlip} {...rest}>
       {children}
     </HeadlessMenuTrigger>
   );
 }
 
-MenuTrigger.displayName = "MenuTrigger";
+MenuTrigger.Menu = Menu;
 
-// Attach Menu as a static sub-component so tests can use MenuTrigger.Menu
-(MenuTrigger as unknown as Record<string, unknown>).Menu = Menu;
+export { Menu, MenuTrigger };
+export type { MenuColorScheme, MenuStyle, MenuDensity };

--- a/packages/react/src/components/Menu/Menu.types.ts
+++ b/packages/react/src/components/Menu/Menu.types.ts
@@ -1,31 +1,57 @@
 import type { ReactNode, Key } from "react";
-import type { AriaMenuProps, AriaMenuItemProps, AriaMenuTriggerProps } from "react-aria";
+import type { AriaMenuProps, AriaMenuTriggerProps } from "react-aria";
+import type { MenuItemProps as RACMenuItemProps } from "react-aria-components";
 import type { SelectionMode } from "react-stately";
 
+// ─── Color, Style, and Density Types ─────────────────────────────────────────
+
 /**
- * Visual variant of the MD3 Menu.
+ * Color scheme for the MD3 Menu container and items.
  *
- * - `standard` — contextual action menu; items fire `onAction` callbacks; no
- *   persistent selection state.
- * - `select` — selection menu; items show a checkmark when selected; supports
- *   `selectionMode` of `"single"` or `"multiple"`.
+ * - `standard` — surface-based colors; default for most use cases
+ * - `vibrant` — tertiary-based colors; higher visual emphasis; use sparingly
+ *
+ * @see https://m3.material.io/components/menus/specs#color
  */
-export type MenuVariant = "standard" | "select";
+export type MenuColorScheme = "standard" | "vibrant";
+
+/**
+ * Visual style of the MD3 Menu.
+ *
+ * - `baseline` — original M3 design; 4dp corner radius; surface container background
+ * - `vertical` — M3 Expressive style; 16dp corner radius; more expressive shapes and motion
+ *
+ * @see https://m3.material.io/components/menus/specs#variants
+ */
+export type MenuStyle = "baseline" | "vertical";
+
+/**
+ * Density level for the MD3 Menu (web only).
+ *
+ * Controls item height via top/bottom padding reduction:
+ * - `0`  → 48dp (default)
+ * - `-1` → 44dp
+ * - `-2` → 40dp
+ * - `-3` → 36dp
+ *
+ * @see https://m3.material.io/m3/pages/understanding-layout/density
+ */
+export type MenuDensity = 0 | -1 | -2 | -3;
 
 // ─── MenuTrigger ─────────────────────────────────────────────────────────────
 
 /**
  * Props for the `MenuTrigger` component (styled Layer 3).
  *
- * Wraps a trigger element (e.g. `Button`, `IconButton`) and a `Menu`. The
- * first child must be the trigger; the second must be the `Menu`.
+ * Wraps a trigger element and a `Menu`. The first child must be the trigger;
+ * the second must be a `Menu` component.
  *
  * @example
  * ```tsx
  * <MenuTrigger>
  *   <Button>Open</Button>
  *   <Menu aria-label="Actions">
- *     <MenuItem id="copy" onAction={() => {}}>Copy</MenuItem>
+ *     <MenuItem id="copy">Copy</MenuItem>
  *   </Menu>
  * </MenuTrigger>
  * ```
@@ -38,6 +64,12 @@ export interface MenuTriggerProps extends AriaMenuTriggerProps {
    * @default 'bottom start'
    */
   placement?: "bottom" | "bottom start" | "bottom end" | "top" | "top start" | "top end";
+  /**
+   * Whether the menu should automatically flip to the opposite side when it
+   * would be cut off by the viewport edge.
+   * @default true
+   */
+  shouldFlip?: boolean;
 }
 
 // ─── Menu ────────────────────────────────────────────────────────────────────
@@ -56,13 +88,23 @@ export interface MenuTriggerProps extends AriaMenuTriggerProps {
  */
 export interface MenuProps<T extends object = object> extends AriaMenuProps<T> {
   /**
-   * Visual variant — standard (action) or select (selection with checkmark).
+   * Color scheme — standard (surface-based) or vibrant (tertiary-based).
+   * Vibrant is more prominent and should be used sparingly.
    * @default 'standard'
    */
-  variant?: MenuVariant;
+  colorScheme?: MenuColorScheme;
   /**
-   * Additional CSS classes merged onto the menu container element.
+   * Visual style — baseline (4dp corners) or vertical (16dp corners, expressive).
+   * @default 'baseline'
    */
+  menuStyle?: MenuStyle;
+  /**
+   * Density level controlling item height (web only).
+   * 0 = 48dp, -1 = 44dp, -2 = 40dp, -3 = 36dp.
+   * @default 0
+   */
+  density?: MenuDensity;
+  /** Additional CSS classes merged onto the menu container element. */
   className?: string;
   /**
    * Disable ripple on all menu items.
@@ -76,8 +118,8 @@ export interface MenuProps<T extends object = object> extends AriaMenuProps<T> {
 /**
  * Props for the `MenuItem` component (styled Layer 3).
  *
- * A single interactive menu item with optional leading icon, trailing icon /
- * keyboard-shortcut label, and disabled state.
+ * A single interactive item within a Menu. Supports leading/trailing icons,
+ * keyboard shortcut labels, supporting text (description), and a badge slot.
  *
  * @example
  * ```tsx
@@ -86,33 +128,50 @@ export interface MenuProps<T extends object = object> extends AriaMenuProps<T> {
  *   Copy
  * </MenuItem>
  *
+ * // With description
+ * <MenuItem id="export" description="Export to various formats">
+ *   Export
+ * </MenuItem>
+ *
  * // Disabled
  * <MenuItem id="paste" isDisabled>Paste</MenuItem>
  * ```
  */
-export interface MenuItemProps extends AriaMenuItemProps {
-  /**
-   * Item label content.
-   */
+export interface MenuItemProps extends RACMenuItemProps {
+  /** Item label content. */
   children?: ReactNode;
   /**
-   * Optional leading icon element (24dp). Rendered with
-   * `text-on-surface-variant`.
+   * Optional leading icon element (24×24dp).
+   * Rendered with `text-on-surface-variant`.
    */
   leadingIcon?: ReactNode;
   /**
-   * Optional trailing icon element (24dp). Rendered with
-   * `text-on-surface-variant`. Mutually exclusive with `trailingText`.
+   * Optional trailing icon element (24×24dp).
+   * Rendered with `text-on-surface-variant`.
+   * Mutually exclusive with `trailingText`.
    */
   trailingIcon?: ReactNode;
   /**
-   * Optional keyboard-shortcut label rendered at the trailing end of the item
-   * (e.g. `"⌘C"`, `"Ctrl+V"`). Mutually exclusive with `trailingIcon`.
+   * Optional keyboard-shortcut label at the trailing end (e.g. `"⌘C"`, `"Ctrl+V"`).
+   * Screen readers announce this via `aria-keyshortcuts`.
+   * Mutually exclusive with `trailingIcon`.
    */
   trailingText?: string;
   /**
-   * Additional CSS classes merged onto the item element.
+   * Optional supporting text (description) rendered below the label.
+   * Uses `text-body-medium text-on-surface-variant`.
+   * When present, item height becomes auto (multi-line).
+   *
+   * @see https://m3.material.io/components/menus/specs - Anatomy item 8
    */
+  description?: ReactNode;
+  /**
+   * Optional badge element rendered between the label and trailing content.
+   *
+   * @see https://m3.material.io/components/menus/specs - Anatomy item 5
+   */
+  badge?: ReactNode;
+  /** Additional CSS classes merged onto the item element. */
   className?: string;
   /**
    * Disable the ripple effect on this specific item.
@@ -126,9 +185,8 @@ export interface MenuItemProps extends AriaMenuItemProps {
 /**
  * Props for the `MenuSection` component (styled Layer 3).
  *
- * Groups related `MenuItem` elements with an optional section header label
- * and a horizontal divider above the group (rendered for all sections except
- * the first when `showDivider` is true).
+ * Groups related `MenuItem` elements with an optional section header and
+ * an optional top divider.
  *
  * @example
  * ```tsx
@@ -138,12 +196,10 @@ export interface MenuItemProps extends AriaMenuItemProps {
  * </MenuSection>
  * ```
  */
-export interface MenuSectionProps {
-  /**
-   * Optional section header label rendered in `text-title-small
-   * text-on-surface-variant`.
-   */
-  header?: string;
+/**
+ * Base props shared by both `MenuSection` variants.
+ */
+interface MenuSectionBaseProps {
   /** Section content — typically `MenuItem` elements. */
   children: ReactNode;
   /**
@@ -151,22 +207,48 @@ export interface MenuSectionProps {
    * @default false
    */
   showDivider?: boolean;
-  /**
-   * Additional CSS classes merged onto the section container element.
-   */
+  /** Additional CSS classes. */
   className?: string;
-  /**
-   * Accessible label for the section. Required when `header` is not provided.
-   */
-  "aria-label"?: string;
 }
+
+/**
+ * Props for the `MenuSection` component (styled Layer 3).
+ *
+ * Either `header` or `aria-label` must be provided so the section has an
+ * accessible name, as required by WCAG 2.1 (ARIA `group` role).
+ *
+ * @example
+ * ```tsx
+ * <MenuSection header="Clipboard" showDivider>
+ *   <MenuItem id="cut">Cut</MenuItem>
+ *   <MenuItem id="copy">Copy</MenuItem>
+ * </MenuSection>
+ * ```
+ */
+export type MenuSectionProps =
+  | (MenuSectionBaseProps & {
+      /**
+       * Section header label (rendered visually and used as the accessible name).
+       * Uses `text-title-small text-on-surface-variant`.
+       */
+      header: string;
+      "aria-label"?: string;
+    })
+  | (MenuSectionBaseProps & {
+      header?: string;
+      /**
+       * Accessible label for the section. Required when `header` is not provided.
+       */
+      "aria-label": string;
+    });
 
 // ─── MenuDivider ─────────────────────────────────────────────────────────────
 
 /**
  * Props for the standalone `MenuDivider` component.
  *
- * Renders a semantic separator styled with `border-outline-variant`.
+ * Renders a semantic `role="separator"` with `border-outline-variant` styling.
+ * 8dp top/bottom padding per MD3 spec.
  *
  * @example
  * ```tsx
@@ -180,52 +262,146 @@ export interface MenuDividerProps {
   className?: string;
 }
 
-// ─── Headless types ───────────────────────────────────────────────────────────
+// ─── MenuGap ─────────────────────────────────────────────────────────────────
+
+/**
+ * Props for the `MenuGap` component.
+ *
+ * A visual gap separator for M3 Expressive vertical menus. Unlike `MenuDivider`
+ * (which renders a border line), `MenuGap` creates a blank spacing area between
+ * item groups. Recommended over dividers for vertical menus.
+ *
+ * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger.Menu menuStyle="vertical">
+ *   <MenuItem id="copy">Copy</MenuItem>
+ *   <MenuGap />
+ *   <MenuItem id="paste">Paste</MenuItem>
+ * </MenuTrigger.Menu>
+ * ```
+ */
+export interface MenuGapProps {
+  /** Additional CSS classes. */
+  className?: string;
+}
+
+// ─── SubmenuTrigger ──────────────────────────────────────────────────────────
+
+/**
+ * Props for the `SubmenuTrigger` component (styled Layer 3).
+ *
+ * Wraps a `MenuItem` (trigger) and a nested `Menu` to create a submenu.
+ * The submenu opens to the side with a chevron indicator on the trigger item.
+ *
+ * Keyboard: `ArrowRight` opens, `ArrowLeft` / `Escape` closes.
+ *
+ * @example
+ * ```tsx
+ * <SubmenuTrigger>
+ *   <MenuItem id="share">Share</MenuItem>
+ *   <Menu aria-label="Share via">
+ *     <MenuItem id="email">Email</MenuItem>
+ *     <MenuItem id="sms">SMS</MenuItem>
+ *   </Menu>
+ * </SubmenuTrigger>
+ * ```
+ */
+export interface SubmenuTriggerProps {
+  /** Must be a `[MenuItem, Menu]` pair. */
+  children: ReactNode;
+  /**
+   * Hover delay in milliseconds before the submenu opens.
+   * @default 200
+   */
+  delay?: number;
+}
+
+// ─── ContextMenuTrigger ──────────────────────────────────────────────────────
+
+/**
+ * Props for the `ContextMenuTrigger` component (styled Layer 3).
+ *
+ * Wraps content and opens a context menu on right-click or two-finger tap.
+ * The menu is positioned at the pointer coordinates.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuTrigger>
+ *   <div>Right-click me</div>
+ *   <Menu aria-label="Context actions">
+ *     <MenuItem id="copy">Copy</MenuItem>
+ *     <MenuItem id="paste">Paste</MenuItem>
+ *   </Menu>
+ * </ContextMenuTrigger>
+ * ```
+ */
+export interface ContextMenuTriggerProps {
+  /** Content element + Menu children. */
+  children: ReactNode;
+  /** Controlled open state. */
+  isOpen?: boolean;
+  /** Called when open state changes. */
+  onOpenChange?: (isOpen: boolean) => void;
+}
+
+// ─── Headless Types ───────────────────────────────────────────────────────────
 
 /**
  * Props for the headless `HeadlessMenuTrigger` primitive (Layer 2).
- * Provides trigger + overlay behavior without visual styling.
  */
 export interface HeadlessMenuTriggerProps extends AriaMenuTriggerProps {
-  /** Trigger element + HeadlessMenu children. */
   children: ReactNode;
-  /**
-   * Preferred placement of the menu relative to the trigger.
-   * @default 'bottom start'
-   */
   placement?: MenuTriggerProps["placement"];
+  shouldFlip?: boolean;
 }
 
 /**
  * Props for the headless `HeadlessMenu` primitive (Layer 2).
  */
 export interface HeadlessMenuProps<T extends object = object> extends AriaMenuProps<T> {
-  /** Additional CSS classes for the `<ul role="menu">` element. */
   className?: string;
 }
 
 /**
  * Props for the headless `HeadlessMenuItem` primitive (Layer 2).
+ *
+ * `className` accepts either a static string or a render-prop function so
+ * MD3 state-dependent styles (selection, disabled) can be applied directly
+ * to the `<li role="menuitem">` element via RAC's render-prop mechanism.
  */
-export interface HeadlessMenuItemProps extends AriaMenuItemProps {
-  /** Item content. */
-  children?: ReactNode;
-  /** Additional CSS classes. */
-  className?: string;
-}
+// HeadlessMenuItemProps inherits children (ChildrenOrFunction) and className
+// (ClassNameOrFunction) directly from RACMenuItemProps — no overrides needed.
+export type HeadlessMenuItemProps = RACMenuItemProps;
 
 /**
  * Props for the headless `HeadlessMenuSection` primitive (Layer 2).
+ *
+ * The section header is handled at Layer 3 (`MenuSection`) using RAC's
+ * `Header` component. At Layer 2, only `aria-label` is used for accessibility.
  */
 export interface HeadlessMenuSectionProps {
-  /** Optional header label. */
-  header?: string;
-  /** Section items. */
   children: ReactNode;
-  /** CSS class for the section group container. */
   className?: string;
-  /** Accessible label for the group. Required when no header is provided. */
   "aria-label"?: string;
+}
+
+/**
+ * Props for the headless `HeadlessSubmenuTrigger` primitive (Layer 2).
+ */
+export interface HeadlessSubmenuTriggerProps {
+  children: ReactNode;
+  delay?: number;
+}
+
+/**
+ * Props for the headless `HeadlessContextMenuTrigger` primitive (Layer 2).
+ */
+export interface HeadlessContextMenuTriggerProps {
+  children: ReactNode;
+  isOpen?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
 }
 
 // ─── Context ──────────────────────────────────────────────────────────────────
@@ -239,9 +415,13 @@ export interface MenuContextValue {
   close: () => void;
   /** Whether ripple is disabled for all items. */
   disableRipple: boolean;
-  /** Visual variant passed down to items (e.g. for checkmark rendering). */
-  variant: MenuVariant;
-  /** Currently selected keys (for select variant). */
+  /** Color scheme — standard or vibrant. */
+  colorScheme: MenuColorScheme;
+  /** Visual style — baseline or vertical. */
+  menuStyle: MenuStyle;
+  /** Density level controlling item height. */
+  density: MenuDensity;
+  /** Currently selected keys (for selection menus). */
   selectedKeys?: Iterable<Key>;
   /** Current selection mode. */
   selectionMode?: SelectionMode;

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -3,54 +3,94 @@ import { cva, type VariantProps } from "class-variance-authority";
 /**
  * Material Design 3 Menu container variants (CVA).
  *
- * Surface: `bg-surface-container`
- * Elevation: `shadow-elevation-2`
- * Shape: `rounded-xs` (4dp per MD3 shape extra-small)
- * Width: min 112dp (`min-w-28`) / max 280dp (`max-w-70`) per MD3 spec
+ * Elevation: `shadow-elevation-2` (both styles)
+ * Width: min 112dp / max 280dp per MD3 spec
  *
- * Entry animation: scale-y + fade-in from top anchor point.
- * - Duration: `duration-medium2` (300ms)
- * - Easing: `ease-emphasized-decelerate`
+ * Shape per menuStyle:
+ * - baseline: `rounded-xs` (4dp extra-small)
+ * - vertical: `rounded-lg` (16dp large)
+ *
+ * Background per colorScheme + menuStyle:
+ * - baseline + standard: `bg-surface-container`
+ * - vertical + standard: `bg-surface-container-low`
+ * - vertical + vibrant:  `bg-tertiary-container`
  *
  * @see https://m3.material.io/components/menus/specs
  */
 export const menuContainerVariants = cva(
   [
-    // Surface and elevation
-    "bg-surface-container",
+    // Elevation
     "shadow-elevation-2",
-    // Shape
-    "rounded-xs",
     // Width constraints per MD3 spec (112dp min / 280dp max)
     "min-w-28 max-w-70",
     // Layout
     "py-2",
+    // Scroll: show scrollbar when content overflows; max height avoids clipping
     "overflow-y-auto",
+    "max-h-[calc(var(--visual-viewport-height,100vh)-2rem)]",
     // Stacking
     "z-50",
     // Focus outline handled by React Aria
     "outline-none",
-    // Animation origin — scale from top anchor point
+    // GPU compositing — promotes menu to its own compositor layer so
+    // scale + opacity animations run without triggering layout reflow.
+    "will-change-[transform,opacity]",
+    // Pointer events blocked during animation to prevent accidental clicks
+    // on menu items while the panel is still animating in or out.
+    "data-[entering]:pointer-events-none data-[exiting]:pointer-events-none",
+    // ── Enter animation ────────────────────────────────────────────────────
+    // @keyframes menu-enter (defined in styles.css): scale(0.8)+opacity:0 →
+    // scale(1)+opacity:1 in 120ms with cubic-bezier(0,0,0.2,1) (standard
+    // decelerate — matches Angular Material's _mat-menu-enter keyframe).
+    "data-[entering]:animate-[menu-enter_120ms_cubic-bezier(0,0,0.2,1)_both]",
+    // ── Exit animation ─────────────────────────────────────────────────────
+    // @keyframes menu-exit (defined in styles.css): opacity:1 → opacity:0
+    // in 100ms after 25ms delay, linear — matches Angular Material's
+    // _mat-menu-exit keyframe (fade-only, no reverse scale).
+    "data-[exiting]:animate-[menu-exit_100ms_25ms_linear_both]",
+    // ── Transform origin (placement-aware) ────────────────────────────────
+    // RAC sets data-placement="bottom|top|left|right" on the Popover element.
+    // Default (bottom): origin at top edge (menu expands downward).
     "origin-top",
-    // Transition for open/close scale+opacity animation
-    "transition-[transform,opacity]",
-    "duration-medium2",
-    "ease-emphasized-decelerate",
+    // top: origin at bottom edge (menu expands upward)
+    "data-[placement=top]:origin-bottom",
+    // left: origin at right edge
+    "data-[placement=left]:origin-right",
+    // right: origin at left edge
+    "data-[placement=right]:origin-left",
+    // ── Reduced motion ────────────────────────────────────────────────────
+    // Skip both animations entirely for users who prefer reduced motion.
+    "motion-reduce:data-[entering]:animate-none motion-reduce:data-[exiting]:animate-none",
   ],
   {
     variants: {
       /**
-       * Open/closed state — drives scale and opacity.
-       * - `true`:  menu visible (`scale-y-100 opacity-100`)
-       * - `false`: menu collapsed (`scale-y-0 opacity-0 pointer-events-none`)
+       * Color scheme — drives the container background.
+       * baseline+standard uses a separate compound variant.
        */
-      open: {
-        true: ["scale-y-100 opacity-100"],
-        false: ["scale-y-0 opacity-0 pointer-events-none"],
+      colorScheme: {
+        standard: [],
+        vibrant: [],
+      },
+      /**
+       * Visual style — drives corner radius and baseline vs vertical background.
+       */
+      menuStyle: {
+        baseline: ["rounded-xs", "bg-surface-container"],
+        vertical: ["rounded-lg", "bg-surface-container-low"],
       },
     },
+    compoundVariants: [
+      // Vertical + vibrant: tertiary container background
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["bg-tertiary-container"],
+      },
+    ],
     defaultVariants: {
-      open: false,
+      colorScheme: "standard",
+      menuStyle: "baseline",
     },
   }
 );
@@ -58,80 +98,128 @@ export const menuContainerVariants = cva(
 /**
  * Material Design 3 Menu item variants (CVA).
  *
- * Item height: 48dp (`h-12`) per MD3 spec.
- * Label: `text-label-large text-on-surface`
- * Leading/trailing icon color: `text-on-surface-variant`
+ * Typography: `text-body-large` per MD3 baseline spec (16sp / 400 weight).
+ * Padding: `px-3` (12dp left/right), `gap-3` (12dp between elements).
  *
  * State layers (MD3 spec):
- * - Hover:         `opacity-8`  on `before:bg-on-surface`
- * - Focus visible: `opacity-12` on `before:bg-on-surface`
- * - Pressed:       `opacity-12` on `before:bg-on-surface`
- * - Disabled:      `opacity-38` on entire item, non-interactive
+ * - Hover:         `opacity-8`  on state layer
+ * - Focus visible: `opacity-12` on state layer
+ * - Pressed:       `opacity-12` on state layer
+ * - Disabled:      `opacity-38` on entire item
+ *
+ * Selection colors per menuStyle + colorScheme:
+ * - baseline (any):         `bg-surface-container-highest`
+ * - vertical + standard:    `bg-tertiary-container text-on-tertiary-container`
+ * - vertical + vibrant:     `bg-tertiary text-on-tertiary`
+ *
+ * Note: item height (48/44/40/36dp) is controlled by density via context,
+ * applied directly in MenuItem component (not CVA) to avoid negative key issues.
  *
  * @see https://m3.material.io/components/menus/specs
  */
 export const menuItemVariants = cva(
   [
-    // Layout
+    // Layout — height set by density context in MenuItem component
     "relative flex w-full items-center",
-    "h-12 px-3 gap-3",
-    // Typography
-    "text-label-large text-on-surface",
+    "px-3 gap-3",
+    // Typography: Body Large per MD3 baseline spec
+    "text-body-large",
     // Interaction
     "cursor-pointer select-none outline-none",
     // State layer pseudo-element
-    "before:absolute before:inset-0",
+    "before:absolute before:inset-0 before:rounded-[inherit]",
     "before:transition-opacity before:duration-short2 before:ease-standard",
     "before:opacity-0",
-    // Hover and focus visible state layers
-    "hover:before:opacity-8 before:bg-on-surface",
+    // Hover state layer
+    "hover:before:opacity-8",
+    // Focus visible state layer
     "focus-visible:before:opacity-12",
     // Active pressed state layer
     "active:before:opacity-12",
-    // Color transition for selection state
+    // Color transition for selection
     "transition-colors duration-short2 ease-standard",
   ],
   {
     variants: {
       /**
-       * Whether this item is disabled.
-       * Applies `opacity-38` and removes pointer interaction per MD3 spec.
+       * Disabled state: reduces opacity and blocks interaction.
        */
       isDisabled: {
         true: ["opacity-38 cursor-not-allowed pointer-events-none"],
         false: [],
       },
       /**
-       * Whether this item is currently selected (select variant).
-       * Applies `bg-secondary-container` / `text-on-secondary-container` and
-       * changes state-layer color to `on-secondary-container`.
+       * Selected state: background and text color driven by compound variants.
        */
       isSelected: {
-        true: [
-          "bg-secondary-container",
-          "text-on-secondary-container",
-          "before:bg-on-secondary-container",
-        ],
+        true: [],
         false: [],
       },
+      /**
+       * Color scheme: drives default text and state layer colors.
+       * - standard: on-surface text, on-surface state layer
+       * - vibrant (vertical only): on-tertiary-container text + state layer
+       */
+      colorScheme: {
+        standard: ["text-on-surface", "before:bg-on-surface"],
+        vibrant: ["text-on-tertiary-container", "before:bg-on-tertiary-container"],
+      },
+      /**
+       * Visual style: drives corner radius on items (vertical uses rounded-lg
+       * inherited from container, items stay flat inside).
+       */
+      menuStyle: {
+        baseline: [],
+        vertical: [],
+      },
     },
+    compoundVariants: [
+      // ── Baseline selection (both colorSchemes) ──────────────────────────
+      {
+        isSelected: true,
+        menuStyle: "baseline",
+        class: [
+          "bg-surface-container-highest",
+          // text-on-surface already applied by standard colorScheme variant
+        ],
+      },
+      // ── Vertical + Standard selection ───────────────────────────────────
+      {
+        isSelected: true,
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: [
+          "bg-tertiary-container",
+          "text-on-tertiary-container",
+          "before:bg-on-tertiary-container",
+        ],
+      },
+      // ── Vertical + Vibrant selection ─────────────────────────────────────
+      {
+        isSelected: true,
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["bg-tertiary", "text-on-tertiary", "before:bg-on-tertiary"],
+      },
+    ],
     defaultVariants: {
       isDisabled: false,
       isSelected: false,
+      colorScheme: "standard",
+      menuStyle: "baseline",
     },
   }
 );
 
 /**
  * Menu section container variants (CVA).
- * Groups related menu items.
  */
 export const menuSectionVariants = cva(["flex flex-col w-full"]);
 
 /**
  * Menu section header variants (CVA).
  *
- * Header text: `text-title-small text-on-surface-variant` per MD3 spec.
+ * Typography: `text-title-small text-on-surface-variant` per MD3 spec.
  */
 export const menuSectionHeaderVariants = cva([
   "px-3 pt-2 pb-1",
@@ -142,18 +230,42 @@ export const menuSectionHeaderVariants = cva([
 /**
  * Menu item divider variants (CVA).
  *
- * Horizontal rule using `border-outline-variant` per MD3 spec.
+ * Renders a horizontal separator with `border-outline-variant`.
+ * Padding: 8dp top/bottom (`my-2`) per MD3 spec.
+ *
+ * @see https://m3.material.io/components/menus/specs — Measurements
  */
-export const menuDividerVariants = cva(["border-t border-outline-variant", "my-1 mx-0"]);
+export const menuDividerVariants = cva(["border-t border-outline-variant", "my-2 mx-0"]);
+
+/**
+ * Menu gap variants (CVA).
+ *
+ * A visual spacer for M3 Expressive vertical menus. Uses spacing instead of
+ * a border line to separate item groups. `aria-hidden` and `role="none"`.
+ *
+ * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
+ */
+export const menuGapVariants = cva(["h-2 w-full"]);
 
 /**
  * Trailing text (keyboard shortcut) variants (CVA).
  *
- * Rendered at the trailing end of a MenuItem for keyboard shortcut hints.
- * Color: `text-on-surface-variant`, size: `text-label-large`.
+ * Color: `text-on-surface-variant`, size: `text-label-large` (14sp).
+ * The element also carries `aria-keyshortcuts` for screen reader support.
  */
 export const menuItemTrailingTextVariants = cva([
   "ml-auto shrink-0 text-label-large text-on-surface-variant",
+  "select-none",
+]);
+
+/**
+ * Menu item description (supporting text) variants (CVA).
+ *
+ * Rendered below the label text.
+ * Typography: `text-body-medium text-on-surface-variant`.
+ */
+export const menuItemDescriptionVariants = cva([
+  "text-body-medium text-on-surface-variant",
   "select-none",
 ]);
 

--- a/packages/react/src/components/Menu/MenuDivider.tsx
+++ b/packages/react/src/components/Menu/MenuDivider.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import type { JSX } from "react";
+import { type JSX } from "react";
 import { HeadlessMenuDivider } from "./MenuHeadless";
 import { menuDividerVariants } from "./Menu.variants";
 import { cn } from "../../utils/cn";
 import type { MenuDividerProps } from "./Menu.types";
 
 /**
- * Material Design 3 Menu Divider (Layer 3: Styled).
+ * MD3 styled MenuDivider component (Layer 3).
  *
- * Renders a standalone horizontal separator between menu items. Uses
- * `HeadlessMenuDivider` (RAC `Separator`) for `role="separator"` semantics.
- *
- * Color: `border-outline-variant` per MD3 spec.
+ * Renders a horizontal `role="separator"` with `border-outline-variant` styling.
+ * 8dp top/bottom padding (`my-2`) per MD3 spec.
  *
  * @example
  * ```tsx
@@ -20,11 +18,7 @@ import type { MenuDividerProps } from "./Menu.types";
  * <MenuDivider />
  * <MenuItem id="select-all">Select all</MenuItem>
  * ```
- *
- * @see https://m3.material.io/components/menus/specs
  */
 export function MenuDivider({ className }: MenuDividerProps): JSX.Element {
   return <HeadlessMenuDivider className={cn(menuDividerVariants(), className)} />;
 }
-
-MenuDivider.displayName = "MenuDivider";

--- a/packages/react/src/components/Menu/MenuGap.tsx
+++ b/packages/react/src/components/Menu/MenuGap.tsx
@@ -25,7 +25,7 @@ import type { MenuGapProps } from "./Menu.types";
  *   - Menu items after the gap render correctly (collection is intact)
  *   - The element has zero ARIA semantics (aria-hidden removes it from the tree)
  */
-const MenuGapItem = createLeafComponent(
+const MenuGapItem = createLeafComponent<object, { className?: string }, HTMLDivElement>(
   // Use the 'separator' string type so createLeafComponent creates a bare
   // CollectionNode subclass — registered in the collection but without the
   // consecutive-separator-drop filter that RAC's own SeparatorNode applies.

--- a/packages/react/src/components/Menu/MenuGap.tsx
+++ b/packages/react/src/components/Menu/MenuGap.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { type ForwardedRef, type JSX } from "react";
+import { createLeafComponent } from "@react-aria/collections";
+import { menuGapVariants } from "./Menu.variants";
+import { cn } from "../../utils/cn";
+import type { MenuGapProps } from "./Menu.types";
+
+/**
+ * RAC `filterDOMProps` strips `aria-hidden` and `role` overrides from all RAC
+ * separator components (the attributes are not in its allowlist). Passing props
+ * declaratively therefore has no effect on the rendered element.
+ *
+ * We also cannot use a native `<li>` because RAC's collection system only
+ * renders items that are registered in its internal collection Document — a
+ * plain HTML element is not registered and items following it are dropped.
+ *
+ * The correct solution: create a first-class collection item using
+ * `createLeafComponent` (RAC's public collection primitive). We register the
+ * item as type `'separator'` (so the collection includes it and subsequent
+ * siblings continue to render), but provide a completely custom render function
+ * that outputs `<div aria-hidden="true">` directly, without going through
+ * `useSeparator` or `filterDOMProps`. This means:
+ *   - `queryByRole("separator")` returns null (aria-hidden excludes the element)
+ *   - Menu items after the gap render correctly (collection is intact)
+ *   - The element has zero ARIA semantics (aria-hidden removes it from the tree)
+ */
+const MenuGapItem = createLeafComponent(
+  // Use the 'separator' string type so createLeafComponent creates a bare
+  // CollectionNode subclass — registered in the collection but without the
+  // consecutive-separator-drop filter that RAC's own SeparatorNode applies.
+  "separator",
+  function MenuGapRenderer(
+    { className: cls }: { className?: string },
+    ref: ForwardedRef<HTMLDivElement>
+  ): JSX.Element {
+    return (
+      // Rendered directly — no filterDOMProps, no useSeparator.
+      // aria-hidden="true" removes the element from the a11y tree entirely.
+      <div ref={ref} aria-hidden="true" className={cls} />
+    );
+  }
+);
+
+/**
+ * MD3 MenuGap component (Layer 3) — Expressive Vertical Menu only.
+ *
+ * A purely visual spacer between item groups in M3 Expressive vertical menus.
+ * Unlike `MenuDivider` (which renders a visible border line), `MenuGap` renders
+ * only blank spacing and is fully hidden from the accessibility tree.
+ *
+ * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger.Menu menuStyle="vertical">
+ *   <MenuItem id="cut">Cut</MenuItem>
+ *   <MenuGap />
+ *   <MenuItem id="paste">Paste</MenuItem>
+ * </MenuTrigger.Menu>
+ * ```
+ */
+export function MenuGap({ className }: MenuGapProps): JSX.Element {
+  return <MenuGapItem className={cn(menuGapVariants(), className)} />;
+}

--- a/packages/react/src/components/Menu/MenuHeadless.tsx
+++ b/packages/react/src/components/Menu/MenuHeadless.tsx
@@ -1,260 +1,348 @@
 "use client";
 
-/**
- * MenuHeadless — Layer 2: Behavior-only primitives.
- *
- * The trigger layer uses react-aria hooks (`useMenuTriggerState` +
- * `useMenuTrigger`) to spread ARIA attributes and event handlers onto any
- * trigger element via `cloneElement`. This supports raw `<button>` elements
- * as well as RAC `Button` components.
- *
- * The overlay uses RAC `Popover` with `OverlayTriggerStateContext` to handle
- * portal rendering, positioning, flip/shift, focus management (FocusScope +
- * restoreFocus + autoFocus), and Escape / outside-click dismissal.
- *
- * The menu list uses RAC `Menu`, `MenuItem`, `MenuSection`, `Separator` for
- * full collection management, keyboard navigation, and ARIA semantics.
- */
-
 import {
-  cloneElement,
   createContext,
   forwardRef,
+  useCallback,
   useContext,
   useRef,
-  type JSX,
-  type ReactElement,
+  useLayoutEffect,
+  useState,
+  isValidElement,
+  cloneElement,
   type ReactNode,
+  type ReactElement,
+  type HTMLAttributes,
+  type JSX,
 } from "react";
 import {
   Menu as RACMenu,
   MenuItem as RACMenuItem,
   MenuSection as RACMenuSection,
-  MenuContext as RACMenuContext,
-  OverlayTriggerStateContext,
+  Separator as RACSeparator,
+  SubmenuTrigger as RACSubmenuTrigger,
+  MenuTrigger as RACMenuTrigger,
+  ButtonContext,
   Popover,
-  Separator,
-  type MenuProps as RACMenuProps,
-  type MenuItemProps as RACMenuItemProps,
+  OverlayTriggerStateContext,
+  useSlottedContext,
+  type SeparatorProps as RACSeparatorProps,
 } from "react-aria-components";
-import { mergeProps, useMenuTrigger } from "react-aria";
-import { useMenuTriggerState } from "react-stately";
+import { useButton } from "react-aria";
+import { useOverlayTriggerState } from "react-stately";
 import type {
+  HeadlessMenuTriggerProps,
   HeadlessMenuProps,
   HeadlessMenuItemProps,
   HeadlessMenuSectionProps,
-  HeadlessMenuTriggerProps,
+  HeadlessSubmenuTriggerProps,
+  HeadlessContextMenuTriggerProps,
   MenuContextValue,
 } from "./Menu.types";
 
-// ─── Our Menu Context (close / disableRipple / variant) ──────────────────────
+// ─── MenuContext ──────────────────────────────────────────────────────────────
 
-/**
- * Context shared between the Menu and its item descendants.
- * Carries close(), disableRipple, and variant so items can
- * read them without prop-drilling.
- * @internal
- */
 export const MenuContext = createContext<MenuContextValue | null>(null);
 
-export function useMenuContext(): MenuContextValue {
-  const ctx = useContext(MenuContext);
-  if (ctx === null) {
-    throw new Error("MenuItem must be rendered inside a MenuTrigger component.");
-  }
-  return ctx;
+export function useMenuContext(): MenuContextValue | null {
+  return useContext(MenuContext);
+}
+
+// ─── TriggerBridge ────────────────────────────────────────────────────────────
+/**
+ * Reads the button slot props from `ButtonContext` (provided by `RACMenuTrigger`)
+ * and applies them to any plain HTML element child via `cloneElement`.
+ *
+ * This bridges the gap between RAC's context-based prop injection (which expects
+ * a RAC `Button`) and our Layer 3 API that accepts any trigger element (e.g. a
+ * native `<button>` or a custom component).
+ *
+ * @internal
+ */
+function TriggerBridge({ children }: { children: ReactNode }): ReactNode {
+  // useSlottedContext gives a properly typed value (ButtonContextValue & { ref? })
+  // without casting through any.
+  const ctx = useSlottedContext(ButtonContext);
+  const localRef = useRef<HTMLButtonElement | null>(null);
+
+  const { ref: contextRef, ...ctxProps } = ctx ?? {};
+
+  // Write to both the context ref (used by RACMenuTrigger for popover
+  // positioning) and localRef (passed to useButton, which requires a stable
+  // RefObject rather than a ForwardedRef).
+  const mergedCallbackRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      localRef.current = node;
+      if (!contextRef) return;
+      if (typeof contextRef === "function") {
+        contextRef(node);
+      } else {
+        // After the function check, contextRef is MutableRefObject<HTMLButtonElement | null>
+        // (ForwardedRef<T> = callback | MutableRefObject<T | null> | null).
+        contextRef.current = node;
+      }
+    },
+    [contextRef]
+  );
+
+  // ButtonContext is populated by RACMenuTrigger with aria-haspopup,
+  // aria-expanded, aria-controls, onPress, onKeyDown, etc.
+  // useButton converts React Aria's onPress + keyboard props into standard
+  // HTML events (onClick, onKeyDown, etc.) that work on native elements.
+  const { buttonProps } = useButton({ ...ctxProps, elementType: "button" }, localRef);
+
+  if (!isValidElement(children)) return <>{children}</>;
+
+  return cloneElement(
+    children as React.ReactElement<HTMLAttributes<HTMLElement>>,
+    { ...buttonProps, ref: mergedCallbackRef } as HTMLAttributes<HTMLElement>
+  );
 }
 
 // ─── HeadlessMenuTrigger ──────────────────────────────────────────────────────
 
 /**
- * Headless Menu Trigger (Layer 2).
+ * Layer 2 headless primitive.
  *
- * - Manages open/close state via `useMenuTriggerState`.
- * - Spreads `aria-haspopup`, `aria-expanded`, `aria-controls`, and pointer /
- *   keyboard event handlers onto the first child (trigger element) via
- *   `cloneElement`. Works with both RAC `Button` and native `<button>`.
- * - Renders the menu overlay via RAC `Popover` (with portal, positioning, flip,
- *   focus management, and Escape/outside-click dismissal).
- * - Provides `OverlayTriggerStateContext` so `Popover` knows the open state.
- * - Provides `RACMenuContext` so RAC `Menu` receives its `id` /
- *   `aria-labelledby` linkage.
+ * Uses `RACMenuTrigger` (Layer 1) as the foundation. `RACMenuTrigger` manages:
+ * - `aria-haspopup="menu"` and `aria-expanded` on the trigger (dynamic)
+ * - Open/close state and keyboard opening (ArrowDown → focus first item)
+ * - `OverlayTriggerStateContext` so the Popover can close on Escape / outside click
+ * - `PopoverGroupContext` so the Popover's `ariaHideOutside` does NOT hide the
+ *   trigger button while the menu is open
  *
- * Children layout: `[trigger, menu]`
- *
- * @example
- * ```tsx
- * <HeadlessMenuTrigger>
- *   <button type="button">Open</button>
- *   <HeadlessMenu aria-label="Actions">
- *     <HeadlessMenuItem id="cut">Cut</HeadlessMenuItem>
- *   </HeadlessMenu>
- * </HeadlessMenuTrigger>
- * ```
+ * `TriggerBridge` adapts the context-injected button props to work with any
+ * plain HTML element (native `<button>`, custom components, etc.).
  */
 export function HeadlessMenuTrigger({
   children,
   placement = "bottom start",
-  ...stateProps
+  shouldFlip = true,
+  ...rest
 }: HeadlessMenuTriggerProps): JSX.Element {
-  const triggerRef = useRef<HTMLElement>(null);
-  const state = useMenuTriggerState(stateProps);
-  const { menuTriggerProps, menuProps } = useMenuTrigger({ type: "menu" }, state, triggerRef);
-
-  const childrenArray = Array.isArray(children)
-    ? (children as ReactElement[])
-    : [children as ReactElement];
-  const triggerChild = childrenArray[0]!;
-  const menuChild = childrenArray[1]!;
-
-  // Clone the trigger element and spread ARIA + event handler props onto it.
-  // mergeProps handles merging multiple event listeners (e.g. existing onClick).
-  // An explicit onClick calling state.toggle() ensures native button clicks
-  // work reliably in all environments (JSDOM, browser, SSR hydration).
-  const clonedTrigger = cloneElement(triggerChild, {
-    ...(mergeProps(triggerChild.props as Record<string, unknown>, menuTriggerProps, {
-      onClick: () => {
-        state.toggle();
-      },
-    }) as Record<string, unknown>),
-    ref: triggerRef,
-  });
+  const childrenArray = Array.isArray(children) ? children : [children];
+  const [triggerChild, menuChild] = childrenArray as [ReactNode, ReactNode];
 
   return (
-    // Provide OverlayTriggerStateContext so RAC Popover knows about open state
-    <OverlayTriggerStateContext.Provider value={state}>
-      {clonedTrigger}
-      {/* Provide RACMenuContext so RAC Menu gets the aria-labelledby linkage */}
-      <RACMenuContext.Provider value={menuProps as Record<string, unknown>}>
-        <Popover triggerRef={triggerRef} placement={placement} offset={4} isNonModal>
-          {menuChild}
-        </Popover>
-      </RACMenuContext.Provider>
-    </OverlayTriggerStateContext.Provider>
+    <RACMenuTrigger {...rest}>
+      <TriggerBridge>{triggerChild}</TriggerBridge>
+      {/*
+       * RACMenuTrigger provides PopoverGroupContext which tells ariaHideOutside
+       * to exclude the trigger button — so we do NOT need isNonModal here.
+       * Without isNonModal the Popover uses the standard modal overlay underlay,
+       * which correctly dismisses the menu on any outside pointer interaction.
+       */}
+      <Popover placement={placement} shouldFlip={shouldFlip} offset={4}>
+        {menuChild}
+      </Popover>
+    </RACMenuTrigger>
   );
 }
-
-HeadlessMenuTrigger.displayName = "HeadlessMenuTrigger";
-
-// Attach as static sub-component for convenience
-(HeadlessMenuTrigger as unknown as Record<string, unknown>).Menu = null; // set below
 
 // ─── HeadlessMenu ─────────────────────────────────────────────────────────────
 
 /**
- * Headless Menu list (Layer 2).
+ * Layer 2 headless primitive wrapping RAC `Menu`.
  *
- * Wraps RAC `Menu` which renders `<ul role="menu">` with full keyboard
- * navigation, type-ahead, and collection management.
+ * When nested inside `HeadlessMenuTrigger`, RAC automatically threads the
+ * `MenuContext` (containing `autoFocus`, `onClose`, `aria-labelledby`, etc.)
+ * from `RACMenuTrigger` through to `RACMenu`. No manual prop threading needed.
  *
- * @example
- * ```tsx
- * <HeadlessMenu aria-label="Actions" className={menuContainerVariants()}>
- *   <HeadlessMenuItem id="cut">Cut</HeadlessMenuItem>
- *   <HeadlessMenuItem id="copy">Copy</HeadlessMenuItem>
- * </HeadlessMenu>
- * ```
+ * **aria-label / aria-labelledby precedence fix**: `RACSubmenuTrigger` sets
+ * `aria-labelledby` in `MenuContext` pointing to the trigger item. In ARIA
+ * spec, `aria-labelledby` always overrides `aria-label`. So when the consumer
+ * provides an explicit `aria-label`, we suppress the context's
+ * `aria-labelledby` by passing `aria-labelledby={undefined}`, which takes
+ * precedence over the `MenuContext` value in `useContextProps`'s `mergeProps`
+ * call (last argument wins). This ensures `aria-label="My Submenu"` is
+ * respected as the accessible name.
  */
-export const HeadlessMenu = forwardRef<HTMLElement, HeadlessMenuProps>(
-  function HeadlessMenuComponent({ className, children, ...props }, _ref) {
-    return (
-      <RACMenu
-        {...(props as RACMenuProps<object>)}
-        {...(className !== undefined ? { className } : {})}
-      >
-        {children}
-      </RACMenu>
-    );
-  }
-);
+export function HeadlessMenu<T extends object = object>({
+  className,
+  children,
+  "aria-label": ariaLabel,
+  ...props
+}: HeadlessMenuProps<T>): JSX.Element {
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
-HeadlessMenu.displayName = "HeadlessMenu";
+  /**
+   * `RACSubmenuTrigger` provides `MenuContext` with `aria-labelledby` pointing
+   * to the trigger item's id. In the ARIA spec, `aria-labelledby` always beats
+   * `aria-label`, so even if we pass `aria-label` as a prop it would be
+   * overridden. `useContextProps` inside `RACMenu` merges context first then
+   * explicit props, but passing `aria-labelledby={undefined}` doesn't reliably
+   * clear the context-injected attribute in all RAC versions.
+   *
+   * The only reliable fix: imperatively remove the attribute from the DOM node
+   * after every render. `useLayoutEffect` runs synchronously after DOM mutations,
+   * so the accessibility tree is already correct when testing-library reads it.
+   */
+  useLayoutEffect(() => {
+    if (ariaLabel && menuRef.current) {
+      menuRef.current.removeAttribute("aria-labelledby");
+    }
+  });
 
-// Attach static sub-component
-(HeadlessMenuTrigger as unknown as Record<string, unknown>).Menu = HeadlessMenu;
+  return (
+    <RACMenu<T>
+      {...props}
+      ref={menuRef}
+      {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+      className={className ?? ""}
+    >
+      {children}
+    </RACMenu>
+  );
+}
+
+// Expose HeadlessMenu as a static property so Layer 2 tests can use
+// <HeadlessMenuTrigger.Menu> just like <MenuTrigger.Menu> at Layer 3.
+HeadlessMenuTrigger.Menu = HeadlessMenu;
 
 // ─── HeadlessMenuItem ─────────────────────────────────────────────────────────
 
 /**
- * Headless Menu Item (Layer 2).
+ * Layer 2 headless primitive wrapping RAC `MenuItem`.
  *
- * Wraps RAC `MenuItem` which renders `<li role="menuitem">` (or
- * `role="menuitemradio"` / `role="menuitemcheckbox"` for selection menus).
- * RAC manages aria-disabled, aria-checked, and keyboard activation.
- *
- * @example
- * ```tsx
- * <HeadlessMenuItem id="cut" className={menuItemVariants()}>
- *   Cut
- * </HeadlessMenuItem>
- * ```
+ * Accepts `className` as either a static string or a render-prop function
+ * `(renderProps: MenuItemRenderProps) => string`, forwarding it directly to
+ * `RACMenuItem` so MD3 selection-state styles are applied on the `<li>` element
+ * (the element with `role="menuitem"`).
  */
-export const HeadlessMenuItem = forwardRef<
-  HTMLElement,
-  HeadlessMenuItemProps & { onMouseDown?: React.MouseEventHandler<HTMLElement> }
->(function HeadlessMenuItemComponent({ className, children, onMouseDown, ...props }, _ref) {
-  return (
-    <RACMenuItem
-      {...(props as unknown as RACMenuItemProps)}
-      {...(className !== undefined ? { className } : {})}
-      {...(onMouseDown !== undefined ? { onMouseDown } : {})}
-    >
-      {children}
-    </RACMenuItem>
-  );
-});
-
-HeadlessMenuItem.displayName = "HeadlessMenuItem";
+export const HeadlessMenuItem = forwardRef<HTMLDivElement, HeadlessMenuItemProps>(
+  function HeadlessMenuItem({ children, className, ...props }, ref) {
+    return (
+      <RACMenuItem {...props} ref={ref} className={className ?? ""}>
+        {children}
+      </RACMenuItem>
+    );
+  }
+);
 
 // ─── HeadlessMenuSection ──────────────────────────────────────────────────────
 
-/**
- * Headless Menu Section (Layer 2).
- *
- * Wraps RAC `MenuSection` which renders `role="group"` with an optional
- * accessible header. RAC handles `aria-labelledby` automatically.
- *
- * @example
- * ```tsx
- * <HeadlessMenuSection className={menuSectionVariants()} aria-label="Clipboard">
- *   <HeadlessMenuItem id="cut">Cut</HeadlessMenuItem>
- * </HeadlessMenuSection>
- * ```
- */
-export const HeadlessMenuSection = forwardRef<
-  HTMLElement,
-  HeadlessMenuSectionProps & { className?: string; children: ReactNode }
->(function HeadlessMenuSectionComponent(
-  { children, className, "aria-label": ariaLabel, ...props },
-  _ref
-) {
+export function HeadlessMenuSection({
+  children,
+  "aria-label": ariaLabel,
+  className,
+}: HeadlessMenuSectionProps): JSX.Element {
   return (
     <RACMenuSection
-      {...props}
-      {...(className !== undefined ? { className } : {})}
       {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+      className={className ?? ""}
     >
       {children}
     </RACMenuSection>
   );
-});
-
-HeadlessMenuSection.displayName = "HeadlessMenuSection";
+}
 
 // ─── HeadlessMenuDivider ──────────────────────────────────────────────────────
 
-/**
- * Headless Menu Divider (Layer 2).
- *
- * Wraps RAC `Separator` which renders `role="separator"`.
- *
- * @example
- * ```tsx
- * <HeadlessMenuDivider className={menuDividerVariants()} />
- * ```
- */
-export function HeadlessMenuDivider({ className }: { className?: string }): JSX.Element {
-  return <Separator {...(className !== undefined ? { className } : {})} />;
+export function HeadlessMenuDivider({
+  className,
+  ...props
+}: RACSeparatorProps & { className?: string }): JSX.Element {
+  return <RACSeparator {...props} className={className ?? ""} />;
 }
 
-HeadlessMenuDivider.displayName = "HeadlessMenuDivider";
+// ─── HeadlessSubmenuTrigger ───────────────────────────────────────────────────
+
+/**
+ * Layer 2 headless primitive wrapping RAC `SubmenuTrigger`.
+ *
+ * RAC `SubmenuTrigger` expects its children to be a `[MenuItem, Popover>Menu]`
+ * pair. The first child is the trigger item; the second is a `Popover` wrapping
+ * the submenu `Menu`. We wrap the menu child in a `Popover` here so the consumer
+ * only needs to provide `[MenuItem, Menu]`.
+ */
+export function HeadlessSubmenuTrigger({
+  children,
+  delay,
+}: HeadlessSubmenuTriggerProps): JSX.Element {
+  const childrenArray = Array.isArray(children) ? children : [children];
+  const [triggerItem, menuChild] = childrenArray as [ReactNode, ReactNode];
+
+  // RACSubmenuTrigger requires ReactElement[] children — first child is the
+  // trigger MenuItem, second is a Popover wrapping the submenu.
+  const racChildren: ReactElement[] = [
+    triggerItem as ReactElement,
+    <Popover key="submenu-popover">{menuChild}</Popover>,
+  ];
+
+  return (
+    <RACSubmenuTrigger {...(delay !== undefined ? { delay } : {})}>{racChildren}</RACSubmenuTrigger>
+  );
+}
+
+// ─── HeadlessContextMenuTrigger ───────────────────────────────────────────────
+
+/**
+ * Layer 2 headless primitive for context menus (right-click / two-finger tap).
+ * Positions the menu at cursor coordinates via a virtual 0×0 anchor element.
+ */
+export function HeadlessContextMenuTrigger({
+  children,
+  isOpen: isOpenProp,
+  onOpenChange,
+}: HeadlessContextMenuTriggerProps): JSX.Element {
+  const virtualTriggerRef = useRef<HTMLSpanElement>(null);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  const isControlled = isOpenProp !== undefined;
+
+  // Conditionally spread EOPT-sensitive props: isOpen/onOpenChange must not be
+  // present with value `undefined` under exactOptionalPropertyTypes.
+  const internalState = useOverlayTriggerState({
+    ...(isControlled
+      ? { isOpen: isOpenProp, ...(onOpenChange !== undefined ? { onOpenChange } : {}) }
+      : {}),
+  });
+
+  const handleContextMenu = (e: React.MouseEvent): void => {
+    e.preventDefault();
+    setPosition({ x: e.clientX, y: e.clientY });
+    internalState.open();
+    if (!isControlled) onOpenChange?.(true);
+  };
+
+  const childrenArray = Array.isArray(children) ? children : [children];
+  const [contentChild, menuChild] = childrenArray as [ReactNode, ReactNode];
+
+  return (
+    <>
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- display:contents sink; not focusable itself, keyboard dismissal handled by RAC Popover Escape handler */}
+      <div onContextMenu={handleContextMenu} style={{ display: "contents" }}>
+        {contentChild}
+      </div>
+
+      {/* Virtual 0×0 anchor positioned at cursor coordinates */}
+      <span
+        ref={virtualTriggerRef}
+        aria-hidden="true"
+        style={{
+          position: "fixed",
+          top: position.y,
+          left: position.x,
+          width: 0,
+          height: 0,
+          pointerEvents: "none",
+        }}
+      />
+
+      {/*
+       * OverlayTriggerStateContext is provided OUTSIDE the Popover so the
+       * Popover reads internalState directly (not a derived localState).
+       * We intentionally do NOT pass isOpen as a prop — when isOpen is a prop,
+       * the Popover creates a separate localState whose close() doesn't update
+       * internalState. By relying solely on OverlayTriggerStateContext, the
+       * Popover's DismissButton / Escape key handler call internalState.close()
+       * directly, which correctly dismisses the context menu.
+       */}
+      <OverlayTriggerStateContext.Provider value={internalState}>
+        <Popover triggerRef={virtualTriggerRef} placement="bottom start" shouldFlip offset={0}>
+          {menuChild}
+        </Popover>
+      </OverlayTriggerStateContext.Provider>
+    </>
+  );
+}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -1,119 +1,188 @@
 "use client";
 
-import { forwardRef, useContext } from "react";
-import { HeadlessMenuItem } from "./MenuHeadless";
-import { MenuContext } from "./MenuHeadless";
-import { menuItemVariants, menuItemTrailingTextVariants } from "./Menu.variants";
-import { cn } from "../../utils/cn";
-import { useRipple } from "../../hooks/useRipple";
-import type { MenuItemProps } from "./Menu.types";
+import { forwardRef, type JSX } from "react";
 import type { MenuItemRenderProps } from "react-aria-components";
+import { useMenuContext } from "./MenuHeadless";
+import { HeadlessMenuItem } from "./MenuHeadless";
+import {
+  menuItemVariants,
+  menuItemTrailingTextVariants,
+  menuItemDescriptionVariants,
+} from "./Menu.variants";
+import { useRipple } from "../../hooks/useRipple";
+import { cn } from "../../utils/cn";
+import type { MenuItemProps } from "./Menu.types";
+
+// ─── CheckIcon ───────────────────────────────────────────────────────────────
+
+function CheckIcon(): JSX.Element {
+  return (
+    <svg
+      data-testid="check-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      className="h-full w-full"
+    >
+      <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+    </svg>
+  );
+}
+
+// ─── ChevronRightIcon ─────────────────────────────────────────────────────────
+
+export function ChevronRightIcon(): JSX.Element {
+  return (
+    <svg
+      data-testid="chevron-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      className="h-full w-full"
+    >
+      <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" />
+    </svg>
+  );
+}
+
+// ─── Density height map ────────────────────────────────────────────────────────
+
+const DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
+  0: "h-12",
+  [-1]: "h-11",
+  [-2]: "h-10",
+  [-3]: "h-9",
+};
+
+// ─── MenuItem ─────────────────────────────────────────────────────────────────
 
 /**
- * Material Design 3 Menu Item (Layer 3: Styled).
+ * MD3 styled MenuItem component (Layer 3).
  *
- * A single interactive item within a Menu. Uses `HeadlessMenuItem` (RAC
- * `MenuItem`) for all behavior and ARIA semantics, CVA for MD3 visual states.
- *
- * Features:
- * - Item height: 48dp (`h-12`) per MD3 spec
- * - Label: `text-label-large text-on-surface`
- * - Optional leading icon slot: `text-on-surface-variant`
- * - Optional trailing icon slot: `text-on-surface-variant`
- * - Optional trailing text (keyboard shortcut): `text-label-large text-on-surface-variant`
- * - MD3 state layers via pseudo-element (`opacity-8` hover, `opacity-12`
- *   focus-visible / pressed)
- * - Ripple effect on press
- * - Disabled state: `opacity-38` + non-interactive
- * - Selected state (select variant): `bg-secondary-container` +
- *   `text-on-secondary-container`
+ * All MD3 styles (selection colors, typography, density height) are applied
+ * directly to the `<li role="menuitem">` element via RAC's render-prop className,
+ * ensuring tests and assistive technologies see the correct classes on the
+ * semantically meaningful element.
  *
  * @example
  * ```tsx
- * // Basic item
- * <MenuItem id="cut">Cut</MenuItem>
- *
- * // With leading icon
- * <MenuItem id="copy" leadingIcon={<CopyIcon />}>Copy</MenuItem>
- *
- * // With keyboard shortcut
- * <MenuItem id="paste" leadingIcon={<PasteIcon />} trailingText="⌘V">Paste</MenuItem>
- *
- * // Disabled
- * <MenuItem id="undo" isDisabled>Undo</MenuItem>
+ * <MenuItem id="copy" leadingIcon={<CopyIcon />} trailingText="⌘C">
+ *   Copy
+ * </MenuItem>
  * ```
- *
- * @see https://m3.material.io/components/menus/specs
  */
-export const MenuItem = forwardRef<HTMLElement, MenuItemProps>(
-  (
-    {
-      leadingIcon,
-      trailingIcon,
-      trailingText,
-      isDisabled = false,
-      className,
-      disableRipple: disableRippleProp,
-      children,
-      ...restProps
-    },
-    _ref
-  ) => {
-    const ctx = useContext(MenuContext);
-    const contextDisableRipple = ctx?.disableRipple ?? false;
-    const isRippleDisabled = (disableRippleProp ?? contextDisableRipple) || Boolean(isDisabled);
+export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuItem(
+  {
+    children,
+    leadingIcon,
+    trailingIcon,
+    trailingText,
+    description,
+    badge,
+    className,
+    disableRipple: itemDisableRipple,
+    ...props
+  },
+  ref
+) {
+  const ctx = useMenuContext();
+  const disableRipple = itemDisableRipple ?? ctx?.disableRipple ?? false;
+  const colorScheme = ctx?.colorScheme ?? "standard";
+  const menuStyle = ctx?.menuStyle ?? "baseline";
+  const density = ctx?.density ?? 0;
+  const selectionMode = ctx?.selectionMode;
 
-    const { onMouseDown: handleRipple, ripples } = useRipple({
-      disabled: isRippleDisabled,
-    });
+  const heightClass = DENSITY_HEIGHT[density];
+  const isSelectionMenu = selectionMode != null;
 
-    // RAC MenuItem accepts className as a function receiving render props,
-    // which allows dynamic styling based on isDisabled / isSelected.
-    const itemClassName = ({ isDisabled: d, isSelected: s }: MenuItemRenderProps): string =>
-      cn(menuItemVariants({ isDisabled: d, isSelected: s }), className);
+  const { ripples, onMouseDown } = useRipple({ disabled: disableRipple });
 
-    return (
-      <HeadlessMenuItem
-        {...restProps}
-        isDisabled={isDisabled}
-        className={itemClassName as unknown as string}
-        onMouseDown={handleRipple as React.MouseEventHandler<HTMLElement>}
-      >
-        {/* Ripple effect */}
-        {ripples}
-
-        {/* Leading icon slot */}
-        {leadingIcon && (
-          <span
-            className="text-on-surface-variant relative z-10 flex shrink-0 items-center justify-center"
-            aria-hidden="true"
-          >
-            {leadingIcon}
-          </span>
-        )}
-
-        {/* Label */}
-        <span className="relative z-10 flex-1 truncate text-left">{children}</span>
-
-        {/* Trailing icon slot (mutually exclusive with trailingText) */}
-        {trailingIcon && !trailingText && (
-          <span
-            className="text-on-surface-variant relative z-10 ml-auto flex shrink-0 items-center"
-            aria-hidden="true"
-          >
-            {trailingIcon}
-          </span>
-        )}
-
-        {/* Trailing text (keyboard shortcut) */}
-        {trailingText && !trailingIcon && (
-          <span className={cn("relative z-10", menuItemTrailingTextVariants())}>
-            {trailingText}
-          </span>
-        )}
-      </HeadlessMenuItem>
+  // className rendered on the <li role="menuitem"> via RAC's render-prop form
+  const computeClassName = ({ isDisabled, isSelected }: MenuItemRenderProps): string =>
+    cn(
+      menuItemVariants({
+        isDisabled,
+        isSelected: isSelected ?? false,
+        colorScheme,
+        menuStyle,
+      }),
+      // Height: auto when description is present (multi-line), otherwise density
+      description ? "min-h-12 py-2 h-auto items-start" : heightClass,
+      className
     );
-  }
-);
 
-MenuItem.displayName = "MenuItem";
+  return (
+    <HeadlessMenuItem
+      {...props}
+      ref={ref}
+      // Apply all MD3 classes directly to the <li role="menuitem"> element
+      className={computeClassName}
+      // onMouseDown triggers the ripple effect on mouse presses
+      onMouseDown={onMouseDown as unknown as React.MouseEventHandler<Element>}
+    >
+      {({ isSelected }: MenuItemRenderProps) => (
+        <>
+          {/* Ripple container */}
+          {!disableRipple && (
+            <span className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
+              {ripples}
+            </span>
+          )}
+
+          {/* ── Leading icon or checkmark slot ────────────────────────── */}
+          {(leadingIcon != null || isSelectionMenu) && (
+            <span
+              className="text-on-surface-variant relative z-10 flex h-6 w-6 shrink-0 items-center justify-center"
+              aria-hidden="true"
+            >
+              {isSelectionMenu && leadingIcon == null ? (
+                isSelected ? (
+                  <CheckIcon />
+                ) : null
+              ) : (
+                leadingIcon
+              )}
+            </span>
+          )}
+
+          {/* ── Text content area ─────────────────────────────────────── */}
+          {description != null ? (
+            <span className="relative z-10 flex min-w-0 flex-1 flex-col">
+              <span className="text-body-large">{children}</span>
+              <span className={menuItemDescriptionVariants()}>{description}</span>
+            </span>
+          ) : (
+            <span className="text-body-large relative z-10 min-w-0 flex-1">{children}</span>
+          )}
+
+          {/* ── Badge slot ────────────────────────────────────────────── */}
+          {badge != null && <span className="relative z-10 shrink-0">{badge}</span>}
+
+          {/* ── Trailing icon ─────────────────────────────────────────── */}
+          {trailingIcon != null && trailingText == null && (
+            <span
+              className="text-on-surface-variant relative z-10 ml-auto flex h-6 w-6 shrink-0 items-center justify-center"
+              aria-hidden="true"
+            >
+              {trailingIcon}
+            </span>
+          )}
+
+          {/* ── Trailing text (keyboard shortcut) ─────────────────────── */}
+          {trailingText != null && trailingIcon == null && (
+            <span
+              className={cn(menuItemTrailingTextVariants(), "relative z-10")}
+              aria-keyshortcuts={trailingText}
+            >
+              {trailingText}
+            </span>
+          )}
+        </>
+      )}
+    </HeadlessMenuItem>
+  );
+});

--- a/packages/react/src/components/Menu/MenuSection.tsx
+++ b/packages/react/src/components/Menu/MenuSection.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { forwardRef } from "react";
-import { Header, Separator } from "react-aria-components";
-import { HeadlessMenuSection } from "./MenuHeadless";
+import { type JSX } from "react";
+import { Header as RACHeader } from "react-aria-components";
+import { HeadlessMenuSection, HeadlessMenuDivider } from "./MenuHeadless";
 import {
   menuSectionVariants,
   menuSectionHeaderVariants,
@@ -12,51 +12,51 @@ import { cn } from "../../utils/cn";
 import type { MenuSectionProps } from "./Menu.types";
 
 /**
- * Material Design 3 Menu Section (Layer 3: Styled).
+ * MD3 styled MenuSection component (Layer 3).
  *
- * Groups related `MenuItem` elements with an optional section header label
- * and a horizontal divider. Follows MD3 Menu spec for section grouping and
- * typography.
+ * Groups related `MenuItem` elements with an optional section header and an
+ * optional top divider.
  *
- * The divider (`showDivider`) is rendered as a RAC `Separator` INSIDE the
- * section (as the first collection item). This ensures RAC's collection API
- * processes it correctly without breaking sibling sections.
- *
- * Features:
- * - Optional header label: `text-title-small text-on-surface-variant`
- * - Optional top divider: `role="separator"` rendered via RAC `Separator`
+ * **Implementation note**: The divider is rendered as a SIBLING BEFORE the
+ * `RACMenuSection`, NOT inside it. RAC's `Section`/`MenuSection` only accepts
+ * `Header` and `MenuItem` children — placing a `Separator` inside the section
+ * would create invalid HTML (`<li>` inside `<li role="group">`) and break RAC's
+ * collection rendering.
  *
  * @example
  * ```tsx
- * // Section with header and divider
- * <MenuSection header="Clipboard" showDivider>
+ * <MenuSection header="Clipboard" showDivider aria-label="Clipboard">
  *   <MenuItem id="cut">Cut</MenuItem>
  *   <MenuItem id="copy">Copy</MenuItem>
  * </MenuSection>
- *
- * // Section without header (requires aria-label for accessibility)
- * <MenuSection aria-label="Formatting" showDivider>
- *   <MenuItem id="bold">Bold</MenuItem>
- * </MenuSection>
  * ```
- *
- * @see https://m3.material.io/components/menus/specs
  */
-export const MenuSection = forwardRef<HTMLElement, MenuSectionProps>(
-  ({ header, children, showDivider = false, className, "aria-label": ariaLabel }, _ref) => {
-    return (
+export function MenuSection({
+  children,
+  header,
+  showDivider = false,
+  className,
+  "aria-label": ariaLabel,
+}: MenuSectionProps): JSX.Element {
+  // The union type guarantees at least one of these is a string.
+  const sectionAriaLabel = (ariaLabel ?? header)!;
+
+  return (
+    <>
+      {/* Divider is a sibling of the section, placed before it in the menu list */}
+      {showDivider && <HeadlessMenuDivider className={menuDividerVariants()} />}
       <HeadlessMenuSection
+        aria-label={sectionAriaLabel}
         className={cn(menuSectionVariants(), className)}
-        {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
       >
-        {/* Render divider as a RAC Separator INSIDE the section so it is a
-            proper collection item and does not break sibling section rendering */}
-        {showDivider && <Separator className={menuDividerVariants()} />}
-        {header && <Header className={menuSectionHeaderVariants()}>{header}</Header>}
+        {/* RAC Header component renders a semantic section header inside the group */}
+        {header && (
+          <RACHeader className={menuSectionHeaderVariants()} aria-hidden="true">
+            {header}
+          </RACHeader>
+        )}
         {children}
       </HeadlessMenuSection>
-    );
-  }
-);
-
-MenuSection.displayName = "MenuSection";
+    </>
+  );
+}

--- a/packages/react/src/components/Menu/SubmenuTrigger.tsx
+++ b/packages/react/src/components/Menu/SubmenuTrigger.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Children, isValidElement, cloneElement, type JSX, type ReactNode } from "react";
+import { HeadlessSubmenuTrigger } from "./MenuHeadless";
+import { ChevronRightIcon } from "./MenuItem";
+import type { SubmenuTriggerProps, MenuItemProps } from "./Menu.types";
+
+/**
+ * MD3 styled SubmenuTrigger component (Layer 3).
+ *
+ * Wraps a `MenuItem` (trigger) and a nested `Menu` to form a parent→child
+ * submenu relationship. Automatically:
+ * - Appends a `ChevronRight` trailing icon to the trigger `MenuItem`
+ * - Wires `ArrowRight` / `ArrowLeft` keyboard navigation via RAC
+ * - Passes `aria-haspopup="menu"` and `aria-expanded` to the trigger item
+ *
+ * @example
+ * ```tsx
+ * <SubmenuTrigger>
+ *   <MenuItem id="share">Share</MenuItem>
+ *   <MenuTrigger.Menu aria-label="Share via">
+ *     <MenuItem id="email">Email</MenuItem>
+ *     <MenuItem id="sms">SMS</MenuItem>
+ *   </MenuTrigger.Menu>
+ * </SubmenuTrigger>
+ * ```
+ */
+export function SubmenuTrigger({ children, delay }: SubmenuTriggerProps): JSX.Element {
+  const childArray = Children.toArray(children);
+  const [triggerItem, submenuContent] = childArray as [ReactNode, ReactNode];
+
+  // Inject ChevronRight trailing icon into the trigger MenuItem.
+  // Omit trailingText by destructuring it out so we never pass undefined
+  // explicitly, satisfying exactOptionalPropertyTypes.
+  const enhancedTrigger = isValidElement<MenuItemProps>(triggerItem)
+    ? (() => {
+        const { trailingText: _omitted, ...rest } = triggerItem.props;
+        return cloneElement(triggerItem, {
+          ...rest,
+          trailingIcon: <ChevronRightIcon />,
+        } as Partial<MenuItemProps>);
+      })()
+    : triggerItem;
+
+  return (
+    // EOPT: only include delay when it has a definite value.
+    <HeadlessSubmenuTrigger {...(delay !== undefined ? { delay } : {})}>
+      {enhancedTrigger}
+      {submenuContent}
+    </HeadlessSubmenuTrigger>
+  );
+}

--- a/packages/react/src/components/Menu/index.ts
+++ b/packages/react/src/components/Menu/index.ts
@@ -1,44 +1,58 @@
-// Layer 3: MD3 Styled Components (most users use these)
+// ─── Layer 3: MD3 Styled Components (most users use these) ───────────────────
 export { MenuTrigger, Menu } from "./Menu";
 export { MenuItem } from "./MenuItem";
 export { MenuSection } from "./MenuSection";
 export { MenuDivider } from "./MenuDivider";
+export { MenuGap } from "./MenuGap";
+export { SubmenuTrigger } from "./SubmenuTrigger";
+export { ContextMenuTrigger } from "./ContextMenuTrigger";
 
-// Layer 2: Headless Primitives (for advanced customization)
+// ─── Layer 2: Headless Primitives (for advanced customization) ────────────────
 export {
   HeadlessMenuTrigger,
   HeadlessMenu,
   HeadlessMenuItem,
   HeadlessMenuSection,
   HeadlessMenuDivider,
+  HeadlessSubmenuTrigger,
+  HeadlessContextMenuTrigger,
   MenuContext,
   useMenuContext,
 } from "./MenuHeadless";
 
-// CVA Variants
+// ─── CVA Variants ─────────────────────────────────────────────────────────────
 export {
   menuContainerVariants,
   menuItemVariants,
   menuSectionVariants,
   menuSectionHeaderVariants,
   menuDividerVariants,
+  menuGapVariants,
   menuItemTrailingTextVariants,
+  menuItemDescriptionVariants,
   type MenuContainerVariants,
   type MenuItemVariants,
   type MenuSectionVariants,
 } from "./Menu.variants";
 
-// Types
+// ─── Types ────────────────────────────────────────────────────────────────────
 export type {
-  MenuVariant,
+  MenuColorScheme,
+  MenuStyle,
+  MenuDensity,
   MenuProps,
   MenuTriggerProps,
   MenuItemProps,
   MenuSectionProps,
   MenuDividerProps,
+  MenuGapProps,
+  SubmenuTriggerProps,
+  ContextMenuTriggerProps,
   HeadlessMenuProps,
   HeadlessMenuTriggerProps,
   HeadlessMenuItemProps,
   HeadlessMenuSectionProps,
+  HeadlessSubmenuTriggerProps,
+  HeadlessContextMenuTriggerProps,
   MenuContextValue,
 } from "./Menu.types";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -98,7 +98,7 @@ export {
   useMenuContext,
 } from "./Menu";
 export type {
-  MenuVariant,
+  MenuContainerVariants,
   MenuProps,
   MenuTriggerProps,
   MenuItemProps,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -148,7 +148,7 @@ export {
   useMenuContext,
 } from "./components/Menu";
 export type {
-  MenuVariant,
+  MenuContainerVariants,
   MenuProps,
   MenuTriggerProps,
   MenuItemProps,

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -21,6 +21,41 @@
 /* Progress Indicator — indeterminate keyframes */
 @import "./components/Progress/Progress.css";
 
+/* ==========================================================================
+   MENU ANIMATIONS
+   MD3 menu enter/exit keyframes — matched to Angular Material's implementation.
+   Enter: scale(0.8) + opacity → full, 120ms cubic-bezier(0, 0, 0.2, 1)
+   Exit:  opacity → 0, 100ms linear (25ms delay)
+   ========================================================================== */
+
+/**
+ * Menu enter: pop from 80% scale + transparent to full size + opaque.
+ * Transform-origin is set placement-aware via data-placement variants in CVA.
+ */
+@keyframes menu-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/**
+ * Menu exit: fade out only (no scale) — matches Angular Material's exit which
+ * only fades without reversing the scale.
+ */
+@keyframes menu-exit {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 /* TODO: Component-specific styles will be added here as we build components:
  * - State layers (hover, press, focus states)
  * - Ripple effects

--- a/packages/react/src/utils/cn.ts
+++ b/packages/react/src/utils/cn.ts
@@ -1,12 +1,57 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+/**
+ * Extended tailwind-merge that understands MD3 custom Tailwind v4 `@theme` utilities.
+ *
+ * By default, `tailwind-merge` treats ALL `text-*` classes as potentially
+ * conflicting. This causes issues with our custom MD3 tokens:
+ * - Typography scale: `text-body-large`, `text-label-medium`, etc. → font-size group
+ * - Color utilities:  `text-on-surface`, `text-primary`, etc.       → text-color group
+ *
+ * We register the typography-scale tokens so `twMerge` knows they live in the
+ * `font-size` group and do NOT conflict with `text-color` utilities.
+ */
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            // MD3 Display scale
+            "display-large",
+            "display-medium",
+            "display-small",
+            // MD3 Headline scale
+            "headline-large",
+            "headline-medium",
+            "headline-small",
+            // MD3 Title scale
+            "title-large",
+            "title-medium",
+            "title-small",
+            // MD3 Body scale
+            "body-large",
+            "body-medium",
+            "body-small",
+            // MD3 Label scale
+            "label-large",
+            "label-medium",
+            "label-small",
+          ],
+        },
+      ],
+    },
+  },
+});
 
 /**
  * Combines and merges Tailwind CSS classes efficiently.
  *
- * This utility uses:
- * - `clsx` for conditional class joining
- * - `tailwind-merge` to properly merge/deduplicate Tailwind classes
+ * Uses `clsx` for conditional joining + extended `tailwind-merge` that is
+ * aware of MD3 typography scale utilities (`text-body-large`, etc.) so they
+ * are not incorrectly removed when merged alongside color utilities
+ * (`text-on-surface`, `text-primary`, etc.).
  *
  * @example
  * ```tsx
@@ -14,10 +59,16 @@ import { twMerge } from "tailwind-merge";
  * // => 'px-2 py-1 bg-blue-500 text-white'
  * ```
  *
- * @example Merging conflicting classes
+ * @example Merging conflicting classes (later wins)
  * ```tsx
  * cn('px-2', 'px-4')
- * // => 'px-4' (later class wins)
+ * // => 'px-4'
+ * ```
+ *
+ * @example MD3 typography + color (both kept — no false conflict)
+ * ```tsx
+ * cn('text-body-large', 'text-on-surface')
+ * // => 'text-body-large text-on-surface'
  * ```
  */
 export function cn(...inputs: ClassValue[]): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@material/material-color-utilities':
         specifier: ^0.3.0
         version: 0.3.0
+      '@react-aria/collections':
+        specifier: ^3.0.1
+        version: 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/live-announcer':
         specifier: ^3.4.4
         version: 3.4.4


### PR DESCRIPTION
## Summary

Extends the Menu implementation with right-click/context entry via `ContextMenuTrigger`, nested menus via `SubmenuTrigger`, and spacing via `MenuGap`. Headless primitives and package exports are updated accordingly, along with Storybook coverage, tests, and shared styles.

## Release

- Adds a **minor** changeset for `@tinybigui/react` (linked versioning applies on the next release train).

## Review notes

- Target branch: `dev` (day-to-day feature flow per release strategy).
- Intended merge: **squash merge** when merging into `dev`.