### PR TITLE
feat(divider): add MD3 Divider component

### DIFF
--- a/.changeset/divider-component.md
+++ b/.changeset/divider-component.md
@@ -1,0 +1,5 @@
+---
+"@tinybigui/react": minor
+---
+
+feat(divider): add MD3 Divider component with horizontal/vertical orientations, inset variants, and subheader label support

--- a/packages/react/src/components/Divider/Divider.stories.tsx
+++ b/packages/react/src/components/Divider/Divider.stories.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Divider } from "./Divider";
 
@@ -439,5 +440,3 @@ export const Playground: Story = {
     },
   },
 };
-
-import type React from "react";

--- a/packages/react/src/components/Divider/Divider.stories.tsx
+++ b/packages/react/src/components/Divider/Divider.stories.tsx
@@ -1,0 +1,443 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Divider } from "./Divider";
+
+const meta: Meta<typeof Divider> = {
+  title: "Components/Divider",
+  component: Divider,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Material Design 3 Divider — a thin line that groups content in lists and containers. " +
+          "Supports horizontal and vertical orientations, four inset variants (none, start, end, both), " +
+          "and an optional subheader label that renders centered text between two rule lines. " +
+          'Built on React Aria `useSeparator` for WCAG-compliant `role="separator"` semantics. ' +
+          "[MD3 spec](https://m3.material.io/components/divider/overview)",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    orientation: {
+      control: "select",
+      options: ["horizontal", "vertical"],
+      description: "Axis of the visual rule. Use `vertical` inside flex rows.",
+      table: { defaultValue: { summary: "horizontal" } },
+    },
+    inset: {
+      control: "select",
+      options: ["none", "start", "end", "both"],
+      description: "Shifts the start and/or end of the rule by 16dp to align with list content.",
+      table: { defaultValue: { summary: "none" } },
+    },
+    label: {
+      control: "text",
+      description:
+        "Subheader label text. When provided, renders centered text between two rule lines.",
+    },
+    className: {
+      control: "text",
+      description: "Additional Tailwind CSS classes.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Divider>;
+
+// ---------------------------------------------------------------------------
+// Default
+// ---------------------------------------------------------------------------
+
+export const Default: Story = {
+  args: {
+    orientation: "horizontal",
+    inset: "none",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Full-bleed horizontal divider with no inset or label. Use the controls panel " +
+          "to explore all prop combinations.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Orientation
+// ---------------------------------------------------------------------------
+
+export const Horizontal: Story = {
+  render: () => (
+    <div className="bg-surface w-80 rounded-lg p-4">
+      <p className="text-on-surface text-body-medium mb-3">Section A</p>
+      <Divider orientation="horizontal" />
+      <p className="text-on-surface text-body-medium mt-3">Section B</p>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Explicit `orientation="horizontal"` separating two text blocks inside a surface container.',
+      },
+    },
+  },
+};
+
+export const Vertical: Story = {
+  render: () => (
+    <div className="bg-surface flex h-16 items-center gap-4 rounded-lg px-4">
+      <p className="text-on-surface text-body-medium">Left content</p>
+      <Divider orientation="vertical" className="h-8" />
+      <p className="text-on-surface text-body-medium">Right content</p>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Vertical divider inside a `flex` row separating two text blocks. " +
+          "Give the divider an explicit height (e.g. `h-8`) so it fills the desired span " +
+          "within the flex container.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Inset variants
+// ---------------------------------------------------------------------------
+
+export const InsetStart: Story = {
+  render: () => (
+    <div className="bg-surface w-80 rounded-lg p-4">
+      <p className="text-on-surface text-body-medium mb-3">List item above</p>
+      <Divider inset="start" />
+      <p className="text-on-surface text-body-medium mt-3">List item below</p>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`inset="start"` adds a 16dp leading margin. Typical use: list rows where an avatar ' +
+          "or icon occupies the leading edge and the divider should align with the text.",
+      },
+    },
+  },
+};
+
+export const InsetEnd: Story = {
+  render: () => (
+    <div className="bg-surface w-80 rounded-lg p-4">
+      <p className="text-on-surface text-body-medium mb-3">List item above</p>
+      <Divider inset="end" />
+      <p className="text-on-surface text-body-medium mt-3">List item below</p>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`inset="end"` adds a 16dp trailing margin, visually associating the rule with content ' +
+          "that stops before the trailing edge.",
+      },
+    },
+  },
+};
+
+export const InsetBoth: Story = {
+  render: () => (
+    <div className="bg-surface w-80 rounded-lg p-4">
+      <p className="text-on-surface text-body-medium mb-3">List item above</p>
+      <Divider inset="both" />
+      <p className="text-on-surface text-body-medium mt-3">List item below</p>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`inset="both"` adds 16dp margins on both ends, centering the rule between the ' +
+          "container edges.",
+      },
+    },
+  },
+};
+
+export const AllInsetVariants: Story = {
+  render: () => (
+    <div className="bg-surface w-80 rounded-lg p-4">
+      {(["none", "start", "end", "both"] as const).map((inset, idx) => (
+        <div key={inset}>
+          {idx > 0 && <div className="mt-4" />}
+          <p className="text-on-surface-variant text-label-small mb-1 tracking-wider uppercase">
+            inset=&quot;{inset}&quot;
+          </p>
+          <Divider inset={inset} />
+          <p className="text-on-surface text-body-small mt-1">Content below</p>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All four inset variants stacked vertically with labels, so you can compare the " +
+          "visual offset side-by-side.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Subheader (labeled) variant
+// ---------------------------------------------------------------------------
+
+export const WithSubheaderLabel: Story = {
+  render: () => (
+    <div className="bg-surface w-80 rounded-lg p-4">
+      <Divider label="Section Title" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When `label` is provided the component renders a subheader divider: the text is " +
+          "centered between two horizontal rule lines, styled with `text-on-surface-variant` " +
+          'and `text-label-large`. The wrapper uses `role="group"` with `aria-label` for ' +
+          "accessible semantics.",
+      },
+    },
+  },
+};
+
+export const SubheaderVariants: Story = {
+  render: () => (
+    <div className="bg-surface w-80 rounded-lg p-6">
+      <p className="text-on-surface text-body-medium mb-4">Starred messages</p>
+      <Divider label="Today" />
+      <p className="text-on-surface text-body-medium my-4">Recent messages</p>
+      <Divider label="Yesterday" />
+      <p className="text-on-surface text-body-medium my-4">Older messages</p>
+      <Divider label="Last week" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Three subheader dividers used as date-group separators in a message list, " +
+          "demonstrating a real-world subheader pattern.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Composition contexts
+// ---------------------------------------------------------------------------
+
+export const InLayoutContext: Story = {
+  render: () => (
+    <div className="bg-surface-container-low shadow-elevation-1 w-96 rounded-xl p-6">
+      <div className="mb-4">
+        <p className="text-on-surface text-title-medium mb-1">Billing address</p>
+        <p className="text-on-surface-variant text-body-medium">
+          123 Main Street, Suite 400
+          <br />
+          San Francisco, CA 94105
+        </p>
+      </div>
+      <Divider />
+      <div className="mt-4">
+        <p className="text-on-surface text-title-medium mb-1">Shipping address</p>
+        <p className="text-on-surface-variant text-body-medium">Same as billing address</p>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Horizontal divider used as a card section separator between two address blocks, " +
+          "a typical use case in checkout or profile screens.",
+      },
+    },
+  },
+};
+
+// Icon primitives for the toolbar story
+const IconBold = (): React.ReactElement => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M15.6 10.79c.97-.67 1.65-1.77 1.65-2.79 0-2.26-1.75-4-4-4H7v14h7.04c2.09 0 3.71-1.7 3.71-3.79 0-1.52-.86-2.82-2.15-3.42zM10 6.5h3c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5h-3v-3zm3.5 9H10v-3h3.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5z" />
+  </svg>
+);
+
+const IconItalic = (): React.ReactElement => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M10 4v3h2.21l-3.42 8H6v3h8v-3h-2.21l3.42-8H18V4z" />
+  </svg>
+);
+
+const IconUnderline = (): React.ReactElement => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 17c3.31 0 6-2.69 6-6V3h-2.5v8c0 1.93-1.57 3.5-3.5 3.5S8.5 12.93 8.5 11V3H6v8c0 3.31 2.69 6 6 6zm-7 2v2h14v-2H5z" />
+  </svg>
+);
+
+const IconAlignLeft = (): React.ReactElement => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M15 15H3v2h12v-2zm0-8H3v2h12V7zM3 13h18v-2H3v2zm0 8h18v-2H3v2zM3 3v2h18V3H3z" />
+  </svg>
+);
+
+const IconLink = (): React.ReactElement => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z" />
+  </svg>
+);
+
+const ToolbarButton = ({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}): React.ReactElement => (
+  <button
+    type="button"
+    aria-label={label}
+    className="text-on-surface-variant hover:bg-on-surface/8 focus-visible:ring-primary flex h-8 w-8 items-center justify-center rounded focus-visible:ring-2 focus-visible:outline-none"
+  >
+    {children}
+  </button>
+);
+
+export const VerticalInToolbar: Story = {
+  render: () => (
+    <div
+      className="bg-surface-container border-outline-variant inline-flex items-center gap-1 rounded-lg border px-2 py-1"
+      role="toolbar"
+      aria-label="Text formatting"
+    >
+      <ToolbarButton label="Bold">
+        <IconBold />
+      </ToolbarButton>
+      <ToolbarButton label="Italic">
+        <IconItalic />
+      </ToolbarButton>
+      <ToolbarButton label="Underline">
+        <IconUnderline />
+      </ToolbarButton>
+      <Divider orientation="vertical" className="mx-1 h-5" />
+      <ToolbarButton label="Align left">
+        <IconAlignLeft />
+      </ToolbarButton>
+      <Divider orientation="vertical" className="mx-1 h-5" />
+      <ToolbarButton label="Insert link">
+        <IconLink />
+      </ToolbarButton>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Vertical dividers separating logical action groups inside a text-formatting toolbar. " +
+          "The divider height is constrained with `h-5` so it stays proportional to the icon buttons.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Light and Dark theme
+// ---------------------------------------------------------------------------
+
+export const LightAndDarkTheme: Story = {
+  render: () => (
+    <div className="flex gap-8">
+      <div className="light bg-surface shadow-elevation-1 w-64 rounded-xl p-6">
+        <p className="text-on-surface text-label-medium mb-3 font-medium">Light theme</p>
+        <Divider />
+        <div className="mt-3 flex h-12 items-center gap-2">
+          <p className="text-on-surface-variant text-body-small flex-1">Left</p>
+          <Divider orientation="vertical" className="h-6" />
+          <p className="text-on-surface-variant text-body-small flex-1">Right</p>
+        </div>
+        <Divider label="Section" />
+      </div>
+      <div className="dark bg-surface shadow-elevation-1 w-64 rounded-xl p-6">
+        <p className="text-on-surface text-label-medium mb-3 font-medium">Dark theme</p>
+        <Divider />
+        <div className="mt-3 flex h-12 items-center gap-2">
+          <p className="text-on-surface-variant text-body-small flex-1">Left</p>
+          <Divider orientation="vertical" className="h-6" />
+          <p className="text-on-surface-variant text-body-small flex-1">Right</p>
+        </div>
+        <Divider label="Section" />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Side-by-side light and dark surface containers, each showing a horizontal divider, " +
+          "a vertical divider inside a flex row, and a labeled subheader divider. " +
+          "Demonstrates that all divider variants adapt correctly to the active theme.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Playground
+// ---------------------------------------------------------------------------
+
+export const Playground: Story = {
+  args: {
+    orientation: "horizontal",
+    inset: "none",
+    label: "",
+    className: "",
+  },
+  render: (args: {
+    orientation?: "horizontal" | "vertical";
+    inset?: "none" | "start" | "end" | "both";
+    label?: string;
+    className?: string;
+  }) => (
+    <div
+      className={`bg-surface rounded-lg p-6 ${args.orientation === "vertical" ? "flex h-24 items-center" : "w-80"}`}
+    >
+      <Divider
+        orientation={args.orientation}
+        inset={args.inset}
+        label={args.label ?? undefined}
+        className={
+          args.orientation === "vertical" ? `h-12 ${args.className ?? ""}` : args.className
+        }
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Fully controllable story — use the controls panel to combine all props and explore " +
+          "every Divider state. The container switches between a flex row (vertical) and a " +
+          "block layout (horizontal) automatically.",
+      },
+    },
+  },
+};
+
+import type React from "react";

--- a/packages/react/src/components/Divider/Divider.test.tsx
+++ b/packages/react/src/components/Divider/Divider.test.tsx
@@ -76,10 +76,11 @@ describe("Divider", () => {
       expect(screen.getByText("Section")).toBeInTheDocument();
     });
 
-    test("label text element has text-on-surface-variant class", () => {
+    test("label text element has text-on-surface-variant and text-label-large classes", () => {
       render(<Divider label="Section" />);
       const labelEl = screen.getByText("Section");
       expect(labelEl).toHaveClass("text-on-surface-variant");
+      expect(labelEl).toHaveClass("text-label-large");
     });
 
     test("with label renders two separator elements plus label span", () => {

--- a/packages/react/src/components/Divider/Divider.test.tsx
+++ b/packages/react/src/components/Divider/Divider.test.tsx
@@ -1,0 +1,159 @@
+import { createRef } from "react";
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe } from "vitest-axe";
+import { Divider } from "./Divider";
+import { DividerHeadless } from "./DividerHeadless";
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe("Divider", () => {
+  describe("Default rendering", () => {
+    test('renders horizontal divider with role="separator" by default', () => {
+      render(<Divider />);
+      expect(screen.getByRole("separator")).toBeInTheDocument();
+    });
+
+    test('renders aria-orientation="horizontal" by default', () => {
+      render(<Divider />);
+      expect(screen.getByRole("separator")).toHaveAttribute("aria-orientation", "horizontal");
+    });
+
+    test('renders aria-orientation="vertical" when orientation="vertical"', () => {
+      render(<Divider orientation="vertical" />);
+      expect(screen.getByRole("separator")).toHaveAttribute("aria-orientation", "vertical");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Orientation classes
+  // ---------------------------------------------------------------------------
+
+  describe("Orientation classes", () => {
+    test("applies border-t for horizontal orientation", () => {
+      render(<Divider />);
+      expect(screen.getByRole("separator")).toHaveClass("border-t");
+    });
+
+    test("applies border-l for vertical orientation", () => {
+      render(<Divider orientation="vertical" />);
+      expect(screen.getByRole("separator")).toHaveClass("border-l");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Inset classes
+  // ---------------------------------------------------------------------------
+
+  describe("Inset variants", () => {
+    test('applies ml-4 when inset="start"', () => {
+      render(<Divider inset="start" />);
+      expect(screen.getByRole("separator")).toHaveClass("ml-4");
+    });
+
+    test('applies mr-4 when inset="end"', () => {
+      render(<Divider inset="end" />);
+      expect(screen.getByRole("separator")).toHaveClass("mr-4");
+    });
+
+    test('applies both ml-4 and mr-4 when inset="both"', () => {
+      render(<Divider inset="both" />);
+      const separator = screen.getByRole("separator");
+      expect(separator).toHaveClass("ml-4");
+      expect(separator).toHaveClass("mr-4");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Label / subheader variant
+  // ---------------------------------------------------------------------------
+
+  describe("Label / subheader variant", () => {
+    test("renders label text when label prop is provided", () => {
+      render(<Divider label="Section" />);
+      expect(screen.getByText("Section")).toBeInTheDocument();
+    });
+
+    test("label text element has text-on-surface-variant class", () => {
+      render(<Divider label="Section" />);
+      const labelEl = screen.getByText("Section");
+      expect(labelEl).toHaveClass("text-on-surface-variant");
+    });
+
+    test("with label renders two separator elements plus label span", () => {
+      render(<Divider label="Section" />);
+      const separators = screen.getAllByRole("separator");
+      expect(separators).toHaveLength(2);
+      expect(screen.getByText("Section").tagName).toBe("SPAN");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // className passthrough
+  // ---------------------------------------------------------------------------
+
+  describe("Custom className", () => {
+    test("accepts and applies custom className to horizontal divider", () => {
+      render(<Divider className="my-custom-class" />);
+      expect(screen.getByRole("separator")).toHaveClass("my-custom-class");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Ref forwarding
+  // ---------------------------------------------------------------------------
+
+  describe("Ref forwarding", () => {
+    test("forwards ref correctly", () => {
+      const ref = createRef<HTMLElement>();
+      render(<Divider ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Accessibility (axe)
+  // ---------------------------------------------------------------------------
+
+  describe("Accessibility", () => {
+    test("axe: no violations for horizontal divider", async () => {
+      const { container } = render(<Divider />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("axe: no violations for vertical divider", async () => {
+      const { container } = render(
+        <div style={{ display: "flex", height: "48px" }}>
+          <Divider orientation="vertical" />
+        </div>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("axe: no violations for labeled divider", async () => {
+      const { container } = render(<Divider label="Section" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DividerHeadless — layer 2 primitive tests
+// ---------------------------------------------------------------------------
+
+describe("DividerHeadless", () => {
+  test("renders an hr element for horizontal orientation", () => {
+    render(<DividerHeadless />);
+    expect(screen.getByRole("separator").tagName).toBe("HR");
+  });
+
+  test("renders a div element for vertical orientation", () => {
+    render(<DividerHeadless orientation="vertical" />);
+    expect(screen.getByRole("separator").tagName).toBe("DIV");
+  });
+});

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { forwardRef } from "react";
+
+import { cn } from "../../utils/cn";
+import { DividerHeadless } from "./DividerHeadless";
+import { dividerVariants } from "./Divider.variants";
+import type { DividerProps } from "./Divider.types";
+
+/**
+ * Divider — MD3 Styled Component (Layer 3)
+ *
+ * A thin rule that separates content in lists and containers.
+ * Supports horizontal/vertical orientations, inset variants, and an
+ * optional subheader label that renders the text centered between two rules.
+ *
+ * Built on `DividerHeadless` (React Aria `useSeparator`) for accessible
+ * ARIA semantics. Uses CVA variants mapped to MD3 design tokens.
+ *
+ * @example
+ * ```tsx
+ * // Full-bleed horizontal divider
+ * <Divider />
+ *
+ * // Inset from the start (16dp)
+ * <Divider inset="start" />
+ *
+ * // Vertical divider inside a flex row
+ * <Divider orientation="vertical" />
+ *
+ * // Subheader divider
+ * <Divider label="Section Title" />
+ * ```
+ */
+export const Divider = forwardRef<HTMLElement, DividerProps>(
+  ({ orientation = "horizontal", inset = "none", label, className }, ref) => {
+    if (label) {
+      return (
+        <div
+          ref={ref as React.ForwardedRef<HTMLDivElement>}
+          role="group"
+          aria-label={label}
+          className={cn("flex items-center gap-4", className)}
+        >
+          <DividerHeadless
+            orientation="horizontal"
+            className={cn(dividerVariants({ orientation: "horizontal", inset: "none" }), "flex-1")}
+          />
+          <span className="text-on-surface-variant text-label-large whitespace-nowrap">
+            {label}
+          </span>
+          <DividerHeadless
+            orientation="horizontal"
+            className={cn(dividerVariants({ orientation: "horizontal", inset: "none" }), "flex-1")}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <DividerHeadless
+        ref={ref}
+        orientation={orientation}
+        className={cn(dividerVariants({ orientation, inset }), className)}
+      />
+    );
+  }
+);
+
+Divider.displayName = "Divider";

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { forwardRef } from "react";
+import type { ForwardedRef } from "react";
 
 import { cn } from "../../utils/cn";
 import { DividerHeadless } from "./DividerHeadless";
@@ -37,7 +38,7 @@ export const Divider = forwardRef<HTMLElement, DividerProps>(
     if (label) {
       return (
         <div
-          ref={ref as React.ForwardedRef<HTMLDivElement>}
+          ref={ref as ForwardedRef<HTMLDivElement>}
           role="group"
           aria-label={label}
           className={cn("flex items-center gap-4", className)}

--- a/packages/react/src/components/Divider/Divider.types.ts
+++ b/packages/react/src/components/Divider/Divider.types.ts
@@ -1,0 +1,100 @@
+import type React from "react";
+
+/**
+ * Divider orientation — controls the axis of the visual rule.
+ * @default 'horizontal'
+ */
+export type DividerOrientation = "horizontal" | "vertical";
+
+/**
+ * Divider inset — controls which end(s) of the rule are inset by 16dp.
+ * Per MD3 spec: insets create visual association with list content.
+ * @default 'none'
+ */
+export type DividerInset = "none" | "start" | "end" | "both";
+
+/**
+ * Material Design 3 Divider Component Props
+ *
+ * A thin line that groups content in lists and containers.
+ * Supports horizontal/vertical orientations, inset variants, and a
+ * subheader label variant.
+ *
+ * @example
+ * ```tsx
+ * // Full-bleed horizontal divider (default)
+ * <Divider />
+ *
+ * // Inset divider (16dp from start)
+ * <Divider inset="start" />
+ *
+ * // Vertical divider
+ * <Divider orientation="vertical" />
+ *
+ * // Subheader / labeled divider
+ * <Divider label="Section Title" />
+ * ```
+ */
+export interface DividerProps {
+  /**
+   * Orientation of the divider rule.
+   * @default 'horizontal'
+   */
+  orientation?: DividerOrientation;
+
+  /**
+   * Inset — shifts the start and/or end of the rule by 16dp.
+   * @default 'none'
+   */
+  inset?: DividerInset;
+
+  /**
+   * When provided, renders a subheader (labeled) divider with the text
+   * centered between two rule lines.
+   */
+  label?: string;
+
+  /**
+   * Additional Tailwind CSS classes.
+   */
+  className?: string;
+}
+
+/**
+ * Props for the headless Divider primitive.
+ *
+ * Renders an unstyled separator element using React Aria's `useSeparator`
+ * hook. Bring your own styles via `className`.
+ *
+ * @example
+ * ```tsx
+ * <DividerHeadless
+ *   orientation="horizontal"
+ *   className="border-t border-outline-variant w-full"
+ * />
+ * ```
+ */
+export interface DividerHeadlessProps {
+  /**
+   * Orientation passed to `useSeparator` for correct ARIA semantics.
+   * @default 'horizontal'
+   */
+  orientation?: DividerOrientation;
+
+  /**
+   * Additional Tailwind CSS classes.
+   */
+  className?: string;
+
+  /**
+   * Subheader label text. Declared for interface completeness;
+   * rendering is handled by the styled `Divider` layer.
+   */
+  label?: string;
+
+  /**
+   * Child content. Declared for interface extensibility;
+   * the headless primitive itself is a void/leaf element.
+   */
+  children?: React.ReactNode;
+}

--- a/packages/react/src/components/Divider/Divider.variants.ts
+++ b/packages/react/src/components/Divider/Divider.variants.ts
@@ -1,0 +1,52 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Divider Variants (CVA)
+ *
+ * Defines orientation and inset variants for the Divider component.
+ * All classes use MD3 design token utilities — no arbitrary values.
+ *
+ * Orientation:
+ *   horizontal — 1px top border, spans full width
+ *   vertical   — 1px left border, spans full height (self-stretch in flex)
+ *
+ * Inset (MD3 spec: 16dp offset):
+ *   start — ml-4 (indented from the leading edge)
+ *   end   — mr-4 (indented from the trailing edge)
+ *   both  — ml-4 mr-4 (indented from both edges)
+ */
+export const dividerVariants = cva(
+  // Base: always apply the MD3 outline-variant color to the border
+  "border-outline-variant",
+  {
+    variants: {
+      /**
+       * Controls the axis of the visual rule.
+       */
+      orientation: {
+        horizontal: "border-t w-full",
+        vertical: "border-l h-full self-stretch",
+      },
+
+      /**
+       * Inset — which end(s) are offset by 16dp per MD3 spec.
+       */
+      inset: {
+        none: "",
+        start: "ml-4",
+        end: "mr-4",
+        both: "ml-4 mr-4",
+      },
+    },
+
+    defaultVariants: {
+      orientation: "horizontal",
+      inset: "none",
+    },
+  }
+);
+
+/**
+ * Inferred CVA variant prop types for the Divider component.
+ */
+export type DividerVariants = VariantProps<typeof dividerVariants>;

--- a/packages/react/src/components/Divider/DividerHeadless.tsx
+++ b/packages/react/src/components/Divider/DividerHeadless.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { forwardRef } from "react";
+import type { ForwardedRef } from "react";
 import { useSeparator } from "react-aria";
 
 import type { DividerHeadlessProps } from "./Divider.types";
@@ -34,11 +35,7 @@ export const DividerHeadless = forwardRef<HTMLElement, DividerHeadlessProps>(
 
     if (orientation === "vertical") {
       return (
-        <div
-          {...separatorProps}
-          ref={ref as React.ForwardedRef<HTMLDivElement>}
-          className={className}
-        />
+        <div {...separatorProps} ref={ref as ForwardedRef<HTMLDivElement>} className={className} />
       );
     }
 
@@ -46,7 +43,7 @@ export const DividerHeadless = forwardRef<HTMLElement, DividerHeadlessProps>(
       <hr
         {...separatorProps}
         aria-orientation="horizontal"
-        ref={ref as React.ForwardedRef<HTMLHRElement>}
+        ref={ref as ForwardedRef<HTMLHRElement>}
         className={className}
       />
     );

--- a/packages/react/src/components/Divider/DividerHeadless.tsx
+++ b/packages/react/src/components/Divider/DividerHeadless.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { forwardRef } from "react";
+import { useSeparator } from "react-aria";
+
+import type { DividerHeadlessProps } from "./Divider.types";
+
+/**
+ * DividerHeadless — Layer 2 unstyled separator primitive.
+ *
+ * Uses React Aria's `useSeparator` hook to attach the correct
+ * `role="separator"` and `aria-orientation` attributes.
+ *
+ * - Horizontal → renders `<hr>` (implicit ARIA separator role)
+ * - Vertical   → renders `<div>` with explicit `role="separator"`
+ *
+ * Bring your own styles via the `className` prop.
+ *
+ * @example
+ * ```tsx
+ * // Used inside the styled Divider, or directly for custom styling:
+ * <DividerHeadless
+ *   orientation="horizontal"
+ *   className="border-t border-outline-variant w-full"
+ * />
+ * ```
+ */
+export const DividerHeadless = forwardRef<HTMLElement, DividerHeadlessProps>(
+  ({ orientation = "horizontal", className }, ref) => {
+    const { separatorProps } = useSeparator({
+      orientation,
+      elementType: orientation === "vertical" ? "div" : "hr",
+    });
+
+    if (orientation === "vertical") {
+      return (
+        <div
+          {...separatorProps}
+          ref={ref as React.ForwardedRef<HTMLDivElement>}
+          className={className}
+        />
+      );
+    }
+
+    return (
+      <hr
+        {...separatorProps}
+        aria-orientation="horizontal"
+        ref={ref as React.ForwardedRef<HTMLHRElement>}
+        className={className}
+      />
+    );
+  }
+);
+
+DividerHeadless.displayName = "DividerHeadless";

--- a/packages/react/src/components/Divider/index.ts
+++ b/packages/react/src/components/Divider/index.ts
@@ -1,0 +1,16 @@
+// Layer 3: MD3 Styled Component (most users use this)
+export { Divider } from "./Divider";
+
+// Layer 2: Headless Component (for advanced customization)
+export { DividerHeadless } from "./DividerHeadless";
+
+// CVA Variants
+export { dividerVariants, type DividerVariants } from "./Divider.variants";
+
+// Types
+export type {
+  DividerProps,
+  DividerHeadlessProps,
+  DividerOrientation,
+  DividerInset,
+} from "./Divider.types";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -83,12 +83,13 @@ export type {
 export { Progress, ProgressHeadless } from "./Progress";
 export type { ProgressProps, ProgressHeadlessProps } from "./Progress";
 
-export { Divider, DividerHeadless } from "./Divider";
+export { Divider, DividerHeadless, dividerVariants } from "./Divider";
 export type {
   DividerProps,
   DividerHeadlessProps,
   DividerOrientation,
   DividerInset,
+  DividerVariants,
 } from "./Divider";
 
 export {

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -83,6 +83,14 @@ export type {
 export { Progress, ProgressHeadless } from "./Progress";
 export type { ProgressProps, ProgressHeadlessProps } from "./Progress";
 
+export { Divider, DividerHeadless } from "./Divider";
+export type {
+  DividerProps,
+  DividerHeadlessProps,
+  DividerOrientation,
+  DividerInset,
+} from "./Divider";
+
 export {
   MenuTrigger,
   Menu,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -151,12 +151,13 @@ export type {
 export { Progress, ProgressHeadless } from "./components/Progress";
 export type { ProgressProps, ProgressHeadlessProps } from "./components/Progress";
 
-export { Divider, DividerHeadless } from "./components/Divider";
+export { Divider, DividerHeadless, dividerVariants } from "./components/Divider";
 export type {
   DividerProps,
   DividerHeadlessProps,
   DividerOrientation,
   DividerInset,
+  DividerVariants,
 } from "./components/Divider";
 
 export {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -151,6 +151,14 @@ export type {
 export { Progress, ProgressHeadless } from "./components/Progress";
 export type { ProgressProps, ProgressHeadlessProps } from "./components/Progress";
 
+export { Divider, DividerHeadless } from "./components/Divider";
+export type {
+  DividerProps,
+  DividerHeadlessProps,
+  DividerOrientation,
+  DividerInset,
+} from "./components/Divider";
+
 export {
   MenuTrigger,
   Menu,


### PR DESCRIPTION
## Summary

Adds the MD3 Divider component to `@tinybigui/react`.

### What's included

- `Divider` — MD3 styled component with `orientation`, `inset`, and `label` props
- `DividerHeadless` — Headless primitive using `useSeparator` from react-aria
- `dividerVariants` — CVA variant definitions (orientation, inset)
- Full TypeScript types: `DividerProps`, `DividerHeadlessProps`, `DividerOrientation`, `DividerInset`
- Comprehensive test suite (16 tests, axe accessibility checks)
- Storybook stories (13 stories covering all variants and layout contexts)

### MD3 Compliance

- Horizontal: 1dp `border-t`, `border-outline-variant` color
- Vertical: 1dp `border-l`, `border-outline-variant` color
- Inset: 16dp offset via `ml-4` / `mr-4`
- Subheader label: `text-on-surface-variant`, `text-label-large`
- Static/non-interactive — no animations per MD3 spec

### Accessibility

- `role="separator"` via React Aria `useSeparator`
- `aria-orientation` set correctly for both orientations
- Subheader label readable by screen readers
- WCAG 2.1 AA compliant

### Test results

- `pnpm lint` — ✅ zero errors
- `pnpm typecheck` — ✅ zero type errors
- `pnpm test` — ✅ all tests passing (1022 tests, 20 test files)
- `pnpm build` — ✅ build successful