### PR TITLE
chore: release v0.3.0

### DIFF
--- a/.changeset/menu-triggers-layout.md
+++ b/.changeset/menu-triggers-layout.md
@@ -1,0 +1,5 @@
+---
+"@tinybigui/react": minor
+---
+
+Add `ContextMenuTrigger`, `SubmenuTrigger`, and `MenuGap`; expand headless menu primitives and types; update menu styles and stories.

--- a/.changeset/menu-triggers-layout.md
+++ b/.changeset/menu-triggers-layout.md
@@ -1,5 +1,0 @@
----
-"@tinybigui/react": minor
----
-
-Add `ContextMenuTrigger`, `SubmenuTrigger`, and `MenuGap`; expand headless menu primitives and types; update menu styles and stories.

--- a/.changeset/snackbar-stack-and-motion.md
+++ b/.changeset/snackbar-stack-and-motion.md
@@ -1,0 +1,6 @@
+---
+"@tinybigui/react": minor
+"@tinybigui/tokens": patch
+---
+
+Add snackbar stacking with per-position queues and configurable `maxVisible` on `SnackbarProvider`; move layout positioning into the portal stack container; refine enter and exit animations; expose `--spacing-snackbar-max` in token CSS.

--- a/.changeset/snackbar-stack-and-motion.md
+++ b/.changeset/snackbar-stack-and-motion.md
@@ -1,6 +1,0 @@
----
-"@tinybigui/react": minor
-"@tinybigui/tokens": patch
----
-
-Add snackbar stacking with per-position queues and configurable `maxVisible` on `SnackbarProvider`; move layout positioning into the portal stack container; refine enter and exit animations; expose `--spacing-snackbar-max` in token CSS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-13
+
+### Added
+
+#### `@tinybigui/react`
+
+- **Progress** — MD3 Linear and Circular Progress Indicators; determinate and indeterminate modes; `role="progressbar"` with `aria-valuenow`/`min`/`max`; three-layer architecture (React Aria → Headless → Styled)
+- **Dialog** — MD3 Basic and Fullscreen dialog variants; composable `DialogHeadline`, `DialogContent`, and `DialogActions` slots; focus trap; Escape-to-dismiss; WCAG 2.1 AA via React Aria `useDialog`/`useOverlay`
+- **Snackbar** — MD3 Snackbar with `SnackbarProvider` and imperative `useSnackbar` hook; auto-dismiss timer with pause-on-hover/focus; action button support; multi-position placement; stacked queues with configurable `maxVisible`; WCAG 2.1 AA live-region accessibility
+- **Menu** — MD3 Menu with `MenuTrigger`, `Menu`, `MenuItem`, `MenuSection`, `MenuDivider`, `MenuGap`, `ContextMenuTrigger`, and `SubmenuTrigger`; full keyboard navigation (arrows, Home/End, Enter/Space, type-ahead); single and multi-select modes; WCAG 2.1 AA via React Aria collections
+
+#### `@tinybigui/tokens`
+
+- Snackbar spacing token (`--spacing-snackbar-max`) added to Tailwind `@theme`
+
 ## [0.2.0] - 2026-04-25
 
 ### Added
@@ -80,7 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Checkbox inline styles** — Replaced `style={{ fill: "var(--color-on-primary)" }}` with a Tailwind CSS class, eliminating the only inline style violation in the codebase
 - **Axe accessibility coverage** — Verified all 7 components pass automated axe checks; added axe test coverage across the test suite
 
-[Unreleased]: https://github.com/buildinclicks/tinybigui/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/buildinclicks/tinybigui/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/buildinclicks/tinybigui/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/buildinclicks/tinybigui/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/buildinclicks/tinybigui/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/buildinclicks/tinybigui/releases/tag/v0.1.0

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tinybigui/react
 
+## 0.3.0
+
+### Minor Changes
+
+- Add MD3 Dialog component with basic and fullscreen variants, composable `DialogHeadline`, `DialogContent`, and `DialogActions` slots, focus trap, Escape-to-dismiss, and WCAG 2.1 AA accessibility via React Aria `useDialog`/`useOverlay`.
+- Add MD3 Menu component with `MenuTrigger`, `Menu`, `MenuItem`, `MenuSection`, and `MenuDivider`; full keyboard navigation (arrows, Home/End, Enter/Space, type-ahead); single and multi-select modes; and WCAG 2.1 AA accessibility via React Aria collections.
+- 5f22cde: Add `ContextMenuTrigger`, `SubmenuTrigger`, and `MenuGap`; expand headless menu primitives and types; update menu styles and stories.
+- Add MD3 Progress Indicator component with linear and circular variants, determinate and indeterminate modes, full WCAG 2.1 AA accessibility via `role="progressbar"`, and three-layer architecture (React Aria → Headless → Styled).
+- Add MD3 Snackbar component with `SnackbarProvider`, imperative `useSnackbar` hook, auto-dismiss timer, pause-on-hover/focus, action button support, multi-position placement, and WCAG 2.1 AA live-region accessibility.
+- 7cfb578: Add snackbar stacking with per-position queues and configurable `maxVisible` on `SnackbarProvider`; move layout positioning into the portal stack container; refine enter and exit animations; expose `--spacing-snackbar-max` in token CSS.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Material Design 3 React components built with Tailwind CSS",
   "keywords": [
     "react",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@material/material-color-utilities": "^0.3.0",
+    "@react-aria/collections": "^3.0.1",
     "@react-aria/live-announcer": "^3.4.4",
     "@react-aria/utils": "^3.32.0",
     "class-variance-authority": "^0.7.1",

--- a/packages/react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/Dialog/Dialog.stories.tsx
@@ -1,0 +1,351 @@
+import { useState, type JSX } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Dialog } from "./Dialog";
+import { DialogHeadline } from "./DialogHeadline";
+import { DialogContent } from "./DialogContent";
+import { DialogActions } from "./DialogActions";
+import { DialogHeadless } from "./DialogHeadless";
+import { Button } from "../Button";
+import { IconButton } from "../IconButton";
+
+// ─── Inline SVG Icons ─────────────────────────────────────────────────────────
+
+const CloseIcon = (): JSX.Element => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+  </svg>
+);
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Material Design 3 Dialog component.
+ *
+ * Dialogs provide important prompts in a user flow. They can require an action,
+ * communicate information, or help users accomplish a task.
+ *
+ * ## Variants
+ *
+ * - **Basic** (default): A floating card dialog with headline, body text, and
+ *   action buttons. Supports scale + fade entry animation. Closes on scrim
+ *   click or Escape key. Min 280dp, max 560dp width.
+ *
+ * - **Full-screen**: Full viewport overlay suited for mobile and complex forms.
+ *   Replaces the headline with a top app bar row (close icon button + confirm
+ *   action). Slide-up entry animation. Does NOT close on scrim click.
+ *
+ * ## Accessibility
+ *
+ * - `role="dialog"` + `aria-modal="true"` (React Aria `useDialog`)
+ * - `aria-labelledby` → `DialogHeadline` id
+ * - `aria-describedby` → `DialogContent` id
+ * - Focus trap while open (`FocusScope`)
+ * - Focus restores to trigger on close
+ * - Body scroll locked while open (`usePreventScroll`)
+ * - Escape key always closes
+ *
+ * @see https://m3.material.io/components/dialogs/overview
+ */
+const meta: Meta<typeof Dialog> = {
+  title: "Feedback/Dialog",
+  component: Dialog,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Material Design 3 Dialog — provides important prompts requiring user action. Supports Basic and Full-screen variants with composable slot-based API.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["basic", "fullscreen"],
+      description: "Structural variant — Basic (floating card) or Full-screen (full viewport).",
+    },
+    open: {
+      control: "boolean",
+      description: "Controlled open state.",
+    },
+    defaultOpen: {
+      control: "boolean",
+      description: "Default open state for uncontrolled usage.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+// ─── Basic ────────────────────────────────────────────────────────────────────
+
+const BasicDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button variant="filled" onPress={() => setOpen(true)}>
+        Open dialog
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogHeadline>Permanently delete?</DialogHeadline>
+        <DialogContent>
+          Deleting the selected messages will also remove them from all your devices.
+        </DialogContent>
+        <DialogActions>
+          <Button variant="text" onPress={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="filled" onPress={() => setOpen(false)}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+/**
+ * The Basic dialog presents a simple prompt with a headline, body text, and
+ * two action buttons. The primary action uses `variant="filled"` and the
+ * secondary uses `variant="text"` per MD3 spec.
+ */
+export const Basic: Story = {
+  render: () => <BasicDemo />,
+};
+
+// ─── Scrollable content ───────────────────────────────────────────────────────
+
+const ScrollableContentDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button variant="filled" onPress={() => setOpen(true)}>
+        Open scrollable dialog
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogHeadline>Terms of service</DialogHeadline>
+        <DialogContent>
+          <p>
+            By using this service, you agree to these terms. Read them carefully. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua.
+          </p>
+          <p className="mt-4">
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+            commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+            dolore eu fugiat nulla pariatur.
+          </p>
+          <p className="mt-4">
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+            mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit
+            voluptatem accusantium doloremque.
+          </p>
+          <p className="mt-4">
+            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia
+            consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
+          </p>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="text" onPress={() => setOpen(false)}>
+            Decline
+          </Button>
+          <Button variant="filled" onPress={() => setOpen(false)}>
+            Accept
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates the scrollable body content behavior when content exceeds
+ * the available height.
+ */
+export const ScrollableContent: Story = {
+  render: () => <ScrollableContentDemo />,
+};
+
+// ─── Confirmation ─────────────────────────────────────────────────────────────
+
+const ConfirmationDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  const handleConfirm = (): void => {
+    setConfirmed(true);
+    setOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-8">
+      <Button variant="filled" onPress={() => setOpen(true)}>
+        Delete account
+      </Button>
+      {confirmed && <p className="text-body-medium text-on-surface-variant">Account deleted.</p>}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogHeadline>Delete account?</DialogHeadline>
+        <DialogContent>
+          Your account and all associated data will be permanently deleted. This action cannot be
+          undone.
+        </DialogContent>
+        <DialogActions>
+          <Button variant="text" onPress={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="filled" onPress={handleConfirm}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+/**
+ * A destructive action confirmation dialog. The primary action uses a
+ * standard filled button (MD3 does not use an error-colored button in dialogs).
+ */
+export const Confirmation: Story = {
+  render: () => <ConfirmationDemo />,
+};
+
+// ─── Full-screen ───────────────────────────────────────────────────────────────
+
+const FullscreenDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button variant="filled" onPress={() => setOpen(true)}>
+        Open full-screen dialog
+      </Button>
+      <Dialog variant="fullscreen" open={open} onOpenChange={setOpen}>
+        <DialogHeadline
+          closeButton={
+            <IconButton variant="standard" aria-label="Close" onPress={() => setOpen(false)}>
+              <CloseIcon />
+            </IconButton>
+          }
+          confirmButton={
+            <Button variant="text" onPress={() => setOpen(false)}>
+              Save
+            </Button>
+          }
+        >
+          New event
+        </DialogHeadline>
+        <DialogContent>
+          <div className="flex flex-col gap-4">
+            <p className="text-body-medium text-on-surface-variant">
+              Fill in the details for your new event. Use the Save button in the top bar to confirm,
+              or the close icon to discard changes.
+            </p>
+            <label className="flex flex-col gap-1">
+              <span className="text-label-medium text-on-surface">Event name</span>
+              <input
+                type="text"
+                placeholder="My event"
+                className="border-outline text-body-medium text-on-surface bg-surface-container focus:border-primary rounded-md border px-3 py-2 outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-label-medium text-on-surface">Description</span>
+              <textarea
+                rows={4}
+                placeholder="Add a description..."
+                className="border-outline text-body-medium text-on-surface bg-surface-container focus:border-primary resize-none rounded-md border px-3 py-2 outline-none"
+              />
+            </label>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+/**
+ * The Full-screen dialog covers the entire viewport and is suited for mobile
+ * layouts or complex form flows. The headline is replaced with a top app bar
+ * row containing a close icon button and a confirm action.
+ *
+ * Per MD3 spec, the Full-screen dialog does NOT close on scrim click —
+ * only via the close button or Escape key.
+ */
+export const Fullscreen: Story = {
+  render: () => <FullscreenDemo />,
+};
+
+// ─── Uncontrolled ─────────────────────────────────────────────────────────────
+
+/**
+ * Demonstrates the uncontrolled pattern using `defaultOpen`. Useful in
+ * simple scenarios where the dialog state does not need to be lifted up.
+ */
+export const Uncontrolled: Story = {
+  render: () => (
+    <div className="flex items-center justify-center p-8">
+      <Dialog defaultOpen>
+        <DialogHeadline>Uncontrolled dialog</DialogHeadline>
+        <DialogContent>
+          This dialog opens immediately without controlled state. Dismiss it by pressing Escape or
+          clicking the scrim.
+        </DialogContent>
+        <DialogActions>
+          <Button variant="filled">Got it</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  ),
+};
+
+// ─── Headless (advanced customization) ────────────────────────────────────────
+
+const HeadlessDemo = (): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex items-center justify-center p-8">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="bg-secondary text-on-secondary text-label-large rounded-md px-4 py-2"
+      >
+        Open headless dialog
+      </button>
+      <DialogHeadless
+        open={open}
+        onOpenChange={setOpen}
+        aria-label="Custom headless dialog"
+        className="bg-surface-container-high shadow-elevation-3 w-full max-w-md rounded-2xl p-8"
+        scrimClassName="fixed inset-0 z-40 bg-scrim opacity-32"
+      >
+        <DialogHeadline>Custom styled dialog</DialogHeadline>
+        <DialogContent>
+          This dialog uses `DialogHeadless` for fully custom styling while retaining all React Aria
+          behavior and WCAG 2.1 AA compliance.
+        </DialogContent>
+        <DialogActions>
+          <Button variant="text" onPress={() => setOpen(false)}>
+            Close
+          </Button>
+        </DialogActions>
+      </DialogHeadless>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates the headless primitive for fully custom styling while
+ * retaining all MD3 behavior and accessibility semantics.
+ */
+export const Headless: Story = {
+  render: () => <HeadlessDemo />,
+};

--- a/packages/react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react/src/components/Dialog/Dialog.test.tsx
@@ -1,0 +1,519 @@
+import { useState, type ComponentProps } from "react";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { Dialog } from "./Dialog";
+import { DialogHeadline } from "./DialogHeadline";
+import { DialogContent } from "./DialogContent";
+import { DialogActions } from "./DialogActions";
+import { DialogHeadless } from "./DialogHeadless";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderBasicDialog(props: Partial<ComponentProps<typeof Dialog>> = {}) {
+  return render(
+    <Dialog open aria-label="Test dialog" {...props}>
+      <DialogHeadline>Dialog headline</DialogHeadline>
+      <DialogContent>Dialog body content.</DialogContent>
+      <DialogActions>
+        <button type="button">Cancel</button>
+        <button type="button">Confirm</button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+function renderFullscreenDialog(props: Partial<ComponentProps<typeof Dialog>> = {}) {
+  return render(
+    <Dialog variant="fullscreen" open aria-label="Fullscreen dialog" {...props}>
+      <DialogHeadline>Fullscreen headline</DialogHeadline>
+      <DialogContent>Fullscreen body content.</DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Controlled dialog wrapper for open/close interaction tests.
+ */
+function ControlledDialog({
+  onOpenChange,
+  variant,
+}: {
+  onOpenChange?: (open: boolean) => void;
+  variant?: "basic" | "fullscreen";
+}) {
+  const [open, setOpen] = useState(false);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open dialog
+      </button>
+      <Dialog variant={variant} open={open} onOpenChange={handleOpenChange}>
+        <DialogHeadline>Controlled dialog</DialogHeadline>
+        <DialogContent>Controlled content.</DialogContent>
+        <DialogActions>
+          <button type="button" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </button>
+          <button type="button" onClick={() => handleOpenChange(false)}>
+            Confirm
+          </button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+// ─── Advance animation timers ─────────────────────────────────────────────────
+
+function advanceToVisible(): void {
+  act(() => {
+    vi.advanceTimersByTime(0);
+  });
+}
+
+// ─── Dialog (Basic variant) ───────────────────────────────────────────────────
+
+describe("Dialog", () => {
+  // ── Rendering ───────────────────────────────────────────────────────────────
+
+  describe("Rendering", () => {
+    test("renders when open is true", () => {
+      renderBasicDialog({ open: true });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("does not render when open is false", () => {
+      renderBasicDialog({ open: false });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    test("renders headline content", () => {
+      renderBasicDialog();
+      expect(screen.getByText("Dialog headline")).toBeInTheDocument();
+    });
+
+    test("renders body content", () => {
+      renderBasicDialog();
+      expect(screen.getByText("Dialog body content.")).toBeInTheDocument();
+    });
+
+    test("renders action buttons", () => {
+      renderBasicDialog();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    });
+
+    test("defaults to basic variant", () => {
+      renderBasicDialog();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toBeInTheDocument();
+    });
+
+    test("renders scrim overlay when open", () => {
+      renderBasicDialog({ open: true });
+      expect(screen.getByTestId("dialog-scrim")).toBeInTheDocument();
+    });
+
+    test("does not render scrim when closed", () => {
+      renderBasicDialog({ open: false });
+      expect(screen.queryByTestId("dialog-scrim")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── ARIA / Accessibility ─────────────────────────────────────────────────────
+
+  describe("Accessibility", () => {
+    test("has role dialog", () => {
+      renderBasicDialog();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("has aria-modal true", () => {
+      renderBasicDialog();
+      expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+    });
+
+    test("aria-labelledby points to headline id", () => {
+      renderBasicDialog();
+      const dialog = screen.getByRole("dialog");
+      const labelledById = dialog.getAttribute("aria-labelledby");
+      expect(labelledById).toBeTruthy();
+      const headline = document.getElementById(labelledById!);
+      expect(headline).toBeInTheDocument();
+      expect(headline?.textContent).toBe("Dialog headline");
+    });
+
+    test("aria-describedby points to content id", () => {
+      renderBasicDialog();
+      const dialog = screen.getByRole("dialog");
+      const describedById = dialog.getAttribute("aria-describedby");
+      expect(describedById).toBeTruthy();
+      const content = document.getElementById(describedById!);
+      expect(content).toBeInTheDocument();
+      expect(content?.textContent).toBe("Dialog body content.");
+    });
+
+    test("passes axe accessibility audit (basic)", async () => {
+      const { container } = renderBasicDialog();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("passes axe accessibility audit (fullscreen)", async () => {
+      const { container } = renderFullscreenDialog();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("headline renders as h2", () => {
+      renderBasicDialog();
+      const headline = screen.getByRole("heading", { level: 2 });
+      expect(headline).toBeInTheDocument();
+      expect(headline.textContent).toBe("Dialog headline");
+    });
+  });
+
+  // ── Open/Close behavior ──────────────────────────────────────────────────────
+
+  describe("Open/Close behavior", () => {
+    test("controlled: renders when open prop is true", () => {
+      render(
+        <Dialog open onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("controlled: hides when open prop becomes false after exit animation", () => {
+      vi.useFakeTimers();
+      const { rerender } = render(
+        <Dialog open onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+      // Advance to visible state
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+      rerender(
+        <Dialog open={false} onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+      // Advance past exit animation fallback (150ms)
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      vi.useRealTimers();
+    });
+
+    test("uncontrolled: shows dialog when defaultOpen is true", () => {
+      render(
+        <Dialog defaultOpen>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("onOpenChange is called with false when dialog is dismissed", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(<ControlledDialog onOpenChange={onOpenChange} />);
+
+      await user.click(screen.getByRole("button", { name: "Open dialog" }));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // ── Keyboard interactions ────────────────────────────────────────────────────
+
+  describe("Keyboard interactions", () => {
+    test("Escape key closes the basic dialog", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog open onOpenChange={onOpenChange}>
+          <DialogContent>Content</DialogContent>
+          <DialogActions>
+            <button type="button">Cancel</button>
+          </DialogActions>
+        </Dialog>
+      );
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      await user.keyboard("{Escape}");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    test("Escape key closes the fullscreen dialog", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog variant="fullscreen" open onOpenChange={onOpenChange}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      await user.keyboard("{Escape}");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // ── Scrim behavior ───────────────────────────────────────────────────────────
+
+  describe("Scrim behavior", () => {
+    test("clicking scrim closes basic dialog", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog open onOpenChange={onOpenChange}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+
+      const scrim = screen.getByTestId("dialog-scrim");
+      await user.click(scrim);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    test("clicking scrim does NOT close fullscreen dialog", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog variant="fullscreen" open onOpenChange={onOpenChange}>
+          <DialogContent>Content</DialogContent>
+        </Dialog>
+      );
+
+      const scrim = screen.getByTestId("dialog-scrim");
+      await user.click(scrim);
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Focus management ─────────────────────────────────────────────────────────
+
+  describe("Focus management", () => {
+    test("focus moves into dialog when opened", async () => {
+      const user = userEvent.setup();
+
+      render(<ControlledDialog />);
+
+      await user.click(screen.getByRole("button", { name: "Open dialog" }));
+
+      await waitFor(() => {
+        const dialog = screen.getByRole("dialog");
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
+    });
+
+    test("focus is trapped within dialog (Tab stays inside)", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Dialog open onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+          <DialogActions>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+          </DialogActions>
+        </Dialog>
+      );
+
+      const dialog = screen.getByRole("dialog");
+      const buttons = screen.getAllByRole("button");
+
+      // Tab through all buttons — focus should stay within dialog
+      for (const _btn of buttons) {
+        await user.tab();
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      }
+    });
+  });
+
+  // ── Action button callbacks ──────────────────────────────────────────────────
+
+  describe("Action button callbacks", () => {
+    test("action button press fires callback", async () => {
+      const handleConfirm = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Dialog open onOpenChange={vi.fn()}>
+          <DialogContent>Content</DialogContent>
+          <DialogActions>
+            <button type="button" onClick={handleConfirm}>
+              Confirm
+            </button>
+          </DialogActions>
+        </Dialog>
+      );
+
+      await user.click(screen.getByRole("button", { name: "Confirm" }));
+      expect(handleConfirm).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── Variant rendering ────────────────────────────────────────────────────────
+
+  describe("Variant rendering", () => {
+    test("basic variant renders dialog with correct data-variant", () => {
+      renderBasicDialog();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.closest("[data-variant='basic']")).toBeInTheDocument();
+    });
+
+    test("fullscreen variant renders dialog with correct data-variant", () => {
+      renderFullscreenDialog();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.closest("[data-variant='fullscreen']")).toBeInTheDocument();
+    });
+  });
+
+  // ── Animation states ─────────────────────────────────────────────────────────
+
+  describe("Animation states", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("dialog panel starts in entering state on mount", () => {
+      renderBasicDialog({ open: true });
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveAttribute("data-animation-state", "entering");
+    });
+
+    test("dialog panel transitions to visible after zero-delay timer", () => {
+      renderBasicDialog({ open: true });
+      advanceToVisible();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveAttribute("data-animation-state", "visible");
+    });
+  });
+
+  // ── Custom className ─────────────────────────────────────────────────────────
+
+  describe("Custom className", () => {
+    test("className is merged onto dialog panel", () => {
+      renderBasicDialog({ className: "custom-test-class" });
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveClass("custom-test-class");
+    });
+  });
+});
+
+// ─── DialogHeadless (Layer 2) ─────────────────────────────────────────────────
+
+describe("DialogHeadless", () => {
+  test("renders children when open", () => {
+    render(
+      <DialogHeadless open aria-label="Headless dialog">
+        <div>Headless content</div>
+      </DialogHeadless>
+    );
+    expect(screen.getByText("Headless content")).toBeInTheDocument();
+  });
+
+  test("does not render when closed", () => {
+    render(
+      <DialogHeadless open={false} aria-label="Headless dialog">
+        <div>Headless content</div>
+      </DialogHeadless>
+    );
+    expect(screen.queryByText("Headless content")).not.toBeInTheDocument();
+  });
+
+  test("has role dialog with aria-modal", () => {
+    render(
+      <DialogHeadless open aria-label="Headless dialog">
+        <div>Content</div>
+      </DialogHeadless>
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+});
+
+// ─── Sub-components standalone ────────────────────────────────────────────────
+
+describe("DialogHeadline", () => {
+  test("renders headline text", () => {
+    render(
+      <Dialog open>
+        <DialogHeadline>My Headline</DialogHeadline>
+      </Dialog>
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("My Headline");
+  });
+
+  test("headline has a stable id attribute", () => {
+    render(
+      <Dialog open>
+        <DialogHeadline>Headline</DialogHeadline>
+      </Dialog>
+    );
+    const headline = screen.getByRole("heading", { level: 2 });
+    expect(headline.id).toBeTruthy();
+  });
+});
+
+describe("DialogContent", () => {
+  test("renders content text", () => {
+    render(
+      <Dialog open>
+        <DialogContent>My content text</DialogContent>
+      </Dialog>
+    );
+    expect(screen.getByText("My content text")).toBeInTheDocument();
+  });
+
+  test("content has a stable id attribute", () => {
+    render(
+      <Dialog open>
+        <DialogContent>Content</DialogContent>
+      </Dialog>
+    );
+    const content = screen.getByText("Content");
+    expect(content.id).toBeTruthy();
+  });
+});
+
+describe("DialogActions", () => {
+  test("renders action children", () => {
+    render(
+      <Dialog open>
+        <DialogActions>
+          <button type="button">Action</button>
+        </DialogActions>
+      </Dialog>
+    );
+    expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import { DialogHeadless } from "./DialogHeadless";
+import {
+  dialogPanelVariants,
+  dialogScrimVariants,
+  dialogAnimationVariants,
+} from "./Dialog.variants";
+import type { DialogAnimationState } from "./Dialog.types";
+import type { DialogProps } from "./Dialog.types";
+
+/**
+ * `Dialog` — Layer 3 MD3 Styled Dialog Component.
+ *
+ * Supports two structural variants per MD3 spec, with a composable slot-based
+ * API via `DialogHeadline`, `DialogContent`, and `DialogActions`:
+ *
+ * **Basic** (default):
+ * - Floating card: `bg-surface-container-high`, `rounded-xl`, `shadow-elevation-3`
+ * - Centered in viewport (min 280dp, max 560dp width)
+ * - Scale + fade entry animation (`duration-medium4 / ease-emphasized-decelerate`)
+ * - Fade exit animation (`duration-short2 / ease-emphasized-accelerate`)
+ * - Closes on scrim click or Escape key
+ *
+ * **Full-screen**:
+ * - Full viewport coverage — suited for mobile and complex forms
+ * - No rounded corners, no elevation shadow
+ * - Slide-up entry / slide-down exit animation
+ * - Does NOT close on scrim click per MD3 spec (only via Escape or close button)
+ * - Headline replaced by top app bar row (close icon + confirm action)
+ *
+ * Both variants:
+ * - `role="dialog"` + `aria-modal="true"` (React Aria `useDialog`)
+ * - `aria-labelledby` pointing to `DialogHeadline` id
+ * - `aria-describedby` pointing to `DialogContent` id
+ * - Focus trap active while open (`FocusScope`)
+ * - Focus returns to trigger element on close (`FocusScope restoreFocus`)
+ * - Body scroll locked while open (`usePreventScroll`)
+ * - Escape key always closes the dialog
+ * - Portal rendered to `document.body`
+ *
+ * @example
+ * ```tsx
+ * // Basic dialog — controlled
+ * function DeleteDialog() {
+ *   const [open, setOpen] = useState(false);
+ *
+ *   return (
+ *     <>
+ *       <Button onPress={() => setOpen(true)}>Delete file</Button>
+ *       <Dialog open={open} onOpenChange={setOpen}>
+ *         <DialogHeadline>Permanently delete?</DialogHeadline>
+ *         <DialogContent>
+ *           This action cannot be undone. The file and all associated data
+ *           will be permanently removed.
+ *         </DialogContent>
+ *         <DialogActions>
+ *           <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *           <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *         </DialogActions>
+ *       </Dialog>
+ *     </>
+ *   );
+ * }
+ *
+ * // Full-screen dialog — mobile form flow
+ * function NewEventDialog() {
+ *   const [open, setOpen] = useState(false);
+ *
+ *   return (
+ *     <>
+ *       <Button onPress={() => setOpen(true)}>New event</Button>
+ *       <Dialog variant="fullscreen" open={open} onOpenChange={setOpen}>
+ *         <DialogHeadline
+ *           closeButton={
+ *             <IconButton aria-label="Close" onPress={() => setOpen(false)}>
+ *               <CloseIcon />
+ *             </IconButton>
+ *           }
+ *           confirmButton={
+ *             <Button variant="text" onPress={handleSave}>Save</Button>
+ *           }
+ *         >
+ *           New event
+ *         </DialogHeadline>
+ *         <DialogContent>
+ *           <TextField label="Event name" />
+ *           <TextField label="Date" type="date" />
+ *         </DialogContent>
+ *       </Dialog>
+ *     </>
+ *   );
+ * }
+ * ```
+ *
+ * @see https://m3.material.io/components/dialogs/overview
+ * @see https://m3.material.io/components/dialogs/specs
+ */
+export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
+  {
+    variant = "basic",
+    open,
+    defaultOpen = false,
+    onOpenChange,
+    "aria-label": ariaLabel,
+    children,
+    className,
+  },
+  _ref
+) {
+  // Build panel class: structural + visual styles from CVA
+  const panelClassName = cn(dialogPanelVariants({ variant }), className);
+
+  // Scrim class shared between variants
+  const scrimClass = dialogScrimVariants();
+
+  return (
+    <DialogHeadless
+      variant={variant}
+      {...(open !== undefined ? { open } : {})}
+      {...(defaultOpen !== undefined ? { defaultOpen } : {})}
+      {...(onOpenChange !== undefined ? { onOpenChange } : {})}
+      {...(ariaLabel ? { "aria-label": ariaLabel } : {})}
+      className={panelClassName}
+      scrimClassName={scrimClass}
+      getAnimationClassName={(state: DialogAnimationState) =>
+        dialogAnimationVariants({ animationState: state, variant })
+      }
+    >
+      {children}
+    </DialogHeadless>
+  );
+});
+
+Dialog.displayName = "Dialog";

--- a/packages/react/src/components/Dialog/Dialog.types.ts
+++ b/packages/react/src/components/Dialog/Dialog.types.ts
@@ -1,0 +1,320 @@
+import type { ReactNode } from "react";
+
+// ─── Variant ──────────────────────────────────────────────────────────────────
+
+/**
+ * Structural variant of the MD3 Dialog.
+ *
+ * - `basic` — Floating dialog with headline, body, and action buttons.
+ *   Supports scale + fade entry animation. Closes on scrim click or Escape.
+ *   Max width 560dp per MD3 spec.
+ *
+ * - `fullscreen` — Full viewport overlay suited for mobile and complex forms.
+ *   Replaces headline with a top app bar row (close icon + confirm action).
+ *   Slide-up entry animation. Does NOT close on scrim click per MD3 spec.
+ *
+ * @default 'basic'
+ */
+export type DialogVariant = "basic" | "fullscreen";
+
+// ─── Animation ────────────────────────────────────────────────────────────────
+
+/**
+ * Internal animation state machine for the Dialog.
+ *
+ * - `entering` — initial mount state before transition fires
+ * - `visible`  — fully shown, entry animation complete
+ * - `exiting`  — exit animation in progress
+ * - `exited`   — removed from DOM
+ */
+export type DialogAnimationState = "entering" | "visible" | "exiting" | "exited";
+
+// ─── DialogContextValue ───────────────────────────────────────────────────────
+
+/**
+ * Internal context shared between `DialogHeadless` and its slot sub-components
+ * (`DialogHeadline`, `DialogContent`, `DialogActions`).
+ *
+ * Coordinates auto-generated `id` values for `aria-labelledby` and
+ * `aria-describedby`, exposes the close callback, and propagates the variant.
+ *
+ * @internal
+ */
+export interface DialogContextValue {
+  /** Stable id for the headline element — used as `aria-labelledby` on the dialog panel. */
+  headlineId: string;
+  /** Stable id for the content element — used as `aria-describedby` on the dialog panel. */
+  contentId: string;
+  /** Callback to programmatically close the dialog (triggers exit animation). */
+  close: () => void;
+  /** Current structural variant, propagated to sub-components for variant-specific rendering. */
+  variant: DialogVariant;
+}
+
+// ─── DialogHeadlessProps ──────────────────────────────────────────────────────
+
+/**
+ * Props for the headless `DialogHeadless` primitive (Layer 2).
+ *
+ * Provides all Dialog behavior (ARIA roles, focus trap, scroll lock,
+ * portal rendering, animation state machine, open/close state) without
+ * any visual styling.
+ *
+ * @example
+ * ```tsx
+ * <DialogHeadless
+ *   variant="basic"
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   aria-label="Confirm action"
+ *   className="bg-surface-container-high rounded-xl shadow-elevation-3"
+ *   scrimClassName="fixed inset-0 z-40 bg-scrim opacity-32"
+ * >
+ *   <DialogHeadline>Confirm deletion?</DialogHeadline>
+ *   <DialogContent>This action cannot be undone.</DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *   </DialogActions>
+ * </DialogHeadless>
+ * ```
+ */
+export interface DialogHeadlessProps {
+  /**
+   * Structural variant — controls animation, scrim dismissal, and DOM structure.
+   * @default 'basic'
+   */
+  variant?: DialogVariant;
+
+  /**
+   * Controlled open state. Pair with `onOpenChange`.
+   */
+  open?: boolean;
+
+  /**
+   * Default open state for uncontrolled usage.
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Called when the open state changes (e.g. Escape key, scrim click, close button).
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Accessible label for the dialog. Used when no `DialogHeadline` is provided.
+   * When `DialogHeadline` is present, `aria-labelledby` is preferred automatically.
+   */
+  "aria-label"?: string;
+
+  /**
+   * Dialog slot content — typically `DialogHeadline`, `DialogContent`, `DialogActions`.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes applied to the dialog panel element.
+   */
+  className?: string;
+
+  /**
+   * Additional CSS classes applied to the scrim overlay element.
+   */
+  scrimClassName?: string;
+
+  /**
+   * Additional CSS classes injected based on the current animation state.
+   * Called at render time to merge CVA animation classes onto the panel.
+   *
+   * @example
+   * ```tsx
+   * getAnimationClassName={(state) => dialogAnimationVariants({ animationState: state, variant })}
+   * ```
+   */
+  getAnimationClassName?: (state: DialogAnimationState) => string;
+}
+
+// ─── DialogProps ──────────────────────────────────────────────────────────────
+
+/**
+ * Props for the MD3 Styled `Dialog` component (Layer 3).
+ *
+ * Supports two structural variants — Basic (floating dialog) and Full-screen
+ * (full viewport overlay for mobile / complex forms) — with a composable
+ * slot-based API via `DialogHeadline`, `DialogContent`, and `DialogActions`.
+ *
+ * Supports both controlled (`open` + `onOpenChange`) and uncontrolled
+ * (`defaultOpen`) usage patterns.
+ *
+ * @example
+ * ```tsx
+ * // Basic dialog (controlled)
+ * <Dialog open={open} onOpenChange={setOpen}>
+ *   <DialogHeadline>Delete file?</DialogHeadline>
+ *   <DialogContent>This action cannot be undone.</DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *   </DialogActions>
+ * </Dialog>
+ *
+ * // Full-screen dialog (controlled)
+ * <Dialog variant="fullscreen" open={open} onOpenChange={setOpen}>
+ *   <DialogHeadline
+ *     closeButton={<IconButton aria-label="Close" onPress={() => setOpen(false)}><CloseIcon /></IconButton>}
+ *     confirmButton={<Button variant="text" onPress={handleSave}>Save</Button>}
+ *   >
+ *     New event
+ *   </DialogHeadline>
+ *   <DialogContent>
+ *     <TextField label="Event name" />
+ *   </DialogContent>
+ * </Dialog>
+ * ```
+ */
+export interface DialogProps {
+  /**
+   * Structural variant — `basic` (default) or `fullscreen`.
+   * @default 'basic'
+   */
+  variant?: DialogVariant;
+
+  /**
+   * Controlled open state. Pair with `onOpenChange`.
+   */
+  open?: boolean;
+
+  /**
+   * Default open state for uncontrolled usage.
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Called when the open state changes.
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Accessible label for the dialog when no `DialogHeadline` is present.
+   */
+  "aria-label"?: string;
+
+  /**
+   * Dialog slot content — `DialogHeadline`, `DialogContent`, `DialogActions`.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes merged onto the dialog panel element.
+   */
+  className?: string;
+}
+
+// ─── DialogHeadlineProps ──────────────────────────────────────────────────────
+
+/**
+ * Props for the `DialogHeadline` slot sub-component.
+ *
+ * Renders as an `<h2>` element and provides its `id` to `DialogContext`
+ * so the parent dialog panel can reference it via `aria-labelledby`.
+ *
+ * For the `fullscreen` variant, accepts optional `closeButton` and
+ * `confirmButton` slots that are rendered in the top app bar row per MD3 spec.
+ *
+ * @example
+ * ```tsx
+ * // Basic variant
+ * <DialogHeadline>Confirm deletion?</DialogHeadline>
+ *
+ * // Full-screen variant
+ * <DialogHeadline
+ *   closeButton={<IconButton aria-label="Close" onPress={onClose}><CloseIcon /></IconButton>}
+ *   confirmButton={<Button variant="text" onPress={onSave}>Save</Button>}
+ * >
+ *   New event
+ * </DialogHeadline>
+ * ```
+ */
+export interface DialogHeadlineProps {
+  /**
+   * Headline text content.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes merged onto the headline element.
+   */
+  className?: string;
+
+  /**
+   * Close icon button slot — rendered leading in the top app bar row
+   * for the `fullscreen` variant only.
+   */
+  closeButton?: ReactNode;
+
+  /**
+   * Confirm action slot — rendered trailing in the top app bar row
+   * for the `fullscreen` variant only.
+   */
+  confirmButton?: ReactNode;
+}
+
+// ─── DialogContentProps ───────────────────────────────────────────────────────
+
+/**
+ * Props for the `DialogContent` slot sub-component.
+ *
+ * Renders as a scrollable `<div>` and provides its `id` to `DialogContext`
+ * so the parent dialog panel can reference it via `aria-describedby`.
+ *
+ * @example
+ * ```tsx
+ * <DialogContent>
+ *   <p>This action cannot be undone. All associated data will be permanently removed.</p>
+ * </DialogContent>
+ * ```
+ */
+export interface DialogContentProps {
+  /**
+   * Body content — can be any React node.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes merged onto the content element.
+   */
+  className?: string;
+}
+
+// ─── DialogActionsProps ───────────────────────────────────────────────────────
+
+/**
+ * Props for the `DialogActions` slot sub-component.
+ *
+ * Renders a right-aligned flex row of action buttons per MD3 spec.
+ * Typically contains `Button` components with `variant="text"` (secondary)
+ * and `variant="filled"` (primary action).
+ *
+ * Not used in the `fullscreen` variant (confirm action is in the headline row).
+ *
+ * @example
+ * ```tsx
+ * <DialogActions>
+ *   <Button variant="text" onPress={onCancel}>Cancel</Button>
+ *   <Button variant="filled" onPress={onConfirm}>Confirm</Button>
+ * </DialogActions>
+ * ```
+ */
+export interface DialogActionsProps {
+  /**
+   * Action button elements — typically `Button` components.
+   */
+  children: ReactNode;
+
+  /**
+   * Additional CSS classes merged onto the actions container.
+   */
+  className?: string;
+}

--- a/packages/react/src/components/Dialog/Dialog.variants.ts
+++ b/packages/react/src/components/Dialog/Dialog.variants.ts
@@ -1,0 +1,287 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Dialog Variants (CVA)
+ *
+ * Type-safe variant management using Tailwind CSS classes mapped to MD3 tokens.
+ *
+ * MD3 Specifications:
+ * - Basic surface: surface-container-high
+ * - Elevation: level-3 → shadow-elevation-3
+ * - Shape (Basic): extra-large (28dp) → rounded-xl
+ * - Min width (Basic): 280dp → min-w-70
+ * - Max width (Basic): 560dp → max-w-dialog
+ * - Scrim: bg-scrim at opacity-32
+ * - Headline: text-headline-small, text-on-surface
+ * - Body: text-body-medium, text-on-surface-variant
+ * - Action row: right-aligned, gap-2
+ * - Entry motion (Basic): scale + fade, medium4 (400ms) + ease-emphasized-decelerate
+ * - Exit motion (Basic): fade, short2 (100ms) + ease-emphasized-accelerate
+ * - Entry motion (Fullscreen): slide-up, medium4 (400ms) + ease-emphasized-decelerate
+ * - Exit motion (Fullscreen): slide-down, short2 (100ms) + ease-emphasized-accelerate
+ */
+
+// ─── Scrim overlay ─────────────────────────────────────────────────────────────
+
+/**
+ * Scrim overlay variants — matches MD3 spec and Drawer scrim pattern.
+ * Full-screen variant uses the same scrim but onClick is a no-op.
+ */
+export const dialogScrimVariants = cva([
+  "fixed",
+  "inset-0",
+  "z-40",
+  "bg-scrim",
+  "opacity-32",
+  "transition-opacity",
+  "duration-medium2",
+  "ease-standard",
+]);
+
+export type DialogScrimVariants = VariantProps<typeof dialogScrimVariants>;
+
+// ─── Panel container ────────────────────────────────────────────────────────────
+
+/**
+ * Dialog panel container variants.
+ *
+ * - `basic`: floating card with rounded corners, elevation, max-width constraint.
+ * - `fullscreen`: full viewport coverage, no corners, no max-width.
+ *
+ * Positioned and centered by the portal wrapper; `z-50` sits above the scrim.
+ */
+export const dialogPanelVariants = cva(
+  [
+    // Stacking above scrim
+    "z-50",
+
+    // Surface
+    "bg-surface-container-high",
+
+    // Flex column layout for slots
+    "flex",
+    "flex-col",
+
+    // Transition for animation state changes
+    "transition-[opacity,transform]",
+    "will-change-[opacity,transform]",
+  ],
+  {
+    variants: {
+      variant: {
+        basic: [
+          // Shape: MD3 extra-large = 28dp
+          "rounded-xl",
+          // Elevation level 3
+          "shadow-elevation-3",
+          // Width constraints per MD3 spec (280dp min, 560dp max)
+          "min-w-70",
+          "max-w-dialog-max",
+          "w-full",
+          // Internal spacing
+          "pt-6",
+          "pb-3",
+          "px-6",
+          // Positioned in viewport center
+          "relative",
+        ],
+        fullscreen: [
+          // Full viewport
+          "w-full",
+          "h-full",
+          // No rounded corners on fullscreen
+          "rounded-none",
+          // No elevation shadow on fullscreen
+          "shadow-none",
+          // Positioned to fill portal
+          "relative",
+        ],
+      },
+    },
+    defaultVariants: {
+      variant: "basic",
+    },
+  }
+);
+
+export type DialogPanelVariants = VariantProps<typeof dialogPanelVariants>;
+
+// ─── Portal wrapper ─────────────────────────────────────────────────────────────
+
+/**
+ * Wrapper that centers the basic dialog in the viewport.
+ * Not applied to the fullscreen variant (which fills the viewport directly).
+ */
+export const dialogWrapperVariants = cva([], {
+  variants: {
+    variant: {
+      basic: ["fixed", "inset-0", "z-50", "flex", "items-center", "justify-center", "px-4"],
+      fullscreen: ["fixed", "inset-0", "z-50"],
+    },
+  },
+  defaultVariants: {
+    variant: "basic",
+  },
+});
+
+export type DialogWrapperVariants = VariantProps<typeof dialogWrapperVariants>;
+
+// ─── Animation state classes ────────────────────────────────────────────────────
+
+/**
+ * Animation state variants — applied by `DialogHeadless` based on its
+ * internal animation state machine. Variant-specific to match MD3 motion spec:
+ *
+ * Basic: scale + fade (entry) / fade (exit)
+ * Fullscreen: slide-up (entry) / slide-down (exit)
+ */
+export const dialogAnimationVariants = cva("", {
+  variants: {
+    animationState: {
+      entering: [],
+      visible: [],
+      exiting: [],
+      exited: [],
+    },
+    variant: {
+      basic: [],
+      fullscreen: [],
+    },
+  },
+  compoundVariants: [
+    // Basic: entering — start scaled down + transparent
+    {
+      animationState: "entering",
+      variant: "basic",
+      className: ["scale-90", "opacity-0"],
+    },
+    // Basic: visible — scale to full + fade in
+    {
+      animationState: "visible",
+      variant: "basic",
+      className: ["scale-100", "opacity-100", "duration-medium4", "ease-emphasized-decelerate"],
+    },
+    // Basic: exiting — fade out (scale stays at 1)
+    {
+      animationState: "exiting",
+      variant: "basic",
+      className: ["scale-100", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+    },
+    // Basic: exited — fully transparent
+    {
+      animationState: "exited",
+      variant: "basic",
+      className: ["scale-100", "opacity-0"],
+    },
+    // Fullscreen: entering — start below viewport + transparent
+    {
+      animationState: "entering",
+      variant: "fullscreen",
+      className: ["translate-y-full", "opacity-0"],
+    },
+    // Fullscreen: visible — slide up + fade in
+    {
+      animationState: "visible",
+      variant: "fullscreen",
+      className: ["translate-y-0", "opacity-100", "duration-medium4", "ease-emphasized-decelerate"],
+    },
+    // Fullscreen: exiting — slide down + fade out
+    {
+      animationState: "exiting",
+      variant: "fullscreen",
+      className: ["translate-y-full", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+    },
+    // Fullscreen: exited — fully off-screen
+    {
+      animationState: "exited",
+      variant: "fullscreen",
+      className: ["translate-y-full", "opacity-0"],
+    },
+  ],
+  defaultVariants: {
+    animationState: "entering",
+    variant: "basic",
+  },
+});
+
+export type DialogAnimationVariants = VariantProps<typeof dialogAnimationVariants>;
+
+// ─── DialogHeadline ─────────────────────────────────────────────────────────────
+
+/**
+ * Headline element variants.
+ * MD3: text-headline-small, text-on-surface.
+ */
+export const dialogHeadlineVariants = cva(["text-headline-small", "text-on-surface"], {
+  variants: {
+    variant: {
+      basic: ["mb-4"],
+      fullscreen: [
+        // Top app bar row in fullscreen: flex, items-center, gap
+        "flex",
+        "items-center",
+        "gap-4",
+        "px-4",
+        "h-14",
+        "shrink-0",
+        "border-b",
+        "border-outline-variant",
+      ],
+    },
+  },
+  defaultVariants: {
+    variant: "basic",
+  },
+});
+
+export type DialogHeadlineVariants = VariantProps<typeof dialogHeadlineVariants>;
+
+/**
+ * Headline text inside the fullscreen top app bar row.
+ */
+export const dialogHeadlineTitleVariants = cva([
+  "flex-1",
+  "text-headline-small",
+  "text-on-surface",
+  "truncate",
+]);
+
+// ─── DialogContent ──────────────────────────────────────────────────────────────
+
+/**
+ * Scrollable body content variants.
+ * MD3: text-body-medium, text-on-surface-variant, scrollable.
+ */
+export const dialogContentVariants = cva(
+  ["text-body-medium", "text-on-surface-variant", "overflow-y-auto", "flex-1"],
+  {
+    variants: {
+      variant: {
+        basic: ["mb-6"],
+        fullscreen: ["px-6", "py-4"],
+      },
+    },
+    defaultVariants: {
+      variant: "basic",
+    },
+  }
+);
+
+export type DialogContentVariants = VariantProps<typeof dialogContentVariants>;
+
+// ─── DialogActions ──────────────────────────────────────────────────────────────
+
+/**
+ * Action button row variants.
+ * MD3: right-aligned flex row with gap-2, padding-top per spec.
+ */
+export const dialogActionsVariants = cva([
+  "flex",
+  "items-center",
+  "justify-end",
+  "gap-2",
+  "pt-3",
+  "shrink-0",
+]);
+
+export type DialogActionsVariants = VariantProps<typeof dialogActionsVariants>;

--- a/packages/react/src/components/Dialog/DialogActions.tsx
+++ b/packages/react/src/components/Dialog/DialogActions.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import { useDialogContext } from "./DialogHeadless";
+import { dialogActionsVariants } from "./Dialog.variants";
+import type { DialogActionsProps } from "./Dialog.types";
+
+/**
+ * `DialogActions` — Action button row slot sub-component (Layer 3).
+ *
+ * Renders a right-aligned flex row of action buttons per MD3 spec.
+ * Intended to contain `Button` components (typically `variant="text"` for
+ * secondary actions and `variant="filled"` for the primary action).
+ *
+ * Not used in the `fullscreen` variant — the confirm action is placed in the
+ * headline top app bar row via `DialogHeadline`'s `confirmButton` slot.
+ *
+ * Must be rendered inside a `<Dialog>` or `<DialogHeadless>` component.
+ *
+ * @example
+ * ```tsx
+ * <Dialog open onOpenChange={setOpen}>
+ *   <DialogHeadline>Discard changes?</DialogHeadline>
+ *   <DialogContent>Your unsaved changes will be lost.</DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDiscard}>Discard</Button>
+ *   </DialogActions>
+ * </Dialog>
+ * ```
+ */
+export const DialogActions = forwardRef<HTMLDivElement, DialogActionsProps>(function DialogActions(
+  { children, className },
+  ref
+) {
+  // Consume context to validate sub-component is used inside Dialog
+  useDialogContext();
+
+  return (
+    <div ref={ref} className={cn(dialogActionsVariants(), className)}>
+      {children}
+    </div>
+  );
+});
+
+DialogActions.displayName = "DialogActions";

--- a/packages/react/src/components/Dialog/DialogContent.tsx
+++ b/packages/react/src/components/Dialog/DialogContent.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import { useDialogContext } from "./DialogHeadless";
+import { dialogContentVariants } from "./Dialog.variants";
+import type { DialogContentProps } from "./Dialog.types";
+
+/**
+ * `DialogContent` — Scrollable body slot sub-component (Layer 3).
+ *
+ * Renders as a scrollable `<div>` and registers its `id` with the parent
+ * `DialogContext` so the dialog panel can wire `aria-describedby` correctly.
+ *
+ * Styled with `text-body-medium` and `text-on-surface-variant` per MD3 spec.
+ * Overflows vertically when content exceeds the available height.
+ *
+ * Must be rendered inside a `<Dialog>` or `<DialogHeadless>` component.
+ *
+ * @example
+ * ```tsx
+ * <Dialog open onOpenChange={setOpen}>
+ *   <DialogHeadline>Confirm deletion?</DialogHeadline>
+ *   <DialogContent>
+ *     <p>
+ *       This will permanently delete the file and all associated data.
+ *       This action cannot be undone.
+ *     </p>
+ *   </DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *   </DialogActions>
+ * </Dialog>
+ * ```
+ */
+export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(function DialogContent(
+  { children, className },
+  ref
+) {
+  const { contentId, variant } = useDialogContext();
+
+  return (
+    <div ref={ref} id={contentId} className={cn(dialogContentVariants({ variant }), className)}>
+      {children}
+    </div>
+  );
+});
+
+DialogContent.displayName = "DialogContent";

--- a/packages/react/src/components/Dialog/DialogHeadless.tsx
+++ b/packages/react/src/components/Dialog/DialogHeadless.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import type React from "react";
+import { useDialog, useOverlay, usePreventScroll, FocusScope } from "react-aria";
+import { useOverlayTriggerState } from "react-stately";
+import { mergeProps } from "@react-aria/utils";
+import { cn } from "../../utils/cn";
+import type {
+  DialogAnimationState,
+  DialogContextValue,
+  DialogHeadlessProps,
+  DialogVariant,
+} from "./Dialog.types";
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+/**
+ * Context shared between `DialogHeadless` and slot sub-components
+ * (`DialogHeadline`, `DialogContent`, `DialogActions`).
+ *
+ * Provides stable IDs for aria-labelledby / aria-describedby wiring,
+ * the close callback, and the active variant.
+ *
+ * @internal
+ */
+export const DialogContext = createContext<DialogContextValue | null>(null);
+
+/**
+ * Hook to consume `DialogContext` inside dialog slot sub-components.
+ * Throws a descriptive error if used outside a `DialogHeadless` tree.
+ *
+ * @internal
+ */
+export function useDialogContext(): DialogContextValue {
+  const ctx = useContext(DialogContext);
+  if (ctx === null) {
+    throw new Error(
+      "[Dialog] DialogHeadline, DialogContent, and DialogActions must be rendered " +
+        "inside a <Dialog> or <DialogHeadless> component."
+    );
+  }
+  return ctx;
+}
+
+// ─── DialogPanel (internal) ───────────────────────────────────────────────────
+
+/**
+ * Inner dialog panel — wires React Aria hooks (`useDialog`, `useOverlay`,
+ * `usePreventScroll`) and renders the accessible dialog element with the
+ * centering wrapper.
+ *
+ * DOM structure:
+ * ```
+ *   <div> (centering / positioning wrapper, z-50)
+ *     <div role="dialog" aria-modal> (panel — className, animation, data attrs)
+ *       {children}
+ *     </div>
+ *   </div>
+ * ```
+ *
+ * This allows `screen.getByRole("dialog")` to directly return the panel
+ * (with `data-animation-state` and `data-variant` for test assertions).
+ *
+ * @internal
+ */
+interface DialogPanelProps {
+  ariaLabel: string | undefined;
+  headlineId: string;
+  contentId: string;
+  onClose: () => void;
+  onTransitionEnd: () => void;
+  variant: DialogVariant;
+  isDismissable: boolean;
+  wrapperClassName: string;
+  className: string | undefined;
+  animationState: DialogAnimationState;
+  getAnimationClassName: ((state: DialogAnimationState) => string) | undefined;
+  children: React.ReactNode;
+}
+
+const DialogPanel = ({
+  ariaLabel,
+  headlineId,
+  contentId,
+  onClose,
+  onTransitionEnd,
+  variant,
+  isDismissable,
+  wrapperClassName,
+  className,
+  animationState,
+  getAnimationClassName,
+  children,
+}: DialogPanelProps): React.ReactElement => {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Lock body scroll while dialog is open
+  usePreventScroll();
+
+  // useDialog: applies role="dialog", aria-modal="true", aria-labelledby, aria-describedby
+  const { dialogProps } = useDialog(
+    {
+      ...(ariaLabel ? { "aria-label": ariaLabel } : {}),
+      "aria-labelledby": headlineId,
+      "aria-describedby": contentId,
+    },
+    panelRef
+  );
+
+  // useOverlay: handles Escape key dismissal and outside-click dismissal
+  const { overlayProps } = useOverlay(
+    {
+      isOpen: true,
+      onClose,
+      isDismissable,
+      shouldCloseOnBlur: false,
+    },
+    panelRef
+  );
+
+  // Merge animation classes onto the panel element
+  const panelClassName = cn(className, getAnimationClassName?.(animationState));
+
+  return (
+    // Centering/positioning wrapper — structural only, no ARIA role
+    <div className={wrapperClassName}>
+      {/* Panel: semantic dialog element with React Aria hooks, animation, data attrs */}
+      <div
+        {...mergeProps(overlayProps, dialogProps)}
+        ref={panelRef}
+        aria-modal="true"
+        className={panelClassName}
+        data-animation-state={animationState}
+        data-variant={variant}
+        onTransitionEnd={onTransitionEnd}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+DialogPanel.displayName = "DialogPanel";
+
+// ─── DialogHeadless ───────────────────────────────────────────────────────────
+
+/**
+ * `DialogHeadless` — Layer 2 headless primitive.
+ *
+ * Provides all MD3 Dialog behavior and ARIA semantics without any visual styling:
+ *
+ * - **Portal rendering**: dialog and scrim render in `document.body` via
+ *   `createPortal` to avoid stacking context issues.
+ * - **Open/close state**: via `useOverlayTriggerState` (supports controlled
+ *   `open` + `onOpenChange` and uncontrolled `defaultOpen`).
+ * - **Scroll lock**: `usePreventScroll` locks body scroll while open.
+ * - **Focus trap**: `FocusScope` with `contain`, `restoreFocus`, `autoFocus`.
+ * - **Dismiss behavior**: `useOverlay` handles Escape key and outside click.
+ *   Basic variant is dismissable (Escape + outside click);
+ *   Full-screen variant is Escape-dismissable only (no scrim click) per MD3 spec.
+ * - **Animation state machine**: `entering → visible → exiting → exited`
+ *   mirrors the Snackbar animation pattern.
+ * - **ARIA wiring**: `DialogContext` provides stable IDs for `aria-labelledby`
+ *   and `aria-describedby`, consumed by slot sub-components.
+ *
+ * React Aria hooks used:
+ * - `useDialog` — `role="dialog"`, `aria-modal`, `aria-labelledby`, `aria-describedby`
+ * - `useOverlay` — Escape key + outside-click dismissal
+ * - `usePreventScroll` — body scroll lock
+ * - `FocusScope` — focus trap + restoreFocus on close
+ * - `useOverlayTriggerState` — open/close state management
+ *
+ * @example
+ * ```tsx
+ * // Controlled basic dialog
+ * <DialogHeadless
+ *   variant="basic"
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   className={cn(dialogWrapperVariants({ variant: 'basic' }), dialogPanelVariants({ variant: 'basic' }))}
+ *   scrimClassName={dialogScrimVariants()}
+ *   getAnimationClassName={(state) =>
+ *     dialogAnimationVariants({ animationState: state, variant: 'basic' })
+ *   }
+ * >
+ *   <DialogHeadline>Confirm?</DialogHeadline>
+ *   <DialogContent>This action cannot be undone.</DialogContent>
+ *   <DialogActions>
+ *     <Button variant="text" onPress={() => setOpen(false)}>Cancel</Button>
+ *     <Button variant="filled" onPress={handleDelete}>Delete</Button>
+ *   </DialogActions>
+ * </DialogHeadless>
+ * ```
+ */
+export const DialogHeadless = forwardRef<HTMLDivElement, DialogHeadlessProps>(
+  function DialogHeadless(
+    {
+      variant = "basic",
+      open,
+      defaultOpen = false,
+      onOpenChange,
+      "aria-label": ariaLabel,
+      children,
+      className,
+      scrimClassName,
+      getAnimationClassName,
+    },
+    _ref
+  ) {
+    // ── Open/close state ─────────────────────────────────────────────────────
+
+    const state = useOverlayTriggerState({
+      ...(open !== undefined ? { isOpen: open } : {}),
+      ...(defaultOpen !== undefined ? { defaultOpen } : {}),
+      ...(onOpenChange !== undefined ? { onOpenChange } : {}),
+    });
+
+    const isOpen = state.isOpen;
+
+    const close = useCallback(() => {
+      state.close();
+    }, [state]);
+
+    // ── Animation state machine ───────────────────────────────────────────────
+
+    const [animationState, setAnimationState] = useState<DialogAnimationState>("exited");
+    // Guard against calling state updates after unmount / multiple times
+    const closedRef = useRef<boolean>(false);
+    // Fallback timer for exit animation in case onTransitionEnd doesn't fire
+    const exitFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // When isOpen becomes true → start entry animation cycle
+    useEffect(() => {
+      if (!isOpen) return;
+
+      closedRef.current = false;
+      setAnimationState("entering");
+
+      // Zero-delay timer ensures "entering" state is rendered (allowing CSS
+      // transition initial values) before transitioning to "visible".
+      const id = setTimeout(() => {
+        setAnimationState("visible");
+      }, 0);
+
+      return () => clearTimeout(id);
+    }, [isOpen]);
+
+    // When isOpen becomes false while visible → start exit animation cycle
+    useEffect(() => {
+      if (isOpen) return;
+      if (animationState === "exited" || animationState === "entering") return;
+
+      if (animationState === "visible") {
+        setAnimationState("exiting");
+
+        // Fallback: advance to exited if CSS transition doesn't fire
+        exitFallbackRef.current = setTimeout(() => {
+          if (!closedRef.current) {
+            closedRef.current = true;
+            setAnimationState("exited");
+          }
+        }, 150);
+      }
+    }, [isOpen, animationState]);
+
+    // Cleanup on unmount
+    useEffect(
+      () => () => {
+        if (exitFallbackRef.current !== null) {
+          clearTimeout(exitFallbackRef.current);
+        }
+      },
+      []
+    );
+
+    const handleTransitionEnd = useCallback(() => {
+      if (animationState === "exiting" && !closedRef.current) {
+        if (exitFallbackRef.current !== null) {
+          clearTimeout(exitFallbackRef.current);
+          exitFallbackRef.current = null;
+        }
+        closedRef.current = true;
+        setAnimationState("exited");
+      }
+    }, [animationState]);
+
+    // ── ARIA ID coordination ──────────────────────────────────────────────────
+
+    const baseId = useId();
+    const headlineId = `${baseId}-dialog-headline`;
+    const contentId = `${baseId}-dialog-content`;
+
+    const contextValue: DialogContextValue = {
+      headlineId,
+      contentId,
+      close,
+      variant,
+    };
+
+    // ── Scrim dismissal ───────────────────────────────────────────────────────
+
+    // Basic variant: scrim click closes dialog. Full-screen: scrim is inert.
+    const handleScrimClick = useCallback(() => {
+      if (variant === "basic") {
+        close();
+      }
+    }, [variant, close]);
+
+    // ── Portal gate ───────────────────────────────────────────────────────────
+
+    // Do not render portal until open, and remove once animation is fully exited
+    if (!isOpen && animationState === "exited") {
+      return null;
+    }
+
+    // ── Portal content ────────────────────────────────────────────────────────
+
+    const content = (
+      <DialogContext.Provider value={contextValue}>
+        {/* Scrim overlay — click closes for basic, inert for fullscreen */}
+        <div
+          data-testid="dialog-scrim"
+          className={scrimClassName}
+          onClick={handleScrimClick}
+          aria-hidden="true"
+        />
+
+        {/* FocusScope: traps focus, restores focus to trigger on close, auto-focuses first element */}
+        <FocusScope contain restoreFocus autoFocus>
+          <DialogPanel
+            ariaLabel={ariaLabel}
+            headlineId={headlineId}
+            contentId={contentId}
+            onClose={close}
+            onTransitionEnd={handleTransitionEnd}
+            variant={variant}
+            isDismissable={variant === "basic"}
+            wrapperClassName={
+              variant === "basic"
+                ? "fixed inset-0 z-50 flex items-center justify-center px-4"
+                : "fixed inset-0 z-50"
+            }
+            className={className}
+            animationState={animationState}
+            getAnimationClassName={getAnimationClassName}
+          >
+            {children}
+          </DialogPanel>
+        </FocusScope>
+      </DialogContext.Provider>
+    );
+
+    if (typeof document === "undefined") return null;
+
+    return createPortal(content, document.body) as React.ReactElement;
+  }
+);
+
+DialogHeadless.displayName = "DialogHeadless";

--- a/packages/react/src/components/Dialog/DialogHeadline.tsx
+++ b/packages/react/src/components/Dialog/DialogHeadline.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import { useDialogContext } from "./DialogHeadless";
+import { dialogHeadlineVariants, dialogHeadlineTitleVariants } from "./Dialog.variants";
+import type { DialogHeadlineProps } from "./Dialog.types";
+
+/**
+ * `DialogHeadline` — Headline slot sub-component (Layer 3).
+ *
+ * Renders as an `<h2>` element and registers its `id` with the parent
+ * `DialogContext` so the dialog panel can wire `aria-labelledby` correctly.
+ *
+ * For the `fullscreen` variant, the headline renders as a top app bar row
+ * containing optional `closeButton` (leading icon button) and `confirmButton`
+ * (trailing text action) per MD3 Full-screen Dialog spec.
+ *
+ * Must be rendered inside a `<Dialog>` or `<DialogHeadless>` component.
+ *
+ * @example
+ * ```tsx
+ * // Basic variant
+ * <Dialog open onOpenChange={setOpen}>
+ *   <DialogHeadline>Delete file?</DialogHeadline>
+ *   ...
+ * </Dialog>
+ *
+ * // Full-screen variant with app bar controls
+ * <Dialog variant="fullscreen" open onOpenChange={setOpen}>
+ *   <DialogHeadline
+ *     closeButton={
+ *       <IconButton aria-label="Close" onPress={() => setOpen(false)}>
+ *         <CloseIcon />
+ *       </IconButton>
+ *     }
+ *     confirmButton={
+ *       <Button variant="text" onPress={handleSave}>Save</Button>
+ *     }
+ *   >
+ *     New event
+ *   </DialogHeadline>
+ *   ...
+ * </Dialog>
+ * ```
+ */
+export const DialogHeadline = forwardRef<HTMLHeadingElement, DialogHeadlineProps>(
+  function DialogHeadline({ children, className, closeButton, confirmButton }, ref) {
+    const { headlineId, variant } = useDialogContext();
+
+    if (variant === "fullscreen") {
+      return (
+        // Top app bar row for fullscreen variant
+        <div className={cn(dialogHeadlineVariants({ variant: "fullscreen" }), className)}>
+          {/* Leading close icon button */}
+          {closeButton}
+
+          {/* Headline text — grows to fill available space */}
+          <h2 id={headlineId} className={dialogHeadlineTitleVariants()}>
+            {children}
+          </h2>
+
+          {/* Trailing confirm action */}
+          {confirmButton}
+        </div>
+      );
+    }
+
+    return (
+      <h2
+        ref={ref}
+        id={headlineId}
+        className={cn(dialogHeadlineVariants({ variant: "basic" }), className)}
+      >
+        {children}
+      </h2>
+    );
+  }
+);
+
+DialogHeadline.displayName = "DialogHeadline";

--- a/packages/react/src/components/Dialog/index.ts
+++ b/packages/react/src/components/Dialog/index.ts
@@ -1,0 +1,39 @@
+// Layer 3: MD3 Styled Components (most users use these)
+export { Dialog } from "./Dialog";
+export { DialogHeadline } from "./DialogHeadline";
+export { DialogContent } from "./DialogContent";
+export { DialogActions } from "./DialogActions";
+
+// Layer 2: Headless Primitive (for advanced customization)
+export { DialogHeadless, DialogContext, useDialogContext } from "./DialogHeadless";
+
+// CVA Variants
+export {
+  dialogScrimVariants,
+  dialogPanelVariants,
+  dialogWrapperVariants,
+  dialogAnimationVariants,
+  dialogHeadlineVariants,
+  dialogHeadlineTitleVariants,
+  dialogContentVariants,
+  dialogActionsVariants,
+  type DialogScrimVariants,
+  type DialogPanelVariants,
+  type DialogWrapperVariants,
+  type DialogAnimationVariants,
+  type DialogHeadlineVariants,
+  type DialogContentVariants,
+  type DialogActionsVariants,
+} from "./Dialog.variants";
+
+// Types
+export type {
+  DialogVariant,
+  DialogAnimationState,
+  DialogProps,
+  DialogHeadlessProps,
+  DialogHeadlineProps,
+  DialogContentProps,
+  DialogActionsProps,
+  DialogContextValue,
+} from "./Dialog.types";

--- a/packages/react/src/components/Menu/ContextMenuTrigger.tsx
+++ b/packages/react/src/components/Menu/ContextMenuTrigger.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { type JSX } from "react";
+import { HeadlessContextMenuTrigger } from "./MenuHeadless";
+import type { ContextMenuTriggerProps } from "./Menu.types";
+
+/**
+ * MD3 styled ContextMenuTrigger component (Layer 3).
+ *
+ * Wraps arbitrary content and opens a menu on right-click or two-finger tap.
+ * The menu is positioned at the pointer coordinates.
+ *
+ * Keyboard: `Escape` closes the menu.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuTrigger>
+ *   <div>Right-click me</div>
+ *   <MenuTrigger.Menu aria-label="Context actions">
+ *     <MenuItem id="copy">Copy</MenuItem>
+ *     <MenuItem id="paste">Paste</MenuItem>
+ *   </MenuTrigger.Menu>
+ * </ContextMenuTrigger>
+ * ```
+ */
+export function ContextMenuTrigger({
+  children,
+  isOpen,
+  onOpenChange,
+}: ContextMenuTriggerProps): JSX.Element {
+  return (
+    <HeadlessContextMenuTrigger
+      {...(isOpen !== undefined ? { isOpen } : {})}
+      {...(onOpenChange !== undefined ? { onOpenChange } : {})}
+    >
+      {children}
+    </HeadlessContextMenuTrigger>
+  );
+}

--- a/packages/react/src/components/Menu/Menu.stories.tsx
+++ b/packages/react/src/components/Menu/Menu.stories.tsx
@@ -1,0 +1,454 @@
+import { useState, type JSX } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { MenuTrigger } from "./Menu";
+import { MenuItem } from "./MenuItem";
+import { MenuSection } from "./MenuSection";
+import { MenuDivider } from "./MenuDivider";
+import { HeadlessMenuTrigger, HeadlessMenuItem } from "./MenuHeadless";
+import { menuContainerVariants, menuItemVariants } from "./Menu.variants";
+import { cn } from "../../utils/cn";
+
+// ─── Inline SVG Icons ─────────────────────────────────────────────────────────
+
+const CutIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M9.64 7.64A2 2 0 1 0 6.36 4.36L2 8.72V11h2.28L7.5 7.78A2 2 0 0 0 9.64 7.64zm4.72 0a2 2 0 1 0 3.28-3.28L22 8.72V11h-2.28L16.5 7.78a2 2 0 0 0-2.14-.14zM12 10a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm0 6c-1.1 0-2.1.36-2.9.96L6.28 13H4v2.28L7.04 18.3A2 2 0 0 0 9.64 20l-3.28 3.28 1.28 1.28L12 20.12l4.36 4.44 1.28-1.28L14.36 20a2 2 0 0 0 2.6-1.7l3.04-3.02V13h-2.28L14.9 16.96A4 4 0 0 0 12 16z" />
+  </svg>
+);
+
+const CopyIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+  </svg>
+);
+
+const PasteIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19 2h-4.18C14.4.84 13.3 0 12 0c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm7 18H5V4h2v3h10V4h2v16z" />
+  </svg>
+);
+
+const BoldIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M15.6 10.79c.97-.67 1.65-1.77 1.65-2.79 0-2.26-1.75-4-4-4H7v14h7.04c2.09 0 3.71-1.7 3.71-3.79 0-1.52-.86-2.82-2.15-3.42zM10 6.5h3c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5h-3v-3zm3.5 9H10v-3h3.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5z" />
+  </svg>
+);
+
+const GridIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M3 3h7v7H3V3zm0 11h7v7H3v-7zm11-11h7v7h-7V3zm0 11h7v7h-7v-7z" />
+  </svg>
+);
+
+const ListIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z" />
+  </svg>
+);
+
+const MoreVertIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+  </svg>
+);
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof MenuTrigger> = {
+  title: "Feedback/Menu",
+  component: MenuTrigger,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Material Design 3 Menu — a contextual popup list anchored to a trigger element. Supports leading/trailing icons, keyboard shortcuts, section grouping with dividers, disabled items, and select variants.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof MenuTrigger>;
+
+// ─── Basic ────────────────────────────────────────────────────────────────────
+
+export const Basic: Story = {
+  name: "Basic Menu",
+  render: () => (
+    <MenuTrigger>
+      <button
+        type="button"
+        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+      >
+        Open Menu
+      </button>
+      <MenuTrigger.Menu aria-label="Edit actions">
+        <MenuItem id="cut">Cut</MenuItem>
+        <MenuItem id="copy">Copy</MenuItem>
+        <MenuItem id="paste">Paste</MenuItem>
+        <MenuItem id="select-all">Select all</MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── With Icons ───────────────────────────────────────────────────────────────
+
+export const WithLeadingIcons: Story = {
+  name: "With Leading Icons",
+  render: () => (
+    <MenuTrigger>
+      <button
+        type="button"
+        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+      >
+        Edit
+      </button>
+      <MenuTrigger.Menu aria-label="Edit">
+        <MenuItem id="cut" leadingIcon={<CutIcon />}>
+          Cut
+        </MenuItem>
+        <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+          Copy
+        </MenuItem>
+        <MenuItem id="paste" leadingIcon={<PasteIcon />}>
+          Paste
+        </MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── With Keyboard Shortcuts ──────────────────────────────────────────────────
+
+export const WithKeyboardShortcuts: Story = {
+  name: "With Keyboard Shortcuts",
+  render: () => (
+    <MenuTrigger>
+      <button
+        type="button"
+        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+      >
+        Edit
+      </button>
+      <MenuTrigger.Menu aria-label="Edit">
+        <MenuItem id="cut" leadingIcon={<CutIcon />} trailingText="⌘X">
+          Cut
+        </MenuItem>
+        <MenuItem id="copy" leadingIcon={<CopyIcon />} trailingText="⌘C">
+          Copy
+        </MenuItem>
+        <MenuItem id="paste" leadingIcon={<PasteIcon />} trailingText="⌘V">
+          Paste
+        </MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── With Sections ────────────────────────────────────────────────────────────
+
+export const WithSections: Story = {
+  name: "With Sections and Dividers",
+  render: () => (
+    <MenuTrigger>
+      <button
+        type="button"
+        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+      >
+        Edit
+      </button>
+      <MenuTrigger.Menu aria-label="Edit actions">
+        <MenuSection header="Clipboard" aria-label="Clipboard">
+          <MenuItem id="cut" leadingIcon={<CutIcon />} trailingText="⌘X">
+            Cut
+          </MenuItem>
+          <MenuItem id="copy" leadingIcon={<CopyIcon />} trailingText="⌘C">
+            Copy
+          </MenuItem>
+          <MenuItem id="paste" leadingIcon={<PasteIcon />} trailingText="⌘V">
+            Paste
+          </MenuItem>
+        </MenuSection>
+        <MenuSection header="Formatting" showDivider aria-label="Formatting">
+          <MenuItem id="bold" leadingIcon={<BoldIcon />} trailingText="⌘B">
+            Bold
+          </MenuItem>
+        </MenuSection>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── With Standalone Divider ──────────────────────────────────────────────────
+
+export const WithStandaloneDivider: Story = {
+  name: "With Standalone MenuDivider",
+  render: () => (
+    <MenuTrigger>
+      <button
+        type="button"
+        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+      >
+        Actions
+      </button>
+      <MenuTrigger.Menu aria-label="Actions">
+        <MenuItem id="rename">Rename</MenuItem>
+        <MenuItem id="duplicate">Duplicate</MenuItem>
+        <MenuDivider />
+        <MenuItem id="share">Share</MenuItem>
+        <MenuDivider />
+        <MenuItem id="delete">Delete</MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── With Disabled Items ──────────────────────────────────────────────────────
+
+export const WithDisabledItems: Story = {
+  name: "With Disabled Items",
+  render: () => (
+    <MenuTrigger>
+      <button
+        type="button"
+        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+      >
+        Edit
+      </button>
+      <MenuTrigger.Menu aria-label="Edit">
+        <MenuItem id="cut" leadingIcon={<CutIcon />} trailingText="⌘X">
+          Cut
+        </MenuItem>
+        <MenuItem id="copy" leadingIcon={<CopyIcon />} trailingText="⌘C">
+          Copy
+        </MenuItem>
+        <MenuItem id="paste" leadingIcon={<PasteIcon />} trailingText="⌘V" isDisabled>
+          Paste
+        </MenuItem>
+        <MenuItem id="select-all" isDisabled>
+          Select all
+        </MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── Select Variant — Single ──────────────────────────────────────────────────
+
+const SelectSingleDemo = (): JSX.Element => {
+  const [selected, setSelected] = useState<string>("list");
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <MenuTrigger>
+        <button
+          type="button"
+          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+        >
+          View: {selected}
+        </button>
+        <MenuTrigger.Menu
+          aria-label="View options"
+          variant="select"
+          selectionMode="single"
+          selectedKeys={new Set([selected])}
+          onSelectionChange={(keys) => {
+            const key = [...(keys as Set<string>)][0];
+            if (key) setSelected(key);
+          }}
+        >
+          <MenuItem id="grid" leadingIcon={<GridIcon />}>
+            Grid view
+          </MenuItem>
+          <MenuItem id="list" leadingIcon={<ListIcon />}>
+            List view
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+      <p className="text-body-medium text-on-surface-variant">Selected: {selected}</p>
+    </div>
+  );
+};
+
+export const SelectSingle: Story = {
+  name: "Select Variant — Single Selection",
+  render: () => <SelectSingleDemo />,
+};
+
+// ─── Select Variant — Multiple ────────────────────────────────────────────────
+
+const SelectMultipleDemo = (): JSX.Element => {
+  const [selected, setSelected] = useState<Set<string>>(new Set(["bold"]));
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <MenuTrigger>
+        <button
+          type="button"
+          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+        >
+          Formatting
+        </button>
+        <MenuTrigger.Menu
+          aria-label="Text formatting"
+          variant="select"
+          selectionMode="multiple"
+          selectedKeys={selected}
+          onSelectionChange={(keys) => setSelected(new Set([...(keys as Set<string>)]))}
+        >
+          <MenuItem id="bold">Bold</MenuItem>
+          <MenuItem id="italic">Italic</MenuItem>
+          <MenuItem id="underline">Underline</MenuItem>
+          <MenuItem id="strikethrough">Strikethrough</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+      <p className="text-body-medium text-on-surface-variant">
+        Selected: {[...selected].join(", ") || "(none)"}
+      </p>
+    </div>
+  );
+};
+
+export const SelectMultiple: Story = {
+  name: "Select Variant — Multiple Selection",
+  render: () => <SelectMultipleDemo />,
+};
+
+// ─── Controlled Open ──────────────────────────────────────────────────────────
+
+const ControlledOpenDemo = (): JSX.Element => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [lastAction, setLastAction] = useState<string>("(none)");
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+        >
+          Open
+        </button>
+        <button
+          type="button"
+          onClick={() => setIsOpen(false)}
+          className="bg-surface-container text-on-surface text-label-large rounded-full px-6 py-2.5"
+        >
+          Close
+        </button>
+      </div>
+      <MenuTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+        <button
+          type="button"
+          className="bg-surface-container-high text-on-surface text-label-large rounded-full px-6 py-2.5"
+        >
+          Context Menu (controlled)
+        </button>
+        <MenuTrigger.Menu
+          aria-label="Context"
+          onAction={(key) => {
+            setLastAction(String(key));
+            setIsOpen(false);
+          }}
+        >
+          <MenuItem id="rename">Rename</MenuItem>
+          <MenuItem id="share">Share</MenuItem>
+          <MenuDivider />
+          <MenuItem id="delete">Delete</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+      <p className="text-body-medium text-on-surface-variant">Last action: {lastAction}</p>
+    </div>
+  );
+};
+
+export const ControlledOpen: Story = {
+  name: "Controlled Open State",
+  render: () => <ControlledOpenDemo />,
+};
+
+// ─── Context Menu (IconButton trigger) ───────────────────────────────────────
+
+export const IconButtonTrigger: Story = {
+  name: "With IconButton Trigger",
+  render: () => (
+    <MenuTrigger>
+      <button
+        type="button"
+        className="text-on-surface-variant hover:bg-on-surface-variant/8 relative flex h-10 w-10 items-center justify-center rounded-full"
+        aria-label="More options"
+      >
+        <MoreVertIcon />
+      </button>
+      <MenuTrigger.Menu aria-label="More options">
+        <MenuItem id="rename">Rename</MenuItem>
+        <MenuItem id="duplicate">Duplicate</MenuItem>
+        <MenuItem id="share">Share</MenuItem>
+        <MenuDivider />
+        <MenuItem id="delete">Delete</MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── Headless Primitive ───────────────────────────────────────────────────────
+
+export const HeadlessPrimitive: Story = {
+  name: "Headless — Custom Styling",
+  render: () => (
+    <HeadlessMenuTrigger>
+      <button
+        type="button"
+        className="bg-tertiary text-on-tertiary text-label-large rounded-full px-6 py-2.5"
+      >
+        Custom Styled Menu
+      </button>
+      <HeadlessMenuTrigger.Menu
+        aria-label="Custom"
+        className={cn(menuContainerVariants({ open: true }), "border-outline-variant border")}
+      >
+        <HeadlessMenuItem id="option-a" className={cn(menuItemVariants(), "text-secondary")}>
+          Option A (custom)
+        </HeadlessMenuItem>
+        <HeadlessMenuItem id="option-b" className={cn(menuItemVariants())}>
+          Option B
+        </HeadlessMenuItem>
+      </HeadlessMenuTrigger.Menu>
+    </HeadlessMenuTrigger>
+  ),
+};
+
+// ─── Dark Mode ────────────────────────────────────────────────────────────────
+
+export const DarkMode: Story = {
+  name: "Dark Mode",
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  render: () => (
+    <div className="dark">
+      <MenuTrigger>
+        <button
+          type="button"
+          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+        >
+          Open Menu
+        </button>
+        <MenuTrigger.Menu aria-label="Edit">
+          <MenuItem id="cut" leadingIcon={<CutIcon />} trailingText="⌘X">
+            Cut
+          </MenuItem>
+          <MenuItem id="copy" leadingIcon={<CopyIcon />} trailingText="⌘C">
+            Copy
+          </MenuItem>
+          <MenuItem id="paste" leadingIcon={<PasteIcon />} trailingText="⌘V" isDisabled>
+            Paste
+          </MenuItem>
+          <MenuDivider />
+          <MenuItem id="select-all">Select all</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    </div>
+  ),
+};

--- a/packages/react/src/components/Menu/Menu.stories.tsx
+++ b/packages/react/src/components/Menu/Menu.stories.tsx
@@ -4,6 +4,9 @@ import { MenuTrigger } from "./Menu";
 import { MenuItem } from "./MenuItem";
 import { MenuSection } from "./MenuSection";
 import { MenuDivider } from "./MenuDivider";
+import { MenuGap } from "./MenuGap";
+import { SubmenuTrigger } from "./SubmenuTrigger";
+import { ContextMenuTrigger } from "./ContextMenuTrigger";
 import { HeadlessMenuTrigger, HeadlessMenuItem } from "./MenuHeadless";
 import { menuContainerVariants, menuItemVariants } from "./Menu.variants";
 import { cn } from "../../utils/cn";
@@ -46,11 +49,49 @@ const ListIcon = (): JSX.Element => (
   </svg>
 );
 
+const CardViewIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M4 4h7v5H4V4zm0 7h7v9H4v-9zm9-7h7v9h-7V4zm0 11h7v5h-7v-5z" />
+  </svg>
+);
+
 const MoreVertIcon = (): JSX.Element => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
   </svg>
 );
+
+const StarIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+  </svg>
+);
+
+const ShareIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
+  </svg>
+);
+
+const DeleteIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+  </svg>
+);
+
+const InfoIcon = (): JSX.Element => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+  </svg>
+);
+
+// ─── Shared trigger button styles ─────────────────────────────────────────────
+
+const primaryBtn = "bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5";
+const secondaryBtn =
+  "bg-secondary-container text-on-secondary-container text-label-large rounded-full px-6 py-2.5";
+const tertiaryBtn =
+  "bg-tertiary-container text-on-tertiary-container text-label-large rounded-full px-6 py-2.5";
 
 // ─── Meta ─────────────────────────────────────────────────────────────────────
 
@@ -61,8 +102,16 @@ const meta: Meta<typeof MenuTrigger> = {
     layout: "centered",
     docs: {
       description: {
-        component:
-          "Material Design 3 Menu — a contextual popup list anchored to a trigger element. Supports leading/trailing icons, keyboard shortcuts, section grouping with dividers, disabled items, and select variants.",
+        component: [
+          "Material Design 3 Menu — a contextual popup list anchored to a trigger element.",
+          "",
+          "Supports both **Baseline** (standard 4dp corners) and **Expressive Vertical** (16dp corners) styles,",
+          "two color schemes (**standard** surface-based and **vibrant** tertiary-based),",
+          "leading/trailing icons, keyboard shortcuts, supporting text, badges,",
+          "section grouping with dividers and gap separators, density control,",
+          "single/multiple selection with automatic checkmarks,",
+          "nested submenus, and right-click context menus.",
+        ].join("\n"),
       },
     },
   },
@@ -78,10 +127,7 @@ export const Basic: Story = {
   name: "Basic Menu",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Open Menu
       </button>
       <MenuTrigger.Menu aria-label="Edit actions">
@@ -100,10 +146,7 @@ export const WithLeadingIcons: Story = {
   name: "With Leading Icons",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Edit
       </button>
       <MenuTrigger.Menu aria-label="Edit">
@@ -127,10 +170,7 @@ export const WithKeyboardShortcuts: Story = {
   name: "With Keyboard Shortcuts",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Edit
       </button>
       <MenuTrigger.Menu aria-label="Edit">
@@ -148,16 +188,97 @@ export const WithKeyboardShortcuts: Story = {
   ),
 };
 
+// ─── Supporting Text ─────────────────────────────────────────────────────────
+
+export const WithSupportingText: Story = {
+  name: "With Supporting Text",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use the `description` prop to add a secondary line of supporting text below the item label. Per MD3 anatomy item 8.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        Share
+      </button>
+      <MenuTrigger.Menu aria-label="Share via">
+        <MenuItem
+          id="email"
+          leadingIcon={<CopyIcon />}
+          description="Send to anyone with an email address"
+        >
+          Email
+        </MenuItem>
+        <MenuItem id="link" leadingIcon={<ShareIcon />} description="Anyone with the link can view">
+          Copy link
+        </MenuItem>
+        <MenuItem
+          id="message"
+          leadingIcon={<InfoIcon />}
+          description="Send via SMS to a phone number"
+        >
+          Text message
+        </MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── With Badge ───────────────────────────────────────────────────────────────
+
+export const WithBadge: Story = {
+  name: "With Badge",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use the `badge` prop to render a small badge between the label and trailing content. Per MD3 anatomy item 5.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        Notifications
+      </button>
+      <MenuTrigger.Menu aria-label="Notification settings">
+        <MenuItem
+          id="all"
+          badge={
+            <span className="text-label-small bg-error text-on-error flex h-4 min-w-4 items-center justify-center rounded-full px-1">
+              12
+            </span>
+          }
+        >
+          All notifications
+        </MenuItem>
+        <MenuItem
+          id="mentions"
+          badge={
+            <span className="text-label-small bg-tertiary text-on-tertiary flex h-4 min-w-4 items-center justify-center rounded-full px-1">
+              3
+            </span>
+          }
+        >
+          Mentions only
+        </MenuItem>
+        <MenuItem id="none">None</MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
 // ─── With Sections ────────────────────────────────────────────────────────────
 
 export const WithSections: Story = {
   name: "With Sections and Dividers",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Edit
       </button>
       <MenuTrigger.Menu aria-label="Edit actions">
@@ -188,10 +309,7 @@ export const WithStandaloneDivider: Story = {
   name: "With Standalone MenuDivider",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Actions
       </button>
       <MenuTrigger.Menu aria-label="Actions">
@@ -212,10 +330,7 @@ export const WithDisabledItems: Story = {
   name: "With Disabled Items",
   render: () => (
     <MenuTrigger>
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-      >
+      <button type="button" className={primaryBtn}>
         Edit
       </button>
       <MenuTrigger.Menu aria-label="Edit">
@@ -236,22 +351,54 @@ export const WithDisabledItems: Story = {
   ),
 };
 
-// ─── Select Variant — Single ──────────────────────────────────────────────────
+// ─── Density ──────────────────────────────────────────────────────────────────
+
+export const DensityLevels: Story = {
+  name: "Density Levels",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "MD3 web-only density prop controls item height: `0`=48dp (default), `-1`=44dp, `-2`=40dp, `-3`=36dp.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-start gap-4">
+      {([-0, -1, -2, -3] as const).map((density) => (
+        <MenuTrigger key={density}>
+          <button type="button" className={primaryBtn}>
+            density={density}
+          </button>
+          <MenuTrigger.Menu aria-label={`Density ${density}`} density={density}>
+            <MenuItem id="cut" leadingIcon={<CutIcon />}>
+              Cut
+            </MenuItem>
+            <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+              Copy
+            </MenuItem>
+            <MenuItem id="paste" leadingIcon={<PasteIcon />}>
+              Paste
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      ))}
+    </div>
+  ),
+};
+
+// ─── Selection — Single ───────────────────────────────────────────────────────
 
 const SelectSingleDemo = (): JSX.Element => {
   const [selected, setSelected] = useState<string>("list");
   return (
     <div className="flex flex-col items-center gap-4">
       <MenuTrigger>
-        <button
-          type="button"
-          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-        >
+        <button type="button" className={primaryBtn}>
           View: {selected}
         </button>
         <MenuTrigger.Menu
           aria-label="View options"
-          variant="select"
           selectionMode="single"
           selectedKeys={new Set([selected])}
           onSelectionChange={(keys) => {
@@ -265,6 +412,9 @@ const SelectSingleDemo = (): JSX.Element => {
           <MenuItem id="list" leadingIcon={<ListIcon />}>
             List view
           </MenuItem>
+          <MenuItem id="card" leadingIcon={<CardViewIcon />}>
+            Card view
+          </MenuItem>
         </MenuTrigger.Menu>
       </MenuTrigger>
       <p className="text-body-medium text-on-surface-variant">Selected: {selected}</p>
@@ -273,26 +423,30 @@ const SelectSingleDemo = (): JSX.Element => {
 };
 
 export const SelectSingle: Story = {
-  name: "Select Variant — Single Selection",
+  name: "Selection — Single",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Single-selection menus automatically render a leading checkmark on the selected item. Checkmark does not appear when a `leadingIcon` is already provided.",
+      },
+    },
+  },
   render: () => <SelectSingleDemo />,
 };
 
-// ─── Select Variant — Multiple ────────────────────────────────────────────────
+// ─── Selection — Multiple ─────────────────────────────────────────────────────
 
 const SelectMultipleDemo = (): JSX.Element => {
   const [selected, setSelected] = useState<Set<string>>(new Set(["bold"]));
   return (
     <div className="flex flex-col items-center gap-4">
       <MenuTrigger>
-        <button
-          type="button"
-          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-        >
+        <button type="button" className={primaryBtn}>
           Formatting
         </button>
         <MenuTrigger.Menu
           aria-label="Text formatting"
-          variant="select"
           selectionMode="multiple"
           selectedKeys={selected}
           onSelectionChange={(keys) => setSelected(new Set([...(keys as Set<string>)]))}
@@ -311,8 +465,319 @@ const SelectMultipleDemo = (): JSX.Element => {
 };
 
 export const SelectMultiple: Story = {
-  name: "Select Variant — Multiple Selection",
+  name: "Selection — Multiple",
   render: () => <SelectMultipleDemo />,
+};
+
+// ─── Vibrant Color Scheme ─────────────────────────────────────────────────────
+
+export const VibrantColorScheme: Story = {
+  name: "Vibrant Color Scheme",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `vibrant` color scheme uses the **tertiary container** background (vs. surface-container in standard). Designed for expressive vertical menus where stronger visual identity is desired.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-start gap-4">
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Standard</span>
+        <MenuTrigger>
+          <button type="button" className={secondaryBtn}>
+            Standard
+          </button>
+          <MenuTrigger.Menu aria-label="Standard" colorScheme="standard" menuStyle="vertical">
+            <MenuItem id="star" leadingIcon={<StarIcon />}>
+              Add to favourites
+            </MenuItem>
+            <MenuItem id="share" leadingIcon={<ShareIcon />}>
+              Share
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+              Delete
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Vibrant</span>
+        <MenuTrigger>
+          <button type="button" className={tertiaryBtn}>
+            Vibrant
+          </button>
+          <MenuTrigger.Menu aria-label="Vibrant" colorScheme="vibrant" menuStyle="vertical">
+            <MenuItem id="star" leadingIcon={<StarIcon />}>
+              Add to favourites
+            </MenuItem>
+            <MenuItem id="share" leadingIcon={<ShareIcon />}>
+              Share
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+              Delete
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Expressive Vertical Menu ─────────────────────────────────────────────────
+
+export const VerticalMenuStyle: Story = {
+  name: "Expressive Vertical Menu",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `vertical` menu style uses **16dp rounded corners** (vs 4dp in baseline) and supports `MenuGap` — a visual spacing element (not a separator) that groups items without a visible divider line.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        More actions
+      </button>
+      <MenuTrigger.Menu aria-label="More actions" menuStyle="vertical" colorScheme="vibrant">
+        <MenuItem id="star" leadingIcon={<StarIcon />}>
+          Add to favourites
+        </MenuItem>
+        <MenuItem id="share" leadingIcon={<ShareIcon />}>
+          Share
+        </MenuItem>
+        <MenuGap />
+        <MenuItem id="rename">Rename</MenuItem>
+        <MenuItem id="duplicate">Duplicate</MenuItem>
+        <MenuGap />
+        <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+          Delete
+        </MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── Gap vs Divider ───────────────────────────────────────────────────────────
+
+export const GapVsDivider: Story = {
+  name: "Gap vs Divider (Vertical)",
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          "Side-by-side comparison of the two MD3 vertical-menu separator styles.",
+          "",
+          "- **With gap** (left): A purely visual blank space (`MenuGap`) separates item groups. No visible line — the gap is hidden from the accessibility tree.",
+          "- **With divider** (right): A thin horizontal rule (`MenuDivider`) drawn with `outline-variant` colour separates groups.",
+        ].join("\n"),
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-start gap-8">
+      {/* ── With gap ── */}
+      <div className="flex flex-col items-center gap-2">
+        <MenuTrigger defaultOpen>
+          <button type="button" className={primaryBtn}>
+            With gap
+          </button>
+          <MenuTrigger.Menu aria-label="With gap" menuStyle="vertical">
+            <MenuItem id="item1" leadingIcon={<InfoIcon />}>
+              Item 1
+            </MenuItem>
+            <MenuItem id="item2" leadingIcon={<CopyIcon />} trailingText="⌘C">
+              Item 2
+            </MenuItem>
+            <MenuItem id="item3" leadingIcon={<CutIcon />}>
+              Item 3
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="item4" leadingIcon={<StarIcon />} trailingIcon={<span>▸</span>}>
+              Item 4
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+
+      {/* ── With divider ── */}
+      <div className="flex flex-col items-center gap-2">
+        <MenuTrigger defaultOpen>
+          <button type="button" className={primaryBtn}>
+            With divider
+          </button>
+          <MenuTrigger.Menu aria-label="With divider" menuStyle="vertical">
+            <MenuItem id="d-item1" leadingIcon={<InfoIcon />}>
+              Item 1
+            </MenuItem>
+            <MenuItem id="d-item2" leadingIcon={<CopyIcon />} trailingText="⌘C">
+              Item 2
+            </MenuItem>
+            <MenuItem id="d-item3" leadingIcon={<CutIcon />}>
+              Item 3
+            </MenuItem>
+            <MenuDivider />
+            <MenuItem id="d-item4" leadingIcon={<StarIcon />} trailingIcon={<span>▸</span>}>
+              Item 4
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Submenu ──────────────────────────────────────────────────────────────────
+
+export const WithSubmenu: Story = {
+  name: "With Submenu",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use `SubmenuTrigger` to nest a second menu inside a `MenuItem`. A trailing chevron is automatically appended. Keyboard: `ArrowRight` opens, `ArrowLeft` / `Escape` closes and returns focus to the parent item.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        Actions
+      </button>
+      <MenuTrigger.Menu aria-label="Actions">
+        <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+          Copy
+        </MenuItem>
+        <SubmenuTrigger>
+          <MenuItem id="share" leadingIcon={<ShareIcon />}>
+            Share
+          </MenuItem>
+          <MenuTrigger.Menu aria-label="Share via">
+            <MenuItem id="email">Email</MenuItem>
+            <MenuItem id="sms">SMS</MenuItem>
+            <MenuItem id="link" trailingText="⌘L">
+              Copy link
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </SubmenuTrigger>
+        <MenuDivider />
+        <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+          Delete
+        </MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
+};
+
+// ─── Context Menu ─────────────────────────────────────────────────────────────
+
+const ContextMenuDemo = (): JSX.Element => {
+  const [lastAction, setLastAction] = useState<string>("(none)");
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <ContextMenuTrigger>
+        <div className="border-outline text-on-surface-variant text-body-medium flex h-32 w-64 items-center justify-center rounded-lg border-dashed select-none">
+          Right-click anywhere here
+        </div>
+        <MenuTrigger.Menu
+          aria-label="Context actions"
+          onAction={(key) => setLastAction(String(key))}
+        >
+          <MenuItem id="cut" leadingIcon={<CutIcon />} trailingText="⌘X">
+            Cut
+          </MenuItem>
+          <MenuItem id="copy" leadingIcon={<CopyIcon />} trailingText="⌘C">
+            Copy
+          </MenuItem>
+          <MenuItem id="paste" leadingIcon={<PasteIcon />} trailingText="⌘V">
+            Paste
+          </MenuItem>
+          <MenuDivider />
+          <MenuItem id="select-all" trailingText="⌘A">
+            Select all
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </ContextMenuTrigger>
+      <p className="text-body-medium text-on-surface-variant">Last action: {lastAction}</p>
+    </div>
+  );
+};
+
+export const ContextMenu: Story = {
+  name: "Context Menu (Right-click)",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Wrap any content with `ContextMenuTrigger` to open a menu on right-click or two-finger tap. The menu is positioned at the pointer coordinates.",
+      },
+    },
+  },
+  render: () => <ContextMenuDemo />,
+};
+
+// ─── Scrollable ───────────────────────────────────────────────────────────────
+
+export const Scrollable: Story = {
+  name: "Scrollable Menu",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When menu content exceeds the available viewport height the menu becomes scrollable. Max height is `calc(100vh - 2rem)` by default.",
+      },
+    },
+  },
+  render: () => (
+    <MenuTrigger>
+      <button type="button" className={primaryBtn}>
+        Select country
+      </button>
+      <MenuTrigger.Menu aria-label="Countries">
+        {[
+          "Argentina",
+          "Australia",
+          "Brazil",
+          "Canada",
+          "China",
+          "Denmark",
+          "Egypt",
+          "Finland",
+          "France",
+          "Germany",
+          "India",
+          "Indonesia",
+          "Italy",
+          "Japan",
+          "Mexico",
+          "Netherlands",
+          "New Zealand",
+          "Nigeria",
+          "Norway",
+          "Poland",
+          "Portugal",
+          "South Africa",
+          "South Korea",
+          "Spain",
+          "Sweden",
+          "Switzerland",
+          "Turkey",
+          "United Kingdom",
+          "United States",
+          "Vietnam",
+        ].map((country) => (
+          <MenuItem key={country} id={country.toLowerCase().replace(/ /g, "-")}>
+            {country}
+          </MenuItem>
+        ))}
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  ),
 };
 
 // ─── Controlled Open ──────────────────────────────────────────────────────────
@@ -323,11 +788,7 @@ const ControlledOpenDemo = (): JSX.Element => {
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="flex gap-3">
-        <button
-          type="button"
-          onClick={() => setIsOpen(true)}
-          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-        >
+        <button type="button" onClick={() => setIsOpen(true)} className={primaryBtn}>
           Open
         </button>
         <button
@@ -368,10 +829,10 @@ export const ControlledOpen: Story = {
   render: () => <ControlledOpenDemo />,
 };
 
-// ─── Context Menu (IconButton trigger) ───────────────────────────────────────
+// ─── Icon Button Trigger ──────────────────────────────────────────────────────
 
 export const IconButtonTrigger: Story = {
-  name: "With IconButton Trigger",
+  name: "With Icon Button Trigger",
   render: () => (
     <MenuTrigger>
       <button
@@ -384,55 +845,35 @@ export const IconButtonTrigger: Story = {
       <MenuTrigger.Menu aria-label="More options">
         <MenuItem id="rename">Rename</MenuItem>
         <MenuItem id="duplicate">Duplicate</MenuItem>
-        <MenuItem id="share">Share</MenuItem>
+        <MenuItem id="share" leadingIcon={<ShareIcon />}>
+          Share
+        </MenuItem>
         <MenuDivider />
-        <MenuItem id="delete">Delete</MenuItem>
+        <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+          Delete
+        </MenuItem>
       </MenuTrigger.Menu>
     </MenuTrigger>
   ),
 };
 
-// ─── Headless Primitive ───────────────────────────────────────────────────────
-
-export const HeadlessPrimitive: Story = {
-  name: "Headless — Custom Styling",
-  render: () => (
-    <HeadlessMenuTrigger>
-      <button
-        type="button"
-        className="bg-tertiary text-on-tertiary text-label-large rounded-full px-6 py-2.5"
-      >
-        Custom Styled Menu
-      </button>
-      <HeadlessMenuTrigger.Menu
-        aria-label="Custom"
-        className={cn(menuContainerVariants({ open: true }), "border-outline-variant border")}
-      >
-        <HeadlessMenuItem id="option-a" className={cn(menuItemVariants(), "text-secondary")}>
-          Option A (custom)
-        </HeadlessMenuItem>
-        <HeadlessMenuItem id="option-b" className={cn(menuItemVariants())}>
-          Option B
-        </HeadlessMenuItem>
-      </HeadlessMenuTrigger.Menu>
-    </HeadlessMenuTrigger>
-  ),
-};
-
-// ─── Dark Mode ────────────────────────────────────────────────────────────────
+// ─── Dark Mode — Standard ─────────────────────────────────────────────────────
 
 export const DarkMode: Story = {
-  name: "Dark Mode",
+  name: "Dark Mode — Standard",
   parameters: {
     backgrounds: { default: "dark" },
+    docs: {
+      description: {
+        story:
+          "Standard color scheme in dark mode. Tokens automatically adapt via CSS `@media (prefers-color-scheme: dark)` or `.dark` class.",
+      },
+    },
   },
   render: () => (
     <div className="dark">
       <MenuTrigger>
-        <button
-          type="button"
-          className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
-        >
+        <button type="button" className={primaryBtn}>
           Open Menu
         </button>
         <MenuTrigger.Menu aria-label="Edit">
@@ -450,5 +891,73 @@ export const DarkMode: Story = {
         </MenuTrigger.Menu>
       </MenuTrigger>
     </div>
+  ),
+};
+
+// ─── Dark Mode — Vibrant ──────────────────────────────────────────────────────
+
+export const DarkModeVibrant: Story = {
+  name: "Dark Mode — Vibrant Vertical",
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  render: () => (
+    <div className="dark">
+      <MenuTrigger>
+        <button type="button" className={tertiaryBtn}>
+          More actions
+        </button>
+        <MenuTrigger.Menu aria-label="More actions" menuStyle="vertical" colorScheme="vibrant">
+          <MenuItem id="star" leadingIcon={<StarIcon />}>
+            Add to favourites
+          </MenuItem>
+          <MenuItem id="share" leadingIcon={<ShareIcon />}>
+            Share
+          </MenuItem>
+          <MenuGap />
+          <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+            Delete
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    </div>
+  ),
+};
+
+// ─── Headless Primitive ───────────────────────────────────────────────────────
+
+export const HeadlessPrimitive: Story = {
+  name: "Headless — Custom Styling",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Layer 2 headless primitives expose the full RAC API without any MD3 styles applied. Use these as a foundation for fully custom styling.",
+      },
+    },
+  },
+  render: () => (
+    <HeadlessMenuTrigger>
+      <button
+        type="button"
+        className="bg-tertiary text-on-tertiary text-label-large rounded-full px-6 py-2.5"
+      >
+        Custom Styled Menu
+      </button>
+      <HeadlessMenuTrigger.Menu
+        aria-label="Custom"
+        className={cn(
+          menuContainerVariants({ menuStyle: "baseline" }),
+          "border-outline-variant border"
+        )}
+      >
+        <HeadlessMenuItem id="option-a" className={cn(menuItemVariants(), "text-secondary")}>
+          Option A (custom)
+        </HeadlessMenuItem>
+        <HeadlessMenuItem id="option-b" className={cn(menuItemVariants())}>
+          Option B
+        </HeadlessMenuItem>
+      </HeadlessMenuTrigger.Menu>
+    </HeadlessMenuTrigger>
   ),
 };

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -1,0 +1,758 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { MenuTrigger } from "./Menu";
+import { MenuItem } from "./MenuItem";
+import { MenuSection } from "./MenuSection";
+import { MenuDivider } from "./MenuDivider";
+import { HeadlessMenuTrigger } from "./MenuHeadless";
+
+// ─── Test Icon Mocks ───────────────────────────────────────────────────────────
+
+const CopyIcon = () => <svg data-testid="copy-icon" aria-hidden="true" />;
+const CutIcon = () => <svg data-testid="cut-icon" aria-hidden="true" />;
+const PasteIcon = () => <svg data-testid="paste-icon" aria-hidden="true" />;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderBasicMenu(
+  props: Record<string, unknown> = {},
+  itemProps: Record<string, unknown> = {}
+) {
+  return render(
+    <MenuTrigger>
+      <button type="button">Open Menu</button>
+      <MenuTrigger.Menu aria-label="Actions" {...props}>
+        <MenuItem id="cut" {...itemProps}>
+          Cut
+        </MenuItem>
+        <MenuItem id="copy">Copy</MenuItem>
+        <MenuItem id="paste">Paste</MenuItem>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  );
+}
+
+async function openMenu() {
+  const user = userEvent.setup();
+  const trigger = screen.getByRole("button", { name: "Open Menu" });
+  await user.click(trigger);
+  return { user, trigger };
+}
+
+// ─── MenuTrigger ──────────────────────────────────────────────────────────────
+
+describe("MenuTrigger", () => {
+  describe("Rendering", () => {
+    test("renders trigger element", () => {
+      renderBasicMenu();
+      expect(screen.getByRole("button", { name: "Open Menu" })).toBeInTheDocument();
+    });
+
+    test("trigger has aria-haspopup='menu'", () => {
+      renderBasicMenu();
+      // React Aria's useOverlayTrigger sets aria-haspopup: true (boolean) for
+      // type='menu', which React serializes to "true" in the DOM. This is
+      // equivalent to "menu" per the WAI-ARIA spec.
+      const trigger = screen.getByRole("button", { name: "Open Menu" });
+      expect(trigger).toHaveAttribute("aria-haspopup");
+    });
+
+    test("trigger has aria-expanded='false' when closed", () => {
+      renderBasicMenu();
+      expect(screen.getByRole("button", { name: "Open Menu" })).toHaveAttribute(
+        "aria-expanded",
+        "false"
+      );
+    });
+
+    test("trigger has aria-expanded='true' when open", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getByRole("button", { name: "Open Menu" })).toHaveAttribute(
+        "aria-expanded",
+        "true"
+      );
+    });
+
+    test("menu is not visible when closed", () => {
+      renderBasicMenu();
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    test("menu is visible when trigger is clicked", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+  });
+
+  describe("Open/Close Interactions", () => {
+    test("clicking trigger opens the menu", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+
+    test("pressing Escape closes the menu", async () => {
+      renderBasicMenu();
+      const { user } = await openMenu();
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      });
+    });
+
+    test("Escape returns focus to trigger after close", async () => {
+      renderBasicMenu();
+      const { user, trigger } = await openMenu();
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(document.activeElement).toBe(trigger);
+      });
+    });
+
+    test("clicking outside menu closes it", async () => {
+      render(
+        <div>
+          <div data-testid="outside">Outside</div>
+          <MenuTrigger>
+            <button type="button">Open Menu</button>
+            <MenuTrigger.Menu aria-label="Actions">
+              <MenuItem id="cut">Cut</MenuItem>
+            </MenuTrigger.Menu>
+          </MenuTrigger>
+        </div>
+      );
+      await openMenu();
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+      const user = userEvent.setup();
+      // Close via Escape — JSDOM portals have limited pointer-event bubbling for
+      // "interact outside" detection, so Escape is the reliable cross-env close.
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      });
+    });
+
+    test("onOpenChange is called when menu opens", async () => {
+      const onOpenChange = vi.fn();
+      render(
+        <MenuTrigger onOpenChange={onOpenChange}>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    test("onOpenChange is called when menu closes via Escape", async () => {
+      const onOpenChange = vi.fn();
+      render(
+        <MenuTrigger onOpenChange={onOpenChange}>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      const { user } = await openMenu();
+      onOpenChange.mockClear();
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    test("controlled isOpen prop opens menu", () => {
+      render(
+        <MenuTrigger isOpen>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+  });
+});
+
+// ─── Menu ─────────────────────────────────────────────────────────────────────
+
+describe("Menu", () => {
+  describe("Rendering", () => {
+    test("renders with role='menu'", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+
+    test("has correct aria-label", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getByRole("menu")).toHaveAttribute("aria-label", "Actions");
+    });
+
+    test("renders all menu items", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Copy" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Paste" })).toBeInTheDocument();
+    });
+
+    test("accepts custom className", async () => {
+      renderBasicMenu({ className: "custom-menu" });
+      await openMenu();
+      expect(screen.getByRole("menu")).toHaveClass("custom-menu");
+    });
+  });
+
+  describe("Portal", () => {
+    test("menu is rendered in a portal (appended to document.body)", async () => {
+      renderBasicMenu();
+      await openMenu();
+      const menu = screen.getByRole("menu");
+      // The menu should be a descendant of body but not of the component's wrapper
+      expect(document.body.contains(menu)).toBe(true);
+    });
+  });
+});
+
+// ─── MenuItem ─────────────────────────────────────────────────────────────────
+
+describe("MenuItem", () => {
+  describe("Rendering", () => {
+    test("renders with role='menuitem'", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getAllByRole("menuitem").length).toBeGreaterThan(0);
+    });
+
+    test("renders label text", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
+    });
+
+    test("renders leading icon when provided", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(screen.getByTestId("copy-icon")).toBeInTheDocument();
+    });
+
+    test("renders trailing icon when provided", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut" trailingIcon={<CutIcon />}>
+              Cut
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(screen.getByTestId("cut-icon")).toBeInTheDocument();
+    });
+
+    test("renders trailing text (keyboard shortcut) when provided", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" trailingText="⌘C">
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(screen.getByText("⌘C")).toBeInTheDocument();
+    });
+
+    test("accepts custom className", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut" className="custom-item">
+              Cut
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("custom-item");
+    });
+  });
+
+  describe("Disabled state", () => {
+    test("disabled item has aria-disabled='true'", async () => {
+      renderBasicMenu({}, { isDisabled: true });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      );
+    });
+
+    test("disabled item does not fire onAction when clicked", async () => {
+      const onAction = vi.fn();
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut" isDisabled onAction={onAction}>
+              Cut
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      const { user } = await openMenu();
+      await user.click(screen.getByRole("menuitem", { name: "Cut" }));
+      expect(onAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Interactions", () => {
+    test("clicking an item fires onAction", async () => {
+      const onAction = vi.fn();
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions" onAction={onAction}>
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      const { user } = await openMenu();
+      await user.click(screen.getByRole("menuitem", { name: "Cut" }));
+      expect(onAction).toHaveBeenCalledWith("cut");
+    });
+
+    test("selecting an item closes the menu by default", async () => {
+      renderBasicMenu();
+      const { user } = await openMenu();
+      await user.click(screen.getByRole("menuitem", { name: "Cut" }));
+      await waitFor(() => {
+        expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      });
+    });
+  });
+});
+
+// ─── Keyboard Navigation ──────────────────────────────────────────────────────
+
+describe("Keyboard navigation", () => {
+  test("ArrowDown moves focus to next item", async () => {
+    renderBasicMenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toHaveTextContent("Cut");
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toHaveTextContent("Copy");
+  });
+
+  test("ArrowUp moves focus to previous item", async () => {
+    renderBasicMenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowUp}");
+    expect(document.activeElement).toHaveTextContent("Cut");
+  });
+
+  test("Home moves focus to first item", async () => {
+    renderBasicMenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Home}");
+    expect(document.activeElement).toHaveTextContent("Cut");
+  });
+
+  test("End moves focus to last item", async () => {
+    renderBasicMenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{End}");
+    expect(document.activeElement).toHaveTextContent("Paste");
+  });
+
+  test("Enter selects focused item and closes menu", async () => {
+    const onAction = vi.fn();
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Actions" onAction={onAction}>
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Enter}");
+    expect(onAction).toHaveBeenCalledWith("cut");
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  test("Space selects focused item and closes menu", async () => {
+    const onAction = vi.fn();
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Actions" onAction={onAction}>
+          <MenuItem id="cut">Cut</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard(" ");
+    expect(onAction).toHaveBeenCalledWith("cut");
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  test("type-ahead focuses first matching item", async () => {
+    renderBasicMenu();
+    const { user } = await openMenu();
+    await user.keyboard("c");
+    expect(document.activeElement).toHaveTextContent("Cut");
+  });
+});
+
+// ─── MenuSection ──────────────────────────────────────────────────────────────
+
+describe("MenuSection", () => {
+  function renderMenuWithSections() {
+    return render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit">
+          <MenuSection header="Clipboard" aria-label="Clipboard">
+            <MenuItem id="cut" leadingIcon={<CutIcon />}>
+              Cut
+            </MenuItem>
+            <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+              Copy
+            </MenuItem>
+          </MenuSection>
+          <MenuSection header="Actions" showDivider aria-label="Actions">
+            <MenuItem id="paste" leadingIcon={<PasteIcon />}>
+              Paste
+            </MenuItem>
+          </MenuSection>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+  }
+
+  test("renders section with role='group'", async () => {
+    renderMenuWithSections();
+    await openMenu();
+    const groups = screen.getAllByRole("group");
+    expect(groups.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("renders section header text", async () => {
+    renderMenuWithSections();
+    await openMenu();
+    // Sections have aria-label="Clipboard" / "Actions" which gives the group
+    // its accessible name. The Header component provides additional visible text
+    // but the accessible name check is the canonical way to verify labelling.
+    expect(screen.getByRole("group", { name: "Clipboard" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Actions" })).toBeInTheDocument();
+  });
+
+  test("renders divider when showDivider=true", async () => {
+    renderMenuWithSections();
+    await openMenu();
+    expect(screen.getByRole("separator", { hidden: true })).toBeInTheDocument();
+  });
+
+  test("does NOT render divider when showDivider=false (default)", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit">
+          <MenuSection aria-label="Clipboard">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuSection>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    expect(screen.queryByRole("separator", { hidden: true })).not.toBeInTheDocument();
+  });
+
+  test("renders children inside section", async () => {
+    renderMenuWithSections();
+    await openMenu();
+    expect(screen.getByRole("menuitem", { name: /Cut/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Copy/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Paste/i })).toBeInTheDocument();
+  });
+});
+
+// ─── MenuDivider ──────────────────────────────────────────────────────────────
+
+describe("MenuDivider", () => {
+  test("renders as separator", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuDivider />
+          <MenuItem id="paste">Paste</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    expect(screen.getByRole("separator", { hidden: true })).toBeInTheDocument();
+  });
+
+  test("accepts custom className", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuDivider className="custom-divider" />
+          <MenuItem id="paste">Paste</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    expect(screen.getByRole("separator", { hidden: true })).toHaveClass("custom-divider");
+  });
+});
+
+// ─── Select Variant ───────────────────────────────────────────────────────────
+
+describe("Select variant", () => {
+  test("single selection mode works", async () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="View"
+          variant="select"
+          selectionMode="single"
+          onSelectionChange={onSelectionChange}
+        >
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    const { user } = await openMenu();
+    // With selectionMode="single", React Aria gives items role="menuitemradio"
+    await user.click(screen.getByRole("menuitemradio", { name: "Grid view" }));
+    expect(onSelectionChange).toHaveBeenCalled();
+  });
+
+  test("multiple selection mode works", async () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="Filters"
+          variant="select"
+          selectionMode="multiple"
+          onSelectionChange={onSelectionChange}
+        >
+          <MenuItem id="bold">Bold</MenuItem>
+          <MenuItem id="italic">Italic</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    const { user } = await openMenu();
+    // With selectionMode="multiple", React Aria gives items role="menuitemcheckbox"
+    await user.click(screen.getByRole("menuitemcheckbox", { name: "Bold" }));
+    expect(onSelectionChange).toHaveBeenCalled();
+  });
+
+  test("selected items have aria-checked='true' for select variant", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="View"
+          variant="select"
+          selectionMode="single"
+          defaultSelectedKeys={["grid"]}
+        >
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    expect(screen.getByRole("menuitemradio", { name: "Grid view" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+});
+
+// ─── Accessibility ────────────────────────────────────────────────────────────
+
+describe("Accessibility (axe)", () => {
+  test("closed menu trigger passes axe audit", async () => {
+    const { container } = renderBasicMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("open menu passes axe audit", async () => {
+    const { container } = renderBasicMenu();
+    await openMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("menu with sections passes axe audit", async () => {
+    const { container } = render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit">
+          <MenuSection aria-label="Clipboard">
+            <MenuItem id="cut">Cut</MenuItem>
+            <MenuItem id="copy">Copy</MenuItem>
+          </MenuSection>
+          <MenuSection header="Format" showDivider aria-label="Format">
+            <MenuItem id="bold">Bold</MenuItem>
+          </MenuSection>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("menu with disabled items passes axe audit", async () => {
+    const { container } = render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuItem id="paste" isDisabled>
+            Paste
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("select variant menu passes axe audit", async () => {
+    const { container } = render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="View"
+          variant="select"
+          selectionMode="single"
+          defaultSelectedKeys={["grid"]}
+        >
+          <MenuItem id="grid">Grid</MenuItem>
+          <MenuItem id="list">List</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+// ─── Headless Primitives ──────────────────────────────────────────────────────
+
+describe("HeadlessMenuTrigger", () => {
+  test("renders trigger element", () => {
+    render(
+      <HeadlessMenuTrigger>
+        <button type="button">Trigger</button>
+        <HeadlessMenuTrigger.Menu aria-label="Headless">
+          <MenuItem id="a">Item A</MenuItem>
+        </HeadlessMenuTrigger.Menu>
+      </HeadlessMenuTrigger>
+    );
+    expect(screen.getByRole("button", { name: "Trigger" })).toBeInTheDocument();
+  });
+
+  test("trigger has aria-haspopup='menu'", () => {
+    render(
+      <HeadlessMenuTrigger>
+        <button type="button">Trigger</button>
+        <HeadlessMenuTrigger.Menu aria-label="Headless">
+          <MenuItem id="a">Item A</MenuItem>
+        </HeadlessMenuTrigger.Menu>
+      </HeadlessMenuTrigger>
+    );
+    const trigger = screen.getByRole("button", { name: "Trigger" });
+    // React Aria sets aria-haspopup to boolean true (serialized as "true") for menus
+    expect(trigger).toHaveAttribute("aria-haspopup");
+  });
+
+  test("passes axe audit (closed)", async () => {
+    const { container } = render(
+      <HeadlessMenuTrigger>
+        <button type="button">Trigger</button>
+        <HeadlessMenuTrigger.Menu aria-label="Headless">
+          <MenuItem id="a">Item A</MenuItem>
+        </HeadlessMenuTrigger.Menu>
+      </HeadlessMenuTrigger>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+// ─── Focus Management ────────────────────────────────────────────────────────
+
+describe("Focus management", () => {
+  test("focus moves into the menu when opened", async () => {
+    renderBasicMenu();
+    await openMenu();
+    await waitFor(() => {
+      const menu = screen.getByRole("menu");
+      expect(menu.contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  test("focus returns to trigger when menu is closed via Escape", async () => {
+    renderBasicMenu();
+    const { user, trigger } = await openMenu();
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+});

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -6,7 +6,11 @@ import { MenuTrigger } from "./Menu";
 import { MenuItem } from "./MenuItem";
 import { MenuSection } from "./MenuSection";
 import { MenuDivider } from "./MenuDivider";
+import { MenuGap } from "./MenuGap";
+import { SubmenuTrigger } from "./SubmenuTrigger";
+import { ContextMenuTrigger } from "./ContextMenuTrigger";
 import { HeadlessMenuTrigger } from "./MenuHeadless";
+import { menuContainerVariants, menuItemVariants } from "./Menu.variants";
 
 // ─── Test Icon Mocks ───────────────────────────────────────────────────────────
 
@@ -52,9 +56,6 @@ describe("MenuTrigger", () => {
 
     test("trigger has aria-haspopup='menu'", () => {
       renderBasicMenu();
-      // React Aria's useOverlayTrigger sets aria-haspopup: true (boolean) for
-      // type='menu', which React serializes to "true" in the DOM. This is
-      // equivalent to "menu" per the WAI-ARIA spec.
       const trigger = screen.getByRole("button", { name: "Open Menu" });
       expect(trigger).toHaveAttribute("aria-haspopup");
     });
@@ -70,7 +71,11 @@ describe("MenuTrigger", () => {
     test("trigger has aria-expanded='true' when open", async () => {
       renderBasicMenu();
       await openMenu();
-      expect(screen.getByRole("button", { name: "Open Menu" })).toHaveAttribute(
+      // When the menu is open the Popover uses modal overlay behavior — RAC's
+      // ariaHideOutside hides everything outside the popover from the a11y tree,
+      // including the trigger. We use { hidden: true } to assert the attribute
+      // on the DOM node directly while it is aria-hidden.
+      expect(screen.getByRole("button", { name: "Open Menu", hidden: true })).toHaveAttribute(
         "aria-expanded",
         "true"
       );
@@ -116,7 +121,7 @@ describe("MenuTrigger", () => {
     test("clicking outside menu closes it", async () => {
       render(
         <div>
-          <div data-testid="outside">Outside</div>
+          <div data-testid="outside">Outside element</div>
           <MenuTrigger>
             <button type="button">Open Menu</button>
             <MenuTrigger.Menu aria-label="Actions">
@@ -125,12 +130,12 @@ describe("MenuTrigger", () => {
           </MenuTrigger>
         </div>
       );
-      await openMenu();
-      expect(screen.getByRole("menu")).toBeInTheDocument();
       const user = userEvent.setup();
-      // Close via Escape — JSDOM portals have limited pointer-event bubbling for
-      // "interact outside" detection, so Escape is the reliable cross-env close.
-      await user.keyboard("{Escape}");
+      await user.click(screen.getByRole("button", { name: "Open Menu" }));
+      await waitFor(() => {
+        expect(screen.getByRole("menu")).toBeInTheDocument();
+      });
+      await user.click(screen.getByTestId("outside"));
       await waitFor(() => {
         expect(screen.queryByRole("menu")).not.toBeInTheDocument();
       });
@@ -179,6 +184,19 @@ describe("MenuTrigger", () => {
       );
       expect(screen.getByRole("menu")).toBeInTheDocument();
     });
+
+    test("shouldFlip prop passes through to trigger", () => {
+      // shouldFlip defaults to true; test it can be set
+      render(
+        <MenuTrigger shouldFlip={false}>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      expect(screen.getByRole("button", { name: "Open Menu" })).toBeInTheDocument();
+    });
   });
 });
 
@@ -211,6 +229,32 @@ describe("Menu", () => {
       await openMenu();
       expect(screen.getByRole("menu")).toHaveClass("custom-menu");
     });
+
+    test("uses standard colorScheme by default", async () => {
+      renderBasicMenu();
+      await openMenu();
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bg-surface-container");
+    });
+
+    test("vibrant colorScheme applies tertiary container background", async () => {
+      renderBasicMenu({ colorScheme: "vibrant", menuStyle: "vertical" });
+      await openMenu();
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bg-tertiary-container");
+    });
+
+    test("baseline menuStyle uses extra-small corner radius", async () => {
+      renderBasicMenu({ menuStyle: "baseline" });
+      await openMenu();
+      expect(screen.getByRole("menu")).toHaveClass("rounded-xs");
+    });
+
+    test("vertical menuStyle uses large corner radius", async () => {
+      renderBasicMenu({ menuStyle: "vertical" });
+      await openMenu();
+      expect(screen.getByRole("menu")).toHaveClass("rounded-lg");
+    });
   });
 
   describe("Portal", () => {
@@ -218,7 +262,6 @@ describe("Menu", () => {
       renderBasicMenu();
       await openMenu();
       const menu = screen.getByRole("menu");
-      // The menu should be a descendant of body but not of the component's wrapper
       expect(document.body.contains(menu)).toBe(true);
     });
   });
@@ -240,6 +283,13 @@ describe("MenuItem", () => {
       expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
     });
 
+    test("uses body-large typography for label text", async () => {
+      renderBasicMenu();
+      await openMenu();
+      const item = screen.getByRole("menuitem", { name: "Cut" });
+      expect(item).toHaveClass("text-body-large");
+    });
+
     test("renders leading icon when provided", async () => {
       render(
         <MenuTrigger>
@@ -253,6 +303,24 @@ describe("MenuItem", () => {
       );
       await openMenu();
       expect(screen.getByTestId("copy-icon")).toBeInTheDocument();
+    });
+
+    test("leading icon wrapper has 24dp size constraint", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const icon = screen.getByTestId("copy-icon");
+      const wrapper = icon.closest("span");
+      expect(wrapper).toHaveClass("w-6");
+      expect(wrapper).toHaveClass("h-6");
     });
 
     test("renders trailing icon when provided", async () => {
@@ -270,6 +338,24 @@ describe("MenuItem", () => {
       expect(screen.getByTestId("cut-icon")).toBeInTheDocument();
     });
 
+    test("trailing icon wrapper has 24dp size constraint", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="cut" trailingIcon={<CutIcon />}>
+              Cut
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const icon = screen.getByTestId("cut-icon");
+      const wrapper = icon.closest("span");
+      expect(wrapper).toHaveClass("w-6");
+      expect(wrapper).toHaveClass("h-6");
+    });
+
     test("renders trailing text (keyboard shortcut) when provided", async () => {
       render(
         <MenuTrigger>
@@ -285,6 +371,69 @@ describe("MenuItem", () => {
       expect(screen.getByText("⌘C")).toBeInTheDocument();
     });
 
+    test("trailing text has aria-keyshortcuts attribute", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" trailingText="⌘C">
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const shortcut = screen.getByText("⌘C");
+      expect(shortcut).toHaveAttribute("aria-keyshortcuts", "⌘C");
+    });
+
+    test("renders description when provided", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" description="Copy the selected text">
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(screen.getByText("Copy the selected text")).toBeInTheDocument();
+    });
+
+    test("description uses body-medium typography", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="copy" description="Copy description">
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const desc = screen.getByText("Copy description");
+      expect(desc).toHaveClass("text-body-medium");
+      expect(desc).toHaveClass("text-on-surface-variant");
+    });
+
+    test("renders badge when provided", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions">
+            <MenuItem id="notifications" badge={<span data-testid="badge">3</span>}>
+              Notifications
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(screen.getByTestId("badge")).toBeInTheDocument();
+    });
+
     test("accepts custom className", async () => {
       render(
         <MenuTrigger>
@@ -298,6 +447,32 @@ describe("MenuItem", () => {
       );
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("custom-item");
+    });
+  });
+
+  describe("Density", () => {
+    test("density 0 (default) renders items with h-12 class", async () => {
+      renderBasicMenu({ density: 0 });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-12");
+    });
+
+    test("density -1 renders items with h-11 class", async () => {
+      renderBasicMenu({ density: -1 });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-11");
+    });
+
+    test("density -2 renders items with h-10 class", async () => {
+      renderBasicMenu({ density: -2 });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-10");
+    });
+
+    test("density -3 renders items with h-9 class", async () => {
+      renderBasicMenu({ density: -3 });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-9");
     });
   });
 
@@ -439,6 +614,24 @@ describe("Keyboard navigation", () => {
     await user.keyboard("c");
     expect(document.activeElement).toHaveTextContent("Cut");
   });
+
+  test("shouldFocusWrap=true wraps focus from last to first", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Actions" shouldFocusWrap>
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    // With wrap, should cycle back to "Cut"
+    expect(document.activeElement).toHaveTextContent("Cut");
+  });
 });
 
 // ─── MenuSection ──────────────────────────────────────────────────────────────
@@ -477,9 +670,6 @@ describe("MenuSection", () => {
   test("renders section header text", async () => {
     renderMenuWithSections();
     await openMenu();
-    // Sections have aria-label="Clipboard" / "Actions" which gives the group
-    // its accessible name. The Header component provides additional visible text
-    // but the accessible name check is the canonical way to verify labelling.
     expect(screen.getByRole("group", { name: "Clipboard" })).toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Actions" })).toBeInTheDocument();
   });
@@ -532,6 +722,22 @@ describe("MenuDivider", () => {
     expect(screen.getByRole("separator", { hidden: true })).toBeInTheDocument();
   });
 
+  test("divider has correct 8dp top/bottom padding (my-2)", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuDivider />
+          <MenuItem id="paste">Paste</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const divider = screen.getByRole("separator", { hidden: true });
+    expect(divider).toHaveClass("my-2");
+  });
+
   test("accepts custom className", async () => {
     render(
       <MenuTrigger>
@@ -548,9 +754,32 @@ describe("MenuDivider", () => {
   });
 });
 
-// ─── Select Variant ───────────────────────────────────────────────────────────
+// ─── MenuGap ──────────────────────────────────────────────────────────────────
 
-describe("Select variant", () => {
+describe("MenuGap", () => {
+  test("renders as a presentational spacer (no separator role)", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit" menuStyle="vertical">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuGap />
+          <MenuItem id="paste">Paste</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    // MenuGap uses role="none" / aria-hidden - should NOT appear as a separator
+    expect(screen.queryByRole("separator")).not.toBeInTheDocument();
+    // but the menu items still render
+    expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Paste" })).toBeInTheDocument();
+  });
+});
+
+// ─── Selection variant ────────────────────────────────────────────────────────
+
+describe("Selection mode", () => {
   test("single selection mode works", async () => {
     const onSelectionChange = vi.fn();
     render(
@@ -558,7 +787,6 @@ describe("Select variant", () => {
         <button type="button">Open Menu</button>
         <MenuTrigger.Menu
           aria-label="View"
-          variant="select"
           selectionMode="single"
           onSelectionChange={onSelectionChange}
         >
@@ -568,7 +796,6 @@ describe("Select variant", () => {
       </MenuTrigger>
     );
     const { user } = await openMenu();
-    // With selectionMode="single", React Aria gives items role="menuitemradio"
     await user.click(screen.getByRole("menuitemradio", { name: "Grid view" }));
     expect(onSelectionChange).toHaveBeenCalled();
   });
@@ -580,7 +807,6 @@ describe("Select variant", () => {
         <button type="button">Open Menu</button>
         <MenuTrigger.Menu
           aria-label="Filters"
-          variant="select"
           selectionMode="multiple"
           onSelectionChange={onSelectionChange}
         >
@@ -590,21 +816,15 @@ describe("Select variant", () => {
       </MenuTrigger>
     );
     const { user } = await openMenu();
-    // With selectionMode="multiple", React Aria gives items role="menuitemcheckbox"
     await user.click(screen.getByRole("menuitemcheckbox", { name: "Bold" }));
     expect(onSelectionChange).toHaveBeenCalled();
   });
 
-  test("selected items have aria-checked='true' for select variant", async () => {
+  test("selected items have aria-checked='true'", async () => {
     render(
       <MenuTrigger>
         <button type="button">Open Menu</button>
-        <MenuTrigger.Menu
-          aria-label="View"
-          variant="select"
-          selectionMode="single"
-          defaultSelectedKeys={["grid"]}
-        >
+        <MenuTrigger.Menu aria-label="View" selectionMode="single" defaultSelectedKeys={["grid"]}>
           <MenuItem id="grid">Grid view</MenuItem>
           <MenuItem id="list">List view</MenuItem>
         </MenuTrigger.Menu>
@@ -615,6 +835,248 @@ describe("Select variant", () => {
       "aria-checked",
       "true"
     );
+  });
+
+  test("selected item has correct baseline selection background", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="View"
+          selectionMode="single"
+          defaultSelectedKeys={["grid"]}
+          menuStyle="baseline"
+        >
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem).toHaveClass("bg-surface-container-highest");
+  });
+
+  test("selected item in vertical standard has tertiary container background", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="View"
+          selectionMode="single"
+          defaultSelectedKeys={["grid"]}
+          menuStyle="vertical"
+          colorScheme="standard"
+        >
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem).toHaveClass("bg-tertiary-container");
+  });
+
+  test("selected item in vertical vibrant has tertiary background", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu
+          aria-label="View"
+          selectionMode="single"
+          defaultSelectedKeys={["grid"]}
+          menuStyle="vertical"
+          colorScheme="vibrant"
+        >
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem).toHaveClass("bg-tertiary");
+  });
+
+  test("checkmark appears on selected item when selectionMode is set and no leadingIcon", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="View" selectionMode="single" defaultSelectedKeys={["grid"]}>
+          <MenuItem id="grid">Grid view</MenuItem>
+          <MenuItem id="list">List view</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem.querySelector("[data-testid='check-icon']")).toBeInTheDocument();
+  });
+
+  test("checkmark does not appear when leadingIcon is provided", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="View" selectionMode="single" defaultSelectedKeys={["grid"]}>
+          <MenuItem id="grid" leadingIcon={<CopyIcon />}>
+            Grid view
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
+    expect(selectedItem.querySelector("[data-testid='check-icon']")).not.toBeInTheDocument();
+  });
+
+  test("multi-select keeps menu open after selection", async () => {
+    render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Filters" selectionMode="multiple" defaultSelectedKeys={[]}>
+          <MenuItem id="bold">Bold</MenuItem>
+          <MenuItem id="italic">Italic</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    const { user } = await openMenu();
+    await user.click(screen.getByRole("menuitemcheckbox", { name: "Bold" }));
+    // Multi-select menus stay open
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+});
+
+// ─── Submenu ──────────────────────────────────────────────────────────────────
+
+describe("SubmenuTrigger", () => {
+  function renderMenuWithSubmenu() {
+    return render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Actions">
+          <MenuItem id="copy">Copy</MenuItem>
+          <SubmenuTrigger>
+            <MenuItem id="share">Share</MenuItem>
+            <MenuTrigger.Menu aria-label="Share via">
+              <MenuItem id="email">Email</MenuItem>
+              <MenuItem id="sms">SMS</MenuItem>
+            </MenuTrigger.Menu>
+          </SubmenuTrigger>
+          <MenuItem id="delete">Delete</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+  }
+
+  test("renders submenu trigger item with chevron indicator", async () => {
+    renderMenuWithSubmenu();
+    await openMenu();
+    const shareItem = screen.getByRole("menuitem", { name: /Share/i });
+    expect(shareItem).toBeInTheDocument();
+    // Chevron icon should be present in the item
+    expect(shareItem.querySelector("[data-testid='chevron-icon']")).toBeInTheDocument();
+  });
+
+  test("submenu trigger item has aria-haspopup='menu'", async () => {
+    renderMenuWithSubmenu();
+    await openMenu();
+    const shareItem = screen.getByRole("menuitem", { name: /Share/i });
+    expect(shareItem).toHaveAttribute("aria-haspopup", "menu");
+  });
+
+  test("ArrowRight opens submenu from trigger item", async () => {
+    renderMenuWithSubmenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}"); // focus Share
+    await user.keyboard("{ArrowRight}"); // open submenu
+    await waitFor(() => {
+      expect(screen.getByRole("menu", { name: "Share via" })).toBeInTheDocument();
+    });
+  });
+
+  test("submenu items are accessible after opening", async () => {
+    renderMenuWithSubmenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}"); // focus Share
+    await user.keyboard("{ArrowRight}"); // open submenu
+    await waitFor(() => {
+      expect(screen.getByRole("menuitem", { name: "Email" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "SMS" })).toBeInTheDocument();
+    });
+  });
+
+  test("Escape closes submenu and returns focus to parent item", async () => {
+    renderMenuWithSubmenu();
+    const { user } = await openMenu();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowRight}");
+    await waitFor(() => {
+      expect(screen.getByRole("menu", { name: "Share via" })).toBeInTheDocument();
+    });
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByRole("menu", { name: "Share via" })).not.toBeInTheDocument();
+    });
+    // Parent menu should still be open
+    expect(screen.getByRole("menu", { name: "Actions" })).toBeInTheDocument();
+  });
+});
+
+// ─── ContextMenuTrigger ────────────────────────────────────────────────────────
+
+describe("ContextMenuTrigger", () => {
+  test("does not render menu initially", () => {
+    render(
+      <ContextMenuTrigger>
+        <div data-testid="target">Right-click me</div>
+        <MenuTrigger.Menu aria-label="Context">
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuTrigger.Menu>
+      </ContextMenuTrigger>
+    );
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  test("opens menu on right-click (contextmenu event)", async () => {
+    render(
+      <ContextMenuTrigger>
+        <div data-testid="target">Right-click me</div>
+        <MenuTrigger.Menu aria-label="Context">
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuTrigger.Menu>
+      </ContextMenuTrigger>
+    );
+    const target = screen.getByTestId("target");
+    const user = userEvent.setup();
+    await user.pointer({ target, keys: "[MouseRight]" });
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+  });
+
+  test("context menu closes on Escape", async () => {
+    render(
+      <ContextMenuTrigger>
+        <div data-testid="target">Right-click me</div>
+        <MenuTrigger.Menu aria-label="Context">
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuTrigger.Menu>
+      </ContextMenuTrigger>
+    );
+    const target = screen.getByTestId("target");
+    const user = userEvent.setup();
+    await user.pointer({ target, keys: "[MouseRight]" });
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
   });
 });
 
@@ -671,18 +1133,44 @@ describe("Accessibility (axe)", () => {
     expect(results).toHaveNoViolations();
   });
 
-  test("select variant menu passes axe audit", async () => {
+  test("selection mode menu passes axe audit", async () => {
     const { container } = render(
       <MenuTrigger>
         <button type="button">Open Menu</button>
-        <MenuTrigger.Menu
-          aria-label="View"
-          variant="select"
-          selectionMode="single"
-          defaultSelectedKeys={["grid"]}
-        >
+        <MenuTrigger.Menu aria-label="View" selectionMode="single" defaultSelectedKeys={["grid"]}>
           <MenuItem id="grid">Grid</MenuItem>
           <MenuItem id="list">List</MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("menu with description passes axe audit", async () => {
+    const { container } = render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Actions">
+          <MenuItem id="export" description="Export to various formats">
+            Export
+          </MenuItem>
+        </MenuTrigger.Menu>
+      </MenuTrigger>
+    );
+    await openMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("vibrant colorScheme menu passes axe audit", async () => {
+    const { container } = render(
+      <MenuTrigger>
+        <button type="button">Open Menu</button>
+        <MenuTrigger.Menu aria-label="Edit" menuStyle="vertical" colorScheme="vibrant">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuItem id="copy">Copy</MenuItem>
         </MenuTrigger.Menu>
       </MenuTrigger>
     );
@@ -717,7 +1205,6 @@ describe("HeadlessMenuTrigger", () => {
       </HeadlessMenuTrigger>
     );
     const trigger = screen.getByRole("button", { name: "Trigger" });
-    // React Aria sets aria-haspopup to boolean true (serialized as "true") for menus
     expect(trigger).toHaveAttribute("aria-haspopup");
   });
 
@@ -754,5 +1241,58 @@ describe("Focus management", () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(trigger);
     });
+  });
+});
+
+// ─── CVA Variants ─────────────────────────────────────────────────────────────
+
+describe("CVA variants (unit)", () => {
+  test("menuContainerVariants: baseline standard has bg-surface-container and rounded-xs", () => {
+    const cls = menuContainerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("bg-surface-container");
+    expect(cls).toContain("rounded-xs");
+  });
+
+  test("menuContainerVariants: vertical standard has bg-surface-container-low and rounded-lg", () => {
+    const cls = menuContainerVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("bg-surface-container-low");
+    expect(cls).toContain("rounded-lg");
+  });
+
+  test("menuContainerVariants: vertical vibrant has bg-tertiary-container", () => {
+    const cls = menuContainerVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
+    expect(cls).toContain("bg-tertiary-container");
+  });
+
+  test("menuItemVariants: uses text-body-large", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("text-body-large");
+  });
+
+  test("menuItemVariants: baseline selected uses bg-surface-container-highest", () => {
+    const cls = menuItemVariants({
+      isSelected: true,
+      colorScheme: "standard",
+      menuStyle: "baseline",
+    });
+    expect(cls).toContain("bg-surface-container-highest");
+  });
+
+  test("menuItemVariants: vertical standard selected uses bg-tertiary-container", () => {
+    const cls = menuItemVariants({
+      isSelected: true,
+      colorScheme: "standard",
+      menuStyle: "vertical",
+    });
+    expect(cls).toContain("bg-tertiary-container");
+  });
+
+  test("menuItemVariants: vertical vibrant selected uses bg-tertiary", () => {
+    const cls = menuItemVariants({
+      isSelected: true,
+      colorScheme: "vibrant",
+      menuStyle: "vertical",
+    });
+    expect(cls).toContain("bg-tertiary");
   });
 });

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { forwardRef, type JSX } from "react";
+import { HeadlessMenuTrigger, HeadlessMenu, MenuContext } from "./MenuHeadless";
+import { menuContainerVariants } from "./Menu.variants";
+import { cn } from "../../utils/cn";
+import type { MenuProps, MenuTriggerProps } from "./Menu.types";
+
+// ─── Menu ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Material Design 3 Menu list container (Layer 3: Styled).
+ *
+ * Renders `<ul role="menu">` with MD3 surface, elevation, shape, and entry
+ * animation. Must be a child of `MenuTrigger`.
+ *
+ * Features:
+ * - Surface: `bg-surface-container`
+ * - Elevation: `shadow-elevation-2`
+ * - Shape: `rounded-xs` (4dp per MD3 shape extra-small)
+ * - Width: min 112dp / max 280dp per MD3 spec
+ * - Entry animation: scale-y + fade-in (`duration-medium2` /
+ *   `ease-emphasized-decelerate`)
+ * - Focus management handled by RAC `Popover` (FocusScope + restoreFocus)
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger>
+ *   <Button>Open</Button>
+ *   <Menu aria-label="Actions">
+ *     <MenuItem id="cut">Cut</MenuItem>
+ *     <MenuItem id="copy">Copy</MenuItem>
+ *   </Menu>
+ * </MenuTrigger>
+ * ```
+ *
+ * @see https://m3.material.io/components/menus/overview
+ */
+export const Menu = forwardRef<HTMLElement, MenuProps>(
+  ({ variant = "standard", className, disableRipple = false, children, ...props }, _ref) => {
+    const menuClass = cn(menuContainerVariants({ open: true }), className);
+
+    return (
+      <MenuContext.Provider
+        value={{
+          close: () => {
+            /* RAC Popover handles close internally */
+          },
+          disableRipple,
+          variant,
+          ...(props.selectionMode !== undefined ? { selectionMode: props.selectionMode } : {}),
+          ...(props.selectedKeys !== undefined
+            ? { selectedKeys: props.selectedKeys as Iterable<string | number> }
+            : {}),
+        }}
+      >
+        <HeadlessMenu {...props} className={menuClass}>
+          {children}
+        </HeadlessMenu>
+      </MenuContext.Provider>
+    );
+  }
+);
+
+Menu.displayName = "Menu";
+
+// ─── MenuTrigger ─────────────────────────────────────────────────────────────
+
+/**
+ * Material Design 3 Menu Trigger (Layer 3: Styled).
+ *
+ * Compound component that manages trigger state and positions the menu
+ * overlay. Uses `HeadlessMenuTrigger` for accessible overlay management.
+ *
+ * The first child is the trigger element (any pressable element such as
+ * `Button`, `IconButton`, or a native `<button>`). The second child must be a
+ * `Menu` component.
+ *
+ * The trigger element automatically receives:
+ * - `aria-haspopup="menu"`
+ * - `aria-expanded` (true when open, false when closed)
+ * - `aria-controls` (linked to the menu element id)
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * <MenuTrigger>
+ *   <Button>More actions</Button>
+ *   <Menu aria-label="Actions">
+ *     <MenuItem id="copy">Copy</MenuItem>
+ *     <MenuItem id="paste">Paste</MenuItem>
+ *   </Menu>
+ * </MenuTrigger>
+ *
+ * // Controlled
+ * <MenuTrigger isOpen={open} onOpenChange={setOpen}>
+ *   <IconButton aria-label="More"><MoreVertIcon /></IconButton>
+ *   <Menu aria-label="Context menu">
+ *     <MenuItem id="rename">Rename</MenuItem>
+ *     <MenuItem id="delete">Delete</MenuItem>
+ *   </Menu>
+ * </MenuTrigger>
+ * ```
+ *
+ * @see https://m3.material.io/components/menus/overview
+ */
+export function MenuTrigger({
+  children,
+  placement = "bottom start",
+  ...triggerProps
+}: MenuTriggerProps): JSX.Element {
+  return (
+    <HeadlessMenuTrigger {...triggerProps} placement={placement}>
+      {children}
+    </HeadlessMenuTrigger>
+  );
+}
+
+MenuTrigger.displayName = "MenuTrigger";
+
+// Attach Menu as a static sub-component so tests can use MenuTrigger.Menu
+(MenuTrigger as unknown as Record<string, unknown>).Menu = Menu;

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -1,122 +1,122 @@
 "use client";
 
 import { forwardRef, type JSX } from "react";
-import { HeadlessMenuTrigger, HeadlessMenu, MenuContext } from "./MenuHeadless";
+import { HeadlessMenuTrigger } from "./MenuHeadless";
+import { MenuContext } from "./MenuHeadless";
+import { HeadlessMenu } from "./MenuHeadless";
 import { menuContainerVariants } from "./Menu.variants";
 import { cn } from "../../utils/cn";
-import type { MenuProps, MenuTriggerProps } from "./Menu.types";
+import type {
+  MenuProps,
+  MenuTriggerProps,
+  MenuColorScheme,
+  MenuStyle,
+  MenuDensity,
+} from "./Menu.types";
 
-// ─── Menu ─────────────────────────────────────────────────────────────────────
+// ─── Menu ────────────────────────────────────────────────────────────────────
 
 /**
- * Material Design 3 Menu list container (Layer 3: Styled).
+ * MD3 styled Menu component (Layer 3).
  *
- * Renders `<ul role="menu">` with MD3 surface, elevation, shape, and entry
- * animation. Must be a child of `MenuTrigger`.
- *
- * Features:
- * - Surface: `bg-surface-container`
- * - Elevation: `shadow-elevation-2`
- * - Shape: `rounded-xs` (4dp per MD3 shape extra-small)
- * - Width: min 112dp / max 280dp per MD3 spec
- * - Entry animation: scale-y + fade-in (`duration-medium2` /
- *   `ease-emphasized-decelerate`)
- * - Focus management handled by RAC `Popover` (FocusScope + restoreFocus)
+ * Renders a list of `MenuItem`, `MenuSection`, or `MenuDivider` children.
+ * Intended to be used as `MenuTrigger.Menu` (nested inside a `MenuTrigger`).
  *
  * @example
  * ```tsx
  * <MenuTrigger>
  *   <Button>Open</Button>
  *   <Menu aria-label="Actions">
- *     <MenuItem id="cut">Cut</MenuItem>
- *     <MenuItem id="copy">Copy</MenuItem>
- *   </Menu>
- * </MenuTrigger>
- * ```
- *
- * @see https://m3.material.io/components/menus/overview
- */
-export const Menu = forwardRef<HTMLElement, MenuProps>(
-  ({ variant = "standard", className, disableRipple = false, children, ...props }, _ref) => {
-    const menuClass = cn(menuContainerVariants({ open: true }), className);
-
-    return (
-      <MenuContext.Provider
-        value={{
-          close: () => {
-            /* RAC Popover handles close internally */
-          },
-          disableRipple,
-          variant,
-          ...(props.selectionMode !== undefined ? { selectionMode: props.selectionMode } : {}),
-          ...(props.selectedKeys !== undefined
-            ? { selectedKeys: props.selectedKeys as Iterable<string | number> }
-            : {}),
-        }}
-      >
-        <HeadlessMenu {...props} className={menuClass}>
-          {children}
-        </HeadlessMenu>
-      </MenuContext.Provider>
-    );
-  }
-);
-
-Menu.displayName = "Menu";
-
-// ─── MenuTrigger ─────────────────────────────────────────────────────────────
-
-/**
- * Material Design 3 Menu Trigger (Layer 3: Styled).
- *
- * Compound component that manages trigger state and positions the menu
- * overlay. Uses `HeadlessMenuTrigger` for accessible overlay management.
- *
- * The first child is the trigger element (any pressable element such as
- * `Button`, `IconButton`, or a native `<button>`). The second child must be a
- * `Menu` component.
- *
- * The trigger element automatically receives:
- * - `aria-haspopup="menu"`
- * - `aria-expanded` (true when open, false when closed)
- * - `aria-controls` (linked to the menu element id)
- *
- * @example
- * ```tsx
- * // Basic usage
- * <MenuTrigger>
- *   <Button>More actions</Button>
- *   <Menu aria-label="Actions">
  *     <MenuItem id="copy">Copy</MenuItem>
  *     <MenuItem id="paste">Paste</MenuItem>
  *   </Menu>
  * </MenuTrigger>
+ * ```
+ */
+const Menu = forwardRef<HTMLElement, MenuProps>(function Menu(
+  {
+    children,
+    className,
+    colorScheme = "standard",
+    menuStyle = "baseline",
+    density = 0,
+    disableRipple = false,
+    selectionMode,
+    selectedKeys,
+    onSelectionChange,
+    ...props
+  },
+  _ref
+) {
+  /**
+   * Close function injected by parent MenuTrigger.
+   * The Popover's onClose handles the actual close; we provide a no-op here
+   * unless wrapped by a trigger. When used inside MenuTrigger, the context
+   * is overridden by the trigger's close handler.
+   */
+  const close = (): void => {
+    // Controlled via RAC Popover — handled by overlay state context.
+  };
+
+  // Conditionally include optional EOPT-sensitive context fields.
+  const contextValue = {
+    close,
+    disableRipple,
+    colorScheme,
+    menuStyle,
+    density,
+    ...(selectionMode !== undefined ? { selectionMode } : {}),
+    ...(selectedKeys !== undefined ? { selectedKeys } : {}),
+  };
+
+  return (
+    <MenuContext.Provider value={contextValue}>
+      <HeadlessMenu
+        {...props}
+        {...(selectionMode !== undefined ? { selectionMode } : {})}
+        {...(selectedKeys !== undefined ? { selectedKeys } : {})}
+        {...(onSelectionChange !== undefined ? { onSelectionChange } : {})}
+        className={cn(menuContainerVariants({ colorScheme, menuStyle }), className)}
+      >
+        {children}
+      </HeadlessMenu>
+    </MenuContext.Provider>
+  );
+});
+
+// ─── MenuTrigger ─────────────────────────────────────────────────────────────
+
+/**
+ * MD3 styled MenuTrigger component (Layer 3).
  *
- * // Controlled
- * <MenuTrigger isOpen={open} onOpenChange={setOpen}>
- *   <IconButton aria-label="More"><MoreVertIcon /></IconButton>
- *   <Menu aria-label="Context menu">
- *     <MenuItem id="rename">Rename</MenuItem>
- *     <MenuItem id="delete">Delete</MenuItem>
- *   </Menu>
+ * Wraps a trigger element and a `Menu` to create a dropdown.
+ * Attach `MenuTrigger.Menu` to specify the menu content, which gives IDE
+ * autocompletion and makes the parent/child relationship explicit.
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger>
+ *   <button type="button">Open Menu</button>
+ *   <MenuTrigger.Menu aria-label="Actions">
+ *     <MenuItem id="cut">Cut</MenuItem>
+ *   </MenuTrigger.Menu>
  * </MenuTrigger>
  * ```
- *
- * @see https://m3.material.io/components/menus/overview
  */
-export function MenuTrigger({
+function MenuTrigger({
   children,
   placement = "bottom start",
-  ...triggerProps
+  shouldFlip = true,
+  ...rest
 }: MenuTriggerProps): JSX.Element {
   return (
-    <HeadlessMenuTrigger {...triggerProps} placement={placement}>
+    <HeadlessMenuTrigger placement={placement} shouldFlip={shouldFlip} {...rest}>
       {children}
     </HeadlessMenuTrigger>
   );
 }
 
-MenuTrigger.displayName = "MenuTrigger";
+MenuTrigger.Menu = Menu;
 
-// Attach Menu as a static sub-component so tests can use MenuTrigger.Menu
-(MenuTrigger as unknown as Record<string, unknown>).Menu = Menu;
+export { Menu, MenuTrigger };
+export type { MenuColorScheme, MenuStyle, MenuDensity };

--- a/packages/react/src/components/Menu/Menu.types.ts
+++ b/packages/react/src/components/Menu/Menu.types.ts
@@ -1,0 +1,248 @@
+import type { ReactNode, Key } from "react";
+import type { AriaMenuProps, AriaMenuItemProps, AriaMenuTriggerProps } from "react-aria";
+import type { SelectionMode } from "react-stately";
+
+/**
+ * Visual variant of the MD3 Menu.
+ *
+ * - `standard` — contextual action menu; items fire `onAction` callbacks; no
+ *   persistent selection state.
+ * - `select` — selection menu; items show a checkmark when selected; supports
+ *   `selectionMode` of `"single"` or `"multiple"`.
+ */
+export type MenuVariant = "standard" | "select";
+
+// ─── MenuTrigger ─────────────────────────────────────────────────────────────
+
+/**
+ * Props for the `MenuTrigger` component (styled Layer 3).
+ *
+ * Wraps a trigger element (e.g. `Button`, `IconButton`) and a `Menu`. The
+ * first child must be the trigger; the second must be the `Menu`.
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger>
+ *   <Button>Open</Button>
+ *   <Menu aria-label="Actions">
+ *     <MenuItem id="copy" onAction={() => {}}>Copy</MenuItem>
+ *   </Menu>
+ * </MenuTrigger>
+ * ```
+ */
+export interface MenuTriggerProps extends AriaMenuTriggerProps {
+  /** Trigger element + Menu children. */
+  children: ReactNode;
+  /**
+   * Preferred placement of the menu relative to the trigger.
+   * @default 'bottom start'
+   */
+  placement?: "bottom" | "bottom start" | "bottom end" | "top" | "top start" | "top end";
+}
+
+// ─── Menu ────────────────────────────────────────────────────────────────────
+
+/**
+ * Props for the `Menu` component (styled Layer 3).
+ *
+ * @example
+ * ```tsx
+ * <Menu aria-label="Edit">
+ *   <MenuItem id="cut">Cut</MenuItem>
+ *   <MenuItem id="copy">Copy</MenuItem>
+ *   <MenuItem id="paste">Paste</MenuItem>
+ * </Menu>
+ * ```
+ */
+export interface MenuProps<T extends object = object> extends AriaMenuProps<T> {
+  /**
+   * Visual variant — standard (action) or select (selection with checkmark).
+   * @default 'standard'
+   */
+  variant?: MenuVariant;
+  /**
+   * Additional CSS classes merged onto the menu container element.
+   */
+  className?: string;
+  /**
+   * Disable ripple on all menu items.
+   * @default false
+   */
+  disableRipple?: boolean;
+}
+
+// ─── MenuItem ────────────────────────────────────────────────────────────────
+
+/**
+ * Props for the `MenuItem` component (styled Layer 3).
+ *
+ * A single interactive menu item with optional leading icon, trailing icon /
+ * keyboard-shortcut label, and disabled state.
+ *
+ * @example
+ * ```tsx
+ * // With leading icon and keyboard shortcut
+ * <MenuItem id="copy" leadingIcon={<CopyIcon />} trailingText="⌘C">
+ *   Copy
+ * </MenuItem>
+ *
+ * // Disabled
+ * <MenuItem id="paste" isDisabled>Paste</MenuItem>
+ * ```
+ */
+export interface MenuItemProps extends AriaMenuItemProps {
+  /**
+   * Item label content.
+   */
+  children?: ReactNode;
+  /**
+   * Optional leading icon element (24dp). Rendered with
+   * `text-on-surface-variant`.
+   */
+  leadingIcon?: ReactNode;
+  /**
+   * Optional trailing icon element (24dp). Rendered with
+   * `text-on-surface-variant`. Mutually exclusive with `trailingText`.
+   */
+  trailingIcon?: ReactNode;
+  /**
+   * Optional keyboard-shortcut label rendered at the trailing end of the item
+   * (e.g. `"⌘C"`, `"Ctrl+V"`). Mutually exclusive with `trailingIcon`.
+   */
+  trailingText?: string;
+  /**
+   * Additional CSS classes merged onto the item element.
+   */
+  className?: string;
+  /**
+   * Disable the ripple effect on this specific item.
+   * @default false
+   */
+  disableRipple?: boolean;
+}
+
+// ─── MenuSection ─────────────────────────────────────────────────────────────
+
+/**
+ * Props for the `MenuSection` component (styled Layer 3).
+ *
+ * Groups related `MenuItem` elements with an optional section header label
+ * and a horizontal divider above the group (rendered for all sections except
+ * the first when `showDivider` is true).
+ *
+ * @example
+ * ```tsx
+ * <MenuSection header="Clipboard" showDivider>
+ *   <MenuItem id="cut">Cut</MenuItem>
+ *   <MenuItem id="copy">Copy</MenuItem>
+ * </MenuSection>
+ * ```
+ */
+export interface MenuSectionProps {
+  /**
+   * Optional section header label rendered in `text-title-small
+   * text-on-surface-variant`.
+   */
+  header?: string;
+  /** Section content — typically `MenuItem` elements. */
+  children: ReactNode;
+  /**
+   * When `true`, renders a horizontal divider above the section.
+   * @default false
+   */
+  showDivider?: boolean;
+  /**
+   * Additional CSS classes merged onto the section container element.
+   */
+  className?: string;
+  /**
+   * Accessible label for the section. Required when `header` is not provided.
+   */
+  "aria-label"?: string;
+}
+
+// ─── MenuDivider ─────────────────────────────────────────────────────────────
+
+/**
+ * Props for the standalone `MenuDivider` component.
+ *
+ * Renders a semantic separator styled with `border-outline-variant`.
+ *
+ * @example
+ * ```tsx
+ * <MenuItem id="cut">Cut</MenuItem>
+ * <MenuDivider />
+ * <MenuItem id="select-all">Select all</MenuItem>
+ * ```
+ */
+export interface MenuDividerProps {
+  /** Additional CSS classes merged onto the separator element. */
+  className?: string;
+}
+
+// ─── Headless types ───────────────────────────────────────────────────────────
+
+/**
+ * Props for the headless `HeadlessMenuTrigger` primitive (Layer 2).
+ * Provides trigger + overlay behavior without visual styling.
+ */
+export interface HeadlessMenuTriggerProps extends AriaMenuTriggerProps {
+  /** Trigger element + HeadlessMenu children. */
+  children: ReactNode;
+  /**
+   * Preferred placement of the menu relative to the trigger.
+   * @default 'bottom start'
+   */
+  placement?: MenuTriggerProps["placement"];
+}
+
+/**
+ * Props for the headless `HeadlessMenu` primitive (Layer 2).
+ */
+export interface HeadlessMenuProps<T extends object = object> extends AriaMenuProps<T> {
+  /** Additional CSS classes for the `<ul role="menu">` element. */
+  className?: string;
+}
+
+/**
+ * Props for the headless `HeadlessMenuItem` primitive (Layer 2).
+ */
+export interface HeadlessMenuItemProps extends AriaMenuItemProps {
+  /** Item content. */
+  children?: ReactNode;
+  /** Additional CSS classes. */
+  className?: string;
+}
+
+/**
+ * Props for the headless `HeadlessMenuSection` primitive (Layer 2).
+ */
+export interface HeadlessMenuSectionProps {
+  /** Optional header label. */
+  header?: string;
+  /** Section items. */
+  children: ReactNode;
+  /** CSS class for the section group container. */
+  className?: string;
+  /** Accessible label for the group. Required when no header is provided. */
+  "aria-label"?: string;
+}
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+/**
+ * Context value shared between the Menu and its item descendants.
+ * @internal
+ */
+export interface MenuContextValue {
+  /** Close the menu overlay. */
+  close: () => void;
+  /** Whether ripple is disabled for all items. */
+  disableRipple: boolean;
+  /** Visual variant passed down to items (e.g. for checkmark rendering). */
+  variant: MenuVariant;
+  /** Currently selected keys (for select variant). */
+  selectedKeys?: Iterable<Key>;
+  /** Current selection mode. */
+  selectionMode?: SelectionMode;
+}

--- a/packages/react/src/components/Menu/Menu.types.ts
+++ b/packages/react/src/components/Menu/Menu.types.ts
@@ -1,31 +1,57 @@
 import type { ReactNode, Key } from "react";
-import type { AriaMenuProps, AriaMenuItemProps, AriaMenuTriggerProps } from "react-aria";
+import type { AriaMenuProps, AriaMenuTriggerProps } from "react-aria";
+import type { MenuItemProps as RACMenuItemProps } from "react-aria-components";
 import type { SelectionMode } from "react-stately";
 
+// ─── Color, Style, and Density Types ─────────────────────────────────────────
+
 /**
- * Visual variant of the MD3 Menu.
+ * Color scheme for the MD3 Menu container and items.
  *
- * - `standard` — contextual action menu; items fire `onAction` callbacks; no
- *   persistent selection state.
- * - `select` — selection menu; items show a checkmark when selected; supports
- *   `selectionMode` of `"single"` or `"multiple"`.
+ * - `standard` — surface-based colors; default for most use cases
+ * - `vibrant` — tertiary-based colors; higher visual emphasis; use sparingly
+ *
+ * @see https://m3.material.io/components/menus/specs#color
  */
-export type MenuVariant = "standard" | "select";
+export type MenuColorScheme = "standard" | "vibrant";
+
+/**
+ * Visual style of the MD3 Menu.
+ *
+ * - `baseline` — original M3 design; 4dp corner radius; surface container background
+ * - `vertical` — M3 Expressive style; 16dp corner radius; more expressive shapes and motion
+ *
+ * @see https://m3.material.io/components/menus/specs#variants
+ */
+export type MenuStyle = "baseline" | "vertical";
+
+/**
+ * Density level for the MD3 Menu (web only).
+ *
+ * Controls item height via top/bottom padding reduction:
+ * - `0`  → 48dp (default)
+ * - `-1` → 44dp
+ * - `-2` → 40dp
+ * - `-3` → 36dp
+ *
+ * @see https://m3.material.io/m3/pages/understanding-layout/density
+ */
+export type MenuDensity = 0 | -1 | -2 | -3;
 
 // ─── MenuTrigger ─────────────────────────────────────────────────────────────
 
 /**
  * Props for the `MenuTrigger` component (styled Layer 3).
  *
- * Wraps a trigger element (e.g. `Button`, `IconButton`) and a `Menu`. The
- * first child must be the trigger; the second must be the `Menu`.
+ * Wraps a trigger element and a `Menu`. The first child must be the trigger;
+ * the second must be a `Menu` component.
  *
  * @example
  * ```tsx
  * <MenuTrigger>
  *   <Button>Open</Button>
  *   <Menu aria-label="Actions">
- *     <MenuItem id="copy" onAction={() => {}}>Copy</MenuItem>
+ *     <MenuItem id="copy">Copy</MenuItem>
  *   </Menu>
  * </MenuTrigger>
  * ```
@@ -38,6 +64,12 @@ export interface MenuTriggerProps extends AriaMenuTriggerProps {
    * @default 'bottom start'
    */
   placement?: "bottom" | "bottom start" | "bottom end" | "top" | "top start" | "top end";
+  /**
+   * Whether the menu should automatically flip to the opposite side when it
+   * would be cut off by the viewport edge.
+   * @default true
+   */
+  shouldFlip?: boolean;
 }
 
 // ─── Menu ────────────────────────────────────────────────────────────────────
@@ -56,13 +88,23 @@ export interface MenuTriggerProps extends AriaMenuTriggerProps {
  */
 export interface MenuProps<T extends object = object> extends AriaMenuProps<T> {
   /**
-   * Visual variant — standard (action) or select (selection with checkmark).
+   * Color scheme — standard (surface-based) or vibrant (tertiary-based).
+   * Vibrant is more prominent and should be used sparingly.
    * @default 'standard'
    */
-  variant?: MenuVariant;
+  colorScheme?: MenuColorScheme;
   /**
-   * Additional CSS classes merged onto the menu container element.
+   * Visual style — baseline (4dp corners) or vertical (16dp corners, expressive).
+   * @default 'baseline'
    */
+  menuStyle?: MenuStyle;
+  /**
+   * Density level controlling item height (web only).
+   * 0 = 48dp, -1 = 44dp, -2 = 40dp, -3 = 36dp.
+   * @default 0
+   */
+  density?: MenuDensity;
+  /** Additional CSS classes merged onto the menu container element. */
   className?: string;
   /**
    * Disable ripple on all menu items.
@@ -76,8 +118,8 @@ export interface MenuProps<T extends object = object> extends AriaMenuProps<T> {
 /**
  * Props for the `MenuItem` component (styled Layer 3).
  *
- * A single interactive menu item with optional leading icon, trailing icon /
- * keyboard-shortcut label, and disabled state.
+ * A single interactive item within a Menu. Supports leading/trailing icons,
+ * keyboard shortcut labels, supporting text (description), and a badge slot.
  *
  * @example
  * ```tsx
@@ -86,33 +128,50 @@ export interface MenuProps<T extends object = object> extends AriaMenuProps<T> {
  *   Copy
  * </MenuItem>
  *
+ * // With description
+ * <MenuItem id="export" description="Export to various formats">
+ *   Export
+ * </MenuItem>
+ *
  * // Disabled
  * <MenuItem id="paste" isDisabled>Paste</MenuItem>
  * ```
  */
-export interface MenuItemProps extends AriaMenuItemProps {
-  /**
-   * Item label content.
-   */
+export interface MenuItemProps extends RACMenuItemProps {
+  /** Item label content. */
   children?: ReactNode;
   /**
-   * Optional leading icon element (24dp). Rendered with
-   * `text-on-surface-variant`.
+   * Optional leading icon element (24×24dp).
+   * Rendered with `text-on-surface-variant`.
    */
   leadingIcon?: ReactNode;
   /**
-   * Optional trailing icon element (24dp). Rendered with
-   * `text-on-surface-variant`. Mutually exclusive with `trailingText`.
+   * Optional trailing icon element (24×24dp).
+   * Rendered with `text-on-surface-variant`.
+   * Mutually exclusive with `trailingText`.
    */
   trailingIcon?: ReactNode;
   /**
-   * Optional keyboard-shortcut label rendered at the trailing end of the item
-   * (e.g. `"⌘C"`, `"Ctrl+V"`). Mutually exclusive with `trailingIcon`.
+   * Optional keyboard-shortcut label at the trailing end (e.g. `"⌘C"`, `"Ctrl+V"`).
+   * Screen readers announce this via `aria-keyshortcuts`.
+   * Mutually exclusive with `trailingIcon`.
    */
   trailingText?: string;
   /**
-   * Additional CSS classes merged onto the item element.
+   * Optional supporting text (description) rendered below the label.
+   * Uses `text-body-medium text-on-surface-variant`.
+   * When present, item height becomes auto (multi-line).
+   *
+   * @see https://m3.material.io/components/menus/specs - Anatomy item 8
    */
+  description?: ReactNode;
+  /**
+   * Optional badge element rendered between the label and trailing content.
+   *
+   * @see https://m3.material.io/components/menus/specs - Anatomy item 5
+   */
+  badge?: ReactNode;
+  /** Additional CSS classes merged onto the item element. */
   className?: string;
   /**
    * Disable the ripple effect on this specific item.
@@ -126,9 +185,8 @@ export interface MenuItemProps extends AriaMenuItemProps {
 /**
  * Props for the `MenuSection` component (styled Layer 3).
  *
- * Groups related `MenuItem` elements with an optional section header label
- * and a horizontal divider above the group (rendered for all sections except
- * the first when `showDivider` is true).
+ * Groups related `MenuItem` elements with an optional section header and
+ * an optional top divider.
  *
  * @example
  * ```tsx
@@ -138,12 +196,10 @@ export interface MenuItemProps extends AriaMenuItemProps {
  * </MenuSection>
  * ```
  */
-export interface MenuSectionProps {
-  /**
-   * Optional section header label rendered in `text-title-small
-   * text-on-surface-variant`.
-   */
-  header?: string;
+/**
+ * Base props shared by both `MenuSection` variants.
+ */
+interface MenuSectionBaseProps {
   /** Section content — typically `MenuItem` elements. */
   children: ReactNode;
   /**
@@ -151,22 +207,48 @@ export interface MenuSectionProps {
    * @default false
    */
   showDivider?: boolean;
-  /**
-   * Additional CSS classes merged onto the section container element.
-   */
+  /** Additional CSS classes. */
   className?: string;
-  /**
-   * Accessible label for the section. Required when `header` is not provided.
-   */
-  "aria-label"?: string;
 }
+
+/**
+ * Props for the `MenuSection` component (styled Layer 3).
+ *
+ * Either `header` or `aria-label` must be provided so the section has an
+ * accessible name, as required by WCAG 2.1 (ARIA `group` role).
+ *
+ * @example
+ * ```tsx
+ * <MenuSection header="Clipboard" showDivider>
+ *   <MenuItem id="cut">Cut</MenuItem>
+ *   <MenuItem id="copy">Copy</MenuItem>
+ * </MenuSection>
+ * ```
+ */
+export type MenuSectionProps =
+  | (MenuSectionBaseProps & {
+      /**
+       * Section header label (rendered visually and used as the accessible name).
+       * Uses `text-title-small text-on-surface-variant`.
+       */
+      header: string;
+      "aria-label"?: string;
+    })
+  | (MenuSectionBaseProps & {
+      header?: string;
+      /**
+       * Accessible label for the section. Required when `header` is not provided.
+       */
+      "aria-label": string;
+    });
 
 // ─── MenuDivider ─────────────────────────────────────────────────────────────
 
 /**
  * Props for the standalone `MenuDivider` component.
  *
- * Renders a semantic separator styled with `border-outline-variant`.
+ * Renders a semantic `role="separator"` with `border-outline-variant` styling.
+ * 8dp top/bottom padding per MD3 spec.
  *
  * @example
  * ```tsx
@@ -180,52 +262,146 @@ export interface MenuDividerProps {
   className?: string;
 }
 
-// ─── Headless types ───────────────────────────────────────────────────────────
+// ─── MenuGap ─────────────────────────────────────────────────────────────────
+
+/**
+ * Props for the `MenuGap` component.
+ *
+ * A visual gap separator for M3 Expressive vertical menus. Unlike `MenuDivider`
+ * (which renders a border line), `MenuGap` creates a blank spacing area between
+ * item groups. Recommended over dividers for vertical menus.
+ *
+ * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger.Menu menuStyle="vertical">
+ *   <MenuItem id="copy">Copy</MenuItem>
+ *   <MenuGap />
+ *   <MenuItem id="paste">Paste</MenuItem>
+ * </MenuTrigger.Menu>
+ * ```
+ */
+export interface MenuGapProps {
+  /** Additional CSS classes. */
+  className?: string;
+}
+
+// ─── SubmenuTrigger ──────────────────────────────────────────────────────────
+
+/**
+ * Props for the `SubmenuTrigger` component (styled Layer 3).
+ *
+ * Wraps a `MenuItem` (trigger) and a nested `Menu` to create a submenu.
+ * The submenu opens to the side with a chevron indicator on the trigger item.
+ *
+ * Keyboard: `ArrowRight` opens, `ArrowLeft` / `Escape` closes.
+ *
+ * @example
+ * ```tsx
+ * <SubmenuTrigger>
+ *   <MenuItem id="share">Share</MenuItem>
+ *   <Menu aria-label="Share via">
+ *     <MenuItem id="email">Email</MenuItem>
+ *     <MenuItem id="sms">SMS</MenuItem>
+ *   </Menu>
+ * </SubmenuTrigger>
+ * ```
+ */
+export interface SubmenuTriggerProps {
+  /** Must be a `[MenuItem, Menu]` pair. */
+  children: ReactNode;
+  /**
+   * Hover delay in milliseconds before the submenu opens.
+   * @default 200
+   */
+  delay?: number;
+}
+
+// ─── ContextMenuTrigger ──────────────────────────────────────────────────────
+
+/**
+ * Props for the `ContextMenuTrigger` component (styled Layer 3).
+ *
+ * Wraps content and opens a context menu on right-click or two-finger tap.
+ * The menu is positioned at the pointer coordinates.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuTrigger>
+ *   <div>Right-click me</div>
+ *   <Menu aria-label="Context actions">
+ *     <MenuItem id="copy">Copy</MenuItem>
+ *     <MenuItem id="paste">Paste</MenuItem>
+ *   </Menu>
+ * </ContextMenuTrigger>
+ * ```
+ */
+export interface ContextMenuTriggerProps {
+  /** Content element + Menu children. */
+  children: ReactNode;
+  /** Controlled open state. */
+  isOpen?: boolean;
+  /** Called when open state changes. */
+  onOpenChange?: (isOpen: boolean) => void;
+}
+
+// ─── Headless Types ───────────────────────────────────────────────────────────
 
 /**
  * Props for the headless `HeadlessMenuTrigger` primitive (Layer 2).
- * Provides trigger + overlay behavior without visual styling.
  */
 export interface HeadlessMenuTriggerProps extends AriaMenuTriggerProps {
-  /** Trigger element + HeadlessMenu children. */
   children: ReactNode;
-  /**
-   * Preferred placement of the menu relative to the trigger.
-   * @default 'bottom start'
-   */
   placement?: MenuTriggerProps["placement"];
+  shouldFlip?: boolean;
 }
 
 /**
  * Props for the headless `HeadlessMenu` primitive (Layer 2).
  */
 export interface HeadlessMenuProps<T extends object = object> extends AriaMenuProps<T> {
-  /** Additional CSS classes for the `<ul role="menu">` element. */
   className?: string;
 }
 
 /**
  * Props for the headless `HeadlessMenuItem` primitive (Layer 2).
+ *
+ * `className` accepts either a static string or a render-prop function so
+ * MD3 state-dependent styles (selection, disabled) can be applied directly
+ * to the `<li role="menuitem">` element via RAC's render-prop mechanism.
  */
-export interface HeadlessMenuItemProps extends AriaMenuItemProps {
-  /** Item content. */
-  children?: ReactNode;
-  /** Additional CSS classes. */
-  className?: string;
-}
+// HeadlessMenuItemProps inherits children (ChildrenOrFunction) and className
+// (ClassNameOrFunction) directly from RACMenuItemProps — no overrides needed.
+export type HeadlessMenuItemProps = RACMenuItemProps;
 
 /**
  * Props for the headless `HeadlessMenuSection` primitive (Layer 2).
+ *
+ * The section header is handled at Layer 3 (`MenuSection`) using RAC's
+ * `Header` component. At Layer 2, only `aria-label` is used for accessibility.
  */
 export interface HeadlessMenuSectionProps {
-  /** Optional header label. */
-  header?: string;
-  /** Section items. */
   children: ReactNode;
-  /** CSS class for the section group container. */
   className?: string;
-  /** Accessible label for the group. Required when no header is provided. */
   "aria-label"?: string;
+}
+
+/**
+ * Props for the headless `HeadlessSubmenuTrigger` primitive (Layer 2).
+ */
+export interface HeadlessSubmenuTriggerProps {
+  children: ReactNode;
+  delay?: number;
+}
+
+/**
+ * Props for the headless `HeadlessContextMenuTrigger` primitive (Layer 2).
+ */
+export interface HeadlessContextMenuTriggerProps {
+  children: ReactNode;
+  isOpen?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
 }
 
 // ─── Context ──────────────────────────────────────────────────────────────────
@@ -239,9 +415,13 @@ export interface MenuContextValue {
   close: () => void;
   /** Whether ripple is disabled for all items. */
   disableRipple: boolean;
-  /** Visual variant passed down to items (e.g. for checkmark rendering). */
-  variant: MenuVariant;
-  /** Currently selected keys (for select variant). */
+  /** Color scheme — standard or vibrant. */
+  colorScheme: MenuColorScheme;
+  /** Visual style — baseline or vertical. */
+  menuStyle: MenuStyle;
+  /** Density level controlling item height. */
+  density: MenuDensity;
+  /** Currently selected keys (for selection menus). */
   selectedKeys?: Iterable<Key>;
   /** Current selection mode. */
   selectionMode?: SelectionMode;

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -1,0 +1,164 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Menu container variants (CVA).
+ *
+ * Surface: `bg-surface-container`
+ * Elevation: `shadow-elevation-2`
+ * Shape: `rounded-xs` (4dp per MD3 shape extra-small)
+ * Width: min 112dp (`min-w-28`) / max 280dp (`max-w-70`) per MD3 spec
+ *
+ * Entry animation: scale-y + fade-in from top anchor point.
+ * - Duration: `duration-medium2` (300ms)
+ * - Easing: `ease-emphasized-decelerate`
+ *
+ * @see https://m3.material.io/components/menus/specs
+ */
+export const menuContainerVariants = cva(
+  [
+    // Surface and elevation
+    "bg-surface-container",
+    "shadow-elevation-2",
+    // Shape
+    "rounded-xs",
+    // Width constraints per MD3 spec (112dp min / 280dp max)
+    "min-w-28 max-w-70",
+    // Layout
+    "py-2",
+    "overflow-y-auto",
+    // Stacking
+    "z-50",
+    // Focus outline handled by React Aria
+    "outline-none",
+    // Animation origin — scale from top anchor point
+    "origin-top",
+    // Transition for open/close scale+opacity animation
+    "transition-[transform,opacity]",
+    "duration-medium2",
+    "ease-emphasized-decelerate",
+  ],
+  {
+    variants: {
+      /**
+       * Open/closed state — drives scale and opacity.
+       * - `true`:  menu visible (`scale-y-100 opacity-100`)
+       * - `false`: menu collapsed (`scale-y-0 opacity-0 pointer-events-none`)
+       */
+      open: {
+        true: ["scale-y-100 opacity-100"],
+        false: ["scale-y-0 opacity-0 pointer-events-none"],
+      },
+    },
+    defaultVariants: {
+      open: false,
+    },
+  }
+);
+
+/**
+ * Material Design 3 Menu item variants (CVA).
+ *
+ * Item height: 48dp (`h-12`) per MD3 spec.
+ * Label: `text-label-large text-on-surface`
+ * Leading/trailing icon color: `text-on-surface-variant`
+ *
+ * State layers (MD3 spec):
+ * - Hover:         `opacity-8`  on `before:bg-on-surface`
+ * - Focus visible: `opacity-12` on `before:bg-on-surface`
+ * - Pressed:       `opacity-12` on `before:bg-on-surface`
+ * - Disabled:      `opacity-38` on entire item, non-interactive
+ *
+ * @see https://m3.material.io/components/menus/specs
+ */
+export const menuItemVariants = cva(
+  [
+    // Layout
+    "relative flex w-full items-center",
+    "h-12 px-3 gap-3",
+    // Typography
+    "text-label-large text-on-surface",
+    // Interaction
+    "cursor-pointer select-none outline-none",
+    // State layer pseudo-element
+    "before:absolute before:inset-0",
+    "before:transition-opacity before:duration-short2 before:ease-standard",
+    "before:opacity-0",
+    // Hover and focus visible state layers
+    "hover:before:opacity-8 before:bg-on-surface",
+    "focus-visible:before:opacity-12",
+    // Active pressed state layer
+    "active:before:opacity-12",
+    // Color transition for selection state
+    "transition-colors duration-short2 ease-standard",
+  ],
+  {
+    variants: {
+      /**
+       * Whether this item is disabled.
+       * Applies `opacity-38` and removes pointer interaction per MD3 spec.
+       */
+      isDisabled: {
+        true: ["opacity-38 cursor-not-allowed pointer-events-none"],
+        false: [],
+      },
+      /**
+       * Whether this item is currently selected (select variant).
+       * Applies `bg-secondary-container` / `text-on-secondary-container` and
+       * changes state-layer color to `on-secondary-container`.
+       */
+      isSelected: {
+        true: [
+          "bg-secondary-container",
+          "text-on-secondary-container",
+          "before:bg-on-secondary-container",
+        ],
+        false: [],
+      },
+    },
+    defaultVariants: {
+      isDisabled: false,
+      isSelected: false,
+    },
+  }
+);
+
+/**
+ * Menu section container variants (CVA).
+ * Groups related menu items.
+ */
+export const menuSectionVariants = cva(["flex flex-col w-full"]);
+
+/**
+ * Menu section header variants (CVA).
+ *
+ * Header text: `text-title-small text-on-surface-variant` per MD3 spec.
+ */
+export const menuSectionHeaderVariants = cva([
+  "px-3 pt-2 pb-1",
+  "text-title-small text-on-surface-variant",
+  "select-none",
+]);
+
+/**
+ * Menu item divider variants (CVA).
+ *
+ * Horizontal rule using `border-outline-variant` per MD3 spec.
+ */
+export const menuDividerVariants = cva(["border-t border-outline-variant", "my-1 mx-0"]);
+
+/**
+ * Trailing text (keyboard shortcut) variants (CVA).
+ *
+ * Rendered at the trailing end of a MenuItem for keyboard shortcut hints.
+ * Color: `text-on-surface-variant`, size: `text-label-large`.
+ */
+export const menuItemTrailingTextVariants = cva([
+  "ml-auto shrink-0 text-label-large text-on-surface-variant",
+  "select-none",
+]);
+
+// ─── Type exports ─────────────────────────────────────────────────────────────
+
+export type MenuContainerVariants = VariantProps<typeof menuContainerVariants>;
+export type MenuItemVariants = VariantProps<typeof menuItemVariants>;
+export type MenuSectionVariants = VariantProps<typeof menuSectionVariants>;

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -3,54 +3,94 @@ import { cva, type VariantProps } from "class-variance-authority";
 /**
  * Material Design 3 Menu container variants (CVA).
  *
- * Surface: `bg-surface-container`
- * Elevation: `shadow-elevation-2`
- * Shape: `rounded-xs` (4dp per MD3 shape extra-small)
- * Width: min 112dp (`min-w-28`) / max 280dp (`max-w-70`) per MD3 spec
+ * Elevation: `shadow-elevation-2` (both styles)
+ * Width: min 112dp / max 280dp per MD3 spec
  *
- * Entry animation: scale-y + fade-in from top anchor point.
- * - Duration: `duration-medium2` (300ms)
- * - Easing: `ease-emphasized-decelerate`
+ * Shape per menuStyle:
+ * - baseline: `rounded-xs` (4dp extra-small)
+ * - vertical: `rounded-lg` (16dp large)
+ *
+ * Background per colorScheme + menuStyle:
+ * - baseline + standard: `bg-surface-container`
+ * - vertical + standard: `bg-surface-container-low`
+ * - vertical + vibrant:  `bg-tertiary-container`
  *
  * @see https://m3.material.io/components/menus/specs
  */
 export const menuContainerVariants = cva(
   [
-    // Surface and elevation
-    "bg-surface-container",
+    // Elevation
     "shadow-elevation-2",
-    // Shape
-    "rounded-xs",
     // Width constraints per MD3 spec (112dp min / 280dp max)
     "min-w-28 max-w-70",
     // Layout
     "py-2",
+    // Scroll: show scrollbar when content overflows; max height avoids clipping
     "overflow-y-auto",
+    "max-h-[calc(var(--visual-viewport-height,100vh)-2rem)]",
     // Stacking
     "z-50",
     // Focus outline handled by React Aria
     "outline-none",
-    // Animation origin — scale from top anchor point
+    // GPU compositing — promotes menu to its own compositor layer so
+    // scale + opacity animations run without triggering layout reflow.
+    "will-change-[transform,opacity]",
+    // Pointer events blocked during animation to prevent accidental clicks
+    // on menu items while the panel is still animating in or out.
+    "data-[entering]:pointer-events-none data-[exiting]:pointer-events-none",
+    // ── Enter animation ────────────────────────────────────────────────────
+    // @keyframes menu-enter (defined in styles.css): scale(0.8)+opacity:0 →
+    // scale(1)+opacity:1 in 120ms with cubic-bezier(0,0,0.2,1) (standard
+    // decelerate — matches Angular Material's _mat-menu-enter keyframe).
+    "data-[entering]:animate-[menu-enter_120ms_cubic-bezier(0,0,0.2,1)_both]",
+    // ── Exit animation ─────────────────────────────────────────────────────
+    // @keyframes menu-exit (defined in styles.css): opacity:1 → opacity:0
+    // in 100ms after 25ms delay, linear — matches Angular Material's
+    // _mat-menu-exit keyframe (fade-only, no reverse scale).
+    "data-[exiting]:animate-[menu-exit_100ms_25ms_linear_both]",
+    // ── Transform origin (placement-aware) ────────────────────────────────
+    // RAC sets data-placement="bottom|top|left|right" on the Popover element.
+    // Default (bottom): origin at top edge (menu expands downward).
     "origin-top",
-    // Transition for open/close scale+opacity animation
-    "transition-[transform,opacity]",
-    "duration-medium2",
-    "ease-emphasized-decelerate",
+    // top: origin at bottom edge (menu expands upward)
+    "data-[placement=top]:origin-bottom",
+    // left: origin at right edge
+    "data-[placement=left]:origin-right",
+    // right: origin at left edge
+    "data-[placement=right]:origin-left",
+    // ── Reduced motion ────────────────────────────────────────────────────
+    // Skip both animations entirely for users who prefer reduced motion.
+    "motion-reduce:data-[entering]:animate-none motion-reduce:data-[exiting]:animate-none",
   ],
   {
     variants: {
       /**
-       * Open/closed state — drives scale and opacity.
-       * - `true`:  menu visible (`scale-y-100 opacity-100`)
-       * - `false`: menu collapsed (`scale-y-0 opacity-0 pointer-events-none`)
+       * Color scheme — drives the container background.
+       * baseline+standard uses a separate compound variant.
        */
-      open: {
-        true: ["scale-y-100 opacity-100"],
-        false: ["scale-y-0 opacity-0 pointer-events-none"],
+      colorScheme: {
+        standard: [],
+        vibrant: [],
+      },
+      /**
+       * Visual style — drives corner radius and baseline vs vertical background.
+       */
+      menuStyle: {
+        baseline: ["rounded-xs", "bg-surface-container"],
+        vertical: ["rounded-lg", "bg-surface-container-low"],
       },
     },
+    compoundVariants: [
+      // Vertical + vibrant: tertiary container background
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["bg-tertiary-container"],
+      },
+    ],
     defaultVariants: {
-      open: false,
+      colorScheme: "standard",
+      menuStyle: "baseline",
     },
   }
 );
@@ -58,80 +98,128 @@ export const menuContainerVariants = cva(
 /**
  * Material Design 3 Menu item variants (CVA).
  *
- * Item height: 48dp (`h-12`) per MD3 spec.
- * Label: `text-label-large text-on-surface`
- * Leading/trailing icon color: `text-on-surface-variant`
+ * Typography: `text-body-large` per MD3 baseline spec (16sp / 400 weight).
+ * Padding: `px-3` (12dp left/right), `gap-3` (12dp between elements).
  *
  * State layers (MD3 spec):
- * - Hover:         `opacity-8`  on `before:bg-on-surface`
- * - Focus visible: `opacity-12` on `before:bg-on-surface`
- * - Pressed:       `opacity-12` on `before:bg-on-surface`
- * - Disabled:      `opacity-38` on entire item, non-interactive
+ * - Hover:         `opacity-8`  on state layer
+ * - Focus visible: `opacity-12` on state layer
+ * - Pressed:       `opacity-12` on state layer
+ * - Disabled:      `opacity-38` on entire item
+ *
+ * Selection colors per menuStyle + colorScheme:
+ * - baseline (any):         `bg-surface-container-highest`
+ * - vertical + standard:    `bg-tertiary-container text-on-tertiary-container`
+ * - vertical + vibrant:     `bg-tertiary text-on-tertiary`
+ *
+ * Note: item height (48/44/40/36dp) is controlled by density via context,
+ * applied directly in MenuItem component (not CVA) to avoid negative key issues.
  *
  * @see https://m3.material.io/components/menus/specs
  */
 export const menuItemVariants = cva(
   [
-    // Layout
+    // Layout — height set by density context in MenuItem component
     "relative flex w-full items-center",
-    "h-12 px-3 gap-3",
-    // Typography
-    "text-label-large text-on-surface",
+    "px-3 gap-3",
+    // Typography: Body Large per MD3 baseline spec
+    "text-body-large",
     // Interaction
     "cursor-pointer select-none outline-none",
     // State layer pseudo-element
-    "before:absolute before:inset-0",
+    "before:absolute before:inset-0 before:rounded-[inherit]",
     "before:transition-opacity before:duration-short2 before:ease-standard",
     "before:opacity-0",
-    // Hover and focus visible state layers
-    "hover:before:opacity-8 before:bg-on-surface",
+    // Hover state layer
+    "hover:before:opacity-8",
+    // Focus visible state layer
     "focus-visible:before:opacity-12",
     // Active pressed state layer
     "active:before:opacity-12",
-    // Color transition for selection state
+    // Color transition for selection
     "transition-colors duration-short2 ease-standard",
   ],
   {
     variants: {
       /**
-       * Whether this item is disabled.
-       * Applies `opacity-38` and removes pointer interaction per MD3 spec.
+       * Disabled state: reduces opacity and blocks interaction.
        */
       isDisabled: {
         true: ["opacity-38 cursor-not-allowed pointer-events-none"],
         false: [],
       },
       /**
-       * Whether this item is currently selected (select variant).
-       * Applies `bg-secondary-container` / `text-on-secondary-container` and
-       * changes state-layer color to `on-secondary-container`.
+       * Selected state: background and text color driven by compound variants.
        */
       isSelected: {
-        true: [
-          "bg-secondary-container",
-          "text-on-secondary-container",
-          "before:bg-on-secondary-container",
-        ],
+        true: [],
         false: [],
       },
+      /**
+       * Color scheme: drives default text and state layer colors.
+       * - standard: on-surface text, on-surface state layer
+       * - vibrant (vertical only): on-tertiary-container text + state layer
+       */
+      colorScheme: {
+        standard: ["text-on-surface", "before:bg-on-surface"],
+        vibrant: ["text-on-tertiary-container", "before:bg-on-tertiary-container"],
+      },
+      /**
+       * Visual style: drives corner radius on items (vertical uses rounded-lg
+       * inherited from container, items stay flat inside).
+       */
+      menuStyle: {
+        baseline: [],
+        vertical: [],
+      },
     },
+    compoundVariants: [
+      // ── Baseline selection (both colorSchemes) ──────────────────────────
+      {
+        isSelected: true,
+        menuStyle: "baseline",
+        class: [
+          "bg-surface-container-highest",
+          // text-on-surface already applied by standard colorScheme variant
+        ],
+      },
+      // ── Vertical + Standard selection ───────────────────────────────────
+      {
+        isSelected: true,
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: [
+          "bg-tertiary-container",
+          "text-on-tertiary-container",
+          "before:bg-on-tertiary-container",
+        ],
+      },
+      // ── Vertical + Vibrant selection ─────────────────────────────────────
+      {
+        isSelected: true,
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["bg-tertiary", "text-on-tertiary", "before:bg-on-tertiary"],
+      },
+    ],
     defaultVariants: {
       isDisabled: false,
       isSelected: false,
+      colorScheme: "standard",
+      menuStyle: "baseline",
     },
   }
 );
 
 /**
  * Menu section container variants (CVA).
- * Groups related menu items.
  */
 export const menuSectionVariants = cva(["flex flex-col w-full"]);
 
 /**
  * Menu section header variants (CVA).
  *
- * Header text: `text-title-small text-on-surface-variant` per MD3 spec.
+ * Typography: `text-title-small text-on-surface-variant` per MD3 spec.
  */
 export const menuSectionHeaderVariants = cva([
   "px-3 pt-2 pb-1",
@@ -142,18 +230,42 @@ export const menuSectionHeaderVariants = cva([
 /**
  * Menu item divider variants (CVA).
  *
- * Horizontal rule using `border-outline-variant` per MD3 spec.
+ * Renders a horizontal separator with `border-outline-variant`.
+ * Padding: 8dp top/bottom (`my-2`) per MD3 spec.
+ *
+ * @see https://m3.material.io/components/menus/specs — Measurements
  */
-export const menuDividerVariants = cva(["border-t border-outline-variant", "my-1 mx-0"]);
+export const menuDividerVariants = cva(["border-t border-outline-variant", "my-2 mx-0"]);
+
+/**
+ * Menu gap variants (CVA).
+ *
+ * A visual spacer for M3 Expressive vertical menus. Uses spacing instead of
+ * a border line to separate item groups. `aria-hidden` and `role="none"`.
+ *
+ * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
+ */
+export const menuGapVariants = cva(["h-2 w-full"]);
 
 /**
  * Trailing text (keyboard shortcut) variants (CVA).
  *
- * Rendered at the trailing end of a MenuItem for keyboard shortcut hints.
- * Color: `text-on-surface-variant`, size: `text-label-large`.
+ * Color: `text-on-surface-variant`, size: `text-label-large` (14sp).
+ * The element also carries `aria-keyshortcuts` for screen reader support.
  */
 export const menuItemTrailingTextVariants = cva([
   "ml-auto shrink-0 text-label-large text-on-surface-variant",
+  "select-none",
+]);
+
+/**
+ * Menu item description (supporting text) variants (CVA).
+ *
+ * Rendered below the label text.
+ * Typography: `text-body-medium text-on-surface-variant`.
+ */
+export const menuItemDescriptionVariants = cva([
+  "text-body-medium text-on-surface-variant",
   "select-none",
 ]);
 

--- a/packages/react/src/components/Menu/MenuDivider.tsx
+++ b/packages/react/src/components/Menu/MenuDivider.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { JSX } from "react";
+import { HeadlessMenuDivider } from "./MenuHeadless";
+import { menuDividerVariants } from "./Menu.variants";
+import { cn } from "../../utils/cn";
+import type { MenuDividerProps } from "./Menu.types";
+
+/**
+ * Material Design 3 Menu Divider (Layer 3: Styled).
+ *
+ * Renders a standalone horizontal separator between menu items. Uses
+ * `HeadlessMenuDivider` (RAC `Separator`) for `role="separator"` semantics.
+ *
+ * Color: `border-outline-variant` per MD3 spec.
+ *
+ * @example
+ * ```tsx
+ * <MenuItem id="cut">Cut</MenuItem>
+ * <MenuDivider />
+ * <MenuItem id="select-all">Select all</MenuItem>
+ * ```
+ *
+ * @see https://m3.material.io/components/menus/specs
+ */
+export function MenuDivider({ className }: MenuDividerProps): JSX.Element {
+  return <HeadlessMenuDivider className={cn(menuDividerVariants(), className)} />;
+}
+
+MenuDivider.displayName = "MenuDivider";

--- a/packages/react/src/components/Menu/MenuDivider.tsx
+++ b/packages/react/src/components/Menu/MenuDivider.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import type { JSX } from "react";
+import { type JSX } from "react";
 import { HeadlessMenuDivider } from "./MenuHeadless";
 import { menuDividerVariants } from "./Menu.variants";
 import { cn } from "../../utils/cn";
 import type { MenuDividerProps } from "./Menu.types";
 
 /**
- * Material Design 3 Menu Divider (Layer 3: Styled).
+ * MD3 styled MenuDivider component (Layer 3).
  *
- * Renders a standalone horizontal separator between menu items. Uses
- * `HeadlessMenuDivider` (RAC `Separator`) for `role="separator"` semantics.
- *
- * Color: `border-outline-variant` per MD3 spec.
+ * Renders a horizontal `role="separator"` with `border-outline-variant` styling.
+ * 8dp top/bottom padding (`my-2`) per MD3 spec.
  *
  * @example
  * ```tsx
@@ -20,11 +18,7 @@ import type { MenuDividerProps } from "./Menu.types";
  * <MenuDivider />
  * <MenuItem id="select-all">Select all</MenuItem>
  * ```
- *
- * @see https://m3.material.io/components/menus/specs
  */
 export function MenuDivider({ className }: MenuDividerProps): JSX.Element {
   return <HeadlessMenuDivider className={cn(menuDividerVariants(), className)} />;
 }
-
-MenuDivider.displayName = "MenuDivider";

--- a/packages/react/src/components/Menu/MenuGap.tsx
+++ b/packages/react/src/components/Menu/MenuGap.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { type ForwardedRef, type JSX } from "react";
+import { createLeafComponent } from "@react-aria/collections";
+import { menuGapVariants } from "./Menu.variants";
+import { cn } from "../../utils/cn";
+import type { MenuGapProps } from "./Menu.types";
+
+/**
+ * RAC `filterDOMProps` strips `aria-hidden` and `role` overrides from all RAC
+ * separator components (the attributes are not in its allowlist). Passing props
+ * declaratively therefore has no effect on the rendered element.
+ *
+ * We also cannot use a native `<li>` because RAC's collection system only
+ * renders items that are registered in its internal collection Document — a
+ * plain HTML element is not registered and items following it are dropped.
+ *
+ * The correct solution: create a first-class collection item using
+ * `createLeafComponent` (RAC's public collection primitive). We register the
+ * item as type `'separator'` (so the collection includes it and subsequent
+ * siblings continue to render), but provide a completely custom render function
+ * that outputs `<div aria-hidden="true">` directly, without going through
+ * `useSeparator` or `filterDOMProps`. This means:
+ *   - `queryByRole("separator")` returns null (aria-hidden excludes the element)
+ *   - Menu items after the gap render correctly (collection is intact)
+ *   - The element has zero ARIA semantics (aria-hidden removes it from the tree)
+ */
+const MenuGapItem = createLeafComponent<object, { className?: string }, HTMLDivElement>(
+  // Use the 'separator' string type so createLeafComponent creates a bare
+  // CollectionNode subclass — registered in the collection but without the
+  // consecutive-separator-drop filter that RAC's own SeparatorNode applies.
+  "separator",
+  function MenuGapRenderer(
+    { className: cls }: { className?: string },
+    ref: ForwardedRef<HTMLDivElement>
+  ): JSX.Element {
+    return (
+      // Rendered directly — no filterDOMProps, no useSeparator.
+      // aria-hidden="true" removes the element from the a11y tree entirely.
+      <div ref={ref} aria-hidden="true" className={cls} />
+    );
+  }
+);
+
+/**
+ * MD3 MenuGap component (Layer 3) — Expressive Vertical Menu only.
+ *
+ * A purely visual spacer between item groups in M3 Expressive vertical menus.
+ * Unlike `MenuDivider` (which renders a visible border line), `MenuGap` renders
+ * only blank spacing and is fully hidden from the accessibility tree.
+ *
+ * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger.Menu menuStyle="vertical">
+ *   <MenuItem id="cut">Cut</MenuItem>
+ *   <MenuGap />
+ *   <MenuItem id="paste">Paste</MenuItem>
+ * </MenuTrigger.Menu>
+ * ```
+ */
+export function MenuGap({ className }: MenuGapProps): JSX.Element {
+  return <MenuGapItem className={cn(menuGapVariants(), className)} />;
+}

--- a/packages/react/src/components/Menu/MenuHeadless.tsx
+++ b/packages/react/src/components/Menu/MenuHeadless.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+/**
+ * MenuHeadless — Layer 2: Behavior-only primitives.
+ *
+ * The trigger layer uses react-aria hooks (`useMenuTriggerState` +
+ * `useMenuTrigger`) to spread ARIA attributes and event handlers onto any
+ * trigger element via `cloneElement`. This supports raw `<button>` elements
+ * as well as RAC `Button` components.
+ *
+ * The overlay uses RAC `Popover` with `OverlayTriggerStateContext` to handle
+ * portal rendering, positioning, flip/shift, focus management (FocusScope +
+ * restoreFocus + autoFocus), and Escape / outside-click dismissal.
+ *
+ * The menu list uses RAC `Menu`, `MenuItem`, `MenuSection`, `Separator` for
+ * full collection management, keyboard navigation, and ARIA semantics.
+ */
+
+import {
+  cloneElement,
+  createContext,
+  forwardRef,
+  useContext,
+  useRef,
+  type JSX,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import {
+  Menu as RACMenu,
+  MenuItem as RACMenuItem,
+  MenuSection as RACMenuSection,
+  MenuContext as RACMenuContext,
+  OverlayTriggerStateContext,
+  Popover,
+  Separator,
+  type MenuProps as RACMenuProps,
+  type MenuItemProps as RACMenuItemProps,
+} from "react-aria-components";
+import { mergeProps, useMenuTrigger } from "react-aria";
+import { useMenuTriggerState } from "react-stately";
+import type {
+  HeadlessMenuProps,
+  HeadlessMenuItemProps,
+  HeadlessMenuSectionProps,
+  HeadlessMenuTriggerProps,
+  MenuContextValue,
+} from "./Menu.types";
+
+// ─── Our Menu Context (close / disableRipple / variant) ──────────────────────
+
+/**
+ * Context shared between the Menu and its item descendants.
+ * Carries close(), disableRipple, and variant so items can
+ * read them without prop-drilling.
+ * @internal
+ */
+export const MenuContext = createContext<MenuContextValue | null>(null);
+
+export function useMenuContext(): MenuContextValue {
+  const ctx = useContext(MenuContext);
+  if (ctx === null) {
+    throw new Error("MenuItem must be rendered inside a MenuTrigger component.");
+  }
+  return ctx;
+}
+
+// ─── HeadlessMenuTrigger ──────────────────────────────────────────────────────
+
+/**
+ * Headless Menu Trigger (Layer 2).
+ *
+ * - Manages open/close state via `useMenuTriggerState`.
+ * - Spreads `aria-haspopup`, `aria-expanded`, `aria-controls`, and pointer /
+ *   keyboard event handlers onto the first child (trigger element) via
+ *   `cloneElement`. Works with both RAC `Button` and native `<button>`.
+ * - Renders the menu overlay via RAC `Popover` (with portal, positioning, flip,
+ *   focus management, and Escape/outside-click dismissal).
+ * - Provides `OverlayTriggerStateContext` so `Popover` knows the open state.
+ * - Provides `RACMenuContext` so RAC `Menu` receives its `id` /
+ *   `aria-labelledby` linkage.
+ *
+ * Children layout: `[trigger, menu]`
+ *
+ * @example
+ * ```tsx
+ * <HeadlessMenuTrigger>
+ *   <button type="button">Open</button>
+ *   <HeadlessMenu aria-label="Actions">
+ *     <HeadlessMenuItem id="cut">Cut</HeadlessMenuItem>
+ *   </HeadlessMenu>
+ * </HeadlessMenuTrigger>
+ * ```
+ */
+export function HeadlessMenuTrigger({
+  children,
+  placement = "bottom start",
+  ...stateProps
+}: HeadlessMenuTriggerProps): JSX.Element {
+  const triggerRef = useRef<HTMLElement>(null);
+  const state = useMenuTriggerState(stateProps);
+  const { menuTriggerProps, menuProps } = useMenuTrigger({ type: "menu" }, state, triggerRef);
+
+  const childrenArray = Array.isArray(children)
+    ? (children as ReactElement[])
+    : [children as ReactElement];
+  const triggerChild = childrenArray[0]!;
+  const menuChild = childrenArray[1]!;
+
+  // Clone the trigger element and spread ARIA + event handler props onto it.
+  // mergeProps handles merging multiple event listeners (e.g. existing onClick).
+  // An explicit onClick calling state.toggle() ensures native button clicks
+  // work reliably in all environments (JSDOM, browser, SSR hydration).
+  const clonedTrigger = cloneElement(triggerChild, {
+    ...(mergeProps(triggerChild.props as Record<string, unknown>, menuTriggerProps, {
+      onClick: () => {
+        state.toggle();
+      },
+    }) as Record<string, unknown>),
+    ref: triggerRef,
+  });
+
+  return (
+    // Provide OverlayTriggerStateContext so RAC Popover knows about open state
+    <OverlayTriggerStateContext.Provider value={state}>
+      {clonedTrigger}
+      {/* Provide RACMenuContext so RAC Menu gets the aria-labelledby linkage */}
+      <RACMenuContext.Provider value={menuProps as Record<string, unknown>}>
+        <Popover triggerRef={triggerRef} placement={placement} offset={4} isNonModal>
+          {menuChild}
+        </Popover>
+      </RACMenuContext.Provider>
+    </OverlayTriggerStateContext.Provider>
+  );
+}
+
+HeadlessMenuTrigger.displayName = "HeadlessMenuTrigger";
+
+// Attach as static sub-component for convenience
+(HeadlessMenuTrigger as unknown as Record<string, unknown>).Menu = null; // set below
+
+// ─── HeadlessMenu ─────────────────────────────────────────────────────────────
+
+/**
+ * Headless Menu list (Layer 2).
+ *
+ * Wraps RAC `Menu` which renders `<ul role="menu">` with full keyboard
+ * navigation, type-ahead, and collection management.
+ *
+ * @example
+ * ```tsx
+ * <HeadlessMenu aria-label="Actions" className={menuContainerVariants()}>
+ *   <HeadlessMenuItem id="cut">Cut</HeadlessMenuItem>
+ *   <HeadlessMenuItem id="copy">Copy</HeadlessMenuItem>
+ * </HeadlessMenu>
+ * ```
+ */
+export const HeadlessMenu = forwardRef<HTMLElement, HeadlessMenuProps>(
+  function HeadlessMenuComponent({ className, children, ...props }, _ref) {
+    return (
+      <RACMenu
+        {...(props as RACMenuProps<object>)}
+        {...(className !== undefined ? { className } : {})}
+      >
+        {children}
+      </RACMenu>
+    );
+  }
+);
+
+HeadlessMenu.displayName = "HeadlessMenu";
+
+// Attach static sub-component
+(HeadlessMenuTrigger as unknown as Record<string, unknown>).Menu = HeadlessMenu;
+
+// ─── HeadlessMenuItem ─────────────────────────────────────────────────────────
+
+/**
+ * Headless Menu Item (Layer 2).
+ *
+ * Wraps RAC `MenuItem` which renders `<li role="menuitem">` (or
+ * `role="menuitemradio"` / `role="menuitemcheckbox"` for selection menus).
+ * RAC manages aria-disabled, aria-checked, and keyboard activation.
+ *
+ * @example
+ * ```tsx
+ * <HeadlessMenuItem id="cut" className={menuItemVariants()}>
+ *   Cut
+ * </HeadlessMenuItem>
+ * ```
+ */
+export const HeadlessMenuItem = forwardRef<
+  HTMLElement,
+  HeadlessMenuItemProps & { onMouseDown?: React.MouseEventHandler<HTMLElement> }
+>(function HeadlessMenuItemComponent({ className, children, onMouseDown, ...props }, _ref) {
+  return (
+    <RACMenuItem
+      {...(props as unknown as RACMenuItemProps)}
+      {...(className !== undefined ? { className } : {})}
+      {...(onMouseDown !== undefined ? { onMouseDown } : {})}
+    >
+      {children}
+    </RACMenuItem>
+  );
+});
+
+HeadlessMenuItem.displayName = "HeadlessMenuItem";
+
+// ─── HeadlessMenuSection ──────────────────────────────────────────────────────
+
+/**
+ * Headless Menu Section (Layer 2).
+ *
+ * Wraps RAC `MenuSection` which renders `role="group"` with an optional
+ * accessible header. RAC handles `aria-labelledby` automatically.
+ *
+ * @example
+ * ```tsx
+ * <HeadlessMenuSection className={menuSectionVariants()} aria-label="Clipboard">
+ *   <HeadlessMenuItem id="cut">Cut</HeadlessMenuItem>
+ * </HeadlessMenuSection>
+ * ```
+ */
+export const HeadlessMenuSection = forwardRef<
+  HTMLElement,
+  HeadlessMenuSectionProps & { className?: string; children: ReactNode }
+>(function HeadlessMenuSectionComponent(
+  { children, className, "aria-label": ariaLabel, ...props },
+  _ref
+) {
+  return (
+    <RACMenuSection
+      {...props}
+      {...(className !== undefined ? { className } : {})}
+      {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+    >
+      {children}
+    </RACMenuSection>
+  );
+});
+
+HeadlessMenuSection.displayName = "HeadlessMenuSection";
+
+// ─── HeadlessMenuDivider ──────────────────────────────────────────────────────
+
+/**
+ * Headless Menu Divider (Layer 2).
+ *
+ * Wraps RAC `Separator` which renders `role="separator"`.
+ *
+ * @example
+ * ```tsx
+ * <HeadlessMenuDivider className={menuDividerVariants()} />
+ * ```
+ */
+export function HeadlessMenuDivider({ className }: { className?: string }): JSX.Element {
+  return <Separator {...(className !== undefined ? { className } : {})} />;
+}
+
+HeadlessMenuDivider.displayName = "HeadlessMenuDivider";

--- a/packages/react/src/components/Menu/MenuHeadless.tsx
+++ b/packages/react/src/components/Menu/MenuHeadless.tsx
@@ -1,260 +1,348 @@
 "use client";
 
-/**
- * MenuHeadless — Layer 2: Behavior-only primitives.
- *
- * The trigger layer uses react-aria hooks (`useMenuTriggerState` +
- * `useMenuTrigger`) to spread ARIA attributes and event handlers onto any
- * trigger element via `cloneElement`. This supports raw `<button>` elements
- * as well as RAC `Button` components.
- *
- * The overlay uses RAC `Popover` with `OverlayTriggerStateContext` to handle
- * portal rendering, positioning, flip/shift, focus management (FocusScope +
- * restoreFocus + autoFocus), and Escape / outside-click dismissal.
- *
- * The menu list uses RAC `Menu`, `MenuItem`, `MenuSection`, `Separator` for
- * full collection management, keyboard navigation, and ARIA semantics.
- */
-
 import {
-  cloneElement,
   createContext,
   forwardRef,
+  useCallback,
   useContext,
   useRef,
-  type JSX,
-  type ReactElement,
+  useLayoutEffect,
+  useState,
+  isValidElement,
+  cloneElement,
   type ReactNode,
+  type ReactElement,
+  type HTMLAttributes,
+  type JSX,
 } from "react";
 import {
   Menu as RACMenu,
   MenuItem as RACMenuItem,
   MenuSection as RACMenuSection,
-  MenuContext as RACMenuContext,
-  OverlayTriggerStateContext,
+  Separator as RACSeparator,
+  SubmenuTrigger as RACSubmenuTrigger,
+  MenuTrigger as RACMenuTrigger,
+  ButtonContext,
   Popover,
-  Separator,
-  type MenuProps as RACMenuProps,
-  type MenuItemProps as RACMenuItemProps,
+  OverlayTriggerStateContext,
+  useSlottedContext,
+  type SeparatorProps as RACSeparatorProps,
 } from "react-aria-components";
-import { mergeProps, useMenuTrigger } from "react-aria";
-import { useMenuTriggerState } from "react-stately";
+import { useButton } from "react-aria";
+import { useOverlayTriggerState } from "react-stately";
 import type {
+  HeadlessMenuTriggerProps,
   HeadlessMenuProps,
   HeadlessMenuItemProps,
   HeadlessMenuSectionProps,
-  HeadlessMenuTriggerProps,
+  HeadlessSubmenuTriggerProps,
+  HeadlessContextMenuTriggerProps,
   MenuContextValue,
 } from "./Menu.types";
 
-// ─── Our Menu Context (close / disableRipple / variant) ──────────────────────
+// ─── MenuContext ──────────────────────────────────────────────────────────────
 
-/**
- * Context shared between the Menu and its item descendants.
- * Carries close(), disableRipple, and variant so items can
- * read them without prop-drilling.
- * @internal
- */
 export const MenuContext = createContext<MenuContextValue | null>(null);
 
-export function useMenuContext(): MenuContextValue {
-  const ctx = useContext(MenuContext);
-  if (ctx === null) {
-    throw new Error("MenuItem must be rendered inside a MenuTrigger component.");
-  }
-  return ctx;
+export function useMenuContext(): MenuContextValue | null {
+  return useContext(MenuContext);
+}
+
+// ─── TriggerBridge ────────────────────────────────────────────────────────────
+/**
+ * Reads the button slot props from `ButtonContext` (provided by `RACMenuTrigger`)
+ * and applies them to any plain HTML element child via `cloneElement`.
+ *
+ * This bridges the gap between RAC's context-based prop injection (which expects
+ * a RAC `Button`) and our Layer 3 API that accepts any trigger element (e.g. a
+ * native `<button>` or a custom component).
+ *
+ * @internal
+ */
+function TriggerBridge({ children }: { children: ReactNode }): ReactNode {
+  // useSlottedContext gives a properly typed value (ButtonContextValue & { ref? })
+  // without casting through any.
+  const ctx = useSlottedContext(ButtonContext);
+  const localRef = useRef<HTMLButtonElement | null>(null);
+
+  const { ref: contextRef, ...ctxProps } = ctx ?? {};
+
+  // Write to both the context ref (used by RACMenuTrigger for popover
+  // positioning) and localRef (passed to useButton, which requires a stable
+  // RefObject rather than a ForwardedRef).
+  const mergedCallbackRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      localRef.current = node;
+      if (!contextRef) return;
+      if (typeof contextRef === "function") {
+        contextRef(node);
+      } else {
+        // After the function check, contextRef is MutableRefObject<HTMLButtonElement | null>
+        // (ForwardedRef<T> = callback | MutableRefObject<T | null> | null).
+        contextRef.current = node;
+      }
+    },
+    [contextRef]
+  );
+
+  // ButtonContext is populated by RACMenuTrigger with aria-haspopup,
+  // aria-expanded, aria-controls, onPress, onKeyDown, etc.
+  // useButton converts React Aria's onPress + keyboard props into standard
+  // HTML events (onClick, onKeyDown, etc.) that work on native elements.
+  const { buttonProps } = useButton({ ...ctxProps, elementType: "button" }, localRef);
+
+  if (!isValidElement(children)) return <>{children}</>;
+
+  return cloneElement(
+    children as React.ReactElement<HTMLAttributes<HTMLElement>>,
+    { ...buttonProps, ref: mergedCallbackRef } as HTMLAttributes<HTMLElement>
+  );
 }
 
 // ─── HeadlessMenuTrigger ──────────────────────────────────────────────────────
 
 /**
- * Headless Menu Trigger (Layer 2).
+ * Layer 2 headless primitive.
  *
- * - Manages open/close state via `useMenuTriggerState`.
- * - Spreads `aria-haspopup`, `aria-expanded`, `aria-controls`, and pointer /
- *   keyboard event handlers onto the first child (trigger element) via
- *   `cloneElement`. Works with both RAC `Button` and native `<button>`.
- * - Renders the menu overlay via RAC `Popover` (with portal, positioning, flip,
- *   focus management, and Escape/outside-click dismissal).
- * - Provides `OverlayTriggerStateContext` so `Popover` knows the open state.
- * - Provides `RACMenuContext` so RAC `Menu` receives its `id` /
- *   `aria-labelledby` linkage.
+ * Uses `RACMenuTrigger` (Layer 1) as the foundation. `RACMenuTrigger` manages:
+ * - `aria-haspopup="menu"` and `aria-expanded` on the trigger (dynamic)
+ * - Open/close state and keyboard opening (ArrowDown → focus first item)
+ * - `OverlayTriggerStateContext` so the Popover can close on Escape / outside click
+ * - `PopoverGroupContext` so the Popover's `ariaHideOutside` does NOT hide the
+ *   trigger button while the menu is open
  *
- * Children layout: `[trigger, menu]`
- *
- * @example
- * ```tsx
- * <HeadlessMenuTrigger>
- *   <button type="button">Open</button>
- *   <HeadlessMenu aria-label="Actions">
- *     <HeadlessMenuItem id="cut">Cut</HeadlessMenuItem>
- *   </HeadlessMenu>
- * </HeadlessMenuTrigger>
- * ```
+ * `TriggerBridge` adapts the context-injected button props to work with any
+ * plain HTML element (native `<button>`, custom components, etc.).
  */
 export function HeadlessMenuTrigger({
   children,
   placement = "bottom start",
-  ...stateProps
+  shouldFlip = true,
+  ...rest
 }: HeadlessMenuTriggerProps): JSX.Element {
-  const triggerRef = useRef<HTMLElement>(null);
-  const state = useMenuTriggerState(stateProps);
-  const { menuTriggerProps, menuProps } = useMenuTrigger({ type: "menu" }, state, triggerRef);
-
-  const childrenArray = Array.isArray(children)
-    ? (children as ReactElement[])
-    : [children as ReactElement];
-  const triggerChild = childrenArray[0]!;
-  const menuChild = childrenArray[1]!;
-
-  // Clone the trigger element and spread ARIA + event handler props onto it.
-  // mergeProps handles merging multiple event listeners (e.g. existing onClick).
-  // An explicit onClick calling state.toggle() ensures native button clicks
-  // work reliably in all environments (JSDOM, browser, SSR hydration).
-  const clonedTrigger = cloneElement(triggerChild, {
-    ...(mergeProps(triggerChild.props as Record<string, unknown>, menuTriggerProps, {
-      onClick: () => {
-        state.toggle();
-      },
-    }) as Record<string, unknown>),
-    ref: triggerRef,
-  });
+  const childrenArray = Array.isArray(children) ? children : [children];
+  const [triggerChild, menuChild] = childrenArray as [ReactNode, ReactNode];
 
   return (
-    // Provide OverlayTriggerStateContext so RAC Popover knows about open state
-    <OverlayTriggerStateContext.Provider value={state}>
-      {clonedTrigger}
-      {/* Provide RACMenuContext so RAC Menu gets the aria-labelledby linkage */}
-      <RACMenuContext.Provider value={menuProps as Record<string, unknown>}>
-        <Popover triggerRef={triggerRef} placement={placement} offset={4} isNonModal>
-          {menuChild}
-        </Popover>
-      </RACMenuContext.Provider>
-    </OverlayTriggerStateContext.Provider>
+    <RACMenuTrigger {...rest}>
+      <TriggerBridge>{triggerChild}</TriggerBridge>
+      {/*
+       * RACMenuTrigger provides PopoverGroupContext which tells ariaHideOutside
+       * to exclude the trigger button — so we do NOT need isNonModal here.
+       * Without isNonModal the Popover uses the standard modal overlay underlay,
+       * which correctly dismisses the menu on any outside pointer interaction.
+       */}
+      <Popover placement={placement} shouldFlip={shouldFlip} offset={4}>
+        {menuChild}
+      </Popover>
+    </RACMenuTrigger>
   );
 }
-
-HeadlessMenuTrigger.displayName = "HeadlessMenuTrigger";
-
-// Attach as static sub-component for convenience
-(HeadlessMenuTrigger as unknown as Record<string, unknown>).Menu = null; // set below
 
 // ─── HeadlessMenu ─────────────────────────────────────────────────────────────
 
 /**
- * Headless Menu list (Layer 2).
+ * Layer 2 headless primitive wrapping RAC `Menu`.
  *
- * Wraps RAC `Menu` which renders `<ul role="menu">` with full keyboard
- * navigation, type-ahead, and collection management.
+ * When nested inside `HeadlessMenuTrigger`, RAC automatically threads the
+ * `MenuContext` (containing `autoFocus`, `onClose`, `aria-labelledby`, etc.)
+ * from `RACMenuTrigger` through to `RACMenu`. No manual prop threading needed.
  *
- * @example
- * ```tsx
- * <HeadlessMenu aria-label="Actions" className={menuContainerVariants()}>
- *   <HeadlessMenuItem id="cut">Cut</HeadlessMenuItem>
- *   <HeadlessMenuItem id="copy">Copy</HeadlessMenuItem>
- * </HeadlessMenu>
- * ```
+ * **aria-label / aria-labelledby precedence fix**: `RACSubmenuTrigger` sets
+ * `aria-labelledby` in `MenuContext` pointing to the trigger item. In ARIA
+ * spec, `aria-labelledby` always overrides `aria-label`. So when the consumer
+ * provides an explicit `aria-label`, we suppress the context's
+ * `aria-labelledby` by passing `aria-labelledby={undefined}`, which takes
+ * precedence over the `MenuContext` value in `useContextProps`'s `mergeProps`
+ * call (last argument wins). This ensures `aria-label="My Submenu"` is
+ * respected as the accessible name.
  */
-export const HeadlessMenu = forwardRef<HTMLElement, HeadlessMenuProps>(
-  function HeadlessMenuComponent({ className, children, ...props }, _ref) {
-    return (
-      <RACMenu
-        {...(props as RACMenuProps<object>)}
-        {...(className !== undefined ? { className } : {})}
-      >
-        {children}
-      </RACMenu>
-    );
-  }
-);
+export function HeadlessMenu<T extends object = object>({
+  className,
+  children,
+  "aria-label": ariaLabel,
+  ...props
+}: HeadlessMenuProps<T>): JSX.Element {
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
-HeadlessMenu.displayName = "HeadlessMenu";
+  /**
+   * `RACSubmenuTrigger` provides `MenuContext` with `aria-labelledby` pointing
+   * to the trigger item's id. In the ARIA spec, `aria-labelledby` always beats
+   * `aria-label`, so even if we pass `aria-label` as a prop it would be
+   * overridden. `useContextProps` inside `RACMenu` merges context first then
+   * explicit props, but passing `aria-labelledby={undefined}` doesn't reliably
+   * clear the context-injected attribute in all RAC versions.
+   *
+   * The only reliable fix: imperatively remove the attribute from the DOM node
+   * after every render. `useLayoutEffect` runs synchronously after DOM mutations,
+   * so the accessibility tree is already correct when testing-library reads it.
+   */
+  useLayoutEffect(() => {
+    if (ariaLabel && menuRef.current) {
+      menuRef.current.removeAttribute("aria-labelledby");
+    }
+  });
 
-// Attach static sub-component
-(HeadlessMenuTrigger as unknown as Record<string, unknown>).Menu = HeadlessMenu;
+  return (
+    <RACMenu<T>
+      {...props}
+      ref={menuRef}
+      {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+      className={className ?? ""}
+    >
+      {children}
+    </RACMenu>
+  );
+}
+
+// Expose HeadlessMenu as a static property so Layer 2 tests can use
+// <HeadlessMenuTrigger.Menu> just like <MenuTrigger.Menu> at Layer 3.
+HeadlessMenuTrigger.Menu = HeadlessMenu;
 
 // ─── HeadlessMenuItem ─────────────────────────────────────────────────────────
 
 /**
- * Headless Menu Item (Layer 2).
+ * Layer 2 headless primitive wrapping RAC `MenuItem`.
  *
- * Wraps RAC `MenuItem` which renders `<li role="menuitem">` (or
- * `role="menuitemradio"` / `role="menuitemcheckbox"` for selection menus).
- * RAC manages aria-disabled, aria-checked, and keyboard activation.
- *
- * @example
- * ```tsx
- * <HeadlessMenuItem id="cut" className={menuItemVariants()}>
- *   Cut
- * </HeadlessMenuItem>
- * ```
+ * Accepts `className` as either a static string or a render-prop function
+ * `(renderProps: MenuItemRenderProps) => string`, forwarding it directly to
+ * `RACMenuItem` so MD3 selection-state styles are applied on the `<li>` element
+ * (the element with `role="menuitem"`).
  */
-export const HeadlessMenuItem = forwardRef<
-  HTMLElement,
-  HeadlessMenuItemProps & { onMouseDown?: React.MouseEventHandler<HTMLElement> }
->(function HeadlessMenuItemComponent({ className, children, onMouseDown, ...props }, _ref) {
-  return (
-    <RACMenuItem
-      {...(props as unknown as RACMenuItemProps)}
-      {...(className !== undefined ? { className } : {})}
-      {...(onMouseDown !== undefined ? { onMouseDown } : {})}
-    >
-      {children}
-    </RACMenuItem>
-  );
-});
-
-HeadlessMenuItem.displayName = "HeadlessMenuItem";
+export const HeadlessMenuItem = forwardRef<HTMLDivElement, HeadlessMenuItemProps>(
+  function HeadlessMenuItem({ children, className, ...props }, ref) {
+    return (
+      <RACMenuItem {...props} ref={ref} className={className ?? ""}>
+        {children}
+      </RACMenuItem>
+    );
+  }
+);
 
 // ─── HeadlessMenuSection ──────────────────────────────────────────────────────
 
-/**
- * Headless Menu Section (Layer 2).
- *
- * Wraps RAC `MenuSection` which renders `role="group"` with an optional
- * accessible header. RAC handles `aria-labelledby` automatically.
- *
- * @example
- * ```tsx
- * <HeadlessMenuSection className={menuSectionVariants()} aria-label="Clipboard">
- *   <HeadlessMenuItem id="cut">Cut</HeadlessMenuItem>
- * </HeadlessMenuSection>
- * ```
- */
-export const HeadlessMenuSection = forwardRef<
-  HTMLElement,
-  HeadlessMenuSectionProps & { className?: string; children: ReactNode }
->(function HeadlessMenuSectionComponent(
-  { children, className, "aria-label": ariaLabel, ...props },
-  _ref
-) {
+export function HeadlessMenuSection({
+  children,
+  "aria-label": ariaLabel,
+  className,
+}: HeadlessMenuSectionProps): JSX.Element {
   return (
     <RACMenuSection
-      {...props}
-      {...(className !== undefined ? { className } : {})}
       {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+      className={className ?? ""}
     >
       {children}
     </RACMenuSection>
   );
-});
-
-HeadlessMenuSection.displayName = "HeadlessMenuSection";
+}
 
 // ─── HeadlessMenuDivider ──────────────────────────────────────────────────────
 
-/**
- * Headless Menu Divider (Layer 2).
- *
- * Wraps RAC `Separator` which renders `role="separator"`.
- *
- * @example
- * ```tsx
- * <HeadlessMenuDivider className={menuDividerVariants()} />
- * ```
- */
-export function HeadlessMenuDivider({ className }: { className?: string }): JSX.Element {
-  return <Separator {...(className !== undefined ? { className } : {})} />;
+export function HeadlessMenuDivider({
+  className,
+  ...props
+}: RACSeparatorProps & { className?: string }): JSX.Element {
+  return <RACSeparator {...props} className={className ?? ""} />;
 }
 
-HeadlessMenuDivider.displayName = "HeadlessMenuDivider";
+// ─── HeadlessSubmenuTrigger ───────────────────────────────────────────────────
+
+/**
+ * Layer 2 headless primitive wrapping RAC `SubmenuTrigger`.
+ *
+ * RAC `SubmenuTrigger` expects its children to be a `[MenuItem, Popover>Menu]`
+ * pair. The first child is the trigger item; the second is a `Popover` wrapping
+ * the submenu `Menu`. We wrap the menu child in a `Popover` here so the consumer
+ * only needs to provide `[MenuItem, Menu]`.
+ */
+export function HeadlessSubmenuTrigger({
+  children,
+  delay,
+}: HeadlessSubmenuTriggerProps): JSX.Element {
+  const childrenArray = Array.isArray(children) ? children : [children];
+  const [triggerItem, menuChild] = childrenArray as [ReactNode, ReactNode];
+
+  // RACSubmenuTrigger requires ReactElement[] children — first child is the
+  // trigger MenuItem, second is a Popover wrapping the submenu.
+  const racChildren: ReactElement[] = [
+    triggerItem as ReactElement,
+    <Popover key="submenu-popover">{menuChild}</Popover>,
+  ];
+
+  return (
+    <RACSubmenuTrigger {...(delay !== undefined ? { delay } : {})}>{racChildren}</RACSubmenuTrigger>
+  );
+}
+
+// ─── HeadlessContextMenuTrigger ───────────────────────────────────────────────
+
+/**
+ * Layer 2 headless primitive for context menus (right-click / two-finger tap).
+ * Positions the menu at cursor coordinates via a virtual 0×0 anchor element.
+ */
+export function HeadlessContextMenuTrigger({
+  children,
+  isOpen: isOpenProp,
+  onOpenChange,
+}: HeadlessContextMenuTriggerProps): JSX.Element {
+  const virtualTriggerRef = useRef<HTMLSpanElement>(null);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  const isControlled = isOpenProp !== undefined;
+
+  // Conditionally spread EOPT-sensitive props: isOpen/onOpenChange must not be
+  // present with value `undefined` under exactOptionalPropertyTypes.
+  const internalState = useOverlayTriggerState({
+    ...(isControlled
+      ? { isOpen: isOpenProp, ...(onOpenChange !== undefined ? { onOpenChange } : {}) }
+      : {}),
+  });
+
+  const handleContextMenu = (e: React.MouseEvent): void => {
+    e.preventDefault();
+    setPosition({ x: e.clientX, y: e.clientY });
+    internalState.open();
+    if (!isControlled) onOpenChange?.(true);
+  };
+
+  const childrenArray = Array.isArray(children) ? children : [children];
+  const [contentChild, menuChild] = childrenArray as [ReactNode, ReactNode];
+
+  return (
+    <>
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- display:contents sink; not focusable itself, keyboard dismissal handled by RAC Popover Escape handler */}
+      <div onContextMenu={handleContextMenu} style={{ display: "contents" }}>
+        {contentChild}
+      </div>
+
+      {/* Virtual 0×0 anchor positioned at cursor coordinates */}
+      <span
+        ref={virtualTriggerRef}
+        aria-hidden="true"
+        style={{
+          position: "fixed",
+          top: position.y,
+          left: position.x,
+          width: 0,
+          height: 0,
+          pointerEvents: "none",
+        }}
+      />
+
+      {/*
+       * OverlayTriggerStateContext is provided OUTSIDE the Popover so the
+       * Popover reads internalState directly (not a derived localState).
+       * We intentionally do NOT pass isOpen as a prop — when isOpen is a prop,
+       * the Popover creates a separate localState whose close() doesn't update
+       * internalState. By relying solely on OverlayTriggerStateContext, the
+       * Popover's DismissButton / Escape key handler call internalState.close()
+       * directly, which correctly dismisses the context menu.
+       */}
+      <OverlayTriggerStateContext.Provider value={internalState}>
+        <Popover triggerRef={virtualTriggerRef} placement="bottom start" shouldFlip offset={0}>
+          {menuChild}
+        </Popover>
+      </OverlayTriggerStateContext.Provider>
+    </>
+  );
+}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { forwardRef, useContext } from "react";
+import { HeadlessMenuItem } from "./MenuHeadless";
+import { MenuContext } from "./MenuHeadless";
+import { menuItemVariants, menuItemTrailingTextVariants } from "./Menu.variants";
+import { cn } from "../../utils/cn";
+import { useRipple } from "../../hooks/useRipple";
+import type { MenuItemProps } from "./Menu.types";
+import type { MenuItemRenderProps } from "react-aria-components";
+
+/**
+ * Material Design 3 Menu Item (Layer 3: Styled).
+ *
+ * A single interactive item within a Menu. Uses `HeadlessMenuItem` (RAC
+ * `MenuItem`) for all behavior and ARIA semantics, CVA for MD3 visual states.
+ *
+ * Features:
+ * - Item height: 48dp (`h-12`) per MD3 spec
+ * - Label: `text-label-large text-on-surface`
+ * - Optional leading icon slot: `text-on-surface-variant`
+ * - Optional trailing icon slot: `text-on-surface-variant`
+ * - Optional trailing text (keyboard shortcut): `text-label-large text-on-surface-variant`
+ * - MD3 state layers via pseudo-element (`opacity-8` hover, `opacity-12`
+ *   focus-visible / pressed)
+ * - Ripple effect on press
+ * - Disabled state: `opacity-38` + non-interactive
+ * - Selected state (select variant): `bg-secondary-container` +
+ *   `text-on-secondary-container`
+ *
+ * @example
+ * ```tsx
+ * // Basic item
+ * <MenuItem id="cut">Cut</MenuItem>
+ *
+ * // With leading icon
+ * <MenuItem id="copy" leadingIcon={<CopyIcon />}>Copy</MenuItem>
+ *
+ * // With keyboard shortcut
+ * <MenuItem id="paste" leadingIcon={<PasteIcon />} trailingText="⌘V">Paste</MenuItem>
+ *
+ * // Disabled
+ * <MenuItem id="undo" isDisabled>Undo</MenuItem>
+ * ```
+ *
+ * @see https://m3.material.io/components/menus/specs
+ */
+export const MenuItem = forwardRef<HTMLElement, MenuItemProps>(
+  (
+    {
+      leadingIcon,
+      trailingIcon,
+      trailingText,
+      isDisabled = false,
+      className,
+      disableRipple: disableRippleProp,
+      children,
+      ...restProps
+    },
+    _ref
+  ) => {
+    const ctx = useContext(MenuContext);
+    const contextDisableRipple = ctx?.disableRipple ?? false;
+    const isRippleDisabled = (disableRippleProp ?? contextDisableRipple) || Boolean(isDisabled);
+
+    const { onMouseDown: handleRipple, ripples } = useRipple({
+      disabled: isRippleDisabled,
+    });
+
+    // RAC MenuItem accepts className as a function receiving render props,
+    // which allows dynamic styling based on isDisabled / isSelected.
+    const itemClassName = ({ isDisabled: d, isSelected: s }: MenuItemRenderProps): string =>
+      cn(menuItemVariants({ isDisabled: d, isSelected: s }), className);
+
+    return (
+      <HeadlessMenuItem
+        {...restProps}
+        isDisabled={isDisabled}
+        className={itemClassName as unknown as string}
+        onMouseDown={handleRipple as React.MouseEventHandler<HTMLElement>}
+      >
+        {/* Ripple effect */}
+        {ripples}
+
+        {/* Leading icon slot */}
+        {leadingIcon && (
+          <span
+            className="text-on-surface-variant relative z-10 flex shrink-0 items-center justify-center"
+            aria-hidden="true"
+          >
+            {leadingIcon}
+          </span>
+        )}
+
+        {/* Label */}
+        <span className="relative z-10 flex-1 truncate text-left">{children}</span>
+
+        {/* Trailing icon slot (mutually exclusive with trailingText) */}
+        {trailingIcon && !trailingText && (
+          <span
+            className="text-on-surface-variant relative z-10 ml-auto flex shrink-0 items-center"
+            aria-hidden="true"
+          >
+            {trailingIcon}
+          </span>
+        )}
+
+        {/* Trailing text (keyboard shortcut) */}
+        {trailingText && !trailingIcon && (
+          <span className={cn("relative z-10", menuItemTrailingTextVariants())}>
+            {trailingText}
+          </span>
+        )}
+      </HeadlessMenuItem>
+    );
+  }
+);
+
+MenuItem.displayName = "MenuItem";

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -1,119 +1,188 @@
 "use client";
 
-import { forwardRef, useContext } from "react";
-import { HeadlessMenuItem } from "./MenuHeadless";
-import { MenuContext } from "./MenuHeadless";
-import { menuItemVariants, menuItemTrailingTextVariants } from "./Menu.variants";
-import { cn } from "../../utils/cn";
-import { useRipple } from "../../hooks/useRipple";
-import type { MenuItemProps } from "./Menu.types";
+import { forwardRef, type JSX } from "react";
 import type { MenuItemRenderProps } from "react-aria-components";
+import { useMenuContext } from "./MenuHeadless";
+import { HeadlessMenuItem } from "./MenuHeadless";
+import {
+  menuItemVariants,
+  menuItemTrailingTextVariants,
+  menuItemDescriptionVariants,
+} from "./Menu.variants";
+import { useRipple } from "../../hooks/useRipple";
+import { cn } from "../../utils/cn";
+import type { MenuItemProps } from "./Menu.types";
+
+// ─── CheckIcon ───────────────────────────────────────────────────────────────
+
+function CheckIcon(): JSX.Element {
+  return (
+    <svg
+      data-testid="check-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      className="h-full w-full"
+    >
+      <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+    </svg>
+  );
+}
+
+// ─── ChevronRightIcon ─────────────────────────────────────────────────────────
+
+export function ChevronRightIcon(): JSX.Element {
+  return (
+    <svg
+      data-testid="chevron-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      className="h-full w-full"
+    >
+      <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" />
+    </svg>
+  );
+}
+
+// ─── Density height map ────────────────────────────────────────────────────────
+
+const DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
+  0: "h-12",
+  [-1]: "h-11",
+  [-2]: "h-10",
+  [-3]: "h-9",
+};
+
+// ─── MenuItem ─────────────────────────────────────────────────────────────────
 
 /**
- * Material Design 3 Menu Item (Layer 3: Styled).
+ * MD3 styled MenuItem component (Layer 3).
  *
- * A single interactive item within a Menu. Uses `HeadlessMenuItem` (RAC
- * `MenuItem`) for all behavior and ARIA semantics, CVA for MD3 visual states.
- *
- * Features:
- * - Item height: 48dp (`h-12`) per MD3 spec
- * - Label: `text-label-large text-on-surface`
- * - Optional leading icon slot: `text-on-surface-variant`
- * - Optional trailing icon slot: `text-on-surface-variant`
- * - Optional trailing text (keyboard shortcut): `text-label-large text-on-surface-variant`
- * - MD3 state layers via pseudo-element (`opacity-8` hover, `opacity-12`
- *   focus-visible / pressed)
- * - Ripple effect on press
- * - Disabled state: `opacity-38` + non-interactive
- * - Selected state (select variant): `bg-secondary-container` +
- *   `text-on-secondary-container`
+ * All MD3 styles (selection colors, typography, density height) are applied
+ * directly to the `<li role="menuitem">` element via RAC's render-prop className,
+ * ensuring tests and assistive technologies see the correct classes on the
+ * semantically meaningful element.
  *
  * @example
  * ```tsx
- * // Basic item
- * <MenuItem id="cut">Cut</MenuItem>
- *
- * // With leading icon
- * <MenuItem id="copy" leadingIcon={<CopyIcon />}>Copy</MenuItem>
- *
- * // With keyboard shortcut
- * <MenuItem id="paste" leadingIcon={<PasteIcon />} trailingText="⌘V">Paste</MenuItem>
- *
- * // Disabled
- * <MenuItem id="undo" isDisabled>Undo</MenuItem>
+ * <MenuItem id="copy" leadingIcon={<CopyIcon />} trailingText="⌘C">
+ *   Copy
+ * </MenuItem>
  * ```
- *
- * @see https://m3.material.io/components/menus/specs
  */
-export const MenuItem = forwardRef<HTMLElement, MenuItemProps>(
-  (
-    {
-      leadingIcon,
-      trailingIcon,
-      trailingText,
-      isDisabled = false,
-      className,
-      disableRipple: disableRippleProp,
-      children,
-      ...restProps
-    },
-    _ref
-  ) => {
-    const ctx = useContext(MenuContext);
-    const contextDisableRipple = ctx?.disableRipple ?? false;
-    const isRippleDisabled = (disableRippleProp ?? contextDisableRipple) || Boolean(isDisabled);
+export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuItem(
+  {
+    children,
+    leadingIcon,
+    trailingIcon,
+    trailingText,
+    description,
+    badge,
+    className,
+    disableRipple: itemDisableRipple,
+    ...props
+  },
+  ref
+) {
+  const ctx = useMenuContext();
+  const disableRipple = itemDisableRipple ?? ctx?.disableRipple ?? false;
+  const colorScheme = ctx?.colorScheme ?? "standard";
+  const menuStyle = ctx?.menuStyle ?? "baseline";
+  const density = ctx?.density ?? 0;
+  const selectionMode = ctx?.selectionMode;
 
-    const { onMouseDown: handleRipple, ripples } = useRipple({
-      disabled: isRippleDisabled,
-    });
+  const heightClass = DENSITY_HEIGHT[density];
+  const isSelectionMenu = selectionMode != null;
 
-    // RAC MenuItem accepts className as a function receiving render props,
-    // which allows dynamic styling based on isDisabled / isSelected.
-    const itemClassName = ({ isDisabled: d, isSelected: s }: MenuItemRenderProps): string =>
-      cn(menuItemVariants({ isDisabled: d, isSelected: s }), className);
+  const { ripples, onMouseDown } = useRipple({ disabled: disableRipple });
 
-    return (
-      <HeadlessMenuItem
-        {...restProps}
-        isDisabled={isDisabled}
-        className={itemClassName as unknown as string}
-        onMouseDown={handleRipple as React.MouseEventHandler<HTMLElement>}
-      >
-        {/* Ripple effect */}
-        {ripples}
-
-        {/* Leading icon slot */}
-        {leadingIcon && (
-          <span
-            className="text-on-surface-variant relative z-10 flex shrink-0 items-center justify-center"
-            aria-hidden="true"
-          >
-            {leadingIcon}
-          </span>
-        )}
-
-        {/* Label */}
-        <span className="relative z-10 flex-1 truncate text-left">{children}</span>
-
-        {/* Trailing icon slot (mutually exclusive with trailingText) */}
-        {trailingIcon && !trailingText && (
-          <span
-            className="text-on-surface-variant relative z-10 ml-auto flex shrink-0 items-center"
-            aria-hidden="true"
-          >
-            {trailingIcon}
-          </span>
-        )}
-
-        {/* Trailing text (keyboard shortcut) */}
-        {trailingText && !trailingIcon && (
-          <span className={cn("relative z-10", menuItemTrailingTextVariants())}>
-            {trailingText}
-          </span>
-        )}
-      </HeadlessMenuItem>
+  // className rendered on the <li role="menuitem"> via RAC's render-prop form
+  const computeClassName = ({ isDisabled, isSelected }: MenuItemRenderProps): string =>
+    cn(
+      menuItemVariants({
+        isDisabled,
+        isSelected: isSelected ?? false,
+        colorScheme,
+        menuStyle,
+      }),
+      // Height: auto when description is present (multi-line), otherwise density
+      description ? "min-h-12 py-2 h-auto items-start" : heightClass,
+      className
     );
-  }
-);
 
-MenuItem.displayName = "MenuItem";
+  return (
+    <HeadlessMenuItem
+      {...props}
+      ref={ref}
+      // Apply all MD3 classes directly to the <li role="menuitem"> element
+      className={computeClassName}
+      // onMouseDown triggers the ripple effect on mouse presses
+      onMouseDown={onMouseDown as unknown as React.MouseEventHandler<Element>}
+    >
+      {({ isSelected }: MenuItemRenderProps) => (
+        <>
+          {/* Ripple container */}
+          {!disableRipple && (
+            <span className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
+              {ripples}
+            </span>
+          )}
+
+          {/* ── Leading icon or checkmark slot ────────────────────────── */}
+          {(leadingIcon != null || isSelectionMenu) && (
+            <span
+              className="text-on-surface-variant relative z-10 flex h-6 w-6 shrink-0 items-center justify-center"
+              aria-hidden="true"
+            >
+              {isSelectionMenu && leadingIcon == null ? (
+                isSelected ? (
+                  <CheckIcon />
+                ) : null
+              ) : (
+                leadingIcon
+              )}
+            </span>
+          )}
+
+          {/* ── Text content area ─────────────────────────────────────── */}
+          {description != null ? (
+            <span className="relative z-10 flex min-w-0 flex-1 flex-col">
+              <span className="text-body-large">{children}</span>
+              <span className={menuItemDescriptionVariants()}>{description}</span>
+            </span>
+          ) : (
+            <span className="text-body-large relative z-10 min-w-0 flex-1">{children}</span>
+          )}
+
+          {/* ── Badge slot ────────────────────────────────────────────── */}
+          {badge != null && <span className="relative z-10 shrink-0">{badge}</span>}
+
+          {/* ── Trailing icon ─────────────────────────────────────────── */}
+          {trailingIcon != null && trailingText == null && (
+            <span
+              className="text-on-surface-variant relative z-10 ml-auto flex h-6 w-6 shrink-0 items-center justify-center"
+              aria-hidden="true"
+            >
+              {trailingIcon}
+            </span>
+          )}
+
+          {/* ── Trailing text (keyboard shortcut) ─────────────────────── */}
+          {trailingText != null && trailingIcon == null && (
+            <span
+              className={cn(menuItemTrailingTextVariants(), "relative z-10")}
+              aria-keyshortcuts={trailingText}
+            >
+              {trailingText}
+            </span>
+          )}
+        </>
+      )}
+    </HeadlessMenuItem>
+  );
+});

--- a/packages/react/src/components/Menu/MenuSection.tsx
+++ b/packages/react/src/components/Menu/MenuSection.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { forwardRef } from "react";
+import { Header, Separator } from "react-aria-components";
+import { HeadlessMenuSection } from "./MenuHeadless";
+import {
+  menuSectionVariants,
+  menuSectionHeaderVariants,
+  menuDividerVariants,
+} from "./Menu.variants";
+import { cn } from "../../utils/cn";
+import type { MenuSectionProps } from "./Menu.types";
+
+/**
+ * Material Design 3 Menu Section (Layer 3: Styled).
+ *
+ * Groups related `MenuItem` elements with an optional section header label
+ * and a horizontal divider. Follows MD3 Menu spec for section grouping and
+ * typography.
+ *
+ * The divider (`showDivider`) is rendered as a RAC `Separator` INSIDE the
+ * section (as the first collection item). This ensures RAC's collection API
+ * processes it correctly without breaking sibling sections.
+ *
+ * Features:
+ * - Optional header label: `text-title-small text-on-surface-variant`
+ * - Optional top divider: `role="separator"` rendered via RAC `Separator`
+ *
+ * @example
+ * ```tsx
+ * // Section with header and divider
+ * <MenuSection header="Clipboard" showDivider>
+ *   <MenuItem id="cut">Cut</MenuItem>
+ *   <MenuItem id="copy">Copy</MenuItem>
+ * </MenuSection>
+ *
+ * // Section without header (requires aria-label for accessibility)
+ * <MenuSection aria-label="Formatting" showDivider>
+ *   <MenuItem id="bold">Bold</MenuItem>
+ * </MenuSection>
+ * ```
+ *
+ * @see https://m3.material.io/components/menus/specs
+ */
+export const MenuSection = forwardRef<HTMLElement, MenuSectionProps>(
+  ({ header, children, showDivider = false, className, "aria-label": ariaLabel }, _ref) => {
+    return (
+      <HeadlessMenuSection
+        className={cn(menuSectionVariants(), className)}
+        {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+      >
+        {/* Render divider as a RAC Separator INSIDE the section so it is a
+            proper collection item and does not break sibling section rendering */}
+        {showDivider && <Separator className={menuDividerVariants()} />}
+        {header && <Header className={menuSectionHeaderVariants()}>{header}</Header>}
+        {children}
+      </HeadlessMenuSection>
+    );
+  }
+);
+
+MenuSection.displayName = "MenuSection";

--- a/packages/react/src/components/Menu/MenuSection.tsx
+++ b/packages/react/src/components/Menu/MenuSection.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { forwardRef } from "react";
-import { Header, Separator } from "react-aria-components";
-import { HeadlessMenuSection } from "./MenuHeadless";
+import { type JSX } from "react";
+import { Header as RACHeader } from "react-aria-components";
+import { HeadlessMenuSection, HeadlessMenuDivider } from "./MenuHeadless";
 import {
   menuSectionVariants,
   menuSectionHeaderVariants,
@@ -12,51 +12,51 @@ import { cn } from "../../utils/cn";
 import type { MenuSectionProps } from "./Menu.types";
 
 /**
- * Material Design 3 Menu Section (Layer 3: Styled).
+ * MD3 styled MenuSection component (Layer 3).
  *
- * Groups related `MenuItem` elements with an optional section header label
- * and a horizontal divider. Follows MD3 Menu spec for section grouping and
- * typography.
+ * Groups related `MenuItem` elements with an optional section header and an
+ * optional top divider.
  *
- * The divider (`showDivider`) is rendered as a RAC `Separator` INSIDE the
- * section (as the first collection item). This ensures RAC's collection API
- * processes it correctly without breaking sibling sections.
- *
- * Features:
- * - Optional header label: `text-title-small text-on-surface-variant`
- * - Optional top divider: `role="separator"` rendered via RAC `Separator`
+ * **Implementation note**: The divider is rendered as a SIBLING BEFORE the
+ * `RACMenuSection`, NOT inside it. RAC's `Section`/`MenuSection` only accepts
+ * `Header` and `MenuItem` children — placing a `Separator` inside the section
+ * would create invalid HTML (`<li>` inside `<li role="group">`) and break RAC's
+ * collection rendering.
  *
  * @example
  * ```tsx
- * // Section with header and divider
- * <MenuSection header="Clipboard" showDivider>
+ * <MenuSection header="Clipboard" showDivider aria-label="Clipboard">
  *   <MenuItem id="cut">Cut</MenuItem>
  *   <MenuItem id="copy">Copy</MenuItem>
  * </MenuSection>
- *
- * // Section without header (requires aria-label for accessibility)
- * <MenuSection aria-label="Formatting" showDivider>
- *   <MenuItem id="bold">Bold</MenuItem>
- * </MenuSection>
  * ```
- *
- * @see https://m3.material.io/components/menus/specs
  */
-export const MenuSection = forwardRef<HTMLElement, MenuSectionProps>(
-  ({ header, children, showDivider = false, className, "aria-label": ariaLabel }, _ref) => {
-    return (
+export function MenuSection({
+  children,
+  header,
+  showDivider = false,
+  className,
+  "aria-label": ariaLabel,
+}: MenuSectionProps): JSX.Element {
+  // The union type guarantees at least one of these is a string.
+  const sectionAriaLabel = (ariaLabel ?? header)!;
+
+  return (
+    <>
+      {/* Divider is a sibling of the section, placed before it in the menu list */}
+      {showDivider && <HeadlessMenuDivider className={menuDividerVariants()} />}
       <HeadlessMenuSection
+        aria-label={sectionAriaLabel}
         className={cn(menuSectionVariants(), className)}
-        {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
       >
-        {/* Render divider as a RAC Separator INSIDE the section so it is a
-            proper collection item and does not break sibling section rendering */}
-        {showDivider && <Separator className={menuDividerVariants()} />}
-        {header && <Header className={menuSectionHeaderVariants()}>{header}</Header>}
+        {/* RAC Header component renders a semantic section header inside the group */}
+        {header && (
+          <RACHeader className={menuSectionHeaderVariants()} aria-hidden="true">
+            {header}
+          </RACHeader>
+        )}
         {children}
       </HeadlessMenuSection>
-    );
-  }
-);
-
-MenuSection.displayName = "MenuSection";
+    </>
+  );
+}

--- a/packages/react/src/components/Menu/SubmenuTrigger.tsx
+++ b/packages/react/src/components/Menu/SubmenuTrigger.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Children, isValidElement, cloneElement, type JSX, type ReactNode } from "react";
+import { HeadlessSubmenuTrigger } from "./MenuHeadless";
+import { ChevronRightIcon } from "./MenuItem";
+import type { SubmenuTriggerProps, MenuItemProps } from "./Menu.types";
+
+/**
+ * MD3 styled SubmenuTrigger component (Layer 3).
+ *
+ * Wraps a `MenuItem` (trigger) and a nested `Menu` to form a parent→child
+ * submenu relationship. Automatically:
+ * - Appends a `ChevronRight` trailing icon to the trigger `MenuItem`
+ * - Wires `ArrowRight` / `ArrowLeft` keyboard navigation via RAC
+ * - Passes `aria-haspopup="menu"` and `aria-expanded` to the trigger item
+ *
+ * @example
+ * ```tsx
+ * <SubmenuTrigger>
+ *   <MenuItem id="share">Share</MenuItem>
+ *   <MenuTrigger.Menu aria-label="Share via">
+ *     <MenuItem id="email">Email</MenuItem>
+ *     <MenuItem id="sms">SMS</MenuItem>
+ *   </MenuTrigger.Menu>
+ * </SubmenuTrigger>
+ * ```
+ */
+export function SubmenuTrigger({ children, delay }: SubmenuTriggerProps): JSX.Element {
+  const childArray = Children.toArray(children);
+  const [triggerItem, submenuContent] = childArray as [ReactNode, ReactNode];
+
+  // Inject ChevronRight trailing icon into the trigger MenuItem.
+  // Omit trailingText by destructuring it out so we never pass undefined
+  // explicitly, satisfying exactOptionalPropertyTypes.
+  const enhancedTrigger = isValidElement<MenuItemProps>(triggerItem)
+    ? (() => {
+        const { trailingText: _omitted, ...rest } = triggerItem.props;
+        return cloneElement(triggerItem, {
+          ...rest,
+          trailingIcon: <ChevronRightIcon />,
+        } as Partial<MenuItemProps>);
+      })()
+    : triggerItem;
+
+  return (
+    // EOPT: only include delay when it has a definite value.
+    <HeadlessSubmenuTrigger {...(delay !== undefined ? { delay } : {})}>
+      {enhancedTrigger}
+      {submenuContent}
+    </HeadlessSubmenuTrigger>
+  );
+}

--- a/packages/react/src/components/Menu/index.ts
+++ b/packages/react/src/components/Menu/index.ts
@@ -1,0 +1,44 @@
+// Layer 3: MD3 Styled Components (most users use these)
+export { MenuTrigger, Menu } from "./Menu";
+export { MenuItem } from "./MenuItem";
+export { MenuSection } from "./MenuSection";
+export { MenuDivider } from "./MenuDivider";
+
+// Layer 2: Headless Primitives (for advanced customization)
+export {
+  HeadlessMenuTrigger,
+  HeadlessMenu,
+  HeadlessMenuItem,
+  HeadlessMenuSection,
+  HeadlessMenuDivider,
+  MenuContext,
+  useMenuContext,
+} from "./MenuHeadless";
+
+// CVA Variants
+export {
+  menuContainerVariants,
+  menuItemVariants,
+  menuSectionVariants,
+  menuSectionHeaderVariants,
+  menuDividerVariants,
+  menuItemTrailingTextVariants,
+  type MenuContainerVariants,
+  type MenuItemVariants,
+  type MenuSectionVariants,
+} from "./Menu.variants";
+
+// Types
+export type {
+  MenuVariant,
+  MenuProps,
+  MenuTriggerProps,
+  MenuItemProps,
+  MenuSectionProps,
+  MenuDividerProps,
+  HeadlessMenuProps,
+  HeadlessMenuTriggerProps,
+  HeadlessMenuItemProps,
+  HeadlessMenuSectionProps,
+  MenuContextValue,
+} from "./Menu.types";

--- a/packages/react/src/components/Menu/index.ts
+++ b/packages/react/src/components/Menu/index.ts
@@ -1,44 +1,58 @@
-// Layer 3: MD3 Styled Components (most users use these)
+// ─── Layer 3: MD3 Styled Components (most users use these) ───────────────────
 export { MenuTrigger, Menu } from "./Menu";
 export { MenuItem } from "./MenuItem";
 export { MenuSection } from "./MenuSection";
 export { MenuDivider } from "./MenuDivider";
+export { MenuGap } from "./MenuGap";
+export { SubmenuTrigger } from "./SubmenuTrigger";
+export { ContextMenuTrigger } from "./ContextMenuTrigger";
 
-// Layer 2: Headless Primitives (for advanced customization)
+// ─── Layer 2: Headless Primitives (for advanced customization) ────────────────
 export {
   HeadlessMenuTrigger,
   HeadlessMenu,
   HeadlessMenuItem,
   HeadlessMenuSection,
   HeadlessMenuDivider,
+  HeadlessSubmenuTrigger,
+  HeadlessContextMenuTrigger,
   MenuContext,
   useMenuContext,
 } from "./MenuHeadless";
 
-// CVA Variants
+// ─── CVA Variants ─────────────────────────────────────────────────────────────
 export {
   menuContainerVariants,
   menuItemVariants,
   menuSectionVariants,
   menuSectionHeaderVariants,
   menuDividerVariants,
+  menuGapVariants,
   menuItemTrailingTextVariants,
+  menuItemDescriptionVariants,
   type MenuContainerVariants,
   type MenuItemVariants,
   type MenuSectionVariants,
 } from "./Menu.variants";
 
-// Types
+// ─── Types ────────────────────────────────────────────────────────────────────
 export type {
-  MenuVariant,
+  MenuColorScheme,
+  MenuStyle,
+  MenuDensity,
   MenuProps,
   MenuTriggerProps,
   MenuItemProps,
   MenuSectionProps,
   MenuDividerProps,
+  MenuGapProps,
+  SubmenuTriggerProps,
+  ContextMenuTriggerProps,
   HeadlessMenuProps,
   HeadlessMenuTriggerProps,
   HeadlessMenuItemProps,
   HeadlessMenuSectionProps,
+  HeadlessSubmenuTriggerProps,
+  HeadlessContextMenuTriggerProps,
   MenuContextValue,
 } from "./Menu.types";

--- a/packages/react/src/components/Progress/Progress.css
+++ b/packages/react/src/components/Progress/Progress.css
@@ -1,0 +1,106 @@
+/*
+ * Progress Indicator Animations
+ * Material Design 3 motion tokens for indeterminate progress states.
+ *
+ * Keyframes are defined here (co-located with the component) per project
+ * convention — they are NOT added to the global tokens.css.
+ *
+ * Motion tokens referenced (from packages/tokens/src/tokens.css):
+ *   --md-sys-motion-duration-medium4 : 400ms  (determinate transitions — applied via Tailwind)
+ *   --md-sys-motion-duration-long2   : 500ms  (linear indeterminate cycle)
+ *   --md-sys-motion-duration-long4   : 600ms  (circular indeterminate rotation)
+ *   --md-sys-motion-easing-standard  : cubic-bezier(0.2, 0, 0, 1)
+ */
+
+/* ---------------------------------------------------------------------------
+   LINEAR INDETERMINATE
+   Two-segment bar animation per MD3 spec.
+   First segment: starts narrow at left, expands, then slides off right.
+   Second segment: follows the first with a short delay.
+   Duration: long2 = 500ms per cycle (repeating).
+   --------------------------------------------------------------------------- */
+
+@keyframes progress-linear-indeterminate-1 {
+  0% {
+    left: -35%;
+    right: 100%;
+  }
+  60% {
+    left: 100%;
+    right: -90%;
+  }
+  100% {
+    left: 100%;
+    right: -90%;
+  }
+}
+
+@keyframes progress-linear-indeterminate-2 {
+  0% {
+    left: -200%;
+    right: 100%;
+  }
+  60% {
+    left: 107%;
+    right: -8%;
+  }
+  100% {
+    left: 107%;
+    right: -8%;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   CIRCULAR INDETERMINATE
+   Two-part animation per MD3 spec:
+   1. Container rotation: continuous 360° spin.
+   2. Dash animation: stroke-dasharray pulses between a short and long arc.
+   Rotation duration: long4 = 600ms per cycle (repeating).
+   --------------------------------------------------------------------------- */
+
+@keyframes progress-circular-rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes progress-circular-dash {
+  0% {
+    stroke-dasharray: 1, 200;
+    stroke-dashoffset: 0;
+  }
+  50% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -35px;
+  }
+  100% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -124px;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   TAILWIND @theme INTEGRATION
+   Register animations so they can be used as Tailwind utilities:
+     animate-progress-linear-indeterminate-1
+     animate-progress-linear-indeterminate-2
+     animate-progress-circular-rotate
+     animate-progress-circular-dash
+   --------------------------------------------------------------------------- */
+
+@theme {
+  --animate-progress-linear-indeterminate-1: progress-linear-indeterminate-1
+    var(--md-sys-motion-duration-long2) var(--md-sys-motion-easing-standard) infinite;
+
+  --animate-progress-linear-indeterminate-2: progress-linear-indeterminate-2
+    var(--md-sys-motion-duration-long2) var(--md-sys-motion-easing-standard) infinite;
+
+  --animate-progress-circular-rotate: progress-circular-rotate var(--md-sys-motion-duration-long4)
+    linear infinite;
+
+  --animate-progress-circular-dash: progress-circular-dash var(--md-sys-motion-duration-long4)
+    var(--md-sys-motion-easing-standard) infinite;
+}

--- a/packages/react/src/components/Progress/Progress.stories.tsx
+++ b/packages/react/src/components/Progress/Progress.stories.tsx
@@ -1,0 +1,346 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Progress } from "./Progress";
+
+/**
+ * Material Design 3 Progress Indicator Component
+ *
+ * Supports four variants driven by `type` and `indeterminate` props:
+ * - **Linear Determinate** — shows a known progress value on a horizontal track
+ * - **Linear Indeterminate** — animated two-segment bar for unknown duration
+ * - **Circular Determinate** — SVG arc showing a known progress value
+ * - **Circular Indeterminate** — rotating spinner for unknown duration
+ *
+ * ## MD3 Specifications
+ * - Linear track height: 4dp
+ * - Circular default size: 48dp (medium)
+ * - Active track color: `primary`
+ * - Inactive track color: `surface-container-highest`
+ * - Determinate transitions: 400ms ease-standard
+ * - Indeterminate cycle: 500ms (linear) / 600ms (circular)
+ */
+const meta: Meta<typeof Progress> = {
+  title: "Components/Progress",
+  component: Progress,
+  tags: ["autodocs"],
+  argTypes: {
+    type: {
+      control: "radio",
+      options: ["linear", "circular"],
+      description: "Visual type of the progress indicator",
+    },
+    indeterminate: {
+      control: "boolean",
+      description: "Show indeterminate animation (unknown progress duration)",
+    },
+    value: {
+      control: { type: "range", min: 0, max: 100, step: 1 },
+      description: "Current progress value (0–100 by default)",
+    },
+    minValue: {
+      control: "number",
+      description: "Minimum value (default: 0)",
+    },
+    maxValue: {
+      control: "number",
+      description: "Maximum value (default: 100)",
+    },
+    label: {
+      control: "text",
+      description: "Visible label rendered above the indicator",
+    },
+    size: {
+      control: "radio",
+      options: ["small", "medium", "large"],
+      description: "Circular indicator size (ignored for linear)",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Progress indicators communicate the status of an ongoing process. Built with React Aria for accessibility and styled with MD3 design tokens.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Progress>;
+
+// ---------------------------------------------------------------------------
+// Individual variant stories
+// ---------------------------------------------------------------------------
+
+/**
+ * Linear Determinate — shows exact progress on a horizontal track.
+ */
+export const LinearDeterminate: Story = {
+  args: {
+    type: "linear",
+    value: 60,
+    label: "Uploading files",
+  },
+};
+
+/**
+ * Linear Indeterminate — animated for operations with unknown duration.
+ */
+export const LinearIndeterminate: Story = {
+  args: {
+    type: "linear",
+    indeterminate: true,
+    "aria-label": "Loading content",
+  },
+};
+
+/**
+ * Circular Determinate — SVG arc showing known progress.
+ */
+export const CircularDeterminate: Story = {
+  args: {
+    type: "circular",
+    value: 75,
+    label: "Processing",
+  },
+};
+
+/**
+ * Circular Indeterminate — rotating spinner for unknown duration.
+ */
+export const CircularIndeterminate: Story = {
+  args: {
+    type: "circular",
+    indeterminate: true,
+    "aria-label": "Loading",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Label stories
+// ---------------------------------------------------------------------------
+
+/**
+ * With visible label — label is rendered above the indicator and linked via
+ * aria-labelledby for screen reader accessibility.
+ */
+export const WithLabel: Story = {
+  render: function WithLabelRender() {
+    return (
+      <div className="flex flex-col gap-6">
+        <Progress type="linear" value={45} label="Downloading updates" />
+        <Progress type="circular" value={70} label="Syncing data" />
+      </div>
+    );
+  },
+};
+
+/**
+ * With aria-label only — no visible label; aria-label satisfies WCAG.
+ */
+export const WithAriaLabel: Story = {
+  args: {
+    type: "linear",
+    indeterminate: true,
+    "aria-label": "Loading page content",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Custom range
+// ---------------------------------------------------------------------------
+
+/**
+ * Custom min/max values — value=150 on range 0–200 renders as 75%.
+ */
+export const CustomMinMax: Story = {
+  args: {
+    type: "linear",
+    minValue: 0,
+    maxValue: 200,
+    value: 150,
+    label: "Transfer progress",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Circular sizes
+// ---------------------------------------------------------------------------
+
+/**
+ * Circular sizes — small (24dp), medium (48dp, default), large (64dp).
+ */
+export const CircularSizes: Story = {
+  render: function CircularSizesRender() {
+    return (
+      <div className="flex items-end gap-8">
+        <div className="flex flex-col items-center gap-2">
+          <Progress type="circular" indeterminate size="small" aria-label="Loading small" />
+          <span className="text-body-small text-on-surface-variant">Small (24dp)</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Progress type="circular" indeterminate size="medium" aria-label="Loading medium" />
+          <span className="text-body-small text-on-surface-variant">Medium (48dp)</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Progress type="circular" indeterminate size="large" aria-label="Loading large" />
+          <span className="text-body-small text-on-surface-variant">Large (64dp)</span>
+        </div>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// All variants showcase
+// ---------------------------------------------------------------------------
+
+/**
+ * All variants — showcase of all four variant combinations.
+ */
+export const AllVariants: Story = {
+  render: function AllVariantsRender() {
+    return (
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-3">
+          <h3 className="text-title-medium text-on-surface">Linear</h3>
+          <div className="flex flex-col gap-4">
+            <Progress type="linear" value={40} label="Determinate (40%)" />
+            <Progress type="linear" indeterminate aria-label="Linear indeterminate" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-3">
+          <h3 className="text-title-medium text-on-surface">Circular</h3>
+          <div className="flex items-center gap-8">
+            <div className="flex flex-col items-center gap-2">
+              <Progress type="circular" value={65} aria-label="Circular determinate 65%" />
+              <span className="text-body-small text-on-surface-variant">Determinate (65%)</span>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <Progress type="circular" indeterminate aria-label="Circular indeterminate" />
+              <span className="text-body-small text-on-surface-variant">Indeterminate</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Interactive playground
+// ---------------------------------------------------------------------------
+
+/**
+ * Playground — interactive slider to explore determinate progress values.
+ */
+export const Playground: Story = {
+  render: function PlaygroundRender() {
+    const [value, setValue] = useState(30);
+    const [isIndeterminate, setIsIndeterminate] = useState(false);
+
+    return (
+      <div className="flex flex-col gap-8">
+        {/* Controls */}
+        <div className="bg-surface-container-high flex flex-col gap-4 rounded-xl p-4">
+          <div className="flex items-center gap-3">
+            <label className="text-body-medium text-on-surface w-28" htmlFor="value-slider">
+              Value: {value}%
+            </label>
+            <input
+              id="value-slider"
+              type="range"
+              min={0}
+              max={100}
+              value={value}
+              onChange={(e) => setValue(Number(e.target.value))}
+              disabled={isIndeterminate}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-3">
+            <label className="text-body-medium text-on-surface flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={isIndeterminate}
+                onChange={(e) => setIsIndeterminate(e.target.checked)}
+              />
+              Indeterminate
+            </label>
+          </div>
+        </div>
+
+        {/* Linear */}
+        <div className="flex flex-col gap-2">
+          <p className="text-label-large text-on-surface-variant">Linear</p>
+          <Progress
+            type="linear"
+            value={value}
+            indeterminate={isIndeterminate}
+            label={isIndeterminate ? undefined : `Uploading (${value}%)`}
+            aria-label={isIndeterminate ? "Loading" : undefined}
+          />
+        </div>
+
+        {/* Circular */}
+        <div className="flex flex-col items-start gap-2">
+          <p className="text-label-large text-on-surface-variant">Circular</p>
+          <Progress
+            type="circular"
+            value={value}
+            indeterminate={isIndeterminate}
+            label={isIndeterminate ? undefined : `${value}%`}
+            aria-label={isIndeterminate ? "Loading" : undefined}
+          />
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * Simulated upload — demonstrates value updates over time.
+ */
+export const SimulatedUpload: Story = {
+  render: function SimulatedUploadRender() {
+    const [progress, setProgress] = useState(0);
+    const [running, setRunning] = useState(false);
+
+    const start = (): void => {
+      setProgress(0);
+      setRunning(true);
+      const interval = setInterval(() => {
+        setProgress((prev) => {
+          if (prev >= 100) {
+            clearInterval(interval);
+            setRunning(false);
+            return 100;
+          }
+          return prev + 5;
+        });
+      }, 150);
+    };
+
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-3">
+          <Progress type="linear" value={progress} label={`Uploading… ${progress}%`} />
+          <Progress
+            type="circular"
+            value={progress}
+            size="large"
+            aria-label={`Upload progress ${progress}%`}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={start}
+          disabled={running}
+          className="bg-primary text-on-primary w-fit rounded-full px-6 py-2 disabled:opacity-38"
+        >
+          {running ? "Uploading…" : progress === 100 ? "Upload again" : "Start upload"}
+        </button>
+      </div>
+    );
+  },
+};

--- a/packages/react/src/components/Progress/Progress.test.tsx
+++ b/packages/react/src/components/Progress/Progress.test.tsx
@@ -1,0 +1,443 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe } from "vitest-axe";
+import { Progress } from "./Progress";
+import { ProgressHeadless } from "./ProgressHeadless";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const linearDeterminate = (props = {}) =>
+  render(<Progress type="linear" value={50} label="Loading" {...props} />);
+
+const linearIndeterminate = (props = {}) =>
+  render(<Progress type="linear" indeterminate aria-label="Loading content" {...props} />);
+
+const circularDeterminate = (props = {}) =>
+  render(<Progress type="circular" value={75} label="Uploading" {...props} />);
+
+const circularIndeterminate = (props = {}) =>
+  render(<Progress type="circular" indeterminate aria-label="Loading" {...props} />);
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe("Progress", () => {
+  describe("Rendering", () => {
+    test("renders linear determinate progress bar", () => {
+      linearDeterminate();
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    });
+
+    test("renders linear indeterminate progress bar", () => {
+      linearIndeterminate();
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    });
+
+    test("renders circular determinate progress bar", () => {
+      circularDeterminate();
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    });
+
+    test("renders circular indeterminate progress bar", () => {
+      circularIndeterminate();
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    });
+
+    test("defaults to linear type when type is omitted", () => {
+      render(<Progress value={50} aria-label="Loading" />);
+      const bar = screen.getByRole("progressbar");
+      expect(bar).toBeInTheDocument();
+    });
+
+    test("applies custom className to container", () => {
+      render(<Progress type="linear" value={50} aria-label="Loading" className="custom-class" />);
+      const bar = screen.getByRole("progressbar");
+      expect(bar).toHaveClass("custom-class");
+    });
+
+    test("renders SVG for circular variant", () => {
+      const { container } = circularDeterminate();
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+
+    test("does not render SVG for linear variant", () => {
+      const { container } = linearDeterminate();
+      expect(container.querySelector("svg")).not.toBeInTheDocument();
+    });
+
+    test("forwards ref to container element", () => {
+      const ref = { current: null };
+      render(<Progress type="linear" value={50} aria-label="Loading" ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ARIA Attributes
+  // ---------------------------------------------------------------------------
+
+  describe("ARIA Attributes", () => {
+    test("has role=progressbar", () => {
+      linearDeterminate();
+      expect(screen.getByRole("progressbar")).toHaveAttribute("role", "progressbar");
+    });
+
+    test("sets aria-valuenow for determinate linear", () => {
+      render(<Progress type="linear" value={60} aria-label="Loading" />);
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "60");
+    });
+
+    test("sets aria-valuenow for determinate circular", () => {
+      render(<Progress type="circular" value={75} aria-label="Uploading" />);
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "75");
+    });
+
+    test("sets aria-valuemin to 0 by default", () => {
+      linearDeterminate();
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuemin", "0");
+    });
+
+    test("sets aria-valuemax to 100 by default", () => {
+      linearDeterminate();
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuemax", "100");
+    });
+
+    test("does not set aria-valuenow for indeterminate linear", () => {
+      linearIndeterminate();
+      expect(screen.getByRole("progressbar")).not.toHaveAttribute("aria-valuenow");
+    });
+
+    test("does not set aria-valuenow for indeterminate circular", () => {
+      circularIndeterminate();
+      expect(screen.getByRole("progressbar")).not.toHaveAttribute("aria-valuenow");
+    });
+
+    test("sets custom minValue via aria-valuemin", () => {
+      render(
+        <Progress type="linear" minValue={10} maxValue={200} value={100} aria-label="Progress" />
+      );
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuemin", "10");
+    });
+
+    test("sets custom maxValue via aria-valuemax", () => {
+      render(
+        <Progress type="linear" minValue={0} maxValue={200} value={100} aria-label="Progress" />
+      );
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuemax", "200");
+    });
+
+    test("sets aria-labelledby when label prop is provided", () => {
+      linearDeterminate();
+      const bar = screen.getByRole("progressbar");
+      expect(bar).toHaveAttribute("aria-labelledby");
+    });
+
+    test("sets aria-label when aria-label prop is passed", () => {
+      render(<Progress type="linear" indeterminate aria-label="Loading files" />);
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-label", "Loading files");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Label
+  // ---------------------------------------------------------------------------
+
+  describe("Label", () => {
+    test("renders visible label text when label prop is provided", () => {
+      render(<Progress type="linear" value={50} label="Uploading files" />);
+      expect(screen.getByText("Uploading files")).toBeInTheDocument();
+    });
+
+    test("does not render label element when omitted", () => {
+      render(<Progress type="linear" value={50} aria-label="Loading" />);
+      expect(screen.queryByText("Loading")).not.toBeInTheDocument();
+    });
+
+    test("label is linked to progressbar via aria-labelledby", () => {
+      render(<Progress type="linear" value={50} label="File upload" />);
+      const bar = screen.getByRole("progressbar");
+      const labelId = bar.getAttribute("aria-labelledby");
+      expect(labelId).toBeTruthy();
+      const labelEl = document.getElementById(labelId!);
+      expect(labelEl).toBeInTheDocument();
+      expect(labelEl?.textContent).toBe("File upload");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Value & Percentage
+  // ---------------------------------------------------------------------------
+
+  describe("Value", () => {
+    test("calculates 50% for value=50 on default range", () => {
+      const { container } = render(<Progress type="linear" value={50} aria-label="Loading" />);
+      const indicator = container.querySelector("[data-progress-indicator]");
+      expect(indicator).toHaveStyle({ width: "50%" });
+    });
+
+    test("calculates 75% for value=150 on range 0-200", () => {
+      const { container } = render(
+        <Progress type="linear" minValue={0} maxValue={200} value={150} aria-label="Loading" />
+      );
+      const indicator = container.querySelector("[data-progress-indicator]");
+      expect(indicator).toHaveStyle({ width: "75%" });
+    });
+
+    test("calculates 0% for value=0", () => {
+      const { container } = render(<Progress type="linear" value={0} aria-label="Loading" />);
+      const indicator = container.querySelector("[data-progress-indicator]");
+      expect(indicator).toHaveStyle({ width: "0%" });
+    });
+
+    test("calculates 100% for value=100", () => {
+      const { container } = render(<Progress type="linear" value={100} aria-label="Loading" />);
+      const indicator = container.querySelector("[data-progress-indicator]");
+      expect(indicator).toHaveStyle({ width: "100%" });
+    });
+
+    test("renders stop indicator dot for linear determinate", () => {
+      const { container } = render(<Progress type="linear" value={50} aria-label="Loading" />);
+      const dot = container.querySelector("[data-stop-indicator]");
+      expect(dot).toBeInTheDocument();
+    });
+
+    test("does not render stop indicator dot for linear indeterminate", () => {
+      const { container } = linearIndeterminate();
+      const dot = container.querySelector("[data-stop-indicator]");
+      expect(dot).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Linear Variant
+  // ---------------------------------------------------------------------------
+
+  describe("Linear Determinate", () => {
+    test("renders track element", () => {
+      const { container } = linearDeterminate();
+      expect(container.querySelector("[data-progress-track]")).toBeInTheDocument();
+    });
+
+    test("renders indicator element inside track", () => {
+      const { container } = linearDeterminate();
+      expect(container.querySelector("[data-progress-indicator]")).toBeInTheDocument();
+    });
+
+    test("indicator has width matching percentage", () => {
+      const { container } = render(<Progress type="linear" value={60} aria-label="Loading" />);
+      const indicator = container.querySelector("[data-progress-indicator]");
+      expect(indicator).toHaveStyle({ width: "60%" });
+    });
+  });
+
+  describe("Linear Indeterminate", () => {
+    test("renders indeterminate animation wrapper", () => {
+      const { container } = linearIndeterminate();
+      expect(container.querySelector("[data-progress-indeterminate]")).toBeInTheDocument();
+    });
+
+    test("does not render a fixed-width indicator element", () => {
+      const { container } = linearIndeterminate();
+      expect(container.querySelector("[data-progress-indicator]")).not.toBeInTheDocument();
+    });
+
+    test("does not have aria-valuenow when indeterminate", () => {
+      linearIndeterminate();
+      expect(screen.getByRole("progressbar")).not.toHaveAttribute("aria-valuenow");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Circular Variant
+  // ---------------------------------------------------------------------------
+
+  describe("Circular Determinate", () => {
+    test("renders an SVG element", () => {
+      const { container } = circularDeterminate();
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+
+    test("renders two circles (background + foreground)", () => {
+      const { container } = circularDeterminate();
+      const circles = container.querySelectorAll("circle");
+      expect(circles).toHaveLength(2);
+    });
+
+    test("foreground circle has stroke-dashoffset attribute", () => {
+      const { container } = circularDeterminate();
+      const circles = container.querySelectorAll("circle");
+      const foreground = circles[1];
+      expect(foreground).toHaveAttribute("stroke-dashoffset");
+    });
+
+    test("foreground stroke-dashoffset is 0 at 100% value", () => {
+      const { container } = render(<Progress type="circular" value={100} aria-label="Complete" />);
+      const circles = container.querySelectorAll("circle");
+      const foreground = circles[1];
+      expect(Number(foreground?.getAttribute("stroke-dashoffset"))).toBeCloseTo(0, 0);
+    });
+  });
+
+  describe("Circular Indeterminate", () => {
+    test("renders an SVG element", () => {
+      const { container } = circularIndeterminate();
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+
+    test("renders indeterminate SVG wrapper", () => {
+      const { container } = circularIndeterminate();
+      expect(container.querySelector("[data-progress-indeterminate]")).toBeInTheDocument();
+    });
+
+    test("does not have aria-valuenow when indeterminate", () => {
+      circularIndeterminate();
+      expect(screen.getByRole("progressbar")).not.toHaveAttribute("aria-valuenow");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Circular Size Prop
+  // ---------------------------------------------------------------------------
+
+  describe("Circular Size", () => {
+    test("applies small size class for size=small", () => {
+      const { container } = render(
+        <Progress type="circular" indeterminate size="small" aria-label="Loading" />
+      );
+      const svg = container.querySelector("svg");
+      expect(svg?.closest("[data-progress-size]")).toHaveAttribute("data-progress-size", "small");
+    });
+
+    test("applies medium size class for size=medium (default)", () => {
+      const { container } = circularIndeterminate();
+      const svg = container.querySelector("svg");
+      expect(svg?.closest("[data-progress-size]")).toHaveAttribute("data-progress-size", "medium");
+    });
+
+    test("applies large size class for size=large", () => {
+      const { container } = render(
+        <Progress type="circular" indeterminate size="large" aria-label="Loading" />
+      );
+      const svg = container.querySelector("svg");
+      expect(svg?.closest("[data-progress-size]")).toHaveAttribute("data-progress-size", "large");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Accessibility
+  // ---------------------------------------------------------------------------
+
+  describe("Accessibility — axe", () => {
+    test("linear determinate has no axe violations", async () => {
+      const { container } = render(<Progress type="linear" value={50} label="Loading files" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("linear indeterminate has no axe violations", async () => {
+      const { container } = render(
+        <Progress type="linear" indeterminate aria-label="Loading content" />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("circular determinate has no axe violations", async () => {
+      const { container } = render(<Progress type="circular" value={75} label="Uploading" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("circular indeterminate has no axe violations", async () => {
+      const { container } = render(<Progress type="circular" indeterminate aria-label="Loading" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Development Warnings
+  // ---------------------------------------------------------------------------
+
+  describe("Development Warnings", () => {
+    beforeEach(() => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    test("warns when no label or aria-label is provided", () => {
+      render(<Progress type="linear" value={50} />);
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("[Progress]"));
+    });
+
+    test("does not warn when label prop is provided", () => {
+      render(<Progress type="linear" value={50} label="Loading" />);
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    test("does not warn when aria-label is provided", () => {
+      render(<Progress type="linear" value={50} aria-label="Loading" />);
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ProgressHeadless
+  // ---------------------------------------------------------------------------
+
+  describe("ProgressHeadless", () => {
+    test("renders with role=progressbar", () => {
+      render(<ProgressHeadless value={50} aria-label="Loading" />);
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    });
+
+    test("passes progressBarProps to container", () => {
+      render(<ProgressHeadless value={60} aria-label="Loading" />);
+      const bar = screen.getByRole("progressbar");
+      expect(bar).toHaveAttribute("aria-valuenow", "60");
+    });
+
+    test("calls renderProgress with correct state", () => {
+      const renderProgress = vi.fn(() => null);
+      render(<ProgressHeadless value={40} aria-label="Loading" renderProgress={renderProgress} />);
+      expect(renderProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          percentage: 40,
+          isIndeterminate: false,
+          type: "linear",
+        })
+      );
+    });
+
+    test("calls renderProgress with isIndeterminate=true when indeterminate", () => {
+      const renderProgress = vi.fn(() => null);
+      render(
+        <ProgressHeadless indeterminate aria-label="Loading" renderProgress={renderProgress} />
+      );
+      expect(renderProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ isIndeterminate: true })
+      );
+    });
+
+    test("renders children inside container", () => {
+      render(
+        <ProgressHeadless value={50} aria-label="Loading">
+          <span data-testid="custom-child">Custom</span>
+        </ProgressHeadless>
+      );
+      expect(screen.getByTestId("custom-child")).toBeInTheDocument();
+    });
+
+    test("forwards ref to container element", () => {
+      const ref = { current: null };
+      render(<ProgressHeadless value={50} aria-label="Loading" ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+  });
+});

--- a/packages/react/src/components/Progress/Progress.tsx
+++ b/packages/react/src/components/Progress/Progress.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { forwardRef, useRef } from "react";
+import type React from "react";
+import { useProgressBar } from "react-aria";
+import { cn } from "../../utils/cn";
+import {
+  progressContainerVariants,
+  progressTrackVariants,
+  progressIndicatorVariants,
+  progressStopIndicatorVariants,
+  progressCircularSizeVariants,
+  progressLabelVariants,
+} from "./Progress.variants";
+import type { ProgressProps } from "./Progress.types";
+import "./Progress.css";
+
+// ---------------------------------------------------------------------------
+// SVG constants for circular variant
+// MD3 spec: stroke-width = 4dp; size maps to dp values below.
+// ---------------------------------------------------------------------------
+
+const STROKE_WIDTH = 4;
+
+const CIRCULAR_SIZE_PX: Record<"small" | "medium" | "large", number> = {
+  small: 24,
+  medium: 48,
+  large: 64,
+};
+
+function getCircularGeometry(size: "small" | "medium" | "large"): {
+  diameter: number;
+  radius: number;
+  circumference: number;
+  viewBox: string;
+  cx: number;
+  cy: number;
+} {
+  const diameter = CIRCULAR_SIZE_PX[size];
+  const radius = (diameter - STROKE_WIDTH) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const viewBox = `0 0 ${diameter} ${diameter}`;
+  const cx = diameter / 2;
+  const cy = diameter / 2;
+  return { diameter, radius, circumference, viewBox, cx, cy };
+}
+
+/**
+ * Material Design 3 Progress Indicator (Layer 3: Styled)
+ *
+ * Built on React Aria for world-class accessibility.
+ * Supports four variants driven by `type` + `indeterminate` props:
+ *   - Linear Determinate
+ *   - Linear Indeterminate
+ *   - Circular Determinate
+ *   - Circular Indeterminate
+ *
+ * MD3 Specifications:
+ * - Linear track height: 4dp (h-1)
+ * - Linear track shape: rounded-full
+ * - Circular default size: 48dp (medium)
+ * - Circular stroke width: 4dp (SVG attribute)
+ * - Active track: primary
+ * - Inactive track: surface-container-highest
+ * - Determinate transitions: duration-medium4 + ease-standard
+ * - Indeterminate linear cycle: duration-long2
+ * - Indeterminate circular rotation: duration-long4
+ *
+ * @example
+ * ```tsx
+ * // Linear determinate
+ * <Progress type="linear" value={60} label="Uploading" />
+ *
+ * // Linear indeterminate
+ * <Progress type="linear" indeterminate aria-label="Loading" />
+ *
+ * // Circular determinate
+ * <Progress type="circular" value={75} label="Processing" />
+ *
+ * // Circular indeterminate
+ * <Progress type="circular" indeterminate aria-label="Loading" />
+ *
+ * // Circular small spinner
+ * <Progress type="circular" indeterminate size="small" aria-label="Loading" />
+ * ```
+ */
+export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
+  (
+    {
+      type = "linear",
+      indeterminate = false,
+      size = "medium",
+      className,
+      label,
+      value = 0,
+      minValue = 0,
+      maxValue = 100,
+      ...restProps
+    },
+    forwardedRef
+  ) => {
+    const internalRef = useRef<HTMLDivElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
+
+    // React Aria: provides progressBarProps (role, aria-value*) and labelProps
+    const { progressBarProps, labelProps } = useProgressBar({
+      label,
+      value,
+      minValue,
+      maxValue,
+      isIndeterminate: indeterminate,
+      ...restProps,
+    });
+
+    // Percentage for determinate rendering
+    const percentage = indeterminate
+      ? 0
+      : Math.min(100, Math.max(0, ((value - minValue) / (maxValue - minValue)) * 100));
+
+    // Development warning: require accessible label
+    if (process.env.NODE_ENV !== "production") {
+      const ariaProps = restProps as {
+        "aria-label"?: string;
+        "aria-labelledby"?: string;
+      };
+      if (!label && !ariaProps["aria-label"] && !ariaProps["aria-labelledby"]) {
+        console.warn(
+          "[Progress] Progress indicator should have a visible label prop or aria-label for accessibility."
+        );
+      }
+    }
+
+    return (
+      <div
+        {...progressBarProps}
+        ref={ref}
+        className={cn(progressContainerVariants({ type }), className)}
+      >
+        {/* Optional visible label */}
+        {label && (
+          <span {...labelProps} className={cn(progressLabelVariants())}>
+            {label}
+          </span>
+        )}
+
+        {/* Visual rendering: branches on type × indeterminate */}
+        {type === "linear" ? (
+          <LinearProgress percentage={percentage} indeterminate={indeterminate} />
+        ) : (
+          <CircularProgress percentage={percentage} indeterminate={indeterminate} size={size} />
+        )}
+      </div>
+    );
+  }
+);
+
+Progress.displayName = "Progress";
+
+// ---------------------------------------------------------------------------
+// Linear Progress Visual
+// ---------------------------------------------------------------------------
+
+interface LinearProgressProps {
+  percentage: number;
+  indeterminate: boolean;
+}
+
+function LinearProgress({ percentage, indeterminate }: LinearProgressProps): React.JSX.Element {
+  if (indeterminate) {
+    return (
+      <div data-progress-track="" className={cn(progressTrackVariants())}>
+        <div
+          data-progress-indeterminate=""
+          className="absolute inset-0 overflow-hidden rounded-full"
+        >
+          {/* Segment 1 */}
+          <div
+            className={cn(
+              "bg-primary absolute top-0 h-full rounded-full",
+              "animate-progress-linear-indeterminate-1"
+            )}
+          />
+          {/* Segment 2 */}
+          <div
+            className={cn(
+              "bg-primary absolute top-0 h-full rounded-full",
+              "animate-progress-linear-indeterminate-2"
+            )}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-progress-track="" className={cn(progressTrackVariants())}>
+      {/* Determinate indicator bar */}
+      <div
+        data-progress-indicator=""
+        className={cn(progressIndicatorVariants())}
+        style={{ width: `${percentage}%` }}
+      />
+      {/* Stop indicator dot — leading edge of progress head per MD3 */}
+      <div
+        data-stop-indicator=""
+        className={cn(progressStopIndicatorVariants())}
+        style={{ left: `${percentage}%` }}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Circular Progress Visual
+// ---------------------------------------------------------------------------
+
+interface CircularProgressProps {
+  percentage: number;
+  indeterminate: boolean;
+  size: "small" | "medium" | "large";
+}
+
+function CircularProgress({
+  percentage,
+  indeterminate,
+  size,
+}: CircularProgressProps): React.JSX.Element {
+  const { radius, circumference, viewBox, cx, cy } = getCircularGeometry(size);
+
+  // stroke-dashoffset: 0 = full circle (100%), circumference = empty circle (0%)
+  const strokeDashoffset = (1 - percentage / 100) * circumference;
+
+  if (indeterminate) {
+    return (
+      <div
+        data-progress-size={size}
+        data-progress-indeterminate=""
+        className={cn(progressCircularSizeVariants({ size }))}
+      >
+        <svg
+          viewBox={viewBox}
+          className="animate-progress-circular-rotate h-full w-full"
+          aria-hidden="true"
+        >
+          <circle
+            cx={cx}
+            cy={cy}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={STROKE_WIDTH}
+            className="text-surface-container-highest"
+          />
+          <circle
+            cx={cx}
+            cy={cy}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={STROKE_WIDTH}
+            className="animate-progress-circular-dash text-primary"
+            strokeLinecap="round"
+          />
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <div data-progress-size={size} className={cn(progressCircularSizeVariants({ size }))}>
+      <svg viewBox={viewBox} className="h-full w-full -rotate-90" aria-hidden="true">
+        {/* Background circle (inactive track) */}
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={STROKE_WIDTH}
+          className="text-surface-container-highest"
+        />
+        {/* Foreground circle (active track, determinate) */}
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={STROKE_WIDTH}
+          strokeLinecap="round"
+          className="text-primary duration-medium4 ease-standard transition-[stroke-dashoffset]"
+          strokeDasharray={circumference}
+          strokeDashoffset={strokeDashoffset}
+        />
+      </svg>
+    </div>
+  );
+}

--- a/packages/react/src/components/Progress/Progress.tsx
+++ b/packages/react/src/components/Progress/Progress.tsx
@@ -204,7 +204,6 @@ function LinearProgress({ percentage, indeterminate }: LinearProgressProps): Rea
       <div
         data-stop-indicator=""
         className={cn(progressStopIndicatorVariants())}
-        style={{ left: `${percentage}%` }}
         aria-hidden="true"
       />
     </div>

--- a/packages/react/src/components/Progress/Progress.types.ts
+++ b/packages/react/src/components/Progress/Progress.types.ts
@@ -1,0 +1,115 @@
+import type React from "react";
+import type { AriaProgressBarProps } from "react-aria";
+
+/**
+ * Material Design 3 Progress Indicator Component Props
+ *
+ * Built on React Aria for world-class accessibility.
+ * Supports four variants: Linear Determinate, Linear Indeterminate,
+ * Circular Determinate, and Circular Indeterminate.
+ * Implementation uses CVA + Tailwind CSS classes mapped to MD3 tokens.
+ *
+ * @example
+ * ```tsx
+ * // Linear determinate
+ * <Progress type="linear" value={60} label="Loading" />
+ *
+ * // Linear indeterminate
+ * <Progress type="linear" indeterminate aria-label="Loading content" />
+ *
+ * // Circular determinate
+ * <Progress type="circular" value={75} label="Uploading" />
+ *
+ * // Circular indeterminate (default spinner)
+ * <Progress type="circular" indeterminate aria-label="Loading" />
+ *
+ * // Circular with size
+ * <Progress type="circular" indeterminate size="small" aria-label="Loading" />
+ *
+ * // Custom range
+ * <Progress type="linear" minValue={0} maxValue={200} value={150} label="Progress" />
+ * ```
+ */
+export interface ProgressProps extends AriaProgressBarProps {
+  /**
+   * The visual type of the progress indicator.
+   * @default "linear"
+   */
+  type?: "linear" | "circular";
+
+  /**
+   * When true, renders indeterminate (unknown progress) animation.
+   * `value` is ignored when indeterminate is true.
+   * @default false
+   */
+  indeterminate?: boolean;
+
+  /**
+   * Size of the circular progress indicator (ignored for linear).
+   * small=24dp, medium=48dp (default), large=64dp per MD3 spec.
+   * @default "medium"
+   */
+  size?: "small" | "medium" | "large";
+
+  /**
+   * Additional CSS classes (Tailwind).
+   */
+  className?: string;
+}
+
+/**
+ * Props for the headless Progress component.
+ * Provides behavior and accessibility only — bring your own styles.
+ *
+ * @example
+ * ```tsx
+ * <ProgressHeadless
+ *   type="linear"
+ *   value={50}
+ *   label="Upload"
+ *   renderProgress={({ percentage }) => (
+ *     <div style={{ width: `${percentage}%` }} />
+ *   )}
+ * />
+ * ```
+ */
+export interface ProgressHeadlessProps extends AriaProgressBarProps {
+  /**
+   * The visual type of the progress indicator.
+   * @default "linear"
+   */
+  type?: "linear" | "circular";
+
+  /**
+   * When true, renders indeterminate animation.
+   * @default false
+   */
+  indeterminate?: boolean;
+
+  /**
+   * Size for circular variant.
+   * @default "medium"
+   */
+  size?: "small" | "medium" | "large";
+
+  /**
+   * Additional CSS classes.
+   */
+  className?: string;
+
+  /**
+   * Children rendered inside the container.
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Render prop for custom progress visual.
+   * Receives computed state for building custom visuals.
+   */
+  renderProgress?: (state: {
+    percentage: number;
+    isIndeterminate: boolean;
+    type: "linear" | "circular";
+    size: "small" | "medium" | "large";
+  }) => React.ReactNode;
+}

--- a/packages/react/src/components/Progress/Progress.variants.ts
+++ b/packages/react/src/components/Progress/Progress.variants.ts
@@ -1,0 +1,119 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Progress Indicator Variants (CVA)
+ *
+ * Type-safe variant management for Progress component.
+ * Uses Tailwind CSS classes mapped to MD3 design tokens.
+ *
+ * MD3 Specifications:
+ * - Linear track height: 4dp (h-1 = 4px)
+ * - Linear track shape: rounded-full (radius-full)
+ * - Circular default size: 48dp (h-12 w-12)
+ * - Circular stroke width: 4dp (applied as SVG attribute)
+ * - Active track color: primary
+ * - Inactive track color: surface-container-highest
+ * - Label text: on-surface, body-small
+ */
+
+/**
+ * Progress container variants.
+ * Wraps the entire progress indicator (label + visual).
+ */
+export const progressContainerVariants = cva(["inline-flex", "flex-col", "gap-1"], {
+  variants: {
+    /**
+     * The visual type of the indicator.
+     */
+    type: {
+      linear: "w-full",
+      circular: "items-center justify-center w-auto",
+    },
+  },
+  defaultVariants: {
+    type: "linear",
+  },
+});
+
+/**
+ * Linear track variants (the 4dp-height background rail).
+ */
+export const progressTrackVariants = cva([
+  "relative",
+  "w-full",
+  "h-1", // MD3: 4dp track height
+  "rounded-full", // MD3: full corner radius
+  "overflow-hidden",
+  "bg-surface-container-highest", // MD3: inactive track color
+]);
+
+/**
+ * Linear indicator bar variants (the foreground progress fill).
+ */
+export const progressIndicatorVariants = cva([
+  "absolute",
+  "left-0",
+  "top-0",
+  "h-full",
+  "rounded-full",
+  "bg-primary", // MD3: active track color
+  "transition-[width]",
+  "duration-medium4", // MD3: 400ms for value transitions
+  "ease-standard", // MD3: cubic-bezier(0.2, 0, 0, 1)
+]);
+
+/**
+ * Stop indicator dot variants (linear determinate only).
+ * Appears at the leading edge of the track head per MD3 spec.
+ */
+export const progressStopIndicatorVariants = cva([
+  "absolute",
+  "top-1/2",
+  "-translate-y-1/2",
+  "w-1",
+  "h-1",
+  "rounded-full",
+  "bg-primary", // MD3: stop indicator uses primary color
+]);
+
+/**
+ * Circular SVG size variants.
+ * Maps the size prop to MD3-specified dimensions.
+ * - small:  24dp → h-6 w-6
+ * - medium: 48dp → h-12 w-12 (default)
+ * - large:  64dp → h-16 w-16
+ */
+export const progressCircularSizeVariants = cva(
+  ["relative", "flex", "items-center", "justify-center", "flex-shrink-0"],
+  {
+    variants: {
+      size: {
+        small: "h-6 w-6", // MD3: 24dp
+        medium: "h-12 w-12", // MD3: 48dp (default)
+        large: "h-16 w-16", // MD3: 64dp
+      },
+    },
+    defaultVariants: {
+      size: "medium",
+    },
+  }
+);
+
+/**
+ * Label text variants.
+ * Rendered above or beside the indicator per MD3 spec.
+ */
+export const progressLabelVariants = cva([
+  "text-body-small", // MD3: body-small type scale (12px)
+  "text-on-surface", // MD3: on-surface color role
+  "select-none",
+]);
+
+/**
+ * Extract variant prop types from CVA.
+ */
+export type ProgressContainerVariants = VariantProps<typeof progressContainerVariants>;
+export type ProgressTrackVariants = VariantProps<typeof progressTrackVariants>;
+export type ProgressIndicatorVariants = VariantProps<typeof progressIndicatorVariants>;
+export type ProgressCircularSizeVariants = VariantProps<typeof progressCircularSizeVariants>;
+export type ProgressLabelVariants = VariantProps<typeof progressLabelVariants>;

--- a/packages/react/src/components/Progress/Progress.variants.ts
+++ b/packages/react/src/components/Progress/Progress.variants.ts
@@ -68,6 +68,7 @@ export const progressIndicatorVariants = cva([
  */
 export const progressStopIndicatorVariants = cva([
   "absolute",
+  "right-0",
   "top-1/2",
   "-translate-y-1/2",
   "w-1",

--- a/packages/react/src/components/Progress/ProgressHeadless.tsx
+++ b/packages/react/src/components/Progress/ProgressHeadless.tsx
@@ -1,0 +1,84 @@
+import { forwardRef, useRef } from "react";
+import type React from "react";
+import { useProgressBar } from "react-aria";
+import type { ProgressHeadlessProps } from "./Progress.types";
+
+/**
+ * Headless Progress Indicator Component (Layer 2)
+ *
+ * Unstyled progress bar primitive using React Aria for accessibility.
+ * Provides behavior only — bring your own styles.
+ *
+ * Features:
+ * - role="progressbar" with correct aria-value* attributes
+ * - Determinate and indeterminate progress support
+ * - Internationalized value label formatting via React Aria
+ * - Label linkage via aria-labelledby / aria-label
+ * - Render prop for custom visual rendering
+ *
+ * @example
+ * ```tsx
+ * // Custom visual via render prop
+ * <ProgressHeadless
+ *   value={50}
+ *   label="Upload"
+ *   renderProgress={({ percentage }) => (
+ *     <div style={{ width: `${percentage}%` }} />
+ *   )}
+ * />
+ *
+ * // Children-based rendering
+ * <ProgressHeadless value={75} aria-label="Loading">
+ *   <MyCustomProgressVisual />
+ * </ProgressHeadless>
+ * ```
+ */
+export const ProgressHeadless = forwardRef<HTMLDivElement, ProgressHeadlessProps>(
+  (
+    {
+      type = "linear",
+      indeterminate = false,
+      size = "medium",
+      className,
+      children,
+      renderProgress,
+      label,
+      value = 0,
+      minValue = 0,
+      maxValue = 100,
+      ...restProps
+    },
+    forwardedRef
+  ) => {
+    const internalRef = useRef<HTMLDivElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
+
+    // Map our `indeterminate` prop to React Aria's `isIndeterminate`
+    const { progressBarProps, labelProps } = useProgressBar({
+      label,
+      value,
+      minValue,
+      maxValue,
+      isIndeterminate: indeterminate,
+      ...restProps,
+    });
+
+    // Compute percentage for consumers
+    const percentage = indeterminate ? 0 : ((value - minValue) / (maxValue - minValue)) * 100;
+
+    return (
+      <div {...progressBarProps} ref={ref} className={className}>
+        {label && <span {...labelProps}>{label}</span>}
+        {renderProgress?.({
+          percentage,
+          isIndeterminate: indeterminate,
+          type,
+          size,
+        })}
+        {children}
+      </div>
+    );
+  }
+);
+
+ProgressHeadless.displayName = "ProgressHeadless";

--- a/packages/react/src/components/Progress/index.ts
+++ b/packages/react/src/components/Progress/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @tinybigui/react — Progress Component
+ * Material Design 3 Progress Indicator with accessibility support.
+ *
+ * Four variants:
+ *   - Linear Determinate
+ *   - Linear Indeterminate
+ *   - Circular Determinate
+ *   - Circular Indeterminate
+ */
+
+// Layer 3: MD3 Styled Component (most consumers use this)
+export { Progress } from "./Progress";
+
+// Layer 2: Headless Component (for advanced customization)
+export { ProgressHeadless } from "./ProgressHeadless";
+
+// Types
+export type { ProgressProps, ProgressHeadlessProps } from "./Progress.types";
+
+// Variants (for advanced customization)
+export {
+  progressContainerVariants,
+  progressTrackVariants,
+  progressIndicatorVariants,
+  progressStopIndicatorVariants,
+  progressCircularSizeVariants,
+  progressLabelVariants,
+} from "./Progress.variants";
+export type {
+  ProgressContainerVariants,
+  ProgressTrackVariants,
+  ProgressIndicatorVariants,
+  ProgressCircularSizeVariants,
+  ProgressLabelVariants,
+} from "./Progress.variants";

--- a/packages/react/src/components/Snackbar/Snackbar.stories.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,0 +1,487 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState, type JSX } from "react";
+import { Snackbar } from "./Snackbar";
+import { SnackbarProvider, useSnackbar } from "./SnackbarProvider";
+
+/**
+ * Material Design 3 Snackbar Component
+ *
+ * Snackbars provide brief messages about app processes at the bottom of the
+ * screen. They appear temporarily and don't require user input to disappear.
+ *
+ * ## Content Configurations
+ * - **Single-line** — message text only
+ * - **Two-line** — message + supporting text (when content exceeds one line)
+ * - **With action** — single text button for an undo or related action
+ * - **With close icon** — explicit dismiss button for persistent messages
+ *
+ * ## MD3 Specifications
+ * - Surface: `inverse-surface` with `inverse-on-surface` text
+ * - Shape: extra-small corner (4dp) → `rounded-xs`
+ * - Elevation: level 3 → `shadow-elevation-3`
+ * - Width: 288dp min, 568dp max, centered `bottom-4`
+ * - Auto-dismiss: 4000ms default, pauses on hover and focus
+ * - Motion: entry slide-up 200ms / exit fade-out 100ms
+ *
+ * ## Usage
+ * ```tsx
+ * // Wrap your app with SnackbarProvider
+ * <SnackbarProvider>
+ *   <App />
+ * </SnackbarProvider>
+ *
+ * // Trigger from any descendant component
+ * const { showSnackbar } = useSnackbar();
+ * showSnackbar({ message: "File deleted", action: { label: "Undo", onAction: handleUndo } });
+ * ```
+ */
+const meta: Meta<typeof Snackbar> = {
+  title: "Components/Snackbar",
+  component: Snackbar,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <SnackbarProvider>
+        <Story />
+      </SnackbarProvider>
+    ),
+  ],
+  argTypes: {
+    message: {
+      control: "text",
+      description: "Primary message text",
+    },
+    supportingText: {
+      control: "text",
+      description: "Optional second line of text (two-line configuration)",
+    },
+    duration: {
+      control: { type: "number", min: 0, step: 500 },
+      description: "Auto-dismiss duration in ms. Set to 0 to disable.",
+      defaultValue: 4000,
+    },
+    severity: {
+      control: "radio",
+      options: ["default", "error"],
+      description: "Controls ARIA live region — polite (default) or assertive (error)",
+    },
+    showClose: {
+      control: "boolean",
+      description: "Show a close icon button",
+    },
+  },
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Brief, temporary messages rendered at the bottom of the viewport. Supports auto-dismiss with hover/focus pause, sequential queue, and an imperative API via useSnackbar().",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Snackbar>;
+
+// ---------------------------------------------------------------------------
+// Individual content configuration stories
+// ---------------------------------------------------------------------------
+
+/**
+ * Single-line message — the simplest Snackbar configuration.
+ * Auto-dismisses after 4 seconds.
+ */
+export const SingleLine: Story = {
+  args: {
+    message: "File deleted",
+    duration: 0,
+  },
+};
+
+/**
+ * Two-line configuration — message + supporting text.
+ * Used when the message exceeds one line.
+ */
+export const TwoLine: Story = {
+  args: {
+    message: "Connection lost",
+    supportingText: "Please check your network and try again",
+    duration: 0,
+  },
+};
+
+/**
+ * With action button — single text action for an undo or related task.
+ * Action button uses `inverse-primary` color per MD3 spec.
+ */
+export const WithAction: Story = {
+  args: {
+    message: "File deleted",
+    action: { label: "Undo", onAction: () => alert("Undo triggered") },
+    duration: 0,
+  },
+};
+
+/**
+ * With close icon — explicit dismiss button.
+ * Useful when auto-dismiss is disabled or the message is important.
+ */
+export const WithCloseIcon: Story = {
+  args: {
+    message: "File deleted",
+    showClose: true,
+    duration: 0,
+  },
+};
+
+/**
+ * With action and close icon — all interactive elements combined.
+ */
+export const WithActionAndClose: Story = {
+  args: {
+    message: "File deleted",
+    action: { label: "Undo", onAction: () => alert("Undo") },
+    showClose: true,
+    duration: 0,
+  },
+};
+
+/**
+ * Error severity — uses `role="alert" aria-live="assertive"` for urgent
+ * screen reader announcements.
+ */
+export const ErrorSeverity: Story = {
+  args: {
+    message: "Upload failed. Please try again.",
+    severity: "error",
+    showClose: true,
+    duration: 0,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Auto-dismiss demos
+// ---------------------------------------------------------------------------
+
+/**
+ * Short duration — dismisses after 2 seconds.
+ */
+export const ShortDuration: Story = {
+  args: {
+    message: "Copied to clipboard",
+    duration: 2000,
+  },
+};
+
+/**
+ * Persistent — no auto-dismiss (duration=0). Requires explicit close.
+ */
+export const Persistent: Story = {
+  args: {
+    message: "This message will not auto-dismiss",
+    duration: 0,
+    showClose: true,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Interactive queue demo
+// ---------------------------------------------------------------------------
+
+/**
+ * Queue demo — multiple Snackbars displayed sequentially, never stacked.
+ * Click the buttons quickly to queue several messages.
+ */
+export const QueueDemo: Story = {
+  render: function QueueDemoRender() {
+    const { showSnackbar } = useSnackbar();
+
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-body-medium text-on-surface-variant">
+          Click buttons to queue multiple Snackbars. They appear one at a time.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={() => showSnackbar({ message: "File deleted", duration: 3000 })}
+            className="bg-primary text-on-primary text-label-large rounded-full px-4 py-2"
+          >
+            File deleted
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              showSnackbar({
+                message: "Photo saved",
+                action: { label: "View", onAction: () => alert("Viewing photo") },
+                duration: 3000,
+              })
+            }
+            className="bg-secondary text-on-secondary text-label-large rounded-full px-4 py-2"
+          >
+            Photo saved (with action)
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              showSnackbar({
+                message: "Upload failed",
+                severity: "error",
+                showClose: true,
+                duration: 4000,
+              })
+            }
+            className="bg-error text-on-error text-label-large rounded-full px-4 py-2"
+          >
+            Upload failed (error)
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              showSnackbar({
+                message: "Connection lost",
+                supportingText: "Check your network settings",
+                showClose: true,
+                duration: 3000,
+              })
+            }
+            className="bg-surface-container-high text-on-surface text-label-large rounded-full px-4 py-2"
+          >
+            Two-line
+          </button>
+        </div>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Playground
+// ---------------------------------------------------------------------------
+
+/**
+ * Playground — trigger Snackbars with configurable options.
+ */
+export const Playground: Story = {
+  render: function PlaygroundRender(): JSX.Element {
+    const { showSnackbar } = useSnackbar();
+    const [message, setMessage] = useState("Changes saved");
+    const [supportingText, setSupportingText] = useState("");
+    const [actionLabel, setActionLabel] = useState("");
+    const [showCloseIcon, setShowCloseIcon] = useState(false);
+    const [duration, setDuration] = useState(4000);
+    const [severity, setSeverity] = useState<"default" | "error">("default");
+
+    const trigger = (): void => {
+      showSnackbar({
+        message,
+        supportingText: supportingText || undefined,
+        action: actionLabel
+          ? { label: actionLabel, onAction: () => alert(`Action: ${actionLabel}`) }
+          : undefined,
+        showClose: showCloseIcon,
+        duration,
+        severity,
+      });
+    };
+
+    return (
+      <div className="flex w-full max-w-lg flex-col gap-6">
+        <div className="bg-surface-container-high flex flex-col gap-4 rounded-xl p-5">
+          <h3 className="text-title-medium text-on-surface">Configure Snackbar</h3>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="sb-message" className="text-label-large text-on-surface-variant">
+              Message
+            </label>
+            <input
+              id="sb-message"
+              type="text"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-3 py-2"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="sb-supporting" className="text-label-large text-on-surface-variant">
+              Supporting text (optional, makes two-line)
+            </label>
+            <input
+              id="sb-supporting"
+              type="text"
+              value={supportingText}
+              onChange={(e) => setSupportingText(e.target.value)}
+              placeholder="Leave empty for single-line"
+              className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-3 py-2"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="sb-action" className="text-label-large text-on-surface-variant">
+              Action button label (optional)
+            </label>
+            <input
+              id="sb-action"
+              type="text"
+              value={actionLabel}
+              onChange={(e) => setActionLabel(e.target.value)}
+              placeholder="e.g. Undo"
+              className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-3 py-2"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <label className="text-body-medium text-on-surface flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={showCloseIcon}
+                onChange={(e) => setShowCloseIcon(e.target.checked)}
+              />
+              Show close icon
+            </label>
+
+            <div className="flex items-center gap-2">
+              <label htmlFor="sb-duration" className="text-label-large text-on-surface-variant">
+                Duration (ms):
+              </label>
+              <input
+                id="sb-duration"
+                type="number"
+                value={duration}
+                step={500}
+                min={0}
+                onChange={(e) => setDuration(Number(e.target.value))}
+                className="bg-surface border-outline text-body-medium text-on-surface w-24 rounded-sm border px-2 py-1"
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <label htmlFor="sb-severity" className="text-label-large text-on-surface-variant">
+                Severity:
+              </label>
+              <select
+                id="sb-severity"
+                value={severity}
+                onChange={(e) => setSeverity(e.target.value as "default" | "error")}
+                className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-2 py-1"
+              >
+                <option value="default">default</option>
+                <option value="error">error</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={trigger}
+          className="bg-primary text-on-primary text-label-large w-fit rounded-full px-6 py-3"
+        >
+          Show Snackbar
+        </button>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// All configurations showcase
+// ---------------------------------------------------------------------------
+
+/**
+ * All configurations — visual reference for all four MD3 content layouts.
+ * Each Snackbar is rendered declaratively with `duration=0` (no auto-dismiss)
+ * so they remain visible in the docs.
+ */
+export const AllConfigurations: Story = {
+  render: function AllConfigurationsRender() {
+    return (
+      <div className="flex w-full flex-col gap-4">
+        <p className="text-title-medium text-on-surface">
+          All MD3 Snackbar content configurations:
+        </p>
+        <p className="text-body-small text-on-surface-variant">
+          Rendered declaratively — Snackbars are normally positioned fixed at bottom of viewport.
+          Here they are shown inline for documentation purposes.
+        </p>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {/* Single-line */}
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-3"
+          >
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-body-medium text-inverse-on-surface">File deleted</span>
+            </div>
+          </div>
+
+          {/* Two-line */}
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-4"
+          >
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-body-medium text-inverse-on-surface">Connection lost</span>
+              <span className="text-body-medium text-inverse-on-surface opacity-80">
+                Please check your network settings
+              </span>
+            </div>
+          </div>
+
+          {/* With action */}
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-3"
+          >
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-body-medium text-inverse-on-surface">Photo archived</span>
+            </div>
+            <button type="button" className="text-inverse-primary text-label-large shrink-0 px-2">
+              Undo
+            </button>
+          </div>
+
+          {/* With close */}
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-3"
+          >
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-body-medium text-inverse-on-surface">
+                Message sent successfully
+              </span>
+            </div>
+            <button
+              type="button"
+              aria-label="Close"
+              className="text-inverse-on-surface shrink-0 p-1"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};

--- a/packages/react/src/components/Snackbar/Snackbar.stories.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,7 +1,10 @@
+import { within, userEvent, expect } from "storybook/test";
 import type { Meta, StoryObj } from "@storybook/react";
-import { useState, type JSX } from "react";
+import { type JSX } from "react";
+import { Button } from "../Button";
 import { Snackbar } from "./Snackbar";
 import { SnackbarProvider, useSnackbar } from "./SnackbarProvider";
+import type { SnackbarPosition } from "./Snackbar.types";
 
 /**
  * Material Design 3 Snackbar Component
@@ -9,31 +12,36 @@ import { SnackbarProvider, useSnackbar } from "./SnackbarProvider";
  * Snackbars provide brief messages about app processes at the bottom of the
  * screen. They appear temporarily and don't require user input to disappear.
  *
- * ## Content Configurations
- * - **Single-line** — message text only
- * - **Two-line** — message + supporting text (when content exceeds one line)
- * - **With action** — single text button for an undo or related action
- * - **With close icon** — explicit dismiss button for persistent messages
- *
- * ## MD3 Specifications
- * - Surface: `inverse-surface` with `inverse-on-surface` text
- * - Shape: extra-small corner (4dp) → `rounded-xs`
- * - Elevation: level 3 → `shadow-elevation-3`
- * - Width: 288dp min, 568dp max, centered `bottom-4`
- * - Auto-dismiss: 4000ms default, pauses on hover and focus
- * - Motion: entry slide-up 200ms / exit fade-out 100ms
- *
  * ## Usage
+ *
+ * Wrap your application with `SnackbarProvider`, then trigger snackbars from
+ * any descendant component using the `useSnackbar` hook:
+ *
  * ```tsx
- * // Wrap your app with SnackbarProvider
  * <SnackbarProvider>
  *   <App />
  * </SnackbarProvider>
  *
- * // Trigger from any descendant component
+ * // Inside any descendant:
  * const { showSnackbar } = useSnackbar();
  * showSnackbar({ message: "File deleted", action: { label: "Undo", onAction: handleUndo } });
  * ```
+ *
+ * ## Content Configurations
+ *
+ * - **Single-line** — message text only
+ * - **Two-line** — message + supporting text
+ * - **With action** — single text button (Undo / View / etc.)
+ * - **With close icon** — explicit dismiss button for persistent messages
+ *
+ * ## MD3 Specifications
+ *
+ * - Surface: `inverse-surface` with `inverse-on-surface` text
+ * - Shape: extra-small corner (4dp) → `rounded-xs`
+ * - Elevation: level 3 → `shadow-elevation-3`
+ * - Width: 288dp min, 568dp max, centered `bottom-4` by default
+ * - Auto-dismiss: 4000ms default, pauses on hover and focus
+ * - Motion: entry slide 250ms standard-decelerate / exit fade 200ms standard-accelerate
  */
 const meta: Meta<typeof Snackbar> = {
   title: "Components/Snackbar",
@@ -58,12 +66,23 @@ const meta: Meta<typeof Snackbar> = {
     duration: {
       control: { type: "number", min: 0, step: 500 },
       description: "Auto-dismiss duration in ms. Set to 0 to disable.",
-      defaultValue: 4000,
     },
     severity: {
       control: "radio",
       options: ["default", "error"],
       description: "Controls ARIA live region — polite (default) or assertive (error)",
+    },
+    position: {
+      control: "select",
+      options: [
+        "bottom-center",
+        "bottom-left",
+        "bottom-right",
+        "top-center",
+        "top-left",
+        "top-right",
+      ] satisfies SnackbarPosition[],
+      description: "Screen position of the Snackbar",
     },
     showClose: {
       control: "boolean",
@@ -84,404 +103,492 @@ const meta: Meta<typeof Snackbar> = {
 export default meta;
 type Story = StoryObj<typeof Snackbar>;
 
-// ---------------------------------------------------------------------------
-// Individual content configuration stories
-// ---------------------------------------------------------------------------
+// ─── Default ──────────────────────────────────────────────────────────────────
 
 /**
- * Single-line message — the simplest Snackbar configuration.
- * Auto-dismisses after 4 seconds.
+ * The default Snackbar — a single trigger button launches a snackbar with a
+ * message and an Undo action, inspired by the Google Keep demo on m3.material.io.
+ *
+ * Click "Open Snackbar" to see the component in action.
  */
-export const SingleLine: Story = {
-  args: {
-    message: "File deleted",
-    duration: 0,
-  },
+const DefaultDemo = (): JSX.Element => {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button
+        variant="filled"
+        onPress={() =>
+          showSnackbar({
+            message: "Note archived",
+            action: { label: "Undo", onAction: () => undefined },
+          })
+        }
+      >
+        Open Snackbar
+      </Button>
+    </div>
+  );
 };
 
-/**
- * Two-line configuration — message + supporting text.
- * Used when the message exceeds one line.
- */
-export const TwoLine: Story = {
-  args: {
-    message: "Connection lost",
-    supportingText: "Please check your network and try again",
-    duration: 0,
-  },
+export const Default: Story = {
+  render: () => <DefaultDemo />,
 };
 
-/**
- * With action button — single text action for an undo or related task.
- * Action button uses `inverse-primary` color per MD3 spec.
- */
-export const WithAction: Story = {
-  args: {
-    message: "File deleted",
-    action: { label: "Undo", onAction: () => alert("Undo triggered") },
-    duration: 0,
-  },
-};
+// ─── Position ─────────────────────────────────────────────────────────────────
 
 /**
- * With close icon — explicit dismiss button.
- * Useful when auto-dismiss is disabled or the message is important.
+ * Use the `position` prop to control where the Snackbar appears on screen.
+ * All six positions are demonstrated — click any button to see the Snackbar
+ * appear at that corner or edge.
+ *
+ * MD3 recommends `bottom-center` as the default position.
  */
-export const WithCloseIcon: Story = {
-  args: {
-    message: "File deleted",
-    showClose: true,
-    duration: 0,
-  },
-};
+const PositionDemo = (): JSX.Element => {
+  const { showSnackbar } = useSnackbar();
 
-/**
- * With action and close icon — all interactive elements combined.
- */
-export const WithActionAndClose: Story = {
-  args: {
-    message: "File deleted",
-    action: { label: "Undo", onAction: () => alert("Undo") },
-    showClose: true,
-    duration: 0,
-  },
-};
+  const positions: SnackbarPosition[] = [
+    "top-left",
+    "top-center",
+    "top-right",
+    "bottom-left",
+    "bottom-center",
+    "bottom-right",
+  ];
 
-/**
- * Error severity — uses `role="alert" aria-live="assertive"` for urgent
- * screen reader announcements.
- */
-export const ErrorSeverity: Story = {
-  args: {
-    message: "Upload failed. Please try again.",
-    severity: "error",
-    showClose: true,
-    duration: 0,
-  },
-};
+  const labels: Record<SnackbarPosition, string> = {
+    "top-left": "Top-Left",
+    "top-center": "Top-Center",
+    "top-right": "Top-Right",
+    "bottom-left": "Bottom-Left",
+    "bottom-center": "Bottom-Center",
+    "bottom-right": "Bottom-Right",
+  };
 
-// ---------------------------------------------------------------------------
-// Auto-dismiss demos
-// ---------------------------------------------------------------------------
-
-/**
- * Short duration — dismisses after 2 seconds.
- */
-export const ShortDuration: Story = {
-  args: {
-    message: "Copied to clipboard",
-    duration: 2000,
-  },
-};
-
-/**
- * Persistent — no auto-dismiss (duration=0). Requires explicit close.
- */
-export const Persistent: Story = {
-  args: {
-    message: "This message will not auto-dismiss",
-    duration: 0,
-    showClose: true,
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Interactive queue demo
-// ---------------------------------------------------------------------------
-
-/**
- * Queue demo — multiple Snackbars displayed sequentially, never stacked.
- * Click the buttons quickly to queue several messages.
- */
-export const QueueDemo: Story = {
-  render: function QueueDemoRender() {
-    const { showSnackbar } = useSnackbar();
-
-    return (
-      <div className="flex flex-col gap-3">
-        <p className="text-body-medium text-on-surface-variant">
-          Click buttons to queue multiple Snackbars. They appear one at a time.
-        </p>
-        <div className="flex flex-wrap gap-3">
-          <button
-            type="button"
-            onClick={() => showSnackbar({ message: "File deleted", duration: 3000 })}
-            className="bg-primary text-on-primary text-label-large rounded-full px-4 py-2"
-          >
-            File deleted
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              showSnackbar({
-                message: "Photo saved",
-                action: { label: "View", onAction: () => alert("Viewing photo") },
-                duration: 3000,
-              })
-            }
-            className="bg-secondary text-on-secondary text-label-large rounded-full px-4 py-2"
-          >
-            Photo saved (with action)
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              showSnackbar({
-                message: "Upload failed",
-                severity: "error",
-                showClose: true,
-                duration: 4000,
-              })
-            }
-            className="bg-error text-on-error text-label-large rounded-full px-4 py-2"
-          >
-            Upload failed (error)
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              showSnackbar({
-                message: "Connection lost",
-                supportingText: "Check your network settings",
-                showClose: true,
-                duration: 3000,
-              })
-            }
-            className="bg-surface-container-high text-on-surface text-label-large rounded-full px-4 py-2"
-          >
-            Two-line
-          </button>
-        </div>
-      </div>
-    );
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Playground
-// ---------------------------------------------------------------------------
-
-/**
- * Playground — trigger Snackbars with configurable options.
- */
-export const Playground: Story = {
-  render: function PlaygroundRender(): JSX.Element {
-    const { showSnackbar } = useSnackbar();
-    const [message, setMessage] = useState("Changes saved");
-    const [supportingText, setSupportingText] = useState("");
-    const [actionLabel, setActionLabel] = useState("");
-    const [showCloseIcon, setShowCloseIcon] = useState(false);
-    const [duration, setDuration] = useState(4000);
-    const [severity, setSeverity] = useState<"default" | "error">("default");
-
-    const trigger = (): void => {
-      showSnackbar({
-        message,
-        supportingText: supportingText || undefined,
-        action: actionLabel
-          ? { label: actionLabel, onAction: () => alert(`Action: ${actionLabel}`) }
-          : undefined,
-        showClose: showCloseIcon,
-        duration,
-        severity,
-      });
-    };
-
-    return (
-      <div className="flex w-full max-w-lg flex-col gap-6">
-        <div className="bg-surface-container-high flex flex-col gap-4 rounded-xl p-5">
-          <h3 className="text-title-medium text-on-surface">Configure Snackbar</h3>
-
-          <div className="flex flex-col gap-1">
-            <label htmlFor="sb-message" className="text-label-large text-on-surface-variant">
-              Message
-            </label>
-            <input
-              id="sb-message"
-              type="text"
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-              className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-3 py-2"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <label htmlFor="sb-supporting" className="text-label-large text-on-surface-variant">
-              Supporting text (optional, makes two-line)
-            </label>
-            <input
-              id="sb-supporting"
-              type="text"
-              value={supportingText}
-              onChange={(e) => setSupportingText(e.target.value)}
-              placeholder="Leave empty for single-line"
-              className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-3 py-2"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <label htmlFor="sb-action" className="text-label-large text-on-surface-variant">
-              Action button label (optional)
-            </label>
-            <input
-              id="sb-action"
-              type="text"
-              value={actionLabel}
-              onChange={(e) => setActionLabel(e.target.value)}
-              placeholder="e.g. Undo"
-              className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-3 py-2"
-            />
-          </div>
-
-          <div className="flex flex-wrap items-center gap-4">
-            <label className="text-body-medium text-on-surface flex cursor-pointer items-center gap-2">
-              <input
-                type="checkbox"
-                checked={showCloseIcon}
-                onChange={(e) => setShowCloseIcon(e.target.checked)}
-              />
-              Show close icon
-            </label>
-
-            <div className="flex items-center gap-2">
-              <label htmlFor="sb-duration" className="text-label-large text-on-surface-variant">
-                Duration (ms):
-              </label>
-              <input
-                id="sb-duration"
-                type="number"
-                value={duration}
-                step={500}
-                min={0}
-                onChange={(e) => setDuration(Number(e.target.value))}
-                className="bg-surface border-outline text-body-medium text-on-surface w-24 rounded-sm border px-2 py-1"
-              />
-            </div>
-
-            <div className="flex items-center gap-2">
-              <label htmlFor="sb-severity" className="text-label-large text-on-surface-variant">
-                Severity:
-              </label>
-              <select
-                id="sb-severity"
-                value={severity}
-                onChange={(e) => setSeverity(e.target.value as "default" | "error")}
-                className="bg-surface border-outline text-body-medium text-on-surface rounded-sm border px-2 py-1"
-              >
-                <option value="default">default</option>
-                <option value="error">error</option>
-              </select>
-            </div>
-          </div>
-        </div>
-
-        <button
-          type="button"
-          onClick={trigger}
-          className="bg-primary text-on-primary text-label-large w-fit rounded-full px-6 py-3"
+  return (
+    <div className="grid grid-cols-3 gap-3 p-8">
+      {positions.map((pos) => (
+        <Button
+          key={pos}
+          variant="outlined"
+          onPress={() =>
+            showSnackbar({
+              message: "I love snacks",
+              position: pos,
+              duration: 3000,
+            })
+          }
         >
-          Show Snackbar
-        </button>
-      </div>
-    );
+          {labels[pos]}
+        </Button>
+      ))}
+    </div>
+  );
+};
+
+export const Position: Story = {
+  render: () => <PositionDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Click any position button to see the Snackbar appear at that corner. The default is `bottom-center` per MD3 spec.",
+      },
+    },
   },
 };
 
-// ---------------------------------------------------------------------------
-// All configurations showcase
-// ---------------------------------------------------------------------------
+// ─── Content Variations (Variants) ───────────────────────────────────────────
 
 /**
- * All configurations — visual reference for all four MD3 content layouts.
- * Each Snackbar is rendered declaratively with `duration=0` (no auto-dismiss)
- * so they remain visible in the docs.
+ * All four MD3 content configurations, each triggered by a dedicated button.
+ *
+ * - **Single-line** — message text only (simplest form)
+ * - **Two-line** — message + supporting text for longer context
+ * - **With Action** — single text action button (e.g. Undo)
+ * - **With Close** — explicit close icon button for persistent messages
+ * - **Action + Close** — all interactive elements combined
  */
-export const AllConfigurations: Story = {
-  render: function AllConfigurationsRender() {
-    return (
-      <div className="flex w-full flex-col gap-4">
-        <p className="text-title-medium text-on-surface">
-          All MD3 Snackbar content configurations:
-        </p>
-        <p className="text-body-small text-on-surface-variant">
-          Rendered declaratively — Snackbars are normally positioned fixed at bottom of viewport.
-          Here they are shown inline for documentation purposes.
-        </p>
+const ContentVariationsDemo = (): JSX.Element => {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="flex flex-wrap justify-center gap-3 p-8">
+      <Button
+        variant="filled"
+        onPress={() =>
+          showSnackbar({
+            message: "File deleted",
+            duration: 4000,
+          })
+        }
+      >
+        Single-line
+      </Button>
+      <Button
+        variant="tonal"
+        onPress={() =>
+          showSnackbar({
+            message: "Connection lost",
+            supportingText: "Please check your network and try again",
+            duration: 4000,
+          })
+        }
+      >
+        Two-line
+      </Button>
+      <Button
+        variant="outlined"
+        onPress={() =>
+          showSnackbar({
+            message: "Photo archived",
+            action: { label: "Undo", onAction: () => undefined },
+            duration: 4000,
+          })
+        }
+      >
+        With Action
+      </Button>
+      <Button
+        variant="elevated"
+        onPress={() =>
+          showSnackbar({
+            message: "Message sent",
+            showClose: true,
+            duration: 0,
+          })
+        }
+      >
+        With Close
+      </Button>
+      <Button
+        variant="text"
+        onPress={() =>
+          showSnackbar({
+            message: "Changes saved",
+            action: { label: "View", onAction: () => undefined },
+            showClose: true,
+            duration: 0,
+          })
+        }
+      >
+        Action + Close
+      </Button>
+    </div>
+  );
+};
 
-        <div className="mt-4 flex flex-col gap-3">
-          {/* Single-line */}
-          <div
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-3"
-          >
-            <div className="flex min-w-0 flex-1 flex-col">
-              <span className="text-body-medium text-inverse-on-surface">File deleted</span>
-            </div>
-          </div>
+export const ContentVariations: Story = {
+  render: () => <ContentVariationsDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates all four MD3 content configurations. Each button triggers the corresponding layout. Close-icon variants use `duration: 0` (persistent) since they have an explicit dismiss control.",
+      },
+    },
+  },
+};
 
-          {/* Two-line */}
-          <div
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-4"
-          >
-            <div className="flex min-w-0 flex-1 flex-col">
-              <span className="text-body-medium text-inverse-on-surface">Connection lost</span>
-              <span className="text-body-medium text-inverse-on-surface opacity-80">
-                Please check your network settings
-              </span>
-            </div>
-          </div>
+// ─── Auto Dismiss ─────────────────────────────────────────────────────────────
 
-          {/* With action */}
-          <div
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-3"
-          >
-            <div className="flex min-w-0 flex-1 flex-col">
-              <span className="text-body-medium text-inverse-on-surface">Photo archived</span>
-            </div>
-            <button type="button" className="text-inverse-primary text-label-large shrink-0 px-2">
-              Undo
-            </button>
-          </div>
+/**
+ * The `duration` prop controls how long the Snackbar stays visible before
+ * automatically dismissing. The timer pauses when you hover over or focus
+ * inside the Snackbar, and resumes when you move away.
+ *
+ * MD3 recommends providing at least 4 seconds for users to read the message.
+ */
+const AutoDismissDemo = (): JSX.Element => {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button
+        variant="filled"
+        onPress={() =>
+          showSnackbar({
+            message: "This Snackbar will be dismissed in 5 seconds.",
+            duration: 5000,
+          })
+        }
+      >
+        Open Snackbar
+      </Button>
+    </div>
+  );
+};
 
-          {/* With close */}
-          <div
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-            className="bg-inverse-surface text-inverse-on-surface shadow-elevation-3 max-w-snackbar-max flex w-max min-w-72 items-center gap-x-2 rounded-xs px-4 py-3"
-          >
-            <div className="flex min-w-0 flex-1 flex-col">
-              <span className="text-body-medium text-inverse-on-surface">
-                Message sent successfully
-              </span>
-            </div>
-            <button
-              type="button"
-              aria-label="Close"
-              className="text-inverse-on-surface shrink-0 p-1"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
-              </svg>
-            </button>
-          </div>
-        </div>
+export const AutoDismiss: Story = {
+  render: () => <AutoDismissDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Triggers a Snackbar that auto-dismisses after 5 seconds. Hover or focus the Snackbar to pause the timer. Set `duration: 0` to disable auto-dismiss entirely.",
+      },
+    },
+  },
+};
+
+// ─── Accessibility ────────────────────────────────────────────────────────────
+
+/**
+ * The `severity` prop controls the ARIA live region role:
+ *
+ * - `severity="default"` → `role="status" aria-live="polite"` — announced
+ *   at the next available opportunity (non-urgent, informational)
+ * - `severity="error"` → `role="alert" aria-live="assertive"` — announced
+ *   immediately, interrupting any in-progress speech (urgent errors)
+ *
+ * Screen readers will announce the error Snackbar as soon as it appears.
+ */
+const AccessibilityDemo = (): JSX.Element => {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="flex flex-wrap justify-center gap-4 p-8">
+      <Button
+        variant="filled"
+        onPress={() =>
+          showSnackbar({
+            message: "File saved successfully.",
+            severity: "default",
+            duration: 4000,
+          })
+        }
+      >
+        Polite (default)
+      </Button>
+      <Button
+        variant="filled"
+        color="error"
+        onPress={() =>
+          showSnackbar({
+            message: "Upload failed. Please try again.",
+            severity: "error",
+            showClose: true,
+            duration: 0,
+          })
+        }
+      >
+        Assertive (error)
+      </Button>
+    </div>
+  );
+};
+
+export const Accessibility: Story = {
+  render: () => <AccessibilityDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates both ARIA live region modes. "Polite" is for informational updates; "Assertive" interrupts the screen reader immediately for critical errors. The error Snackbar uses `duration: 0` and `showClose` since users may need more time to process an error.',
+      },
+    },
+  },
+};
+
+// ─── Stacked Snackbars ────────────────────────────────────────────────────────
+
+/**
+ * Multiple `showSnackbar` calls produce a visible vertical stack.
+ * Click the buttons in rapid succession to see snackbars stack up with
+ * proper spacing. Each snackbar manages its own independent animation
+ * lifecycle — entry and exit animations run independently per item.
+ *
+ * Bottom positions stack upward (newest at bottom edge);
+ * top positions stack downward (newest at top edge).
+ */
+const StackedSnackbarsDemo = (): JSX.Element => {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="flex flex-col items-center gap-4 p-8">
+      <p className="text-body-medium text-on-surface-variant">
+        Click the buttons quickly to stack multiple Snackbars.
+      </p>
+      <div className="flex gap-3">
+        <Button
+          variant="filled"
+          onPress={() =>
+            showSnackbar({
+              message: "Message A",
+              action: { label: "Undo", onAction: () => undefined },
+              duration: 3000,
+            })
+          }
+        >
+          Show message A
+        </Button>
+        <Button
+          variant="tonal"
+          onPress={() =>
+            showSnackbar({
+              message: "Message B",
+              duration: 3000,
+            })
+          }
+        >
+          Show message B
+        </Button>
+        <Button
+          variant="outlined"
+          onPress={() =>
+            showSnackbar({
+              message: "Message C — with close",
+              showClose: true,
+              duration: 5000,
+            })
+          }
+        >
+          Show message C
+        </Button>
       </div>
-    );
+    </div>
+  );
+};
+
+export const StackedSnackbars: Story = {
+  render: () => <StackedSnackbarsDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Multiple Snackbars stack vertically with 8dp spacing between them. Each item enters and exits independently. Bottom positions stack upward; top positions stack downward. Click all three buttons quickly to see the full stack.",
+      },
+    },
+  },
+};
+
+// ─── Interactive (play function) ──────────────────────────────────────────────
+
+/**
+ * Automated interaction test — the play function clicks the trigger button,
+ * waits for the Snackbar to appear, verifies it contains the expected message,
+ * then clicks the Undo action.
+ */
+const InteractiveDemo = (): JSX.Element => {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button
+        variant="filled"
+        onPress={() =>
+          showSnackbar({
+            message: "File deleted",
+            action: { label: "Undo", onAction: () => undefined },
+            duration: 0,
+          })
+        }
+      >
+        Open Snackbar
+      </Button>
+    </div>
+  );
+};
+
+export const Interactive: Story = {
+  render: () => <InteractiveDemo />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole("button", { name: /open snackbar/i });
+    await userEvent.click(trigger);
+
+    // The Snackbar renders into document.body via a portal, so we query the
+    // full document rather than the canvas element.
+    const snackbar = await within(document.body).findByRole("status");
+    await expect(snackbar).toBeInTheDocument();
+    await expect(snackbar).toHaveTextContent("File deleted");
+
+    const undoButton = within(document.body).getByRole("button", { name: /undo/i });
+    await userEvent.click(undoButton);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Automated interaction test. The play function opens the Snackbar, verifies its content via ARIA role, then clicks the Undo action. The Snackbar renders in a portal so assertions target `document.body`.",
+      },
+    },
+  },
+};
+
+// ─── Playground ───────────────────────────────────────────────────────────────
+
+interface PlaygroundArgs {
+  message: string;
+  supportingText: string;
+  showClose: boolean;
+  duration: number;
+  severity: "default" | "error";
+  position: SnackbarPosition;
+}
+
+/**
+ * Configure all Snackbar options using the Controls panel, then click
+ * "Show Snackbar" to preview the result. Combine props freely to explore
+ * all supported configurations.
+ */
+const PlaygroundDemo = ({
+  message,
+  supportingText,
+  showClose,
+  duration,
+  severity,
+  position,
+}: {
+  message?: string;
+  supportingText?: string;
+  showClose?: boolean;
+  duration?: number;
+  severity?: "default" | "error";
+  position?: SnackbarPosition;
+}): JSX.Element => {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button
+        variant="filled"
+        onPress={() =>
+          showSnackbar({
+            message: message ?? "Changes saved",
+            ...(supportingText ? { supportingText } : {}),
+            showClose: showClose ?? false,
+            duration: duration ?? 4000,
+            severity: severity ?? "default",
+            position: position ?? "bottom-center",
+          })
+        }
+      >
+        Show Snackbar
+      </Button>
+    </div>
+  );
+};
+
+export const Playground: StoryObj<PlaygroundArgs> = {
+  render: (args: PlaygroundArgs) => (
+    <PlaygroundDemo
+      message={args.message}
+      supportingText={args.supportingText}
+      showClose={args.showClose}
+      duration={args.duration}
+      severity={args.severity}
+      position={args.position}
+    />
+  ),
+  args: {
+    message: "Changes saved",
+    supportingText: "",
+    showClose: false,
+    duration: 4000,
+    severity: "default",
+    position: "bottom-center",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use the Controls panel to configure any combination of props, then click Show Snackbar to preview.",
+      },
+    },
   },
 };

--- a/packages/react/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.test.tsx
@@ -1,0 +1,626 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { Snackbar } from "./Snackbar";
+import { SnackbarHeadless } from "./SnackbarHeadless";
+import { SnackbarProvider, useSnackbar } from "./SnackbarProvider";
+import type { SnackbarProps } from "./Snackbar.types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const renderSnackbar = (props: Partial<SnackbarProps> = {}) =>
+  render(
+    <SnackbarProvider>
+      <Snackbar message="File deleted" {...props} />
+    </SnackbarProvider>
+  );
+
+/**
+ * Advance fake timers through all phases of the auto-dismiss lifecycle:
+ * 1. entering → visible (setTimeout 0ms fires, React re-renders)
+ * 2. visible → exiting (dismiss timer fires)
+ * 3. exiting → exited (150ms exit fallback fires → onClose called)
+ *
+ * Each phase is wrapped in its own act() to ensure React flushes state
+ * updates between phases. Must be called with vi.useFakeTimers() active.
+ */
+function advanceAndFinishExit(durationMs: number): void {
+  act(() => {
+    vi.advanceTimersByTime(0);
+  }); // entering → visible
+  act(() => {
+    vi.advanceTimersByTime(durationMs);
+  }); // visible → exiting
+  act(() => {
+    vi.advanceTimersByTime(200);
+  }); // exit fallback fires
+}
+
+const renderWithQueue = () => {
+  const TriggerComponent = () => {
+    const { showSnackbar } = useSnackbar();
+    return (
+      <div>
+        <button onClick={() => showSnackbar({ message: "First", duration: 3000 })}>
+          Show First
+        </button>
+        <button onClick={() => showSnackbar({ message: "Second", duration: 3000 })}>
+          Show Second
+        </button>
+        <button onClick={() => showSnackbar({ message: "Third", duration: 3000 })}>
+          Show Third
+        </button>
+      </div>
+    );
+  };
+  return render(
+    <SnackbarProvider>
+      <TriggerComponent />
+    </SnackbarProvider>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe("Snackbar", () => {
+  describe("Rendering", () => {
+    test("renders single-line message", () => {
+      renderSnackbar({ message: "File deleted" });
+      expect(screen.getByText("File deleted")).toBeInTheDocument();
+    });
+
+    test("renders two-line message with supporting text", () => {
+      renderSnackbar({
+        message: "Connection lost",
+        supportingText: "Please check your network",
+      });
+      expect(screen.getByText("Connection lost")).toBeInTheDocument();
+      expect(screen.getByText("Please check your network")).toBeInTheDocument();
+    });
+
+    test("renders action button when action prop is provided", () => {
+      renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction: vi.fn() },
+      });
+      expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
+    });
+
+    test("does not render action button when action prop is absent", () => {
+      renderSnackbar({ message: "File deleted" });
+      expect(screen.queryByRole("button", { name: /undo/i })).not.toBeInTheDocument();
+    });
+
+    test("renders close icon button when showClose is true", () => {
+      renderSnackbar({ message: "File deleted", showClose: true });
+      expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
+    });
+
+    test("does not render close icon button when showClose is false", () => {
+      renderSnackbar({ message: "File deleted", showClose: false });
+      expect(screen.queryByRole("button", { name: /close/i })).not.toBeInTheDocument();
+    });
+
+    test("renders both action button and close icon when both props provided", () => {
+      renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction: vi.fn() },
+        showClose: true,
+      });
+      expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
+    });
+
+    test("merges custom className onto container", () => {
+      renderSnackbar({ message: "Hello", className: "my-custom-class" });
+      const container = screen.getByRole("status");
+      expect(container).toHaveClass("my-custom-class");
+    });
+
+    test("forwards ref to container element", () => {
+      const ref = { current: null };
+      render(
+        <SnackbarProvider>
+          <Snackbar message="Hello" ref={ref} />
+        </SnackbarProvider>
+      );
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Accessibility
+  // ---------------------------------------------------------------------------
+
+  describe("Accessibility", () => {
+    test("has role=status and aria-live=polite for default severity", () => {
+      renderSnackbar({ message: "File deleted", severity: "default" });
+      const el = screen.getByRole("status");
+      expect(el).toHaveAttribute("aria-live", "polite");
+      expect(el).toHaveAttribute("aria-atomic", "true");
+    });
+
+    test("has role=alert and aria-live=assertive for error severity", () => {
+      renderSnackbar({ message: "Upload failed", severity: "error" });
+      const el = screen.getByRole("alert");
+      expect(el).toHaveAttribute("aria-live", "assertive");
+    });
+
+    test("action button has an accessible name", () => {
+      renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction: vi.fn() },
+      });
+      const btn = screen.getByRole("button", { name: "Undo" });
+      expect(btn).toBeInTheDocument();
+    });
+
+    test("close icon button has an accessible label", () => {
+      renderSnackbar({ message: "File deleted", showClose: true });
+      const closeBtn = screen.getByRole("button", { name: /close/i });
+      expect(closeBtn).toHaveAttribute("aria-label");
+    });
+
+    test("single-line default snackbar has no axe violations", async () => {
+      const { container } = renderSnackbar({ message: "File deleted" });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("snackbar with action has no axe violations", async () => {
+      const { container } = renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction: vi.fn() },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("snackbar with close icon has no axe violations", async () => {
+      const { container } = renderSnackbar({
+        message: "File deleted",
+        showClose: true,
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("error severity snackbar has no axe violations", async () => {
+      const { container } = renderSnackbar({
+        message: "Upload failed",
+        severity: "error",
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Auto-dismiss
+  // ---------------------------------------------------------------------------
+
+  describe("Auto-dismiss", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("calls onClose after default 4000ms duration", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", onClose });
+
+      expect(onClose).not.toHaveBeenCalled();
+      advanceAndFinishExit(4000);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("calls onClose after custom duration", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "Quick message", duration: 2000, onClose });
+
+      advanceAndFinishExit(2000);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not auto-dismiss when duration is 0", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "Persistent", duration: 0, onClose });
+
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test("does not auto-dismiss before duration elapses", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      // Flush entering→visible then advance to just before dismiss
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      act(() => {
+        vi.advanceTimersByTime(3999);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pause on hover
+  // ---------------------------------------------------------------------------
+
+  describe("Pause on hover", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("pauses auto-dismiss timer on mouseenter", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      const el = screen.getByRole("status");
+
+      // Flush entering→visible so event handlers see animationState="visible"
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      // Advance 2s
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      // Hover — pauses timer (separate act so React state is flushed before event)
+      act(() => {
+        fireEvent.mouseEnter(el);
+      });
+      // Advance past original duration — should NOT fire
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test("resumes auto-dismiss timer on mouseleave", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      const el = screen.getByRole("status");
+
+      // Flush entering→visible
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      // Advance 2s (2000ms consumed, 2000ms remaining)
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      // Hover
+      act(() => {
+        fireEvent.mouseEnter(el);
+      });
+      // Leave — resumes timer with remaining 2000ms
+      act(() => {
+        fireEvent.mouseLeave(el);
+      });
+      // Advance past remaining 2000ms → exit triggered
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      // Advance past 150ms exit fallback
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pause on focus
+  // ---------------------------------------------------------------------------
+
+  describe("Pause on focus", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("pauses auto-dismiss timer on focus", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      const el = screen.getByRole("status");
+
+      // Flush entering→visible
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      // Advance 1s
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      // Focus — pauses timer
+      act(() => {
+        fireEvent.focus(el);
+      });
+      // Advance 5s more — should NOT fire since paused
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test("resumes auto-dismiss timer on blur", () => {
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", duration: 4000, onClose });
+
+      const el = screen.getByRole("status");
+
+      // Flush entering→visible
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+      // Advance 1s (1000ms consumed, 3000ms remaining)
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      // Focus — pauses timer
+      act(() => {
+        fireEvent.focus(el);
+      });
+      // Blur — resumes timer
+      act(() => {
+        fireEvent.blur(el);
+      });
+      // Advance past remaining 3000ms
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+      // Advance past 150ms exit fallback
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Action callback
+  // ---------------------------------------------------------------------------
+
+  describe("Action callback", () => {
+    test("fires onAction when action button is pressed", async () => {
+      const onAction = vi.fn();
+      renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction },
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Undo" }));
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not fire onAction when action is not provided", () => {
+      renderSnackbar({ message: "File deleted" });
+      expect(screen.queryByRole("button", { name: /undo/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Close icon
+  // ---------------------------------------------------------------------------
+
+  describe("Close icon", () => {
+    test("fires onClose when close icon button is pressed", () => {
+      vi.useFakeTimers();
+      const onClose = vi.fn();
+      renderSnackbar({ message: "File deleted", showClose: true, onClose });
+
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: /close/i }));
+      });
+
+      // Advance past the 150ms exit fallback timer
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    test("close button is keyboard accessible", () => {
+      renderSnackbar({ message: "File deleted", showClose: true });
+      const closeBtn = screen.getByRole("button", { name: /close/i });
+      expect(closeBtn.tagName).toBe("BUTTON");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Animation
+  // ---------------------------------------------------------------------------
+
+  describe("Animation states", () => {
+    test("container starts with entering animation class", () => {
+      renderSnackbar({ message: "Hello" });
+      const el = screen.getByRole("status");
+      expect(el.className).toMatch(/transition/);
+    });
+
+    test("container applies opacity class for visibility", () => {
+      renderSnackbar({ message: "Hello" });
+      const el = screen.getByRole("status");
+      expect(el.className).toMatch(/opacity/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Queue ordering
+  // ---------------------------------------------------------------------------
+
+  describe("Queue ordering", () => {
+    // Queue display tests use real timers with userEvent for reliability.
+    // The "shows second after first" test uses fake timers for the timer phase.
+
+    test("shows first snackbar immediately", async () => {
+      renderWithQueue();
+
+      await userEvent.click(screen.getByRole("button", { name: "Show First" }));
+
+      expect(screen.getByText("First")).toBeInTheDocument();
+    });
+
+    test("shows only one snackbar at a time (no stacking)", async () => {
+      renderWithQueue();
+
+      await userEvent.click(screen.getByRole("button", { name: "Show First" }));
+      await userEvent.click(screen.getByRole("button", { name: "Show Second" }));
+
+      expect(screen.getByText("First")).toBeInTheDocument();
+      expect(screen.queryByText("Second")).not.toBeInTheDocument();
+    });
+
+    test("shows second snackbar after first dismisses", () => {
+      vi.useFakeTimers();
+      renderWithQueue();
+
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Show First" }));
+      });
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Show Second" }));
+      });
+
+      expect(screen.getByText("First")).toBeInTheDocument();
+
+      // Advance through first snackbar's full lifecycle
+      advanceAndFinishExit(3000);
+
+      vi.useRealTimers();
+
+      expect(screen.getByText("Second")).toBeInTheDocument();
+      expect(screen.queryByText("First")).not.toBeInTheDocument();
+    });
+
+    test("useSnackbar throws when used outside SnackbarProvider", () => {
+      const BadConsumer = () => {
+        useSnackbar();
+        return null;
+      };
+
+      expect(() => render(<BadConsumer />)).toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // SnackbarHeadless
+  // ---------------------------------------------------------------------------
+
+  describe("SnackbarHeadless", () => {
+    test("renders with role=status for default severity", () => {
+      render(<SnackbarHeadless message="Hello" />);
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    test("renders with role=alert for error severity", () => {
+      render(<SnackbarHeadless message="Error" severity="error" />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    test("has aria-live=polite for default severity", () => {
+      render(<SnackbarHeadless message="Hello" />);
+      expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+    });
+
+    test("has aria-live=assertive for error severity", () => {
+      render(<SnackbarHeadless message="Error" severity="error" />);
+      expect(screen.getByRole("alert")).toHaveAttribute("aria-live", "assertive");
+    });
+
+    test("has aria-atomic=true", () => {
+      render(<SnackbarHeadless message="Hello" />);
+      expect(screen.getByRole("status")).toHaveAttribute("aria-atomic", "true");
+    });
+
+    test("renders ReactNode children", () => {
+      render(
+        <SnackbarHeadless message="Hello">
+          <span data-testid="custom-child">Custom content</span>
+        </SnackbarHeadless>
+      );
+      expect(screen.getByTestId("custom-child")).toBeInTheDocument();
+    });
+
+    test("renders children as render function with animationState", () => {
+      const renderFn = vi.fn((_state: { animationState: string; onClose: () => void }) => (
+        <span>rendered</span>
+      ));
+      render(<SnackbarHeadless message="Hello">{renderFn}</SnackbarHeadless>);
+      const calls = renderFn.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      expect(typeof (calls[0]?.[0] as { animationState: string }).animationState).toBe("string");
+    });
+
+    test("forwards ref to container element", () => {
+      const ref = { current: null };
+      render(<SnackbarHeadless message="Hello" ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+
+    test("applies custom className to container", () => {
+      render(<SnackbarHeadless message="Hello" className="custom-headless" />);
+      expect(screen.getByRole("status")).toHaveClass("custom-headless");
+    });
+
+    describe("Auto-dismiss timer", () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      test("calls onClose after duration", () => {
+        const onClose = vi.fn();
+        render(<SnackbarHeadless message="Hello" duration={2000} onClose={onClose} />);
+
+        advanceAndFinishExit(2000);
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+
+      test("does not call onClose when duration is 0", () => {
+        const onClose = vi.fn();
+        render(<SnackbarHeadless message="Hello" duration={0} onClose={onClose} />);
+
+        act(() => {
+          vi.advanceTimersByTime(10000);
+        });
+
+        expect(onClose).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/react/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.test.tsx
@@ -5,7 +5,7 @@ import { axe } from "vitest-axe";
 import { Snackbar } from "./Snackbar";
 import { SnackbarHeadless } from "./SnackbarHeadless";
 import { SnackbarProvider, useSnackbar } from "./SnackbarProvider";
-import type { SnackbarProps } from "./Snackbar.types";
+import type { SnackbarPosition, SnackbarProps } from "./Snackbar.types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,23 +20,27 @@ const renderSnackbar = (props: Partial<SnackbarProps> = {}) =>
 
 /**
  * Advance fake timers through all phases of the auto-dismiss lifecycle:
- * 1. entering → visible (setTimeout 0ms fires, React re-renders)
+ * 1. entering → visible (two rAF frames ≈ 32ms fires, React re-renders)
  * 2. visible → exiting (dismiss timer fires)
- * 3. exiting → exited (150ms exit fallback fires → onClose called)
+ * 3. exiting → exited (250ms exit fallback fires → onClose called)
  *
  * Each phase is wrapped in its own act() to ensure React flushes state
  * updates between phases. Must be called with vi.useFakeTimers() active.
+ *
+ * The 32ms advance covers the double requestAnimationFrame used to trigger
+ * the entry animation. With vi.useFakeTimers(), rAF is faked as setTimeout(~16ms),
+ * so two frames require advancing by at least 32ms.
  */
 function advanceAndFinishExit(durationMs: number): void {
   act(() => {
-    vi.advanceTimersByTime(0);
-  }); // entering → visible
+    vi.advanceTimersByTime(32);
+  }); // entering → visible (double rAF: 2 × ~16ms)
   act(() => {
     vi.advanceTimersByTime(durationMs);
   }); // visible → exiting
   act(() => {
-    vi.advanceTimersByTime(200);
-  }); // exit fallback fires
+    vi.advanceTimersByTime(300);
+  }); // exit fallback fires (250ms + buffer)
 }
 
 const renderWithQueue = () => {
@@ -245,9 +249,9 @@ describe("Snackbar", () => {
       const onClose = vi.fn();
       renderSnackbar({ message: "File deleted", duration: 4000, onClose });
 
-      // Flush entering→visible then advance to just before dismiss
+      // Flush entering→visible (double rAF ≈ 32ms) then advance to just before dismiss
       act(() => {
-        vi.advanceTimersByTime(0);
+        vi.advanceTimersByTime(32);
       });
       act(() => {
         vi.advanceTimersByTime(3999);
@@ -276,9 +280,9 @@ describe("Snackbar", () => {
 
       const el = screen.getByRole("status");
 
-      // Flush entering→visible so event handlers see animationState="visible"
+      // Flush entering→visible (double rAF ≈ 32ms) so event handlers see animationState="visible"
       act(() => {
-        vi.advanceTimersByTime(0);
+        vi.advanceTimersByTime(32);
       });
       // Advance 2s
       act(() => {
@@ -302,9 +306,9 @@ describe("Snackbar", () => {
 
       const el = screen.getByRole("status");
 
-      // Flush entering→visible
+      // Flush entering→visible (double rAF ≈ 32ms)
       act(() => {
-        vi.advanceTimersByTime(0);
+        vi.advanceTimersByTime(32);
       });
       // Advance 2s (2000ms consumed, 2000ms remaining)
       act(() => {
@@ -322,9 +326,9 @@ describe("Snackbar", () => {
       act(() => {
         vi.advanceTimersByTime(2000);
       });
-      // Advance past 150ms exit fallback
+      // Advance past 250ms exit fallback
       act(() => {
-        vi.advanceTimersByTime(200);
+        vi.advanceTimersByTime(300);
       });
 
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -350,9 +354,9 @@ describe("Snackbar", () => {
 
       const el = screen.getByRole("status");
 
-      // Flush entering→visible
+      // Flush entering→visible (double rAF ≈ 32ms)
       act(() => {
-        vi.advanceTimersByTime(0);
+        vi.advanceTimersByTime(32);
       });
       // Advance 1s
       act(() => {
@@ -376,9 +380,9 @@ describe("Snackbar", () => {
 
       const el = screen.getByRole("status");
 
-      // Flush entering→visible
+      // Flush entering→visible (double rAF ≈ 32ms)
       act(() => {
-        vi.advanceTimersByTime(0);
+        vi.advanceTimersByTime(32);
       });
       // Advance 1s (1000ms consumed, 3000ms remaining)
       act(() => {
@@ -396,9 +400,9 @@ describe("Snackbar", () => {
       act(() => {
         vi.advanceTimersByTime(3000);
       });
-      // Advance past 150ms exit fallback
+      // Advance past 250ms exit fallback
       act(() => {
-        vi.advanceTimersByTime(200);
+        vi.advanceTimersByTime(300);
       });
 
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -441,9 +445,9 @@ describe("Snackbar", () => {
         fireEvent.click(screen.getByRole("button", { name: /close/i }));
       });
 
-      // Advance past the 150ms exit fallback timer
+      // Advance past the 250ms exit fallback timer
       act(() => {
-        vi.advanceTimersByTime(200);
+        vi.advanceTimersByTime(300);
       });
 
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -476,6 +480,101 @@ describe("Snackbar", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Position
+  // ---------------------------------------------------------------------------
+
+  describe("Position", () => {
+    // Position classes are now applied to the stack container (parent of the
+    // snackbar element), rendered via the portal by SnackbarProvider. Tests
+    // must trigger snackbars through the queue so the container exists.
+
+    function renderWithPosition(position: string) {
+      const TriggerComponent = () => {
+        const { showSnackbar } = useSnackbar();
+        return (
+          <button
+            onClick={() =>
+              showSnackbar({ message: "Hello", position: position as SnackbarPosition })
+            }
+          >
+            Trigger
+          </button>
+        );
+      };
+      render(
+        <SnackbarProvider>
+          <TriggerComponent />
+        </SnackbarProvider>
+      );
+    }
+
+    test("defaults to bottom-center position classes", async () => {
+      renderWithPosition("bottom-center");
+      await userEvent.click(screen.getByRole("button", { name: "Trigger" }));
+      const container = screen.getByRole("status").parentElement!;
+      expect(container.className).toMatch(/bottom-4/);
+      expect(container.className).toMatch(/left-1\/2/);
+    });
+
+    test("applies bottom-left position classes", async () => {
+      renderWithPosition("bottom-left");
+      await userEvent.click(screen.getByRole("button", { name: "Trigger" }));
+      const container = screen.getByRole("status").parentElement!;
+      expect(container.className).toMatch(/bottom-4/);
+      expect(container.className).toMatch(/left-4/);
+    });
+
+    test("applies bottom-right position classes", async () => {
+      renderWithPosition("bottom-right");
+      await userEvent.click(screen.getByRole("button", { name: "Trigger" }));
+      const container = screen.getByRole("status").parentElement!;
+      expect(container.className).toMatch(/bottom-4/);
+      expect(container.className).toMatch(/right-4/);
+    });
+
+    test("applies top-center position classes", async () => {
+      renderWithPosition("top-center");
+      await userEvent.click(screen.getByRole("button", { name: "Trigger" }));
+      const container = screen.getByRole("status").parentElement!;
+      expect(container.className).toMatch(/top-4/);
+      expect(container.className).toMatch(/left-1\/2/);
+    });
+
+    test("applies top-left position classes", async () => {
+      renderWithPosition("top-left");
+      await userEvent.click(screen.getByRole("button", { name: "Trigger" }));
+      const container = screen.getByRole("status").parentElement!;
+      expect(container.className).toMatch(/top-4/);
+      expect(container.className).toMatch(/left-4/);
+    });
+
+    test("applies top-right position classes", async () => {
+      renderWithPosition("top-right");
+      await userEvent.click(screen.getByRole("button", { name: "Trigger" }));
+      const container = screen.getByRole("status").parentElement!;
+      expect(container.className).toMatch(/top-4/);
+      expect(container.className).toMatch(/right-4/);
+    });
+
+    test("bottom positions enter with scale-75 and origin-bottom (zoom-in from bottom)", () => {
+      renderSnackbar({ message: "Hello", position: "bottom-center" });
+      const el = screen.getByRole("status");
+      // In entering state (before the zero-delay setTimeout fires), the snackbar
+      // starts at scale-75 + opacity-0, anchored at origin-bottom for the zoom.
+      expect(el.className).toMatch(/scale-75/);
+      expect(el.className).toMatch(/origin-bottom/);
+    });
+
+    test("top positions enter with scale-75 and origin-top (zoom-in from top)", () => {
+      renderSnackbar({ message: "Hello", position: "top-center" });
+      const el = screen.getByRole("status");
+      // In entering state with "down" direction, scale anchors at origin-top.
+      expect(el.className).toMatch(/scale-75/);
+      expect(el.className).toMatch(/origin-top/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Queue ordering
   // ---------------------------------------------------------------------------
 
@@ -491,36 +590,101 @@ describe("Snackbar", () => {
       expect(screen.getByText("First")).toBeInTheDocument();
     });
 
-    test("shows only one snackbar at a time (no stacking)", async () => {
+    test("shows multiple snackbars simultaneously (stacking)", async () => {
       renderWithQueue();
 
       await userEvent.click(screen.getByRole("button", { name: "Show First" }));
       await userEvent.click(screen.getByRole("button", { name: "Show Second" }));
 
       expect(screen.getByText("First")).toBeInTheDocument();
-      expect(screen.queryByText("Second")).not.toBeInTheDocument();
+      expect(screen.getByText("Second")).toBeInTheDocument();
     });
 
-    test("shows second snackbar after first dismisses", () => {
-      vi.useFakeTimers();
+    test("shows all three snackbars simultaneously when stacked", async () => {
       renderWithQueue();
 
-      act(() => {
-        fireEvent.click(screen.getByRole("button", { name: "Show First" }));
-      });
-      act(() => {
-        fireEvent.click(screen.getByRole("button", { name: "Show Second" }));
-      });
+      await userEvent.click(screen.getByRole("button", { name: "Show First" }));
+      await userEvent.click(screen.getByRole("button", { name: "Show Second" }));
+      await userEvent.click(screen.getByRole("button", { name: "Show Third" }));
 
       expect(screen.getByText("First")).toBeInTheDocument();
+      expect(screen.getByText("Second")).toBeInTheDocument();
+      expect(screen.getByText("Third")).toBeInTheDocument();
+    });
 
-      // Advance through first snackbar's full lifecycle
-      advanceAndFinishExit(3000);
+    test("dismisses individual snackbars independently", () => {
+      vi.useFakeTimers();
+
+      // Use a component that lets us trigger two snackbars with different durations
+      const TriggerComponent = () => {
+        const { showSnackbar } = useSnackbar();
+        return (
+          <div>
+            <button onClick={() => showSnackbar({ message: "Short", duration: 1000 })}>
+              Show Short
+            </button>
+            <button onClick={() => showSnackbar({ message: "Long", duration: 10000 })}>
+              Show Long
+            </button>
+          </div>
+        );
+      };
+      render(
+        <SnackbarProvider>
+          <TriggerComponent />
+        </SnackbarProvider>
+      );
+
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Show Short" }));
+      });
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Show Long" }));
+      });
+
+      // Both should be visible immediately
+      expect(screen.getByText("Short")).toBeInTheDocument();
+      expect(screen.getByText("Long")).toBeInTheDocument();
+
+      // Advance only past the Short snackbar's duration (1000ms) + exit fallback
+      advanceAndFinishExit(1000);
 
       vi.useRealTimers();
 
-      expect(screen.getByText("Second")).toBeInTheDocument();
-      expect(screen.queryByText("First")).not.toBeInTheDocument();
+      // Long should still be visible, Short should be gone
+      expect(screen.getByText("Long")).toBeInTheDocument();
+      expect(screen.queryByText("Short")).not.toBeInTheDocument();
+    });
+
+    test("respects maxVisible cap — excess snackbars are hidden until space opens", async () => {
+      const TriggerComponent = () => {
+        const { showSnackbar } = useSnackbar();
+        return (
+          <div>
+            {["A", "B", "C"].map((label) => (
+              <button
+                key={label}
+                onClick={() => showSnackbar({ message: `Message ${label}`, duration: 3000 })}
+              >
+                {`Show ${label}`}
+              </button>
+            ))}
+          </div>
+        );
+      };
+      render(
+        <SnackbarProvider maxVisible={2}>
+          <TriggerComponent />
+        </SnackbarProvider>
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Show A" }));
+      await userEvent.click(screen.getByRole("button", { name: "Show B" }));
+      await userEvent.click(screen.getByRole("button", { name: "Show C" }));
+
+      expect(screen.getByText("Message A")).toBeInTheDocument();
+      expect(screen.getByText("Message B")).toBeInTheDocument();
+      expect(screen.queryByText("Message C")).not.toBeInTheDocument();
     });
 
     test("useSnackbar throws when used outside SnackbarProvider", () => {

--- a/packages/react/src/components/Snackbar/Snackbar.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { forwardRef } from "react";
+import { Button } from "../Button";
+import { IconButton } from "../IconButton";
+import { cn } from "../../utils/cn";
+import { SnackbarHeadless } from "./SnackbarHeadless";
+import {
+  snackbarAnimationVariants,
+  snackbarBaseVariants,
+  snackbarContentVariants,
+  snackbarMessageVariants,
+  snackbarSupportingTextVariants,
+  snackbarActionVariants,
+  snackbarCloseVariants,
+} from "./Snackbar.variants";
+import type { SnackbarAnimationState } from "./SnackbarHeadless";
+import type { SnackbarProps } from "./Snackbar.types";
+
+/**
+ * Close icon SVG (24dp, MD3 standard close symbol).
+ * Inline to avoid any icon library dependency.
+ */
+function CloseIcon(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+    </svg>
+  );
+}
+
+/**
+ * `Snackbar` — Layer 3 MD3 Styled Component.
+ *
+ * Renders one of four MD3 Snackbar content configurations:
+ * 1. Single-line message only
+ * 2. Two-line message + `supportingText`
+ * 3. Single-line with text `action` button (styled `Button variant="text"` with
+ *    `inverse-primary` color per MD3 spec)
+ * 4. Single-line with close icon (or combined with action)
+ *
+ * Uses `SnackbarHeadless` for all behavioral concerns (ARIA live region,
+ * auto-dismiss timer with pause/resume, animation state machine) and CVA
+ * variants for MD3-compliant visual styling.
+ *
+ * For typical app usage, render inside `SnackbarProvider` and trigger via
+ * the `useSnackbar` hook. For declarative/test usage, it can be rendered
+ * standalone.
+ *
+ * @example
+ * ```tsx
+ * // Imperative via hook (typical)
+ * const { showSnackbar } = useSnackbar();
+ * showSnackbar({ message: "File deleted", action: { label: "Undo", onAction: handleUndo } });
+ *
+ * // Declarative standalone
+ * <SnackbarProvider>
+ *   <Snackbar message="Saved" severity="default" showClose onClose={() => {}} />
+ * </SnackbarProvider>
+ * ```
+ */
+export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(function Snackbar(
+  {
+    message,
+    supportingText,
+    action,
+    showClose = false,
+    duration = 4000,
+    severity = "default",
+    onClose,
+    className,
+  },
+  ref
+) {
+  const isTwoLine = Boolean(supportingText);
+
+  // Base structural classes (not animation-state-dependent)
+  const baseClassName = cn(snackbarBaseVariants({ twoLine: isTwoLine }), className);
+
+  return (
+    <SnackbarHeadless
+      ref={ref}
+      message={message}
+      {...(supportingText !== undefined && { supportingText })}
+      {...(action !== undefined && { action })}
+      showClose={showClose}
+      duration={duration}
+      severity={severity}
+      {...(onClose !== undefined && { onClose })}
+      className={baseClassName}
+      getAnimationClassName={(state: SnackbarAnimationState) =>
+        snackbarAnimationVariants({ animationState: state })
+      }
+    >
+      {({ onClose: triggerClose }) => (
+        <>
+          {/* Content column: message + optional supporting text */}
+          <div className={snackbarContentVariants()}>
+            <span className={snackbarMessageVariants()}>{message}</span>
+            {supportingText && (
+              <span className={snackbarSupportingTextVariants()}>{supportingText}</span>
+            )}
+          </div>
+
+          {/* Action button — MD3: text variant with inverse-primary color */}
+          {action && (
+            <span className={snackbarActionVariants()}>
+              <Button
+                variant="text"
+                onPress={action.onAction}
+                className="text-inverse-primary hover:text-inverse-primary"
+              >
+                {action.label}
+              </Button>
+            </span>
+          )}
+
+          {/* Close icon button — MD3: standard icon button with inverse-on-surface */}
+          {showClose && (
+            <span className={snackbarCloseVariants()}>
+              <IconButton
+                variant="standard"
+                aria-label="Close"
+                onPress={triggerClose}
+                className="text-inverse-on-surface hover:text-inverse-on-surface"
+              >
+                <CloseIcon />
+              </IconButton>
+            </span>
+          )}
+        </>
+      )}
+    </SnackbarHeadless>
+  );
+});
+
+Snackbar.displayName = "Snackbar";

--- a/packages/react/src/components/Snackbar/Snackbar.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.tsx
@@ -13,9 +13,10 @@ import {
   snackbarSupportingTextVariants,
   snackbarActionVariants,
   snackbarCloseVariants,
+  getEnterDirection,
 } from "./Snackbar.variants";
 import type { SnackbarAnimationState } from "./SnackbarHeadless";
-import type { SnackbarProps } from "./Snackbar.types";
+import type { SnackbarPosition, SnackbarProps } from "./Snackbar.types";
 
 /**
  * Close icon SVG (24dp, MD3 standard close symbol).
@@ -74,6 +75,7 @@ export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(function Snack
     showClose = false,
     duration = 4000,
     severity = "default",
+    position = "bottom-center",
     onClose,
     className,
   },
@@ -81,7 +83,8 @@ export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(function Snack
 ) {
   const isTwoLine = Boolean(supportingText);
 
-  // Base structural classes (not animation-state-dependent)
+  // Base structural classes only — positioning is handled by the stack container
+  // in SnackbarProvider. pointer-events-auto is included in snackbarBaseVariants.
   const baseClassName = cn(snackbarBaseVariants({ twoLine: isTwoLine }), className);
 
   return (
@@ -93,10 +96,11 @@ export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(function Snack
       showClose={showClose}
       duration={duration}
       severity={severity}
+      position={position}
       {...(onClose !== undefined && { onClose })}
       className={baseClassName}
-      getAnimationClassName={(state: SnackbarAnimationState) =>
-        snackbarAnimationVariants({ animationState: state })
+      getAnimationClassName={(state: SnackbarAnimationState, pos: SnackbarPosition) =>
+        snackbarAnimationVariants({ animationState: state, enterDirection: getEnterDirection(pos) })
       }
     >
       {({ onClose: triggerClose }) => (

--- a/packages/react/src/components/Snackbar/Snackbar.types.ts
+++ b/packages/react/src/components/Snackbar/Snackbar.types.ts
@@ -1,0 +1,220 @@
+import type { ReactNode } from "react";
+
+// ─── Severity ────────────────────────────────────────────────────────────────
+
+/**
+ * Severity level of the Snackbar message.
+ *
+ * Controls the ARIA live region role:
+ * - `default` → `role="status" aria-live="polite"` (non-urgent information)
+ * - `error`   → `role="alert"  aria-live="assertive"` (urgent error messages)
+ *
+ * @default 'default'
+ */
+export type SnackbarSeverity = "default" | "error";
+
+// ─── Animation ───────────────────────────────────────────────────────────────
+
+/**
+ * Internal animation state machine for the Snackbar.
+ *
+ * - `entering` → slide-up + fade-in (MD3 entry: short4 / emphasized-decelerate)
+ * - `visible`  → fully shown, auto-dismiss timer running
+ * - `exiting`  → fade-out (MD3 exit: short2 / emphasized-accelerate)
+ * - `exited`   → removed from DOM / queue advanced
+ */
+export type SnackbarAnimationState = "entering" | "visible" | "exiting" | "exited";
+
+// ─── Action ──────────────────────────────────────────────────────────────────
+
+/**
+ * Configuration for the single text action button on the Snackbar.
+ *
+ * @example
+ * ```tsx
+ * action={{ label: "Undo", onAction: () => handleUndo() }}
+ * ```
+ */
+export interface SnackbarAction {
+  /** Visible label for the action button. Also used as the accessible name. */
+  label: string;
+  /** Callback fired when the action button is pressed. */
+  onAction: () => void;
+}
+
+// ─── SnackbarProps ───────────────────────────────────────────────────────────
+
+/**
+ * Props for the MD3 Styled `Snackbar` component (Layer 3).
+ *
+ * Renders one of four MD3 content configurations:
+ * 1. Single-line message only
+ * 2. Two-line (message + supportingText)
+ * 3. Single-line with action button
+ * 4. Single-line with close icon
+ *
+ * @example
+ * ```tsx
+ * // Single-line
+ * <Snackbar message="File deleted" />
+ *
+ * // With action
+ * <Snackbar message="File deleted" action={{ label: "Undo", onAction: handleUndo }} />
+ *
+ * // With close icon
+ * <Snackbar message="Connection lost" showClose onClose={() => {}} />
+ *
+ * // Error severity (assertive announcement)
+ * <Snackbar message="Upload failed" severity="error" />
+ * ```
+ */
+export interface SnackbarProps {
+  /**
+   * Primary message text shown on the Snackbar.
+   * Styled with `text-body-medium`.
+   */
+  message: string;
+
+  /**
+   * Optional supporting text shown below the message (two-line configuration).
+   * Styled with `text-body-medium`.
+   */
+  supportingText?: string;
+
+  /**
+   * Optional text action button configuration.
+   * Action button is styled as `Button variant="text"` with `inverse-primary` color.
+   */
+  action?: SnackbarAction;
+
+  /**
+   * When `true`, renders a close icon button at the trailing end.
+   * @default false
+   */
+  showClose?: boolean;
+
+  /**
+   * Auto-dismiss duration in milliseconds. Set to `0` to disable auto-dismiss.
+   * Timer pauses on pointer hover and keyboard focus.
+   * @default 4000
+   */
+  duration?: number;
+
+  /**
+   * Severity level — controls the ARIA live region role.
+   * @default 'default'
+   */
+  severity?: SnackbarSeverity;
+
+  /**
+   * Callback fired when the Snackbar finishes its exit animation and is removed.
+   * Also fires when the close icon is pressed.
+   */
+  onClose?: () => void;
+
+  /**
+   * Additional CSS classes merged onto the Snackbar container.
+   */
+  className?: string;
+}
+
+// ─── SnackbarHeadlessProps ───────────────────────────────────────────────────
+
+/**
+ * Props for the headless `SnackbarHeadless` primitive (Layer 2).
+ *
+ * Provides all Snackbar behavior (ARIA live region, auto-dismiss timer with
+ * pause/resume, animation state machine) without any visual styling.
+ *
+ * @example
+ * ```tsx
+ * <SnackbarHeadless message="Hello" duration={3000} onClose={dismiss}>
+ *   {({ animationState }) => (
+ *     <div className={animationState === 'visible' ? 'opacity-100' : 'opacity-0'}>
+ *       Hello
+ *     </div>
+ *   )}
+ * </SnackbarHeadless>
+ * ```
+ */
+export interface SnackbarHeadlessProps extends Omit<SnackbarProps, "className"> {
+  /**
+   * Children as a render function receiving the current animation state and
+   * an imperative `onClose` callback to trigger the exit animation, or
+   * static ReactNode content.
+   */
+  children?:
+    | ReactNode
+    | ((state: { animationState: SnackbarAnimationState; onClose: () => void }) => ReactNode);
+
+  /**
+   * Additional CSS classes passed to the container element (base/structural classes).
+   */
+  className?: string;
+
+  /**
+   * Optional callback that returns additional CSS classes based on the current
+   * animation state. Used by the styled `Snackbar` layer to inject CVA
+   * animation variant classes onto the headless container div at render time.
+   *
+   * @example
+   * ```tsx
+   * getAnimationClassName={(state) => snackbarAnimationVariants({ animationState: state })}
+   * ```
+   */
+  getAnimationClassName?: (state: SnackbarAnimationState) => string;
+}
+
+// ─── Queue ───────────────────────────────────────────────────────────────────
+
+/**
+ * Internal queue entry type used by `SnackbarProvider`.
+ * Extends `SnackbarProps` with a unique `id` for queue management.
+ */
+export interface SnackbarItem extends SnackbarProps {
+  /** Unique identifier for this Snackbar instance. */
+  id: string;
+}
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+/**
+ * Value exposed by `SnackbarContext` and consumed via `useSnackbar`.
+ *
+ * @example
+ * ```tsx
+ * const { showSnackbar } = useSnackbar();
+ * showSnackbar({ message: "Saved successfully" });
+ * ```
+ */
+export interface SnackbarContextValue {
+  /**
+   * Enqueue a new Snackbar. Returns the unique id assigned to this item.
+   * Multiple calls are displayed sequentially, not stacked.
+   */
+  showSnackbar: (options: SnackbarProps) => string;
+  /**
+   * Imperatively dismiss the currently displayed Snackbar (triggers exit animation).
+   */
+  closeSnackbar: () => void;
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────────
+
+/**
+ * Props for `SnackbarProvider`.
+ *
+ * Wrap your application (or Storybook decorator) with this provider to enable
+ * the Snackbar queue and portal.
+ *
+ * @example
+ * ```tsx
+ * <SnackbarProvider>
+ *   <App />
+ * </SnackbarProvider>
+ * ```
+ */
+export interface SnackbarProviderProps {
+  /** Application children. */
+  children: ReactNode;
+}

--- a/packages/react/src/components/Snackbar/Snackbar.types.ts
+++ b/packages/react/src/components/Snackbar/Snackbar.types.ts
@@ -1,5 +1,23 @@
 import type { ReactNode } from "react";
 
+// ─── Position ────────────────────────────────────────────────────────────────
+
+/**
+ * Screen position of the Snackbar.
+ *
+ * MD3 default is `bottom-center`. All six positions are supported for
+ * application-specific layout needs (e.g. presence of a FAB or navigation bar).
+ *
+ * @default 'bottom-center'
+ */
+export type SnackbarPosition =
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right";
+
 // ─── Severity ────────────────────────────────────────────────────────────────
 
 /**
@@ -18,10 +36,10 @@ export type SnackbarSeverity = "default" | "error";
 /**
  * Internal animation state machine for the Snackbar.
  *
- * - `entering` → slide-up + fade-in (MD3 entry: short4 / emphasized-decelerate)
- * - `visible`  → fully shown, auto-dismiss timer running
- * - `exiting`  → fade-out (MD3 exit: short2 / emphasized-accelerate)
- * - `exited`   → removed from DOM / queue advanced
+ * - `entering` → zoom-in start: scale-75 + opacity-0 (no duration, paints before transition)
+ * - `visible`  → scale-100 + opacity-100 (medium1 / standard-decelerate = 250ms)
+ * - `exiting`  → scale-75 + opacity-0 (short4 / standard-accelerate = 200ms)
+ * - `exited`   → removed from DOM / stack updated
  */
 export type SnackbarAnimationState = "entering" | "visible" | "exiting" | "exited";
 
@@ -107,6 +125,12 @@ export interface SnackbarProps {
   severity?: SnackbarSeverity;
 
   /**
+   * Screen position of the Snackbar.
+   * @default 'bottom-center'
+   */
+  position?: SnackbarPosition;
+
+  /**
    * Callback fired when the Snackbar finishes its exit animation and is removed.
    * Also fires when the close icon is pressed.
    */
@@ -154,15 +178,17 @@ export interface SnackbarHeadlessProps extends Omit<SnackbarProps, "className"> 
 
   /**
    * Optional callback that returns additional CSS classes based on the current
-   * animation state. Used by the styled `Snackbar` layer to inject CVA
-   * animation variant classes onto the headless container div at render time.
+   * animation state and position. Used by the styled `Snackbar` layer to inject
+   * CVA animation + position variant classes onto the headless container div.
    *
    * @example
    * ```tsx
-   * getAnimationClassName={(state) => snackbarAnimationVariants({ animationState: state })}
+   * getAnimationClassName={(state, pos) =>
+   *   snackbarAnimationVariants({ animationState: state, enterDirection: getEnterDirection(pos) })
+   * }
    * ```
    */
-  getAnimationClassName?: (state: SnackbarAnimationState) => string;
+  getAnimationClassName?: (state: SnackbarAnimationState, position: SnackbarPosition) => string;
 }
 
 // ─── Queue ───────────────────────────────────────────────────────────────────
@@ -189,12 +215,14 @@ export interface SnackbarItem extends SnackbarProps {
  */
 export interface SnackbarContextValue {
   /**
-   * Enqueue a new Snackbar. Returns the unique id assigned to this item.
-   * Multiple calls are displayed sequentially, not stacked.
+   * Show a new Snackbar. Returns the unique id assigned to this item.
+   * Multiple snackbars are displayed simultaneously in a vertical stack,
+   * grouped by their `position` prop. Once the stack reaches `maxVisible`,
+   * additional items wait until existing ones are dismissed.
    */
   showSnackbar: (options: SnackbarProps) => string;
   /**
-   * Imperatively dismiss the currently displayed Snackbar (triggers exit animation).
+   * Imperatively dismiss the oldest currently displayed Snackbar (triggers exit animation).
    */
   closeSnackbar: () => void;
 }
@@ -205,11 +233,16 @@ export interface SnackbarContextValue {
  * Props for `SnackbarProvider`.
  *
  * Wrap your application (or Storybook decorator) with this provider to enable
- * the Snackbar queue and portal.
+ * the Snackbar stack and portal.
  *
  * @example
  * ```tsx
  * <SnackbarProvider>
+ *   <App />
+ * </SnackbarProvider>
+ *
+ * // Limit visible snackbars per position group
+ * <SnackbarProvider maxVisible={3}>
  *   <App />
  * </SnackbarProvider>
  * ```
@@ -217,4 +250,12 @@ export interface SnackbarContextValue {
 export interface SnackbarProviderProps {
   /** Application children. */
   children: ReactNode;
+
+  /**
+   * Maximum number of snackbars visible at once per position group.
+   * Additional snackbars beyond this cap are queued and shown as existing
+   * ones are dismissed.
+   * @default 5
+   */
+  maxVisible?: number;
 }

--- a/packages/react/src/components/Snackbar/Snackbar.variants.ts
+++ b/packages/react/src/components/Snackbar/Snackbar.variants.ts
@@ -1,0 +1,221 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Snackbar Variants (CVA)
+ *
+ * Type-safe variant management using Tailwind CSS classes mapped to MD3 tokens.
+ *
+ * MD3 Specifications:
+ * - Surface color: inverse-surface
+ * - Text color: inverse-on-surface
+ * - Shape: extra-small (4dp) → rounded-xs
+ * - Elevation: level-3 → shadow-elevation-3
+ * - Min width: 288dp → min-w-72
+ * - Max width: 568dp → max-w-snackbar-max
+ * - Position: fixed bottom-4, horizontally centered
+ * - Message text: body-medium
+ * - Action text: label-large, inverse-primary color
+ * - Entry motion: short4 (200ms) + ease-emphasized-decelerate (slide up + fade in)
+ * - Exit motion:  short2 (100ms) + ease-emphasized-accelerate (fade out)
+ */
+
+// ─── Base container (positioning, surface, shape, layout) ────────────────────
+
+/**
+ * Snackbar base container variants — structural, surface, and layout classes.
+ * Split from animation variants so the headless layer can merge its own
+ * animation-state classes at render time.
+ */
+export const snackbarBaseVariants = cva(
+  [
+    // Positioning (portal renders to body; fixed centers at bottom)
+    "fixed",
+    "bottom-4",
+    "left-1/2",
+    "-translate-x-1/2",
+    "z-50",
+
+    // Sizing (MD3 spec: 288dp min, 568dp max)
+    "min-w-72",
+    "max-w-snackbar-max",
+    "w-max",
+
+    // Surface
+    "bg-inverse-surface",
+
+    // Shape: MD3 extra-small corner = 4dp
+    "rounded-xs",
+
+    // Elevation level 3
+    "shadow-elevation-3",
+
+    // Layout
+    "flex",
+    "items-center",
+    "gap-x-2",
+    "px-4",
+
+    // Typography
+    "text-body-medium",
+    "text-inverse-on-surface",
+
+    // Transition (properties used by both entry and exit)
+    "transition-[opacity,transform]",
+    "will-change-[opacity,transform]",
+  ],
+  {
+    variants: {
+      /**
+       * Whether the Snackbar has supporting text (two-line layout).
+       * Adjusts vertical padding to MD3 spec for two-line configuration.
+       */
+      twoLine: {
+        true: "py-4",
+        false: "py-3",
+      },
+    },
+    defaultVariants: {
+      twoLine: false,
+    },
+  }
+);
+
+export type SnackbarBaseVariants = VariantProps<typeof snackbarBaseVariants>;
+
+// ─── Animation state classes ──────────────────────────────────────────────────
+
+/**
+ * Snackbar animation state variants.
+ * Applied by `SnackbarHeadless` based on its internal animation state machine.
+ *
+ * - `entering`: initial mount state — starts below + transparent before rAF
+ * - `visible`:  slide up + fade in (short4 / emphasized-decelerate)
+ * - `exiting`:  fade out (short2 / emphasized-accelerate)
+ * - `exited`:   fully transparent (removed from DOM by provider)
+ */
+export const snackbarAnimationVariants = cva("", {
+  variants: {
+    animationState: {
+      entering: ["translate-y-4", "opacity-0"],
+      visible: ["translate-y-0", "opacity-100", "duration-short4", "ease-emphasized-decelerate"],
+      exiting: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+      exited: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+    },
+  },
+  defaultVariants: {
+    animationState: "entering",
+  },
+});
+
+export type SnackbarAnimationVariants = VariantProps<typeof snackbarAnimationVariants>;
+
+/**
+ * Combined container variants (base + animation) for convenience.
+ * The headless layer uses `snackbarAnimationVariants` directly; this export
+ * is kept for consumers who want the full combined class string without the
+ * render-prop pattern.
+ */
+export const snackbarContainerVariants = cva(
+  [
+    "fixed",
+    "bottom-4",
+    "left-1/2",
+    "-translate-x-1/2",
+    "z-50",
+    "min-w-72",
+    "max-w-snackbar-max",
+    "w-max",
+    "bg-inverse-surface",
+    "rounded-xs",
+    "shadow-elevation-3",
+    "flex",
+    "items-center",
+    "gap-x-2",
+    "px-4",
+    "text-body-medium",
+    "text-inverse-on-surface",
+    "transition-[opacity,transform]",
+    "will-change-[opacity,transform]",
+  ],
+  {
+    variants: {
+      animationState: {
+        entering: ["translate-y-4", "opacity-0"],
+        visible: ["translate-y-0", "opacity-100", "duration-short4", "ease-emphasized-decelerate"],
+        exiting: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+        exited: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+      },
+      twoLine: {
+        true: "py-4",
+        false: "py-3",
+      },
+    },
+    defaultVariants: {
+      animationState: "entering",
+      twoLine: false,
+    },
+  }
+);
+
+export type SnackbarContainerVariants = VariantProps<typeof snackbarContainerVariants>;
+
+// ─── Message ─────────────────────────────────────────────────────────────────
+
+/**
+ * Message text variants.
+ * MD3: body-medium, inverse-on-surface color.
+ */
+export const snackbarMessageVariants = cva([
+  "flex-1",
+  "text-body-medium",
+  "text-inverse-on-surface",
+]);
+
+// ─── Supporting text ─────────────────────────────────────────────────────────
+
+/**
+ * Supporting text variants (two-line configuration).
+ * Same color role as message text per MD3 spec.
+ */
+export const snackbarSupportingTextVariants = cva([
+  "text-body-medium",
+  "text-inverse-on-surface",
+  "opacity-80",
+]);
+
+// ─── Action button wrapper ────────────────────────────────────────────────────
+
+/**
+ * Wrapper applied around the action `Button` to override its color to
+ * `inverse-primary` as required by MD3 Snackbar spec.
+ */
+export const snackbarActionVariants = cva([
+  "shrink-0",
+  // Color override for the nested Button's text — applied via CSS variable
+  // override on the wrapper; the Button(variant="text") reads text color
+  // from the current text color context.
+  "text-inverse-primary",
+]);
+
+// ─── Close icon button wrapper ────────────────────────────────────────────────
+
+/**
+ * Wrapper applied around the close `IconButton` to use `inverse-on-surface`
+ * as required by MD3 Snackbar spec.
+ */
+export const snackbarCloseVariants = cva(["shrink-0", "text-inverse-on-surface"]);
+
+// ─── Text+action layout ───────────────────────────────────────────────────────
+
+/**
+ * Inner content column (message + optional supporting text).
+ */
+export const snackbarContentVariants = cva(["flex", "flex-col", "flex-1", "min-w-0"]);
+
+// ─── Initial hidden state ─────────────────────────────────────────────────────
+
+/**
+ * Classes applied before the enter animation begins (component just mounted).
+ * Positioned off-screen below and transparent.
+ */
+export const snackbarInitialVariants = cva(["translate-y-4", "opacity-0"]);

--- a/packages/react/src/components/Snackbar/Snackbar.variants.ts
+++ b/packages/react/src/components/Snackbar/Snackbar.variants.ts
@@ -12,33 +12,69 @@ import { cva, type VariantProps } from "class-variance-authority";
  * - Elevation: level-3 → shadow-elevation-3
  * - Min width: 288dp → min-w-72
  * - Max width: 568dp → max-w-snackbar-max
- * - Position: fixed bottom-4, horizontally centered
+ * - Default position: fixed bottom-4, horizontally centered
  * - Message text: body-medium
  * - Action text: label-large, inverse-primary color
- * - Entry motion: short4 (200ms) + ease-emphasized-decelerate (slide up + fade in)
- * - Exit motion:  short2 (100ms) + ease-emphasized-accelerate (fade out)
+ * - Entry motion: medium1 (250ms) + ease-emphasized-decelerate (zoom in)
+ * - Exit motion:  short4 (200ms) + ease-standard-accelerate (fade out)
  */
 
-// ─── Base container (positioning, surface, shape, layout) ────────────────────
+// ─── Stack container (fixed viewport anchor, per-position group) ──────────────
+
+/**
+ * Outer wrapper rendered once per active position group by `SnackbarProvider`.
+ * Handles the fixed viewport positioning and stacking direction for all
+ * snackbars sharing the same `position` value.
+ *
+ * - Bottom positions use `flex-col-reverse` so the newest snackbar sits at
+ *   the bottom edge and older ones push upward.
+ * - Top positions use `flex-col` so the newest sits at the top edge and
+ *   older ones push downward.
+ * - `pointer-events-none` on the container lets clicks pass through the gaps
+ *   between snackbars; each snackbar restores `pointer-events-auto`.
+ */
+export const snackbarStackContainerVariants = cva(
+  ["fixed", "z-50", "flex", "gap-2", "pointer-events-none"],
+  {
+    variants: {
+      position: {
+        "bottom-center": [
+          "bottom-4",
+          "left-1/2",
+          "-translate-x-1/2",
+          "flex-col-reverse",
+          "items-center",
+        ],
+        "bottom-left": ["bottom-4", "left-4", "flex-col-reverse", "items-start"],
+        "bottom-right": ["bottom-4", "right-4", "flex-col-reverse", "items-end"],
+        "top-center": ["top-4", "left-1/2", "-translate-x-1/2", "flex-col", "items-center"],
+        "top-left": ["top-4", "left-4", "flex-col", "items-start"],
+        "top-right": ["top-4", "right-4", "flex-col", "items-end"],
+      },
+    },
+    defaultVariants: { position: "bottom-center" },
+  }
+);
+
+export type SnackbarStackContainerVariants = VariantProps<typeof snackbarStackContainerVariants>;
+
+// ─── Base container (surface, shape, layout — no positioning) ─────────────────
 
 /**
  * Snackbar base container variants — structural, surface, and layout classes.
- * Split from animation variants so the headless layer can merge its own
- * animation-state classes at render time.
+ * Positioning is handled by the stack container (`snackbarStackContainerVariants`)
+ * so individual snackbars only carry surface/shape/layout concerns.
  */
 export const snackbarBaseVariants = cva(
   [
-    // Positioning (portal renders to body; fixed centers at bottom)
-    "fixed",
-    "bottom-4",
-    "left-1/2",
-    "-translate-x-1/2",
-    "z-50",
-
     // Sizing (MD3 spec: 288dp min, 568dp max)
     "min-w-72",
     "max-w-snackbar-max",
     "w-max",
+    "min-h-12",
+
+    // Restore pointer events so hover/focus timer pause works
+    "pointer-events-auto",
 
     // Surface
     "bg-inverse-surface",
@@ -52,8 +88,8 @@ export const snackbarBaseVariants = cva(
     // Layout
     "flex",
     "items-center",
-    "gap-x-2",
-    "px-4",
+    "gap-x-1",
+    "pl-4 pr-2",
 
     // Typography
     "text-body-medium",
@@ -70,8 +106,8 @@ export const snackbarBaseVariants = cva(
        * Adjusts vertical padding to MD3 spec for two-line configuration.
        */
       twoLine: {
-        true: "py-4",
-        false: "py-3",
+        true: "py-1",
+        false: "py-1",
       },
     },
     defaultVariants: {
@@ -82,80 +118,118 @@ export const snackbarBaseVariants = cva(
 
 export type SnackbarBaseVariants = VariantProps<typeof snackbarBaseVariants>;
 
+// ─── Position variants ────────────────────────────────────────────────────────
+
+/**
+ * Snackbar screen position variants.
+ *
+ * These classes are now applied to the **stack container** rather than
+ * individual snackbars. Kept as a separate export so standalone (non-provider)
+ * usage of `SnackbarHeadless` can still apply position classes directly.
+ *
+ * MD3 default is `bottom-center`.
+ */
+export const snackbarPositionVariants = cva("", {
+  variants: {
+    position: {
+      "bottom-center": ["bottom-4", "left-1/2", "-translate-x-1/2"],
+      "bottom-left": ["bottom-4", "left-4"],
+      "bottom-right": ["bottom-4", "right-4"],
+      "top-center": ["top-4", "left-1/2", "-translate-x-1/2"],
+      "top-left": ["top-4", "left-4"],
+      "top-right": ["top-4", "right-4"],
+    },
+  },
+  defaultVariants: {
+    position: "bottom-center",
+  },
+});
+
+export type SnackbarPositionVariants = VariantProps<typeof snackbarPositionVariants>;
+
 // ─── Animation state classes ──────────────────────────────────────────────────
 
 /**
  * Snackbar animation state variants.
  * Applied by `SnackbarHeadless` based on its internal animation state machine.
  *
- * - `entering`: initial mount state — starts below + transparent before rAF
- * - `visible`:  slide up + fade in (short4 / emphasized-decelerate)
- * - `exiting`:  fade out (short2 / emphasized-accelerate)
+ * The `enterDirection` sets the transform-origin for the scale animation so the
+ * snackbar appears to grow from the correct viewport edge:
+ * - `up`   (bottom positions): `origin-bottom` — scales up from the bottom edge
+ * - `down` (top positions):    `origin-top`    — scales up from the top edge
+ *
+ * MD3 motion spec (Emphasized easing set — appropriate for high-attention UI entries):
+ * - `entering`: initial mount state — scaled down (75%) + transparent (no duration)
+ * - `visible`:  scale-100 + opacity-100 (medium1 / emphasized-decelerate = 250ms) — zoom in
+ * - `exiting`:  scale-75 + opacity-0 (short4 / standard-accelerate = 200ms) — zoom out
  * - `exited`:   fully transparent (removed from DOM by provider)
+ *
+ * `ease-emphasized-decelerate` (cubic-bezier(0.05, 0.7, 0.1, 1)) is used for entry
+ * instead of `ease-standard-decelerate` (cubic-bezier(0, 0, 0, 1)) because the
+ * standard-decelerate curve has an infinite initial velocity — it snaps to ~50%
+ * progress in the first few milliseconds, making the zoom feel abrupt. The
+ * emphasized-decelerate curve has a finite (but high) initial velocity that
+ * produces a visible, smooth movement from scale-75 to scale-100.
  */
 export const snackbarAnimationVariants = cva("", {
   variants: {
     animationState: {
-      entering: ["translate-y-4", "opacity-0"],
-      visible: ["translate-y-0", "opacity-100", "duration-short4", "ease-emphasized-decelerate"],
-      exiting: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
-      exited: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
+      entering: ["opacity-0", "scale-75"],
+      visible: ["scale-100", "opacity-100", "duration-medium1", "ease-emphasized-decelerate"],
+      exiting: ["scale-75", "opacity-0", "duration-short4", "ease-standard-accelerate"],
+      exited: ["scale-75", "opacity-0", "duration-short4", "ease-standard-accelerate"],
+    },
+    enterDirection: {
+      up: ["origin-bottom"],
+      down: ["origin-top"],
     },
   },
   defaultVariants: {
     animationState: "entering",
+    enterDirection: "up",
   },
 });
 
 export type SnackbarAnimationVariants = VariantProps<typeof snackbarAnimationVariants>;
 
 /**
- * Combined container variants (base + animation) for convenience.
+ * Combined container variants (base + position + animation) for convenience.
  * The headless layer uses `snackbarAnimationVariants` directly; this export
  * is kept for consumers who want the full combined class string without the
- * render-prop pattern.
+ * render-prop pattern (e.g. standalone headless usage outside the provider).
  */
-export const snackbarContainerVariants = cva(
-  [
-    "fixed",
-    "bottom-4",
-    "left-1/2",
-    "-translate-x-1/2",
-    "z-50",
-    "min-w-72",
-    "max-w-snackbar-max",
-    "w-max",
-    "bg-inverse-surface",
-    "rounded-xs",
-    "shadow-elevation-3",
-    "flex",
-    "items-center",
-    "gap-x-2",
-    "px-4",
-    "text-body-medium",
-    "text-inverse-on-surface",
-    "transition-[opacity,transform]",
-    "will-change-[opacity,transform]",
-  ],
-  {
-    variants: {
-      animationState: {
-        entering: ["translate-y-4", "opacity-0"],
-        visible: ["translate-y-0", "opacity-100", "duration-short4", "ease-emphasized-decelerate"],
-        exiting: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
-        exited: ["translate-y-0", "opacity-0", "duration-short2", "ease-emphasized-accelerate"],
-      },
-      twoLine: {
-        true: "py-4",
-        false: "py-3",
-      },
+export const snackbarContainerVariants = cva([...snackbarBaseVariants()], {
+  variants: {
+    animationState: {
+      entering: ["opacity-0", "scale-75"],
+      visible: ["scale-100", "opacity-100", "duration-medium1", "ease-emphasized-decelerate"],
+      exiting: ["scale-75", "opacity-0", "duration-short4", "ease-standard-accelerate"],
+      exited: ["scale-75", "opacity-0", "duration-short4", "ease-standard-accelerate"],
     },
-    defaultVariants: {
-      animationState: "entering",
-      twoLine: false,
+    enterDirection: {
+      up: ["origin-bottom"],
+      down: ["origin-top"],
     },
-  }
-);
+    position: {
+      "bottom-center": ["bottom-4", "left-1/2", "-translate-x-1/2"],
+      "bottom-left": ["bottom-4", "left-4"],
+      "bottom-right": ["bottom-4", "right-4"],
+      "top-center": ["top-4", "left-1/2", "-translate-x-1/2"],
+      "top-left": ["top-4", "left-4"],
+      "top-right": ["top-4", "right-4"],
+    },
+    twoLine: {
+      true: "py-1",
+      false: "py-1",
+    },
+  },
+  defaultVariants: {
+    animationState: "entering",
+    enterDirection: "up",
+    position: "bottom-center",
+    twoLine: false,
+  },
+});
 
 export type SnackbarContainerVariants = VariantProps<typeof snackbarContainerVariants>;
 
@@ -189,13 +263,7 @@ export const snackbarSupportingTextVariants = cva([
  * Wrapper applied around the action `Button` to override its color to
  * `inverse-primary` as required by MD3 Snackbar spec.
  */
-export const snackbarActionVariants = cva([
-  "shrink-0",
-  // Color override for the nested Button's text — applied via CSS variable
-  // override on the wrapper; the Button(variant="text") reads text color
-  // from the current text color context.
-  "text-inverse-primary",
-]);
+export const snackbarActionVariants = cva(["shrink-0", "text-inverse-primary"]);
 
 // ─── Close icon button wrapper ────────────────────────────────────────────────
 
@@ -210,12 +278,22 @@ export const snackbarCloseVariants = cva(["shrink-0", "text-inverse-on-surface"]
 /**
  * Inner content column (message + optional supporting text).
  */
-export const snackbarContentVariants = cva(["flex", "flex-col", "flex-1", "min-w-0"]);
+export const snackbarContentVariants = cva(["flex", "flex-col", "flex-1", "min-w-0 py-2 pr-2"]);
 
 // ─── Initial hidden state ─────────────────────────────────────────────────────
 
 /**
  * Classes applied before the enter animation begins (component just mounted).
- * Positioned off-screen below and transparent.
+ * Scaled down and transparent — the zoom-in entry starts from this state.
  */
-export const snackbarInitialVariants = cva(["translate-y-4", "opacity-0"]);
+export const snackbarInitialVariants = cva(["scale-75", "opacity-0"]);
+
+// ─── Position → direction helper ─────────────────────────────────────────────
+
+/**
+ * Derives the enter animation direction from the Snackbar position.
+ * Bottom positions slide up; top positions slide down.
+ */
+export function getEnterDirection(position: string): "up" | "down" {
+  return position.startsWith("top") ? "down" : "up";
+}

--- a/packages/react/src/components/Snackbar/SnackbarHeadless.tsx
+++ b/packages/react/src/components/Snackbar/SnackbarHeadless.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "../../utils/cn";
+import type { SnackbarAnimationState, SnackbarHeadlessProps } from "./Snackbar.types";
+
+/**
+ * SnackbarHeadless — Layer 2 headless primitive.
+ *
+ * Handles all Snackbar behavior without opinionated visual styling:
+ * - ARIA live region with correct `role`/`aria-live` pairing per severity
+ * - Auto-dismiss timer with configurable `duration`
+ * - Timer pause/resume on pointer hover (`mouseenter`/`mouseleave`) and
+ *   keyboard focus (`focusin`/`focusout`)
+ * - Animation state machine: `entering → visible → exiting → exited`
+ * - Exposes `onClose` imperative trigger via render-prop for close icon/action
+ * - Merges base `className` with animation-state-dependent classes via
+ *   the optional `getAnimationClassName` prop
+ *
+ * No React Aria hook covers Snackbar; ARIA live region patterns follow the
+ * ARIA authoring practices specification for status/alert regions.
+ *
+ * @example
+ * ```tsx
+ * // With render-prop children (typical usage from styled layer)
+ * <SnackbarHeadless
+ *   message="Saved"
+ *   duration={3000}
+ *   onClose={dismiss}
+ *   className={baseClasses}
+ *   getAnimationClassName={(state) => snackbarAnimationVariants({ animationState: state })}
+ * >
+ *   {({ onClose }) => (
+ *     <>
+ *       <span>Saved</span>
+ *       <button onClick={onClose}>Dismiss</button>
+ *     </>
+ *   )}
+ * </SnackbarHeadless>
+ * ```
+ */
+export const SnackbarHeadless = forwardRef<HTMLDivElement, SnackbarHeadlessProps>(
+  function SnackbarHeadless(
+    {
+      message,
+      supportingText,
+      action,
+      showClose,
+      duration = 4000,
+      severity = "default",
+      onClose,
+      children,
+      className,
+      getAnimationClassName,
+    },
+    ref
+  ) {
+    const [animationState, setAnimationState] = useState<SnackbarAnimationState>("entering");
+
+    // Tracks how many ms remain when the timer is paused
+    const remainingRef = useRef<number>(duration);
+    // Tracks wall-clock time when the current timer segment started
+    const startedAtRef = useRef<number>(Date.now());
+    // Active auto-dismiss setTimeout handle (separate from exit fallback)
+    const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Fallback timer for exit animation (fires onClose if onTransitionEnd doesn't)
+    const exitFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Whether the timer is currently paused (hover / focus)
+    const pausedRef = useRef<boolean>(false);
+    // Guard against calling onClose multiple times
+    const closedRef = useRef<boolean>(false);
+
+    const clearDismissTimer = useCallback(() => {
+      if (dismissTimerRef.current !== null) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
+      }
+    }, []);
+
+    const triggerExit = useCallback(() => {
+      if (closedRef.current) return;
+      clearDismissTimer(); // stop auto-dismiss timer
+      setAnimationState("exiting");
+      // Fallback: if onTransitionEnd does not fire (jsdom, reduced-motion,
+      // or CSS transitions disabled), ensure onClose is called after the
+      // exit animation duration (MD3 short2 = 100ms + small buffer).
+      exitFallbackRef.current = setTimeout(() => {
+        if (!closedRef.current) {
+          closedRef.current = true;
+          setAnimationState("exited");
+          onClose?.();
+        }
+      }, 150);
+    }, [clearDismissTimer, onClose]);
+
+    const startDismissTimer = useCallback(
+      (ms: number) => {
+        if (ms <= 0) return;
+        clearDismissTimer();
+        startedAtRef.current = Date.now();
+        dismissTimerRef.current = setTimeout(triggerExit, ms);
+      },
+      [clearDismissTimer, triggerExit]
+    );
+
+    // Entry animation: a zero-delay timer ensures the component is painted
+    // in its initial "entering" state before transitioning to "visible",
+    // allowing CSS transitions to fire. Using setTimeout instead of rAF
+    // ensures compatibility with vi.useFakeTimers() in tests.
+    useEffect(() => {
+      const id = setTimeout(() => {
+        setAnimationState("visible");
+      }, 0);
+      return () => clearTimeout(id);
+    }, []);
+
+    // Start auto-dismiss timer once the component is in `visible` state.
+    useEffect(() => {
+      if (animationState !== "visible") return;
+      if (duration <= 0) return;
+
+      remainingRef.current = duration;
+      startDismissTimer(duration);
+
+      // Only clear the dismiss timer on cleanup (not the exit fallback)
+      return clearDismissTimer;
+    }, [animationState, duration, startDismissTimer, clearDismissTimer]);
+
+    // Cleanup all timers on unmount
+    useEffect(
+      () => () => {
+        clearDismissTimer();
+        if (exitFallbackRef.current !== null) {
+          clearTimeout(exitFallbackRef.current);
+          exitFallbackRef.current = null;
+        }
+      },
+      [clearDismissTimer]
+    );
+
+    // When the exit CSS transition completes, advance to `exited` and fire onClose.
+    // Also cancels the fallback timer since the transition fired properly.
+    const handleTransitionEnd = useCallback(() => {
+      if (animationState === "exiting" && !closedRef.current) {
+        if (exitFallbackRef.current !== null) {
+          clearTimeout(exitFallbackRef.current);
+          exitFallbackRef.current = null;
+        }
+        closedRef.current = true;
+        setAnimationState("exited");
+        onClose?.();
+      }
+    }, [animationState, onClose]);
+
+    // Pause timer on pointer hover ─────────────────────────────────────────────
+
+    const handleMouseEnter = useCallback(() => {
+      if (pausedRef.current || animationState !== "visible") return;
+      pausedRef.current = true;
+      const elapsed = Date.now() - startedAtRef.current;
+      remainingRef.current = Math.max(remainingRef.current - elapsed, 0);
+      clearDismissTimer();
+    }, [animationState, clearDismissTimer]);
+
+    const handleMouseLeave = useCallback(() => {
+      if (!pausedRef.current || animationState !== "visible") return;
+      pausedRef.current = false;
+      if (duration > 0) startDismissTimer(remainingRef.current);
+    }, [animationState, duration, startDismissTimer]);
+
+    // Pause timer on keyboard focus ────────────────────────────────────────────
+
+    const handleFocusIn = useCallback(() => {
+      if (pausedRef.current || animationState !== "visible") return;
+      pausedRef.current = true;
+      const elapsed = Date.now() - startedAtRef.current;
+      remainingRef.current = Math.max(remainingRef.current - elapsed, 0);
+      clearDismissTimer();
+    }, [animationState, clearDismissTimer]);
+
+    const handleFocusOut = useCallback(() => {
+      if (!pausedRef.current || animationState !== "visible") return;
+      pausedRef.current = false;
+      if (duration > 0) startDismissTimer(remainingRef.current);
+    }, [animationState, duration, startDismissTimer]);
+
+    // Imperative close (close icon pressed, action button, programmatic close)
+    const handleClose = useCallback(() => {
+      triggerExit();
+    }, [triggerExit]);
+
+    // ARIA live region attributes per MD3 / ARIA authoring practices spec
+    const ariaProps =
+      severity === "error"
+        ? ({ role: "alert", "aria-live": "assertive", "aria-atomic": "true" } as const)
+        : ({ role: "status", "aria-live": "polite", "aria-atomic": "true" } as const);
+
+    // Merge base className with animation-state-dependent classes
+    const computedClassName = cn(className, getAnimationClassName?.(animationState));
+
+    // Resolve children — render-prop or static ReactNode
+    const childContent =
+      typeof children === "function"
+        ? children({ animationState, onClose: handleClose })
+        : (children ?? (
+            <>
+              <span>{message}</span>
+              {supportingText && <span>{supportingText}</span>}
+              {action && (
+                <button type="button" onClick={action.onAction}>
+                  {action.label}
+                </button>
+              )}
+              {showClose && (
+                <button type="button" aria-label="Close" onClick={handleClose}>
+                  ✕
+                </button>
+              )}
+            </>
+          ));
+
+    return (
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <div
+        ref={ref}
+        className={computedClassName}
+        {...ariaProps}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onFocus={handleFocusIn}
+        onBlur={handleFocusOut}
+        onTransitionEnd={handleTransitionEnd}
+        data-animation-state={animationState}
+      >
+        {childContent}
+      </div>
+    );
+  }
+);
+
+SnackbarHeadless.displayName = "SnackbarHeadless";
+
+export type { SnackbarAnimationState };

--- a/packages/react/src/components/Snackbar/SnackbarHeadless.tsx
+++ b/packages/react/src/components/Snackbar/SnackbarHeadless.tsx
@@ -48,6 +48,7 @@ export const SnackbarHeadless = forwardRef<HTMLDivElement, SnackbarHeadlessProps
       showClose,
       duration = 4000,
       severity = "default",
+      position = "bottom-center",
       onClose,
       children,
       className,
@@ -83,14 +84,14 @@ export const SnackbarHeadless = forwardRef<HTMLDivElement, SnackbarHeadlessProps
       setAnimationState("exiting");
       // Fallback: if onTransitionEnd does not fire (jsdom, reduced-motion,
       // or CSS transitions disabled), ensure onClose is called after the
-      // exit animation duration (MD3 short2 = 100ms + small buffer).
+      // exit animation duration (MD3 short4 = 200ms + small buffer).
       exitFallbackRef.current = setTimeout(() => {
         if (!closedRef.current) {
           closedRef.current = true;
           setAnimationState("exited");
           onClose?.();
         }
-      }, 150);
+      }, 250);
     }, [clearDismissTimer, onClose]);
 
     const startDismissTimer = useCallback(
@@ -103,15 +104,22 @@ export const SnackbarHeadless = forwardRef<HTMLDivElement, SnackbarHeadlessProps
       [clearDismissTimer, triggerExit]
     );
 
-    // Entry animation: a zero-delay timer ensures the component is painted
-    // in its initial "entering" state before transitioning to "visible",
-    // allowing CSS transitions to fire. Using setTimeout instead of rAF
-    // ensures compatibility with vi.useFakeTimers() in tests.
+    // Entry animation: double requestAnimationFrame guarantees the browser
+    // completes at least one full paint cycle with the component in its
+    // "entering" state (scale-75 + opacity-0) before we transition to
+    // "visible" (scale-100 + opacity-100). A single setTimeout(0) is not
+    // reliable — browsers may batch the renders and never paint the initial
+    // state, preventing the CSS zoom-in transition from firing entirely.
+    // With fake timers (vi.useFakeTimers), rAF is faked as setTimeout(~16ms),
+    // so advancing by 32ms in tests fires both frames correctly.
     useEffect(() => {
-      const id = setTimeout(() => {
-        setAnimationState("visible");
-      }, 0);
-      return () => clearTimeout(id);
+      let frameId: number;
+      frameId = requestAnimationFrame(() => {
+        frameId = requestAnimationFrame(() => {
+          setAnimationState("visible");
+        });
+      });
+      return () => cancelAnimationFrame(frameId);
     }, []);
 
     // Start auto-dismiss timer once the component is in `visible` state.
@@ -195,8 +203,8 @@ export const SnackbarHeadless = forwardRef<HTMLDivElement, SnackbarHeadlessProps
         ? ({ role: "alert", "aria-live": "assertive", "aria-atomic": "true" } as const)
         : ({ role: "status", "aria-live": "polite", "aria-atomic": "true" } as const);
 
-    // Merge base className with animation-state-dependent classes
-    const computedClassName = cn(className, getAnimationClassName?.(animationState));
+    // Merge base className with animation-state and position-dependent classes
+    const computedClassName = cn(className, getAnimationClassName?.(animationState, position));
 
     // Resolve children — render-prop or static ReactNode
     const childContent =

--- a/packages/react/src/components/Snackbar/SnackbarProvider.tsx
+++ b/packages/react/src/components/Snackbar/SnackbarProvider.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { createContext, useCallback, useContext, useId, useRef, useState, type JSX } from "react";
+import { createPortal } from "react-dom";
+import { Snackbar } from "./Snackbar";
+import type {
+  SnackbarContextValue,
+  SnackbarItem,
+  SnackbarProps,
+  SnackbarProviderProps,
+} from "./Snackbar.types";
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+/**
+ * React context for the Snackbar queue.
+ * Consumed via the `useSnackbar` hook.
+ */
+export const SnackbarContext = createContext<SnackbarContextValue | null>(null);
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+/**
+ * `useSnackbar` — imperative API for triggering Snackbars.
+ *
+ * Must be called inside a component that is a descendant of `SnackbarProvider`.
+ * Throws a descriptive error in development if used outside the provider.
+ *
+ * @example
+ * ```tsx
+ * const { showSnackbar } = useSnackbar();
+ *
+ * // Single-line
+ * showSnackbar({ message: "File deleted" });
+ *
+ * // With action
+ * showSnackbar({
+ *   message: "File deleted",
+ *   action: { label: "Undo", onAction: () => handleUndo() },
+ * });
+ *
+ * // Error severity (assertive announcement)
+ * showSnackbar({ message: "Upload failed", severity: "error" });
+ * ```
+ */
+export function useSnackbar(): SnackbarContextValue {
+  const ctx = useContext(SnackbarContext);
+  if (!ctx) {
+    throw new Error(
+      "[Snackbar] useSnackbar must be used inside <SnackbarProvider>. " +
+        "Wrap your application (or Storybook decorator) with <SnackbarProvider>."
+    );
+  }
+  return ctx;
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────────
+
+/**
+ * `SnackbarProvider` — context provider, queue manager, and portal host.
+ *
+ * Wrap your application (or Storybook preview) with this component to enable
+ * the Snackbar queue and portal rendering.
+ *
+ * - Multiple `showSnackbar` calls are **queued** and displayed sequentially
+ *   (never stacked) per MD3 spec.
+ * - The active Snackbar is rendered via `createPortal` into `document.body`,
+ *   positioned `fixed bottom-4 left-1/2 -translate-x-1/2` per MD3 spec.
+ *
+ * @example
+ * ```tsx
+ * // Application root
+ * <SnackbarProvider>
+ *   <App />
+ * </SnackbarProvider>
+ *
+ * // Storybook preview.tsx decorator
+ * export const decorators = [
+ *   (Story) => (
+ *     <SnackbarProvider>
+ *       <Story />
+ *     </SnackbarProvider>
+ *   ),
+ * ];
+ * ```
+ */
+export function SnackbarProvider({ children }: SnackbarProviderProps): JSX.Element {
+  const [queue, setQueue] = useState<SnackbarItem[]>([]);
+  // Monotonically increasing counter for unique id generation without hooks
+  const counterRef = useRef<number>(0);
+  const baseId = useId();
+
+  /**
+   * Enqueue a new Snackbar. Returns the assigned id.
+   * If no Snackbar is currently shown, the new item is displayed immediately.
+   * Otherwise it is appended to the queue.
+   */
+  const showSnackbar = useCallback(
+    (options: SnackbarProps): string => {
+      const id = `${baseId}-snackbar-${++counterRef.current}`;
+      setQueue((prev) => [...prev, { ...options, id }]);
+      return id;
+    },
+    [baseId]
+  );
+
+  /**
+   * Imperatively dismiss the currently displayed Snackbar.
+   * Triggers the exit animation; removal happens via the `onClose` callback.
+   */
+  const closeSnackbar = useCallback(() => {
+    setQueue((prev) => {
+      if (prev.length === 0) return prev;
+      // Mark the current item for removal by clearing the queue head.
+      // The Snackbar's own onClose callback (fired after exit animation)
+      // will drive the actual dequeue below.
+      return prev;
+    });
+    // Signal to the active Snackbar to begin its exit animation by removing
+    // it from the queue head — we do this by firing handleClose on the current item.
+    // The onClose callback below handles the actual shift.
+    setQueue((prev) => (prev.length > 0 ? prev.slice(1) : prev));
+  }, []);
+
+  /**
+   * Called by the active Snackbar after its exit animation completes.
+   * Shifts the queue so the next item (if any) is displayed.
+   */
+  const handleCurrentClose = useCallback(() => {
+    setQueue((prev) => prev.slice(1));
+  }, []);
+
+  const contextValue: SnackbarContextValue = { showSnackbar, closeSnackbar };
+
+  // The active Snackbar is always the first item in the queue (if any).
+  const active = queue[0];
+
+  return (
+    <SnackbarContext.Provider value={contextValue}>
+      {children}
+      {active &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <Snackbar
+            key={active.id}
+            message={active.message}
+            {...(active.supportingText !== undefined && { supportingText: active.supportingText })}
+            {...(active.action !== undefined && { action: active.action })}
+            {...(active.showClose !== undefined && { showClose: active.showClose })}
+            {...(active.duration !== undefined && { duration: active.duration })}
+            {...(active.severity !== undefined && { severity: active.severity })}
+            {...(active.className !== undefined && { className: active.className })}
+            onClose={() => {
+              active.onClose?.();
+              handleCurrentClose();
+            }}
+          />,
+          document.body
+        )}
+    </SnackbarContext.Provider>
+  );
+}

--- a/packages/react/src/components/Snackbar/SnackbarProvider.tsx
+++ b/packages/react/src/components/Snackbar/SnackbarProvider.tsx
@@ -1,11 +1,22 @@
 "use client";
 
-import { createContext, useCallback, useContext, useId, useRef, useState, type JSX } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+} from "react";
 import { createPortal } from "react-dom";
 import { Snackbar } from "./Snackbar";
+import { snackbarStackContainerVariants } from "./Snackbar.variants";
 import type {
   SnackbarContextValue,
   SnackbarItem,
+  SnackbarPosition,
   SnackbarProps,
   SnackbarProviderProps,
 } from "./Snackbar.types";
@@ -60,17 +71,27 @@ export function useSnackbar(): SnackbarContextValue {
  * `SnackbarProvider` — context provider, queue manager, and portal host.
  *
  * Wrap your application (or Storybook preview) with this component to enable
- * the Snackbar queue and portal rendering.
+ * the Snackbar stack and portal rendering.
  *
- * - Multiple `showSnackbar` calls are **queued** and displayed sequentially
- *   (never stacked) per MD3 spec.
- * - The active Snackbar is rendered via `createPortal` into `document.body`,
- *   positioned `fixed bottom-4 left-1/2 -translate-x-1/2` per MD3 spec.
+ * - Multiple `showSnackbar` calls are displayed simultaneously in a vertical
+ *   stack, grouped by their `position` prop.
+ * - Each position group is rendered in its own fixed container via `createPortal`
+ *   into `document.body`.
+ * - Bottom positions stack upward (newest at bottom); top positions stack
+ *   downward (newest at top).
+ * - The `maxVisible` prop caps how many snackbars can be visible at once per
+ *   position group. Snackbars beyond the cap are queued and shown as existing
+ *   ones are dismissed.
  *
  * @example
  * ```tsx
  * // Application root
  * <SnackbarProvider>
+ *   <App />
+ * </SnackbarProvider>
+ *
+ * // With custom cap (default is 5)
+ * <SnackbarProvider maxVisible={3}>
  *   <App />
  * </SnackbarProvider>
  *
@@ -84,16 +105,15 @@ export function useSnackbar(): SnackbarContextValue {
  * ];
  * ```
  */
-export function SnackbarProvider({ children }: SnackbarProviderProps): JSX.Element {
+export function SnackbarProvider({ children, maxVisible = 5 }: SnackbarProviderProps): JSX.Element {
   const [queue, setQueue] = useState<SnackbarItem[]>([]);
-  // Monotonically increasing counter for unique id generation without hooks
   const counterRef = useRef<number>(0);
   const baseId = useId();
 
   /**
    * Enqueue a new Snackbar. Returns the assigned id.
-   * If no Snackbar is currently shown, the new item is displayed immediately.
-   * Otherwise it is appended to the queue.
+   * The snackbar is immediately visible if the position group has fewer than
+   * `maxVisible` items currently displayed.
    */
   const showSnackbar = useCallback(
     (options: SnackbarProps): string => {
@@ -105,56 +125,73 @@ export function SnackbarProvider({ children }: SnackbarProviderProps): JSX.Eleme
   );
 
   /**
-   * Imperatively dismiss the currently displayed Snackbar.
-   * Triggers the exit animation; removal happens via the `onClose` callback.
+   * Imperatively dismiss the oldest snackbar across all position groups.
+   * The snackbar's own exit animation plays before it is removed.
    */
   const closeSnackbar = useCallback(() => {
     setQueue((prev) => {
       if (prev.length === 0) return prev;
-      // Mark the current item for removal by clearing the queue head.
-      // The Snackbar's own onClose callback (fired after exit animation)
-      // will drive the actual dequeue below.
-      return prev;
+      return prev.slice(1);
     });
-    // Signal to the active Snackbar to begin its exit animation by removing
-    // it from the queue head — we do this by firing handleClose on the current item.
-    // The onClose callback below handles the actual shift.
-    setQueue((prev) => (prev.length > 0 ? prev.slice(1) : prev));
   }, []);
 
   /**
-   * Called by the active Snackbar after its exit animation completes.
-   * Shifts the queue so the next item (if any) is displayed.
+   * Removes a specific snackbar by id after its exit animation completes.
    */
-  const handleCurrentClose = useCallback(() => {
-    setQueue((prev) => prev.slice(1));
+  const removeById = useCallback((id: string) => {
+    setQueue((prev) => prev.filter((item) => item.id !== id));
   }, []);
 
   const contextValue: SnackbarContextValue = { showSnackbar, closeSnackbar };
 
-  // The active Snackbar is always the first item in the queue (if any).
-  const active = queue[0];
+  // Group visible queue items by position, respecting maxVisible per group.
+  const positionGroups = useMemo(() => {
+    const groups = new Map<SnackbarPosition, SnackbarItem[]>();
+    const countByPosition = new Map<SnackbarPosition, number>();
+
+    for (const item of queue) {
+      const pos: SnackbarPosition = item.position ?? "bottom-center";
+      const count = countByPosition.get(pos) ?? 0;
+      if (count < maxVisible) {
+        const existing = groups.get(pos) ?? [];
+        groups.set(pos, [...existing, item]);
+        countByPosition.set(pos, count + 1);
+      }
+    }
+
+    return groups;
+  }, [queue, maxVisible]);
 
   return (
     <SnackbarContext.Provider value={contextValue}>
       {children}
-      {active &&
-        typeof document !== "undefined" &&
+      {typeof document !== "undefined" &&
         createPortal(
-          <Snackbar
-            key={active.id}
-            message={active.message}
-            {...(active.supportingText !== undefined && { supportingText: active.supportingText })}
-            {...(active.action !== undefined && { action: active.action })}
-            {...(active.showClose !== undefined && { showClose: active.showClose })}
-            {...(active.duration !== undefined && { duration: active.duration })}
-            {...(active.severity !== undefined && { severity: active.severity })}
-            {...(active.className !== undefined && { className: active.className })}
-            onClose={() => {
-              active.onClose?.();
-              handleCurrentClose();
-            }}
-          />,
+          <>
+            {Array.from(positionGroups.entries()).map(([position, items]) => (
+              <div key={position} className={snackbarStackContainerVariants({ position })}>
+                {items.map((item) => (
+                  <Snackbar
+                    key={item.id}
+                    message={item.message}
+                    {...(item.supportingText !== undefined && {
+                      supportingText: item.supportingText,
+                    })}
+                    {...(item.action !== undefined && { action: item.action })}
+                    {...(item.showClose !== undefined && { showClose: item.showClose })}
+                    {...(item.duration !== undefined && { duration: item.duration })}
+                    {...(item.severity !== undefined && { severity: item.severity })}
+                    {...(item.position !== undefined && { position: item.position })}
+                    {...(item.className !== undefined && { className: item.className })}
+                    onClose={() => {
+                      item.onClose?.();
+                      removeById(item.id);
+                    }}
+                  />
+                ))}
+              </div>
+            ))}
+          </>,
           document.body
         )}
     </SnackbarContext.Provider>

--- a/packages/react/src/components/Snackbar/index.ts
+++ b/packages/react/src/components/Snackbar/index.ts
@@ -1,0 +1,35 @@
+// Layer 3: MD3 Styled Component
+export { Snackbar } from "./Snackbar";
+
+// Layer 2: Headless Primitive (for advanced customization)
+export { SnackbarHeadless } from "./SnackbarHeadless";
+export type { SnackbarAnimationState } from "./SnackbarHeadless";
+
+// Provider + Hook (required for imperative queue API)
+export { SnackbarProvider, SnackbarContext, useSnackbar } from "./SnackbarProvider";
+
+// CVA Variants
+export {
+  snackbarBaseVariants,
+  snackbarAnimationVariants,
+  snackbarContainerVariants,
+  snackbarMessageVariants,
+  snackbarSupportingTextVariants,
+  snackbarActionVariants,
+  snackbarCloseVariants,
+  snackbarContentVariants,
+  type SnackbarBaseVariants,
+  type SnackbarAnimationVariants,
+  type SnackbarContainerVariants,
+} from "./Snackbar.variants";
+
+// Types
+export type {
+  SnackbarSeverity,
+  SnackbarProps,
+  SnackbarHeadlessProps,
+  SnackbarAction,
+  SnackbarItem,
+  SnackbarContextValue,
+  SnackbarProviderProps,
+} from "./Snackbar.types";

--- a/packages/react/src/components/Snackbar/index.ts
+++ b/packages/react/src/components/Snackbar/index.ts
@@ -10,22 +10,28 @@ export { SnackbarProvider, SnackbarContext, useSnackbar } from "./SnackbarProvid
 
 // CVA Variants
 export {
+  snackbarStackContainerVariants,
   snackbarBaseVariants,
   snackbarAnimationVariants,
+  snackbarPositionVariants,
   snackbarContainerVariants,
   snackbarMessageVariants,
   snackbarSupportingTextVariants,
   snackbarActionVariants,
   snackbarCloseVariants,
   snackbarContentVariants,
+  getEnterDirection,
+  type SnackbarStackContainerVariants,
   type SnackbarBaseVariants,
   type SnackbarAnimationVariants,
+  type SnackbarPositionVariants,
   type SnackbarContainerVariants,
 } from "./Snackbar.variants";
 
 // Types
 export type {
   SnackbarSeverity,
+  SnackbarPosition,
   SnackbarProps,
   SnackbarHeadlessProps,
   SnackbarAction,

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -82,3 +82,31 @@ export type {
 
 export { Progress, ProgressHeadless } from "./Progress";
 export type { ProgressProps, ProgressHeadlessProps } from "./Progress";
+
+export {
+  MenuTrigger,
+  Menu,
+  MenuItem,
+  MenuSection,
+  MenuDivider,
+  HeadlessMenuTrigger,
+  HeadlessMenu,
+  HeadlessMenuItem,
+  HeadlessMenuSection,
+  HeadlessMenuDivider,
+  MenuContext,
+  useMenuContext,
+} from "./Menu";
+export type {
+  MenuVariant,
+  MenuProps,
+  MenuTriggerProps,
+  MenuItemProps,
+  MenuSectionProps,
+  MenuDividerProps,
+  HeadlessMenuProps,
+  HeadlessMenuTriggerProps,
+  HeadlessMenuItemProps,
+  HeadlessMenuSectionProps,
+  MenuContextValue,
+} from "./Menu";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -79,3 +79,6 @@ export type {
   HeadlessDrawerItemProps,
   DrawerContextValue,
 } from "./Drawer";
+
+export { Progress, ProgressHeadless } from "./Progress";
+export type { ProgressProps, ProgressHeadlessProps } from "./Progress";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -110,3 +110,20 @@ export type {
   HeadlessMenuSectionProps,
   MenuContextValue,
 } from "./Menu";
+
+export {
+  Snackbar,
+  SnackbarHeadless,
+  SnackbarProvider,
+  SnackbarContext,
+  useSnackbar,
+} from "./Snackbar";
+export type {
+  SnackbarProps,
+  SnackbarHeadlessProps,
+  SnackbarProviderProps,
+  SnackbarContextValue,
+  SnackbarSeverity,
+  SnackbarAction,
+  SnackbarItem,
+} from "./Snackbar";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -127,3 +127,23 @@ export type {
   SnackbarAction,
   SnackbarItem,
 } from "./Snackbar";
+
+export {
+  Dialog,
+  DialogHeadline,
+  DialogContent,
+  DialogActions,
+  DialogHeadless,
+  DialogContext,
+  useDialogContext,
+} from "./Dialog";
+export type {
+  DialogVariant,
+  DialogAnimationState,
+  DialogProps,
+  DialogHeadlessProps,
+  DialogHeadlineProps,
+  DialogContentProps,
+  DialogActionsProps,
+  DialogContextValue,
+} from "./Dialog";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -98,7 +98,7 @@ export {
   useMenuContext,
 } from "./Menu";
 export type {
-  MenuVariant,
+  MenuContainerVariants,
   MenuProps,
   MenuTriggerProps,
   MenuItemProps,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -129,3 +129,6 @@ export type {
   HeadlessDrawerItemProps,
   DrawerContextValue,
 } from "./components/Drawer";
+
+export { Progress, ProgressHeadless } from "./components/Progress";
+export type { ProgressProps, ProgressHeadlessProps } from "./components/Progress";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -177,3 +177,23 @@ export type {
   SnackbarAction,
   SnackbarItem,
 } from "./components/Snackbar";
+
+export {
+  Dialog,
+  DialogHeadline,
+  DialogContent,
+  DialogActions,
+  DialogHeadless,
+  DialogContext,
+  useDialogContext,
+} from "./components/Dialog";
+export type {
+  DialogVariant,
+  DialogAnimationState,
+  DialogProps,
+  DialogHeadlessProps,
+  DialogHeadlineProps,
+  DialogContentProps,
+  DialogActionsProps,
+  DialogContextValue,
+} from "./components/Dialog";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -132,3 +132,31 @@ export type {
 
 export { Progress, ProgressHeadless } from "./components/Progress";
 export type { ProgressProps, ProgressHeadlessProps } from "./components/Progress";
+
+export {
+  MenuTrigger,
+  Menu,
+  MenuItem,
+  MenuSection,
+  MenuDivider,
+  HeadlessMenuTrigger,
+  HeadlessMenu,
+  HeadlessMenuItem,
+  HeadlessMenuSection,
+  HeadlessMenuDivider,
+  MenuContext,
+  useMenuContext,
+} from "./components/Menu";
+export type {
+  MenuVariant,
+  MenuProps,
+  MenuTriggerProps,
+  MenuItemProps,
+  MenuSectionProps,
+  MenuDividerProps,
+  HeadlessMenuProps,
+  HeadlessMenuTriggerProps,
+  HeadlessMenuItemProps,
+  HeadlessMenuSectionProps,
+  MenuContextValue,
+} from "./components/Menu";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -160,3 +160,20 @@ export type {
   HeadlessMenuSectionProps,
   MenuContextValue,
 } from "./components/Menu";
+
+export {
+  Snackbar,
+  SnackbarHeadless,
+  SnackbarProvider,
+  SnackbarContext,
+  useSnackbar,
+} from "./components/Snackbar";
+export type {
+  SnackbarProps,
+  SnackbarHeadlessProps,
+  SnackbarProviderProps,
+  SnackbarContextValue,
+  SnackbarSeverity,
+  SnackbarAction,
+  SnackbarItem,
+} from "./components/Snackbar";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -148,7 +148,7 @@ export {
   useMenuContext,
 } from "./components/Menu";
 export type {
-  MenuVariant,
+  MenuContainerVariants,
   MenuProps,
   MenuTriggerProps,
   MenuItemProps,

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -18,6 +18,9 @@
    Base styles for all components (future)
    ========================================================================== */
 
+/* Progress Indicator — indeterminate keyframes */
+@import "./components/Progress/Progress.css";
+
 /* TODO: Component-specific styles will be added here as we build components:
  * - State layers (hover, press, focus states)
  * - Ripple effects

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -21,6 +21,41 @@
 /* Progress Indicator — indeterminate keyframes */
 @import "./components/Progress/Progress.css";
 
+/* ==========================================================================
+   MENU ANIMATIONS
+   MD3 menu enter/exit keyframes — matched to Angular Material's implementation.
+   Enter: scale(0.8) + opacity → full, 120ms cubic-bezier(0, 0, 0.2, 1)
+   Exit:  opacity → 0, 100ms linear (25ms delay)
+   ========================================================================== */
+
+/**
+ * Menu enter: pop from 80% scale + transparent to full size + opaque.
+ * Transform-origin is set placement-aware via data-placement variants in CVA.
+ */
+@keyframes menu-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/**
+ * Menu exit: fade out only (no scale) — matches Angular Material's exit which
+ * only fades without reversing the scale.
+ */
+@keyframes menu-exit {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 /* TODO: Component-specific styles will be added here as we build components:
  * - State layers (hover, press, focus states)
  * - Ripple effects

--- a/packages/react/src/utils/cn.ts
+++ b/packages/react/src/utils/cn.ts
@@ -1,12 +1,57 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+/**
+ * Extended tailwind-merge that understands MD3 custom Tailwind v4 `@theme` utilities.
+ *
+ * By default, `tailwind-merge` treats ALL `text-*` classes as potentially
+ * conflicting. This causes issues with our custom MD3 tokens:
+ * - Typography scale: `text-body-large`, `text-label-medium`, etc. → font-size group
+ * - Color utilities:  `text-on-surface`, `text-primary`, etc.       → text-color group
+ *
+ * We register the typography-scale tokens so `twMerge` knows they live in the
+ * `font-size` group and do NOT conflict with `text-color` utilities.
+ */
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            // MD3 Display scale
+            "display-large",
+            "display-medium",
+            "display-small",
+            // MD3 Headline scale
+            "headline-large",
+            "headline-medium",
+            "headline-small",
+            // MD3 Title scale
+            "title-large",
+            "title-medium",
+            "title-small",
+            // MD3 Body scale
+            "body-large",
+            "body-medium",
+            "body-small",
+            // MD3 Label scale
+            "label-large",
+            "label-medium",
+            "label-small",
+          ],
+        },
+      ],
+    },
+  },
+});
 
 /**
  * Combines and merges Tailwind CSS classes efficiently.
  *
- * This utility uses:
- * - `clsx` for conditional class joining
- * - `tailwind-merge` to properly merge/deduplicate Tailwind classes
+ * Uses `clsx` for conditional joining + extended `tailwind-merge` that is
+ * aware of MD3 typography scale utilities (`text-body-large`, etc.) so they
+ * are not incorrectly removed when merged alongside color utilities
+ * (`text-on-surface`, `text-primary`, etc.).
  *
  * @example
  * ```tsx
@@ -14,10 +59,16 @@ import { twMerge } from "tailwind-merge";
  * // => 'px-2 py-1 bg-blue-500 text-white'
  * ```
  *
- * @example Merging conflicting classes
+ * @example Merging conflicting classes (later wins)
  * ```tsx
  * cn('px-2', 'px-4')
- * // => 'px-4' (later class wins)
+ * // => 'px-4'
+ * ```
+ *
+ * @example MD3 typography + color (both kept — no false conflict)
+ * ```tsx
+ * cn('text-body-large', 'text-on-surface')
+ * // => 'text-body-large text-on-surface'
  * ```
  */
 export function cn(...inputs: ClassValue[]): string {

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinybigui/tokens
 
+## 0.3.0
+
+### Patch Changes
+
+- 7cfb578: Add snackbar stacking with per-position queues and configurable `maxVisible` on `SnackbarProvider`; move layout positioning into the portal stack container; refine enter and exit animations; expose `--spacing-snackbar-max` in token CSS.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/tokens",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Material Design 3 design tokens as CSS variables",
   "keywords": [
     "material-design",

--- a/packages/tokens/src/tokens.css
+++ b/packages/tokens/src/tokens.css
@@ -65,6 +65,11 @@
   /* Scrim */
   --md-sys-color-scrim: #000000;
 
+  /* Inverse */
+  --md-sys-color-inverse-surface: #313033;
+  --md-sys-color-inverse-on-surface: #f4eff4;
+  --md-sys-color-inverse-primary: #d0bcff;
+
   /* ==========================================================================
      TYPOGRAPHY TOKENS
      Material Design 3 Type Scale - 5 categories, 3 sizes each (15 total)
@@ -257,6 +262,11 @@
 
   /* Scrim */
   --md-sys-color-scrim: #000000;
+
+  /* Inverse */
+  --md-sys-color-inverse-surface: #e6e1e5;
+  --md-sys-color-inverse-on-surface: #313033;
+  --md-sys-color-inverse-primary: #6750a4;
 }
 
 /* System/OS dark mode preference (activates when no .light class is present) */
@@ -309,6 +319,11 @@
 
     /* Scrim */
     --md-sys-color-scrim: #000000;
+
+    /* Inverse */
+    --md-sys-color-inverse-surface: #e6e1e5;
+    --md-sys-color-inverse-on-surface: #313033;
+    --md-sys-color-inverse-primary: #6750a4;
   }
 }
 
@@ -382,6 +397,11 @@ body {
 
   /* Scrim color */
   --color-scrim: var(--md-sys-color-scrim);
+
+  /* Inverse colors */
+  --color-inverse-surface: var(--md-sys-color-inverse-surface);
+  --color-inverse-on-surface: var(--md-sys-color-inverse-on-surface);
+  --color-inverse-primary: var(--md-sys-color-inverse-primary);
 
   /* Elevation/Shadow utilities
      Maps MD3 elevation levels to Tailwind box-shadow utilities
@@ -495,6 +515,9 @@ body {
 
   /* Drawer width: MD3 spec = 360dp */
   --spacing-drawer: 22.5rem; /* 360px */
+
+  /* Snackbar max width: MD3 spec = 568dp */
+  --spacing-snackbar-max: 35.5rem; /* 568px */
 
   /* Shape radius utilities for MD3 components */
   --radius-xs: var(--md-sys-shape-corner-extra-small); /* 4px */

--- a/packages/tokens/src/tokens.css
+++ b/packages/tokens/src/tokens.css
@@ -519,6 +519,9 @@ body {
   /* Snackbar max width: MD3 spec = 568dp */
   --spacing-snackbar-max: 35.5rem; /* 568px */
 
+  /* Dialog max width: MD3 spec = 560dp */
+  --spacing-dialog-max: 35rem; /* 560px */
+
   /* Shape radius utilities for MD3 components */
   --radius-xs: var(--md-sys-shape-corner-extra-small); /* 4px */
   --radius-sm: var(--md-sys-shape-corner-small); /* 8px */

--- a/packages/tokens/src/tokens.css
+++ b/packages/tokens/src/tokens.css
@@ -204,6 +204,8 @@
   --md-sys-motion-duration-long4: 600ms;
 
   --md-sys-motion-easing-standard: cubic-bezier(0.2, 0, 0, 1);
+  --md-sys-motion-easing-standard-decelerate: cubic-bezier(0, 0, 0, 1);
+  --md-sys-motion-easing-standard-accelerate: cubic-bezier(0.3, 0, 1, 1);
   --md-sys-motion-easing-emphasized: cubic-bezier(0.2, 0, 0, 1);
   --md-sys-motion-easing-emphasized-decelerate: cubic-bezier(0.05, 0.7, 0.1, 1);
   --md-sys-motion-easing-emphasized-accelerate: cubic-bezier(0.3, 0, 0.8, 0.15);
@@ -503,6 +505,8 @@ body {
      Maps MD3 easing tokens to Tailwind transition-timing-function utilities
      Usage: ease-standard, ease-emphasized, etc. */
   --ease-standard: var(--md-sys-motion-easing-standard);
+  --ease-standard-decelerate: var(--md-sys-motion-easing-standard-decelerate);
+  --ease-standard-accelerate: var(--md-sys-motion-easing-standard-accelerate);
   --ease-emphasized: var(--md-sys-motion-easing-emphasized);
   --ease-emphasized-decelerate: var(--md-sys-motion-easing-emphasized-decelerate);
   --ease-emphasized-accelerate: var(--md-sys-motion-easing-emphasized-accelerate);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@material/material-color-utilities':
         specifier: ^0.3.0
         version: 0.3.0
+      '@react-aria/collections':
+        specifier: ^3.0.1
+        version: 3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/live-announcer':
         specifier: ^3.4.4
         version: 3.4.4


### PR DESCRIPTION
## Release v0.3.0

Merges all Phase 3 feedback component work from \`dev\` into \`main\`.

### New components

- **Progress** — Linear and Circular indicators; determinate/indeterminate modes; `role="progressbar"`; WCAG 2.1 AA
- **Dialog** — Basic and Fullscreen variants; composable headline/content/actions; focus trap; Escape-to-dismiss; React Aria `useDialog`/`useOverlay`
- **Snackbar** — `SnackbarProvider` + `useSnackbar` hook; auto-dismiss; stacked queues; multi-position placement; configurable `maxVisible`; WCAG 2.1 AA live-region
- **Menu** — `MenuTrigger`, `Menu`, `MenuItem`, `MenuSection`, `MenuDivider`, `MenuGap`, `ContextMenuTrigger`, `SubmenuTrigger`; full keyboard navigation; single/multi-select; React Aria collections

### Token changes

- Snackbar spacing token (`--spacing-snackbar-max`) added to `@tinybigui/tokens`

### Versions

- `@tinybigui/react`: 0.2.0 → 0.3.0
- `@tinybigui/tokens`: 0.2.0 → 0.3.0