### PR TITLE
feat(list): add MD3 List component

### DIFF
--- a/.changeset/list-component.md
+++ b/.changeset/list-component.md
@@ -1,0 +1,5 @@
+---
+"@tinybigui/react": minor
+---
+
+feat(list): add MD3 List component with static and interactive modes, slot-based sub-components, selection management, and Divider integration

--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -1,0 +1,931 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type React from "react";
+import { useState } from "react";
+import type { Selection } from "react-stately";
+import { Checkbox } from "../Checkbox";
+import { List, ListItem } from "./index";
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+const IconWifi = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M1 9l2 2c4.97-4.97 13.03-4.97 18 0l2-2C16.93 2.93 7.08 2.93 1 9zm8 8l3 3 3-3a4.237 4.237 0 00-6 0zm-4-4l2 2a7.074 7.074 0 0110 0l2-2C15.14 9.14 8.87 9.14 5 13z" />
+  </svg>
+);
+
+const IconBluetooth = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M17.71 7.71L12 2h-1v7.59L6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 11 14.41V22h1l5.71-5.71-4.3-4.29 4.3-4.29zM13 5.83l1.88 1.88L13 9.59V5.83zm1.88 10.46L13 18.17v-3.76l1.88 1.88z" />
+  </svg>
+);
+
+const IconNotifications = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z" />
+  </svg>
+);
+
+const IconDisplay = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h5v2h8v-2h5c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h18v14z" />
+  </svg>
+);
+
+const IconSecurity = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 4l5 2.18V11c0 3.5-2.33 6.79-5 7.93-2.67-1.14-5-4.43-5-7.93V7.18L12 5z" />
+  </svg>
+);
+
+const IconChevronRight = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" />
+  </svg>
+);
+
+const IconMoreVert = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+  </svg>
+);
+
+const IconPerson = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+  </svg>
+);
+
+const IconMail = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
+  </svg>
+);
+
+const IconShare = (): React.ReactElement => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
+  </svg>
+);
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof List> = {
+  title: "Components/List",
+  component: List,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Material Design 3 List component for displaying vertically arranged items. Supports static and interactive modes with single/multiple selection, leading/trailing slots, and dividers. [MD3 Spec](https://m3.material.io/components/lists/overview)",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    selectionMode: {
+      control: "select",
+      options: ["none", "single", "multiple"],
+      description: "Controls whether items are selectable and how many can be active at once",
+    },
+    showDividers: {
+      control: "boolean",
+      description: "Renders full-width dividers between items using `border-outline-variant`",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof List>;
+
+// ─── Static density stories ───────────────────────────────────────────────────
+
+export const Default: Story = {
+  args: {
+    "aria-label": "Default list",
+  },
+  render: (args) => (
+    <List {...args}>
+      <ListItem value="item-1" headline="List item one" />
+      <ListItem value="item-2" headline="List item two" />
+      <ListItem value="item-3" headline="List item three" />
+    </List>
+  ),
+};
+
+export const OneLine: Story = {
+  render: () => (
+    <List aria-label="One-line list">
+      <ListItem value="wifi" headline="Wi-Fi" />
+      <ListItem value="bluetooth" headline="Bluetooth" />
+      <ListItem value="notifications" headline="Notifications" />
+      <ListItem value="display" headline="Display" />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "One-line density — headline only. Minimum height 56dp per MD3 spec.",
+      },
+    },
+  },
+};
+
+export const TwoLine: Story = {
+  render: () => (
+    <List aria-label="Two-line list">
+      <ListItem value="wifi" headline="Wi-Fi" supportingText="Connected to Home Network" />
+      <ListItem value="bluetooth" headline="Bluetooth" supportingText="3 devices connected" />
+      <ListItem
+        value="notifications"
+        headline="Notifications"
+        supportingText="Banners and alerts"
+      />
+      <ListItem value="display" headline="Display" supportingText="Brightness, font size" />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Two-line density — headline + supportingText. Minimum height 72dp per MD3 spec.",
+      },
+    },
+  },
+};
+
+export const ThreeLine: Story = {
+  render: () => (
+    <List aria-label="Three-line list">
+      <ListItem
+        value="wifi"
+        overline="Network"
+        headline="Wi-Fi"
+        supportingText="Connected to Home Network"
+      />
+      <ListItem
+        value="bluetooth"
+        overline="Devices"
+        headline="Bluetooth"
+        supportingText="3 devices connected"
+      />
+      <ListItem
+        value="notifications"
+        overline="Alerts"
+        headline="Notifications"
+        supportingText="Banners, badges, and alerts"
+      />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Three-line density — overline + headline + supportingText. Minimum height 88dp per MD3 spec. Leading/trailing slots top-align.",
+      },
+    },
+  },
+};
+
+export const AllDensities: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-full">
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <div className="flex gap-4">
+      <div className="w-56">
+        <p className="text-label-medium text-on-surface-variant mb-2">One-line</p>
+        <List aria-label="One-line density">
+          <ListItem value="a" headline="Headline" />
+          <ListItem value="b" headline="Headline" />
+        </List>
+      </div>
+      <div className="w-56">
+        <p className="text-label-medium text-on-surface-variant mb-2">Two-line</p>
+        <List aria-label="Two-line density">
+          <ListItem value="a" headline="Headline" supportingText="Supporting text" />
+          <ListItem value="b" headline="Headline" supportingText="Supporting text" />
+        </List>
+      </div>
+      <div className="w-56">
+        <p className="text-label-medium text-on-surface-variant mb-2">Three-line</p>
+        <List aria-label="Three-line density">
+          <ListItem
+            value="a"
+            overline="Overline"
+            headline="Headline"
+            supportingText="Supporting text"
+          />
+          <ListItem
+            value="b"
+            overline="Overline"
+            headline="Headline"
+            supportingText="Supporting text"
+          />
+        </List>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        story: "Side-by-side comparison of all three density levels derived from content.",
+      },
+    },
+  },
+};
+
+// ─── Leading slot stories ─────────────────────────────────────────────────────
+
+export const WithLeadingIcon: Story = {
+  render: () => (
+    <List aria-label="Settings">
+      <ListItem
+        value="wifi"
+        headline="Wi-Fi"
+        supportingText="Connected"
+        leadingType="icon"
+        leadingSlot={<IconWifi />}
+      />
+      <ListItem
+        value="bluetooth"
+        headline="Bluetooth"
+        supportingText="3 devices"
+        leadingType="icon"
+        leadingSlot={<IconBluetooth />}
+      />
+      <ListItem
+        value="notifications"
+        headline="Notifications"
+        leadingType="icon"
+        leadingSlot={<IconNotifications />}
+      />
+      <ListItem
+        value="display"
+        headline="Display"
+        leadingType="icon"
+        leadingSlot={<IconDisplay />}
+      />
+    </List>
+  ),
+};
+
+export const WithLeadingAvatar: Story = {
+  render: () => (
+    <List aria-label="Contacts">
+      <ListItem
+        value="alice"
+        headline="Alice Johnson"
+        supportingText="alice@example.com"
+        leadingType="avatar"
+        leadingSlot={
+          <div className="bg-primary text-on-primary flex size-full items-center justify-center text-sm font-medium">
+            AJ
+          </div>
+        }
+      />
+      <ListItem
+        value="bob"
+        headline="Bob Smith"
+        supportingText="bob@example.com"
+        leadingType="avatar"
+        leadingSlot={
+          <div className="bg-secondary text-on-secondary flex size-full items-center justify-center text-sm font-medium">
+            BS
+          </div>
+        }
+      />
+      <ListItem
+        value="carol"
+        headline="Carol White"
+        supportingText="carol@example.com"
+        leadingType="avatar"
+        leadingSlot={
+          <div className="bg-tertiary text-on-tertiary flex size-full items-center justify-center text-sm font-medium">
+            CW
+          </div>
+        }
+      />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Avatar type applies `size-10 overflow-hidden rounded-full` to the leading container. Pass any element — `<div>` with initials, or `<img>` — as the `leadingSlot`.",
+      },
+    },
+  },
+};
+
+// ─── Trailing slot stories ────────────────────────────────────────────────────
+
+export const WithTrailingIcon: Story = {
+  render: () => (
+    <List aria-label="Navigation">
+      <ListItem
+        value="profile"
+        headline="Profile"
+        trailingType="icon"
+        trailingSlot={<IconChevronRight />}
+      />
+      <ListItem
+        value="settings"
+        headline="Settings"
+        trailingType="icon"
+        trailingSlot={<IconChevronRight />}
+      />
+      <ListItem
+        value="more"
+        headline="More options"
+        trailingType="icon"
+        trailingSlot={<IconMoreVert />}
+      />
+    </List>
+  ),
+};
+
+export const WithTrailingText: Story = {
+  render: () => (
+    <List aria-label="Messages">
+      <ListItem
+        value="msg-1"
+        headline="Alice Johnson"
+        supportingText="Hey, are you free tonight?"
+        trailingType="text"
+        trailingSlot={<span>2 min</span>}
+      />
+      <ListItem
+        value="msg-2"
+        headline="Bob Smith"
+        supportingText="The meeting has been moved."
+        trailingType="text"
+        trailingSlot={<span>1 hr</span>}
+      />
+      <ListItem
+        value="msg-3"
+        headline="Team Announcements"
+        supportingText="New office policy update."
+        trailingType="text"
+        trailingSlot={<span>Yesterday</span>}
+      />
+      <ListItem
+        value="msg-4"
+        headline="Carol White"
+        supportingText="Thanks for your help!"
+        trailingType="text"
+        trailingSlot={<span>Mon</span>}
+      />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Trailing `text` type renders meta content (e.g. timestamps) styled with `text-label-small text-on-surface-variant`.",
+      },
+    },
+  },
+};
+
+// ─── Interactive selection stories ───────────────────────────────────────────
+
+const WithLeadingCheckboxExample = (): React.ReactElement => {
+  const [selected, setSelected] = useState<Selection>(new Set<string>());
+
+  const isChecked = (key: string): boolean => {
+    if (selected === "all") return true;
+    return (selected as Set<string>).has(key);
+  };
+
+  return (
+    <List
+      aria-label="Task list"
+      selectionMode="multiple"
+      selectedKeys={selected}
+      onSelectionChange={setSelected}
+    >
+      <ListItem
+        value="task-1"
+        headline="Send weekly report"
+        leadingType="checkbox"
+        leadingSlot={<Checkbox isSelected={isChecked("task-1")} aria-label="Send weekly report" />}
+      />
+      <ListItem
+        value="task-2"
+        headline="Review pull requests"
+        leadingType="checkbox"
+        leadingSlot={
+          <Checkbox isSelected={isChecked("task-2")} aria-label="Review pull requests" />
+        }
+      />
+      <ListItem
+        value="task-3"
+        headline="Update documentation"
+        leadingType="checkbox"
+        leadingSlot={
+          <Checkbox isSelected={isChecked("task-3")} aria-label="Update documentation" />
+        }
+      />
+      <ListItem
+        value="task-4"
+        headline="Deploy to staging"
+        leadingType="checkbox"
+        leadingSlot={<Checkbox isSelected={isChecked("task-4")} aria-label="Deploy to staging" />}
+      />
+    </List>
+  );
+};
+
+export const WithLeadingCheckbox: Story = {
+  render: () => <WithLeadingCheckboxExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Multiple-selection list with `Checkbox` in the leading slot. `ListItemLeading` wraps the checkbox in `aria-hidden` — selection semantics come from the `listbox` role and `aria-selected` on each option. The `isSelected` prop syncs visual state with the List's controlled `selectedKeys`. Click an item row (not the checkbox itself) to toggle selection.",
+      },
+    },
+  },
+};
+
+/**
+ * Simple SVG-based radio indicator used as a decorative leading slot.
+ *
+ * The `Radio` component from this library requires `RadioGroup` context (React Aria),
+ * which conflicts with nesting inside a `listbox`. Since `leadingType="radio"` wraps
+ * the slot in `aria-hidden`, the indicator is purely visual — selection semantics are
+ * provided by the List's `useOption` / `aria-selected`.
+ */
+const RadioIndicator = ({ isSelected }: { isSelected: boolean }): React.ReactElement => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    fill="none"
+    aria-hidden="true"
+    className="text-on-surface-variant"
+  >
+    <circle cx="10" cy="10" r="9" stroke="currentColor" strokeWidth="2" />
+    {isSelected && <circle cx="10" cy="10" r="5" fill="currentColor" />}
+  </svg>
+);
+
+const WithLeadingRadioExample = (): React.ReactElement => {
+  const [selected, setSelected] = useState<Selection>(new Set<string>());
+
+  const isItemSelected = (key: string): boolean => {
+    if (selected === "all") return true;
+    return (selected as Set<string>).has(key);
+  };
+
+  return (
+    <List
+      aria-label="Notification sound"
+      selectionMode="single"
+      selectedKeys={selected}
+      onSelectionChange={setSelected}
+    >
+      <ListItem
+        value="chime"
+        headline="Chime"
+        leadingType="radio"
+        leadingSlot={<RadioIndicator isSelected={isItemSelected("chime")} />}
+      />
+      <ListItem
+        value="bell"
+        headline="Bell"
+        leadingType="radio"
+        leadingSlot={<RadioIndicator isSelected={isItemSelected("bell")} />}
+      />
+      <ListItem
+        value="ping"
+        headline="Ping"
+        leadingType="radio"
+        leadingSlot={<RadioIndicator isSelected={isItemSelected("ping")} />}
+      />
+      <ListItem
+        value="none"
+        headline="None"
+        leadingType="radio"
+        leadingSlot={<RadioIndicator isSelected={isItemSelected("none")} />}
+      />
+    </List>
+  );
+};
+
+export const WithLeadingRadio: Story = {
+  render: () => <WithLeadingRadioExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Single-selection list with a radio indicator in the leading slot. `ListItemLeading` wraps the indicator in `aria-hidden` since `role="option"` with `aria-selected` already conveys selection state to assistive technology. A custom `RadioIndicator` SVG is used instead of the `Radio` component because `Radio` requires `RadioGroup` context which conflicts with nesting inside a `listbox`.',
+      },
+    },
+  },
+};
+
+const SingleSelectionExample = (): React.ReactElement => {
+  const [selected, setSelected] = useState<Selection>(new Set<string>(["center"]));
+
+  return (
+    <List
+      aria-label="Text alignment"
+      selectionMode="single"
+      selectedKeys={selected}
+      onSelectionChange={setSelected}
+    >
+      <ListItem value="left" headline="Left" />
+      <ListItem value="center" headline="Center" />
+      <ListItem value="right" headline="Right" />
+      <ListItem value="justify" headline="Justify" />
+    </List>
+  );
+};
+
+export const SingleSelection: Story = {
+  render: () => <SingleSelectionExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Single-selection listbox. The selected item receives a `bg-secondary-container` highlight. Click a different item to move the selection.",
+      },
+    },
+  },
+};
+
+const MultipleSelectionExample = (): React.ReactElement => {
+  const [selected, setSelected] = useState<Selection>(new Set<string>(["bold", "italic"]));
+
+  return (
+    <List
+      aria-label="Text formatting"
+      selectionMode="multiple"
+      selectedKeys={selected}
+      onSelectionChange={setSelected}
+    >
+      <ListItem value="bold" headline="Bold" />
+      <ListItem value="italic" headline="Italic" />
+      <ListItem value="underline" headline="Underline" />
+      <ListItem value="strikethrough" headline="Strikethrough" />
+    </List>
+  );
+};
+
+export const MultipleSelection: Story = {
+  render: () => <MultipleSelectionExample />,
+  parameters: {
+    docs: {
+      description: {
+        story: "Multiple-selection listbox. Any number of items can be selected simultaneously.",
+      },
+    },
+  },
+};
+
+// ─── Divider stories ──────────────────────────────────────────────────────────
+
+export const WithShowDividers: Story = {
+  render: () => (
+    <List aria-label="Settings with dividers" showDividers>
+      <ListItem value="wifi" headline="Wi-Fi" supportingText="Connected" />
+      <ListItem value="bluetooth" headline="Bluetooth" supportingText="Off" />
+      <ListItem
+        value="notifications"
+        headline="Notifications"
+        supportingText="Banners and alerts"
+      />
+      <ListItem value="display" headline="Display" supportingText="Brightness, font size" />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Full-width `<hr role="presentation">` dividers are interleaved between items when `showDividers={true}`. The `role="presentation"` prevents ARIA violations inside the `listbox`.',
+      },
+    },
+  },
+};
+
+export const WithInsetDividers: Story = {
+  render: () => (
+    <List aria-label="Messages with inset dividers">
+      <ListItem
+        value="msg-1"
+        headline="Alice Johnson"
+        supportingText="Hey, are you free tonight?"
+        leadingType="icon"
+        leadingSlot={<IconPerson />}
+        insetDivider
+      />
+      <ListItem
+        value="msg-2"
+        headline="Bob Smith"
+        supportingText="The meeting has been moved."
+        leadingType="icon"
+        leadingSlot={<IconPerson />}
+        insetDivider
+      />
+      <ListItem
+        value="msg-3"
+        headline="Carol White"
+        supportingText="Thanks for your help!"
+        leadingType="icon"
+        leadingSlot={<IconPerson />}
+        insetDivider
+      />
+      <ListItem
+        value="msg-4"
+        headline="Team Announcements"
+        supportingText="New office policy update."
+        leadingType="icon"
+        leadingSlot={<IconPerson />}
+      />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Inset dividers sit at the bottom of each item and are indented from the start edge — ideal for lists with leading icons or avatars to maintain visual alignment.",
+      },
+    },
+  },
+};
+
+// ─── State stories ────────────────────────────────────────────────────────────
+
+export const WithDisabledItems: Story = {
+  render: () => (
+    <List aria-label="Options with disabled items" selectionMode="single">
+      <ListItem value="option-1" headline="Available option" />
+      <ListItem
+        value="option-2"
+        headline="Disabled option"
+        supportingText="Not available"
+        isDisabled
+      />
+      <ListItem value="option-3" headline="Another available option" />
+      <ListItem value="option-4" headline="Also disabled" isDisabled />
+      <ListItem value="option-5" headline="Final option" />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Disabled items render with `opacity-38` and `pointer-events-none`. They are skipped during keyboard navigation and cannot receive selection.",
+      },
+    },
+  },
+};
+
+export const KeyboardNavigation: Story = {
+  render: () => (
+    <List aria-label="Keyboard navigable list" selectionMode="single">
+      <ListItem value="option-1" headline="Option one" />
+      <ListItem value="option-2" headline="Option two" />
+      <ListItem value="option-3" headline="Option three" />
+      <ListItem value="option-4" headline="Option four" />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**Keyboard navigation:** `Tab` to focus the list, then `ArrowUp` / `ArrowDown` to move between items. Press `Enter` or `Space` to select the focused item. Disabled items are skipped automatically by React Aria.",
+      },
+    },
+  },
+};
+
+const ActionListExample = (): React.ReactElement => {
+  const [lastAction, setLastAction] = useState<string | null>(null);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <List
+        aria-label="Action list"
+        onAction={(key) => {
+          setLastAction(String(key));
+          console.log("Action triggered:", key);
+        }}
+      >
+        <ListItem
+          value="edit"
+          headline="Edit"
+          leadingType="icon"
+          leadingSlot={<IconMail />}
+          trailingType="icon"
+          trailingSlot={<IconChevronRight />}
+        />
+        <ListItem
+          value="share"
+          headline="Share"
+          leadingType="icon"
+          leadingSlot={<IconShare />}
+          trailingType="icon"
+          trailingSlot={<IconChevronRight />}
+        />
+        <ListItem
+          value="more"
+          headline="More options"
+          leadingType="icon"
+          leadingSlot={<IconMoreVert />}
+          trailingType="icon"
+          trailingSlot={<IconChevronRight />}
+        />
+      </List>
+      {lastAction && (
+        <p className="text-body-small text-on-surface-variant">
+          Last action: <strong>{lastAction}</strong>
+        </p>
+      )}
+    </div>
+  );
+};
+
+export const ActionList: Story = {
+  render: () => <ActionListExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Action lists use `onAction` instead of `selectionMode`. Clicking an item triggers the callback with the item's `value` key — useful for menus and command lists where items should not retain selected state.",
+      },
+    },
+  },
+};
+
+// ─── Realistic composition stories ───────────────────────────────────────────
+
+const contacts = [
+  {
+    id: "alice",
+    name: "Alice Johnson",
+    phone: "+1 555 012 3456",
+    initials: "AJ",
+    colorClass: "bg-primary text-on-primary",
+  },
+  {
+    id: "bob",
+    name: "Bob Smith",
+    phone: "+1 555 987 6543",
+    initials: "BS",
+    colorClass: "bg-secondary text-on-secondary",
+  },
+  {
+    id: "carol",
+    name: "Carol White",
+    phone: "+1 555 246 8100",
+    initials: "CW",
+    colorClass: "bg-tertiary text-on-tertiary",
+  },
+  {
+    id: "david",
+    name: "David Lee",
+    phone: "+1 555 135 7924",
+    initials: "DL",
+    colorClass: "bg-error text-on-error",
+  },
+  {
+    id: "emma",
+    name: "Emma Brown",
+    phone: "+1 555 864 2048",
+    initials: "EB",
+    colorClass: "bg-primary text-on-primary",
+  },
+];
+
+export const ContactList: Story = {
+  render: () => (
+    <List aria-label="Contacts" showDividers>
+      {contacts.map((contact) => (
+        <ListItem
+          key={contact.id}
+          value={contact.id}
+          headline={contact.name}
+          leadingType="avatar"
+          leadingSlot={
+            <div
+              className={`flex size-full items-center justify-center text-sm font-medium ${contact.colorClass}`}
+            >
+              {contact.initials}
+            </div>
+          }
+          trailingType="text"
+          trailingSlot={<span>{contact.phone}</span>}
+        />
+      ))}
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Realistic contact list combining avatar leading slots, full-width dividers, and trailing phone numbers as metadata text.",
+      },
+    },
+  },
+};
+
+const settingsItems = [
+  {
+    id: "wifi",
+    icon: <IconWifi />,
+    title: "Wi-Fi",
+    description: "Connected to Home Network",
+  },
+  {
+    id: "bluetooth",
+    icon: <IconBluetooth />,
+    title: "Bluetooth",
+    description: "3 devices connected",
+  },
+  {
+    id: "notifications",
+    icon: <IconNotifications />,
+    title: "Notifications",
+    description: "Banners, badges, and sounds",
+  },
+  {
+    id: "display",
+    icon: <IconDisplay />,
+    title: "Display",
+    description: "Brightness, night mode",
+  },
+  {
+    id: "security",
+    icon: <IconSecurity />,
+    title: "Privacy & Security",
+    description: "Lock screen, biometrics",
+  },
+];
+
+export const SettingsList: Story = {
+  render: () => (
+    <List aria-label="Device settings">
+      {settingsItems.map((setting) => (
+        <ListItem
+          key={setting.id}
+          value={setting.id}
+          headline={setting.title}
+          supportingText={setting.description}
+          leadingType="icon"
+          leadingSlot={setting.icon}
+          trailingType="icon"
+          trailingSlot={<IconChevronRight />}
+          insetDivider
+        />
+      ))}
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Realistic settings screen: icon leading slots, supporting text descriptions, chevron trailing icons, and inset dividers. Non-interactive (static list).",
+      },
+    },
+  },
+};
+
+// ─── Playground ───────────────────────────────────────────────────────────────
+
+export const Playground: Story = {
+  args: {
+    "aria-label": "Playground list",
+    selectionMode: "none",
+    showDividers: false,
+  },
+  render: (args) => (
+    <List {...args}>
+      <ListItem value="item-1" headline="List item one" supportingText="Supporting text" />
+      <ListItem value="item-2" headline="List item two" supportingText="Supporting text" />
+      <ListItem value="item-3" headline="List item three" supportingText="Supporting text" />
+      <ListItem value="item-4" headline="List item four" supportingText="Supporting text" />
+    </List>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use the Controls panel to adjust `selectionMode` and `showDividers` and see how the list adapts.",
+      },
+    },
+  },
+};

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "vitest-axe";
 import { ListHeadless, ListItemHeadless } from "./ListHeadless";
+import { List } from "./List";
+import { ListItem } from "./ListItem";
 
 // ---------------------------------------------------------------------------
 // Static List (selectionMode="none", no onAction)
@@ -353,6 +355,492 @@ describe("ListHeadless — accessibility", () => {
         <ListItemHeadless value="bt" headline="Bluetooth" />
       </ListHeadless>
     );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+// ===========================================================================
+// Styled Layer Tests (26–45)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Item height / density
+// ---------------------------------------------------------------------------
+
+describe("List — styled density classes", () => {
+  test("26. One-line item applies min-h-14", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    expect(item).toHaveClass("min-h-14");
+  });
+
+  test("27. Two-line item (with supportingText) applies min-h-18", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" supportingText="Supporting" />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    expect(item).toHaveClass("min-h-18");
+  });
+
+  test("28. Three-line item (with overline) applies min-h-22", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" overline="Overline" supportingText="Details" />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    expect(item).toHaveClass("min-h-22");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token classes
+// ---------------------------------------------------------------------------
+
+describe("List — styled token classes", () => {
+  test("29. List container has bg-surface", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const list = screen.getByRole("list");
+    expect(list).toHaveClass("bg-surface");
+  });
+
+  test("30. Selected item has bg-secondary-container", async () => {
+    const user = userEvent.setup();
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+        <ListItem value="2" headline="Item 2" />
+      </List>
+    );
+    await user.click(screen.getByRole("option", { name: "Item 1" }));
+    expect(screen.getByRole("option", { name: "Item 1" })).toHaveClass("bg-secondary-container");
+  });
+
+  test("31. Unselected item has no bg-secondary-container", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    expect(item).not.toHaveClass("bg-secondary-container");
+  });
+
+  test("32. Disabled item has opacity-38 and pointer-events-none", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" isDisabled />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    expect(item).toHaveClass("opacity-38");
+    expect(item).toHaveClass("pointer-events-none");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State layer
+// ---------------------------------------------------------------------------
+
+describe("List — state layer", () => {
+  test("33. State layer div present with opacity-0 and group-hover:opacity-8", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    const stateLayer = item.querySelector(".bg-on-surface");
+    expect(stateLayer).toBeInTheDocument();
+    expect(stateLayer).toHaveClass("opacity-0");
+    expect(stateLayer).toHaveClass("group-hover:opacity-8");
+  });
+
+  test("34. transition-[background-color] duration-short4 ease-standard on item root", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    expect(item).toHaveClass("transition-[background-color]");
+    expect(item).toHaveClass("duration-short4");
+    expect(item).toHaveClass("ease-standard");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Leading slot
+// ---------------------------------------------------------------------------
+
+describe("List — leading slot", () => {
+  test("35. type='icon': renders with size-6 text-on-surface-variant", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem
+          value="1"
+          headline="Item 1"
+          leadingSlot={<span data-testid="icon">★</span>}
+          leadingType="icon"
+        />
+      </List>
+    );
+    const icon = screen.getByTestId("icon");
+    const container = icon.parentElement!;
+    expect(container).toHaveClass("size-6");
+    expect(container).toHaveClass("text-on-surface-variant");
+  });
+
+  test("36. type='avatar': renders with size-10 rounded-full", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem
+          value="1"
+          headline="Item 1"
+          leadingSlot={<img data-testid="avatar" src="a.png" alt="" />}
+          leadingType="avatar"
+        />
+      </List>
+    );
+    const avatar = screen.getByTestId("avatar");
+    const container = avatar.parentElement!;
+    expect(container).toHaveClass("size-10");
+    expect(container).toHaveClass("rounded-full");
+  });
+
+  test("37. type='checkbox': inner control wrapper has aria-hidden='true'", () => {
+    render(
+      <List aria-label="Test" selectionMode="multiple">
+        <ListItem
+          value="1"
+          headline="Item 1"
+          leadingSlot={<input type="checkbox" data-testid="cb" readOnly />}
+          leadingType="checkbox"
+        />
+      </List>
+    );
+    const cb = screen.getByTestId("cb");
+    expect(cb.closest("[aria-hidden='true']")).toBeInTheDocument();
+  });
+
+  test("38. type='radio': inner control wrapper has aria-hidden='true' and tabIndex={-1}", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem
+          value="1"
+          headline="Item 1"
+          leadingSlot={<input type="radio" data-testid="radio" readOnly />}
+          leadingType="radio"
+        />
+      </List>
+    );
+    const radio = screen.getByTestId("radio");
+    const wrapper = radio.closest("[aria-hidden='true']");
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveAttribute("tabindex", "-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trailing slot
+// ---------------------------------------------------------------------------
+
+describe("List — trailing slot", () => {
+  test("39. type='text': renders with text-label-small text-on-surface-variant", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem
+          value="1"
+          headline="Item 1"
+          trailingSlot={<span data-testid="meta">100+</span>}
+          trailingType="text"
+        />
+      </List>
+    );
+    const meta = screen.getByTestId("meta");
+    const container = meta.parentElement!;
+    expect(container).toHaveClass("text-label-small");
+    expect(container).toHaveClass("text-on-surface-variant");
+  });
+
+  test("40. type='icon': renders with size-6", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem
+          value="1"
+          headline="Item 1"
+          trailingSlot={<span data-testid="trail-icon">→</span>}
+          trailingType="icon"
+        />
+      </List>
+    );
+    const icon = screen.getByTestId("trail-icon");
+    const container = icon.parentElement!;
+    expect(container).toHaveClass("size-6");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Text
+// ---------------------------------------------------------------------------
+
+describe("List — text sub-component", () => {
+  test("41. Headline has text-body-large text-on-surface", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Headline" />
+      </List>
+    );
+    const headline = screen.getByText("Headline");
+    expect(headline).toHaveClass("text-body-large");
+    expect(headline).toHaveClass("text-on-surface");
+  });
+
+  test("42. Supporting text has text-body-medium text-on-surface-variant", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Title" supportingText="Sub" />
+      </List>
+    );
+    const supporting = screen.getByText("Sub");
+    expect(supporting).toHaveClass("text-body-medium");
+    expect(supporting).toHaveClass("text-on-surface-variant");
+  });
+
+  test("43. Overline has text-label-small text-on-surface-variant", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Title" overline="OVERLINE" supportingText="Sub" />
+      </List>
+    );
+    const overline = screen.getByText("OVERLINE");
+    expect(overline).toHaveClass("text-label-small");
+    expect(overline).toHaveClass("text-on-surface-variant");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ripple
+// ---------------------------------------------------------------------------
+
+describe("List — ripple", () => {
+  test("44. Ripple container present in interactive list item", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    expect(item.querySelector("[data-ripple-container]")).toBeInTheDocument();
+  });
+
+  test("45. Ripple NOT present in static list item", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    expect(item.querySelector("[data-ripple-container]")).not.toBeInTheDocument();
+  });
+});
+
+// ===========================================================================
+// Divider Integration Tests (46–59)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// showDividers prop
+// ---------------------------------------------------------------------------
+
+describe("List — showDividers", () => {
+  test("46. showDividers={true} renders Divider elements between list items", () => {
+    const { container } = render(
+      <List aria-label="Test" showDividers>
+        <ListItem value="1" headline="Item 1" />
+        <ListItem value="2" headline="Item 2" />
+        <ListItem value="3" headline="Item 3" />
+      </List>
+    );
+    const dividers = container.querySelectorAll("hr");
+    expect(dividers.length).toBeGreaterThan(0);
+  });
+
+  test("47. With 3 items and showDividers={true}: renders exactly 2 Dividers", () => {
+    const { container } = render(
+      <List aria-label="Test" showDividers>
+        <ListItem value="1" headline="Item 1" />
+        <ListItem value="2" headline="Item 2" />
+        <ListItem value="3" headline="Item 3" />
+      </List>
+    );
+    const dividers = container.querySelectorAll("hr");
+    expect(dividers).toHaveLength(2);
+  });
+
+  test("48. With 1 item and showDividers={true}: renders NO Dividers", () => {
+    const { container } = render(
+      <List aria-label="Test" showDividers>
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const dividers = container.querySelectorAll("hr");
+    expect(dividers).toHaveLength(0);
+  });
+
+  test("49. Divider has border-outline-variant class (token compliance)", () => {
+    const { container } = render(
+      <List aria-label="Test" showDividers>
+        <ListItem value="1" headline="Item 1" />
+        <ListItem value="2" headline="Item 2" />
+      </List>
+    );
+    const divider = container.querySelector("hr");
+    expect(divider).toHaveClass("border-outline-variant");
+  });
+
+  test("50. showDividers={false} (default): renders no Dividers", () => {
+    const { container } = render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" />
+        <ListItem value="2" headline="Item 2" />
+      </List>
+    );
+    const dividers = container.querySelectorAll("hr");
+    expect(dividers).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// insetDivider prop
+// ---------------------------------------------------------------------------
+
+describe("List — insetDivider", () => {
+  test("51. insetDivider={true} renders a Divider at the bottom of the item", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" insetDivider />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    const divider = item.querySelector("hr");
+    expect(divider).toBeInTheDocument();
+  });
+
+  test("52. Inset Divider has ml-4 class (16dp inset from start)", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" insetDivider />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    const divider = item.querySelector("hr");
+    expect(divider).toHaveClass("ml-4");
+  });
+
+  test("53. insetDivider={false} (default): no Divider inside item", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    const divider = item.querySelector("hr");
+    expect(divider).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composition
+// ---------------------------------------------------------------------------
+
+describe("List — divider composition", () => {
+  test("54. showDividers and insetDivider can coexist without duplicate dividers at the same boundary", () => {
+    const { container } = render(
+      <List aria-label="Test" showDividers>
+        <ListItem value="1" headline="Item 1" insetDivider />
+        <ListItem value="2" headline="Item 2" insetDivider />
+      </List>
+    );
+    const allDividers = container.querySelectorAll("hr");
+    // 1 showDividers divider between items + 2 insetDivider dividers inside items = 3
+    expect(allDividers).toHaveLength(3);
+  });
+
+  test("55. Divider in showDividers mode uses inset='none' (full-width)", () => {
+    const { container } = render(
+      <List aria-label="Test" showDividers>
+        <ListItem value="1" headline="Item 1" />
+        <ListItem value="2" headline="Item 2" />
+      </List>
+    );
+    const list = container.querySelector("[role='list']")!;
+    const betweenDivider = list.querySelector(":scope > hr");
+    expect(betweenDivider).toBeInTheDocument();
+    expect(betweenDivider).not.toHaveClass("ml-4");
+    expect(betweenDivider).toHaveClass("w-full");
+  });
+
+  test("56. Divider in insetDivider mode uses inset='start' (leading inset)", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" insetDivider />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    const divider = item.querySelector("hr");
+    expect(divider).toHaveClass("ml-4");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Divider accessibility
+// ---------------------------------------------------------------------------
+
+describe("List — divider accessibility", () => {
+  test("57. axe check — list with showDividers={true}, no violations", async () => {
+    const { container } = render(
+      <List aria-label="Settings" showDividers>
+        <ListItem value="wifi" headline="Wi-Fi" />
+        <ListItem value="bt" headline="Bluetooth" />
+        <ListItem value="nfc" headline="NFC" />
+      </List>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("58. axe check — list with insetDivider={true}, no violations", async () => {
+    const { container } = render(
+      <List aria-label="Settings">
+        <ListItem value="wifi" headline="Wi-Fi" insetDivider />
+        <ListItem value="bt" headline="Bluetooth" insetDivider />
+      </List>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("59. <hr> elements from Dividers do not break listbox/list accessibility roles", async () => {
+    const { container } = render(
+      <List aria-label="Settings" showDividers>
+        <ListItem value="wifi" headline="Wi-Fi" insetDivider />
+        <ListItem value="bt" headline="Bluetooth" />
+      </List>
+    );
+    const list = screen.getByRole("list");
+    expect(list).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -478,6 +478,30 @@ describe("List — state layer", () => {
     expect(item).toHaveClass("duration-short4");
     expect(item).toHaveClass("ease-standard");
   });
+
+  test("35a. State layer has transition-opacity duration-short2 ease-standard", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    const stateLayer = item.querySelector(".bg-on-surface");
+    expect(stateLayer).toHaveClass("transition-opacity");
+    expect(stateLayer).toHaveClass("duration-short2");
+    expect(stateLayer).toHaveClass("ease-standard");
+  });
+
+  test("35b. State layer has group-active:opacity-12 for press state", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    const stateLayer = item.querySelector(".bg-on-surface");
+    expect(stateLayer).toHaveClass("group-active:opacity-12");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -1,0 +1,359 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { ListHeadless, ListItemHeadless } from "./ListHeadless";
+
+// ---------------------------------------------------------------------------
+// Static List (selectionMode="none", no onAction)
+// ---------------------------------------------------------------------------
+
+describe("ListHeadless — static mode", () => {
+  test("1. renders <ul role='list'> when selectionMode='none' and no onAction", () => {
+    render(
+      <ListHeadless aria-label="Settings">
+        <ListItemHeadless value="wifi" headline="Wi-Fi" />
+        <ListItemHeadless value="bt" headline="Bluetooth" />
+      </ListHeadless>
+    );
+    const list = screen.getByRole("list");
+    expect(list.tagName).toBe("UL");
+  });
+
+  test("2. renders <li role='listitem'> for each ListItem", () => {
+    render(
+      <ListHeadless aria-label="Settings">
+        <ListItemHeadless value="wifi" headline="Wi-Fi" />
+        <ListItemHeadless value="bt" headline="Bluetooth" />
+      </ListHeadless>
+    );
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    items.forEach((item) => expect(item.tagName).toBe("LI"));
+  });
+
+  test("3. items are NOT focusable in static mode (no tabIndex)", () => {
+    render(
+      <ListHeadless aria-label="Settings">
+        <ListItemHeadless value="wifi" headline="Wi-Fi" />
+      </ListHeadless>
+    );
+    const item = screen.getByRole("listitem");
+    expect(item).not.toHaveAttribute("tabindex");
+  });
+
+  test("4. does NOT render aria-selected in static mode", () => {
+    render(
+      <ListHeadless aria-label="Settings">
+        <ListItemHeadless value="wifi" headline="Wi-Fi" />
+      </ListHeadless>
+    );
+    const item = screen.getByRole("listitem");
+    expect(item).not.toHaveAttribute("aria-selected");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interactive List (selectionMode="single")
+// ---------------------------------------------------------------------------
+
+describe("ListHeadless — interactive (single select)", () => {
+  test("5. renders with role='listbox'", () => {
+    render(
+      <ListHeadless aria-label="Alignment" selectionMode="single">
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+      </ListHeadless>
+    );
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  test("6. each item has role='option'", () => {
+    render(
+      <ListHeadless aria-label="Alignment" selectionMode="single">
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+      </ListHeadless>
+    );
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(2);
+  });
+
+  test("7. calls onSelectionChange when item clicked", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <ListHeadless
+        aria-label="Alignment"
+        selectionMode="single"
+        onSelectionChange={onSelectionChange}
+      >
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+      </ListHeadless>
+    );
+    await user.click(screen.getByRole("option", { name: "Left" }));
+    expect(onSelectionChange).toHaveBeenCalled();
+  });
+
+  test("8. Arrow Down moves focus to next item", async () => {
+    const user = userEvent.setup();
+    render(
+      <ListHeadless aria-label="Alignment" selectionMode="single">
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+        <ListItemHeadless value="right" headline="Right" />
+      </ListHeadless>
+    );
+    const options = screen.getAllByRole("option");
+    await user.tab();
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(options[1]);
+  });
+
+  test("9. Arrow Up moves focus to previous item", async () => {
+    const user = userEvent.setup();
+    render(
+      <ListHeadless aria-label="Alignment" selectionMode="single">
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+        <ListItemHeadless value="right" headline="Right" />
+      </ListHeadless>
+    );
+    const options = screen.getAllByRole("option");
+    // Focus the last item, then move up
+    await user.tab();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(options[2]);
+    await user.keyboard("{ArrowUp}");
+    expect(document.activeElement).toBe(options[1]);
+  });
+
+  test("10. Home moves focus to first item", async () => {
+    const user = userEvent.setup();
+    render(
+      <ListHeadless aria-label="Alignment" selectionMode="single">
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+        <ListItemHeadless value="right" headline="Right" />
+      </ListHeadless>
+    );
+    const options = screen.getAllByRole("option");
+    await user.tab();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Home}");
+    expect(document.activeElement).toBe(options[0]);
+  });
+
+  test("11. End moves focus to last item", async () => {
+    const user = userEvent.setup();
+    render(
+      <ListHeadless aria-label="Alignment" selectionMode="single">
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+        <ListItemHeadless value="right" headline="Right" />
+      </ListHeadless>
+    );
+    const options = screen.getAllByRole("option");
+    await user.tab();
+    await user.keyboard("{End}");
+    expect(document.activeElement).toBe(options[2]);
+  });
+
+  test("12. Enter selects focused item", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <ListHeadless
+        aria-label="Alignment"
+        selectionMode="single"
+        onSelectionChange={onSelectionChange}
+      >
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+      </ListHeadless>
+    );
+    await user.tab();
+    await user.keyboard("{Enter}");
+    expect(onSelectionChange).toHaveBeenCalled();
+  });
+
+  test("13. Space selects focused item", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <ListHeadless
+        aria-label="Alignment"
+        selectionMode="single"
+        onSelectionChange={onSelectionChange}
+      >
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+      </ListHeadless>
+    );
+    await user.tab();
+    await user.keyboard(" ");
+    expect(onSelectionChange).toHaveBeenCalled();
+  });
+
+  test("14. selected item has aria-selected='true'", async () => {
+    const user = userEvent.setup();
+    render(
+      <ListHeadless aria-label="Alignment" selectionMode="single">
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+      </ListHeadless>
+    );
+    await user.click(screen.getByRole("option", { name: "Left" }));
+    expect(screen.getByRole("option", { name: "Left" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("15. onAction called when item activated", async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    render(
+      <ListHeadless aria-label="Settings" selectionMode="none" onAction={onAction}>
+        <ListItemHeadless value="wifi" headline="Wi-Fi" />
+        <ListItemHeadless value="bt" headline="Bluetooth" />
+      </ListHeadless>
+    );
+    await user.click(screen.getByRole("option", { name: "Wi-Fi" }));
+    expect(onAction).toHaveBeenCalledWith("wifi");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple selection
+// ---------------------------------------------------------------------------
+
+describe("ListHeadless — multiple selection", () => {
+  test("16. multiple items can have aria-selected='true' simultaneously", async () => {
+    const user = userEvent.setup();
+    render(
+      <ListHeadless aria-label="Tags" selectionMode="multiple">
+        <ListItemHeadless value="react" headline="React" />
+        <ListItemHeadless value="vue" headline="Vue" />
+        <ListItemHeadless value="angular" headline="Angular" />
+      </ListHeadless>
+    );
+    await user.click(screen.getByRole("option", { name: "React" }));
+    await user.click(screen.getByRole("option", { name: "Vue" }));
+    expect(screen.getByRole("option", { name: "React" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("option", { name: "Vue" })).toHaveAttribute("aria-selected", "true");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Disabled items
+// ---------------------------------------------------------------------------
+
+describe("ListHeadless — disabled items", () => {
+  test("17. disabled item has aria-disabled='true'", () => {
+    render(
+      <ListHeadless aria-label="Settings" selectionMode="single">
+        <ListItemHeadless value="wifi" headline="Wi-Fi" isDisabled />
+      </ListHeadless>
+    );
+    expect(screen.getByRole("option", { name: "Wi-Fi" })).toHaveAttribute("aria-disabled", "true");
+  });
+
+  test("18. disabled item is NOT selectable via click", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <ListHeadless
+        aria-label="Settings"
+        selectionMode="single"
+        onSelectionChange={onSelectionChange}
+      >
+        <ListItemHeadless value="wifi" headline="Wi-Fi" isDisabled />
+        <ListItemHeadless value="bt" headline="Bluetooth" />
+      </ListHeadless>
+    );
+    await user.click(screen.getByRole("option", { name: "Wi-Fi" }));
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accessibility
+// ---------------------------------------------------------------------------
+
+describe("ListHeadless — accessibility", () => {
+  test("19. list has aria-label when provided", () => {
+    render(
+      <ListHeadless aria-label="Navigation">
+        <ListItemHeadless value="home" headline="Home" />
+      </ListHeadless>
+    );
+    expect(screen.getByRole("list")).toHaveAttribute("aria-label", "Navigation");
+  });
+
+  test("20. list has aria-labelledby when provided", () => {
+    render(
+      <>
+        <h2 id="list-heading">Settings</h2>
+        <ListHeadless aria-labelledby="list-heading">
+          <ListItemHeadless value="wifi" headline="Wi-Fi" />
+        </ListHeadless>
+      </>
+    );
+    expect(screen.getByRole("list")).toHaveAttribute("aria-labelledby", "list-heading");
+  });
+
+  test("21. forwardRef: ref attached to <ul> element", () => {
+    const ref = { current: null as HTMLUListElement | null };
+    render(
+      <ListHeadless ref={ref} aria-label="Settings">
+        <ListItemHeadless value="wifi" headline="Wi-Fi" />
+      </ListHeadless>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLUListElement);
+  });
+
+  test("22. axe check — static list, no violations", async () => {
+    const { container } = render(
+      <ListHeadless aria-label="Settings">
+        <ListItemHeadless value="wifi" headline="Wi-Fi" />
+        <ListItemHeadless value="bt" headline="Bluetooth" />
+      </ListHeadless>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("23. axe check — interactive single-select list, no violations", async () => {
+    const { container } = render(
+      <ListHeadless aria-label="Alignment" selectionMode="single">
+        <ListItemHeadless value="left" headline="Left" />
+        <ListItemHeadless value="center" headline="Center" />
+      </ListHeadless>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("24. axe check — interactive multi-select list, no violations", async () => {
+    const { container } = render(
+      <ListHeadless aria-label="Tags" selectionMode="multiple">
+        <ListItemHeadless value="react" headline="React" />
+        <ListItemHeadless value="vue" headline="Vue" />
+      </ListHeadless>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("25. axe check — list with disabled item, no violations", async () => {
+    const { container } = render(
+      <ListHeadless aria-label="Settings" selectionMode="single">
+        <ListItemHeadless value="wifi" headline="Wi-Fi" isDisabled />
+        <ListItemHeadless value="bt" headline="Bluetooth" />
+      </ListHeadless>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Children, forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import { ListHeadless } from "./ListHeadless";
+import { listVariants } from "./List.variants";
+import type { ListProps } from "./List.types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Interleaves presentational `<hr>` dividers between each child.
+ * Uses `role="presentation"` to keep the element out of the ARIA tree,
+ * avoiding `aria-required-children` violations inside `<ul role="list">`.
+ */
+function interleaveWithDividers(children: React.ReactNode): React.ReactNode[] {
+  const items = Children.toArray(children);
+
+  return items.reduce<React.ReactNode[]>((acc, child, index) => {
+    if (index > 0) {
+      acc.push(
+        <hr
+          key={`divider-${index}`}
+          role="presentation"
+          className="border-outline-variant w-full border-t"
+        />
+      );
+    }
+    acc.push(child);
+    return acc;
+  }, []);
+}
+
+/**
+ * Material Design 3 List Component (Layer 3: Styled)
+ *
+ * Wraps `ListHeadless` with MD3 surface color and layout tokens.
+ *
+ * @example
+ * ```tsx
+ * // Static list
+ * <List aria-label="Settings">
+ *   <ListItem value="wifi" headline="Wi-Fi" />
+ *   <ListItem value="bt" headline="Bluetooth" />
+ * </List>
+ *
+ * // Interactive single-select list
+ * <List aria-label="Alignment" selectionMode="single" onSelectionChange={setSelection}>
+ *   <ListItem value="left" headline="Left" />
+ *   <ListItem value="center" headline="Center" />
+ *   <ListItem value="right" headline="Right" />
+ * </List>
+ *
+ * // With dividers between items
+ * <List aria-label="Settings" showDividers>
+ *   <ListItem value="wifi" headline="Wi-Fi" />
+ *   <ListItem value="bt" headline="Bluetooth" />
+ * </List>
+ * ```
+ */
+export const List = forwardRef<HTMLUListElement, ListProps>(function List(
+  { className, showDividers = false, children, ...props },
+  ref
+) {
+  const renderedChildren = showDividers ? interleaveWithDividers(children) : children;
+
+  return (
+    <ListHeadless ref={ref} className={cn(listVariants(), className)} {...props}>
+      {renderedChildren}
+    </ListHeadless>
+  );
+});
+
+List.displayName = "List";

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Children, forwardRef } from "react";
+import type React from "react";
 import { cn } from "../../utils/cn";
 import { ListHeadless } from "./ListHeadless";
 import { listVariants } from "./List.variants";

--- a/packages/react/src/components/List/List.types.ts
+++ b/packages/react/src/components/List/List.types.ts
@@ -1,0 +1,191 @@
+import type React from "react";
+import type { Key, Selection, SelectionMode } from "react-stately";
+
+/**
+ * Visual density based on content lines (MD3 List)
+ *
+ * - `one-line`: headline only (48dp)
+ * - `two-line`: headline + supporting text (64dp)
+ * - `three-line`: overline + headline + supporting text (88dp)
+ */
+export type ListDensity = "one-line" | "two-line" | "three-line";
+
+/**
+ * Leading slot content type
+ */
+export type ListLeadingType = "icon" | "avatar" | "checkbox" | "radio";
+
+/**
+ * Trailing slot content type
+ */
+export type ListTrailingType = "icon" | "checkbox" | "radio" | "text";
+
+/**
+ * MD3 List container props.
+ *
+ * Supports two modes:
+ * - **Static**: `selectionMode="none"` (default) and no `onAction` → `role="list"`
+ * - **Interactive**: `selectionMode` is `"single"` or `"multiple"`, or `onAction` provided → `role="listbox"`
+ *
+ * @example
+ * ```tsx
+ * // Static list
+ * <ListHeadless aria-label="Settings">
+ *   <ListItemHeadless value="wifi" headline="Wi-Fi" />
+ *   <ListItemHeadless value="bt" headline="Bluetooth" />
+ * </ListHeadless>
+ *
+ * // Interactive single-select list
+ * <ListHeadless
+ *   aria-label="Alignment"
+ *   selectionMode="single"
+ *   onSelectionChange={setSelection}
+ * >
+ *   <ListItemHeadless value="left" headline="Left" />
+ *   <ListItemHeadless value="center" headline="Center" />
+ *   <ListItemHeadless value="right" headline="Right" />
+ * </ListHeadless>
+ * ```
+ */
+export interface ListProps {
+  /**
+   * Selection mode.
+   * @default 'none'
+   */
+  selectionMode?: SelectionMode;
+
+  /** Controlled selected keys */
+  selectedKeys?: Selection;
+
+  /** Initial selected keys (uncontrolled) */
+  defaultSelectedKeys?: Iterable<Key>;
+
+  /** Called when the selection changes */
+  onSelectionChange?: (keys: Selection) => void;
+
+  /** Per-item action callback (triggered on click or Enter/Space) */
+  onAction?: (key: Key) => void;
+
+  /** Render a Divider between items */
+  showDividers?: boolean;
+
+  /** Accessible label for the list */
+  "aria-label"?: string;
+
+  /** ID of the element that labels this list */
+  "aria-labelledby"?: string;
+
+  /** Additional CSS classes */
+  className?: string;
+
+  /** ListItem children */
+  children: React.ReactNode;
+}
+
+/**
+ * MD3 List Item props.
+ *
+ * Each item requires a unique `value` used as the collection key.
+ *
+ * @example
+ * ```tsx
+ * <ListItemHeadless
+ *   value="wifi"
+ *   headline="Wi-Fi"
+ *   supportingText="Connected to Home Network"
+ * />
+ * ```
+ */
+export interface ListItemProps {
+  /** Unique key for selection tracking */
+  value: string | number;
+
+  /** Primary text content */
+  headline: string;
+
+  /**
+   * Secondary text below the headline.
+   * When present, density becomes two-line.
+   */
+  supportingText?: string;
+
+  /**
+   * Overline text above the headline.
+   * Three-line density requires overline OR long supporting text.
+   */
+  overline?: string;
+
+  /** Content rendered in the leading slot */
+  leadingSlot?: React.ReactNode;
+
+  /** Semantic type of the leading content */
+  leadingType?: ListLeadingType;
+
+  /** Content rendered in the trailing slot */
+  trailingSlot?: React.ReactNode;
+
+  /** Semantic type of the trailing content */
+  trailingType?: ListTrailingType;
+
+  /** Whether this item is disabled */
+  isDisabled?: boolean;
+
+  /** Render an inset Divider at the bottom of this item */
+  insetDivider?: boolean;
+
+  /** Additional CSS classes */
+  className?: string;
+
+  /** Item-specific action callback */
+  onAction?: (value: string | number) => void;
+}
+
+/**
+ * Props for the ListItem leading slot
+ */
+export interface ListItemLeadingProps {
+  /** Semantic content type */
+  type: ListLeadingType;
+
+  /** Additional CSS classes */
+  className?: string;
+
+  /** Slot content */
+  children: React.ReactNode;
+}
+
+/**
+ * Props for the ListItem trailing slot
+ */
+export interface ListItemTrailingProps {
+  /** Semantic content type */
+  type: ListTrailingType;
+
+  /** Additional CSS classes */
+  className?: string;
+
+  /** Slot content */
+  children: React.ReactNode;
+}
+
+/**
+ * Props for the ListItem text area
+ */
+export interface ListItemTextProps {
+  /** Primary text */
+  headline: string;
+
+  /** Secondary text */
+  supportingText?: string;
+
+  /** Overline text */
+  overline?: string;
+
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Headless List container props — identical to ListProps for the foundation layer.
+ */
+export type ListHeadlessProps = ListProps;

--- a/packages/react/src/components/List/List.variants.ts
+++ b/packages/react/src/components/List/List.variants.ts
@@ -1,0 +1,53 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * MD3 List container CVA variants.
+ */
+export const listVariants = cva("w-full bg-surface");
+
+/**
+ * MD3 ListItem CVA variants.
+ *
+ * Density is auto-derived from content (overline / supportingText), not a user prop.
+ * Three-line items use `items-start` so leading/trailing slots top-align.
+ */
+export const listItemVariants = cva(
+  [
+    "group relative flex items-center overflow-hidden px-4 py-2 cursor-pointer",
+    "transition-[background-color] duration-short4 ease-standard",
+  ],
+  {
+    variants: {
+      density: {
+        "one-line": "min-h-14",
+        "two-line": "min-h-18",
+        "three-line": "min-h-22 items-start",
+      },
+
+      isSelected: {
+        true: "bg-secondary-container text-on-secondary-container",
+        false: "",
+      },
+
+      isDisabled: {
+        true: "opacity-38 pointer-events-none",
+        false: "",
+      },
+
+      isInteractive: {
+        true: "",
+        false: "cursor-default",
+      },
+    },
+
+    defaultVariants: {
+      density: "one-line",
+      isSelected: false,
+      isDisabled: false,
+      isInteractive: true,
+    },
+  }
+);
+
+export type ListVariants = VariantProps<typeof listVariants>;
+export type ListItemVariants = VariantProps<typeof listItemVariants>;

--- a/packages/react/src/components/List/ListHeadless.tsx
+++ b/packages/react/src/components/List/ListHeadless.tsx
@@ -16,7 +16,7 @@ interface ListContextValue {
 
 const ListContext = createContext<ListContextValue | null>(null);
 
-function useListContext(): ListContextValue | null {
+export function useListContext(): ListContextValue | null {
   return useContext(ListContext);
 }
 

--- a/packages/react/src/components/List/ListHeadless.tsx
+++ b/packages/react/src/components/List/ListHeadless.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { Children, createContext, forwardRef, isValidElement, useContext, useRef } from "react";
+import type React from "react";
+import { useListBox, useOption } from "react-aria";
+import { Item, useListState } from "react-stately";
+import type { ListState } from "react-stately";
+import type { ListHeadlessProps, ListItemProps } from "./List.types";
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+interface ListContextValue {
+  isInteractive: true;
+  state: ListState<object>;
+}
+
+const ListContext = createContext<ListContextValue | null>(null);
+
+function useListContext(): ListContextValue | null {
+  return useContext(ListContext);
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Extracts ListItemHeadless props from children so we can build the
+ * React Aria `Item` collection required by `useListState`.
+ */
+function extractItemProps(children: React.ReactNode): ListItemProps[] {
+  const items: ListItemProps[] = [];
+  Children.forEach(children, (child) => {
+    if (isValidElement<ListItemProps>(child)) {
+      items.push(child.props);
+    }
+  });
+  return items;
+}
+
+// ─── ListHeadless ─────────────────────────────────────────────────────────────
+
+/**
+ * Headless List container (Layer 2).
+ *
+ * Renders an accessible list with two operating modes:
+ *
+ * | Condition | Element | ARIA role |
+ * |---|---|---|
+ * | `selectionMode === 'none'` AND no `onAction` | `<ul>` | `list` |
+ * | `selectionMode` is `'single'`/`'multiple'`, OR `onAction` given | `<ul>` | `listbox` (via `useListBox`) |
+ *
+ * @example
+ * ```tsx
+ * // Static
+ * <ListHeadless aria-label="Settings">
+ *   <ListItemHeadless value="wifi" headline="Wi-Fi" />
+ * </ListHeadless>
+ *
+ * // Interactive
+ * <ListHeadless aria-label="Alignment" selectionMode="single">
+ *   <ListItemHeadless value="left" headline="Left" />
+ * </ListHeadless>
+ * ```
+ */
+export const ListHeadless = forwardRef<HTMLUListElement, ListHeadlessProps>(function ListHeadless(
+  {
+    selectionMode = "none",
+    selectedKeys,
+    defaultSelectedKeys,
+    onSelectionChange,
+    onAction,
+    className,
+    children,
+    ...rest
+  },
+  forwardedRef
+) {
+  const isInteractive = selectionMode !== "none" || onAction !== undefined;
+
+  if (isInteractive) {
+    return (
+      <InteractiveList
+        ref={forwardedRef}
+        selectionMode={selectionMode}
+        {...(selectedKeys !== undefined ? { selectedKeys } : {})}
+        {...(defaultSelectedKeys !== undefined ? { defaultSelectedKeys } : {})}
+        {...(onSelectionChange ? { onSelectionChange } : {})}
+        {...(onAction ? { onAction } : {})}
+        {...(className !== undefined ? { className } : {})}
+        {...(rest["aria-label"] !== undefined ? { "aria-label": rest["aria-label"] } : {})}
+        {...(rest["aria-labelledby"] !== undefined
+          ? { "aria-labelledby": rest["aria-labelledby"] }
+          : {})}
+      >
+        {children}
+      </InteractiveList>
+    );
+  }
+
+  return (
+    <ul
+      ref={forwardedRef}
+      role="list"
+      className={className}
+      aria-label={rest["aria-label"]}
+      aria-labelledby={rest["aria-labelledby"]}
+    >
+      {children}
+    </ul>
+  );
+});
+
+ListHeadless.displayName = "ListHeadless";
+
+// ─── InteractiveList (internal) ───────────────────────────────────────────────
+
+/**
+ * Separated into its own component so React Aria hooks (`useListState`,
+ * `useListBox`) are always called unconditionally (Rules of Hooks).
+ */
+const InteractiveList = forwardRef<HTMLUListElement, ListHeadlessProps>(function InteractiveList(
+  {
+    selectionMode = "none",
+    selectedKeys,
+    defaultSelectedKeys,
+    onSelectionChange,
+    onAction,
+    className,
+    children,
+    ...rest
+  },
+  forwardedRef
+) {
+  const internalRef = useRef<HTMLUListElement>(null);
+  const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLUListElement>;
+
+  const itemProps = extractItemProps(children);
+
+  const disabledKeys = itemProps.filter((item) => item.isDisabled).map((item) => item.value);
+
+  const collectionChildren = itemProps.map((item) => (
+    <Item key={item.value} textValue={item.headline}>
+      {item.headline}
+    </Item>
+  ));
+
+  const resolvedMode = selectionMode === "none" ? undefined : selectionMode;
+
+  const state = useListState({
+    children: collectionChildren,
+    ...(resolvedMode !== undefined ? { selectionMode: resolvedMode } : {}),
+    ...(selectedKeys !== undefined ? { selectedKeys } : {}),
+    ...(defaultSelectedKeys !== undefined ? { defaultSelectedKeys } : {}),
+    ...(onSelectionChange ? { onSelectionChange } : {}),
+    ...(onAction ? { onAction } : {}),
+    disabledKeys,
+  });
+
+  const ariaLabel = rest["aria-label"];
+  const ariaLabelledby = rest["aria-labelledby"];
+
+  const { listBoxProps } = useListBox(
+    {
+      ...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {}),
+      ...(ariaLabelledby !== undefined ? { "aria-labelledby": ariaLabelledby } : {}),
+      ...(resolvedMode !== undefined ? { selectionMode: resolvedMode } : {}),
+      ...(selectedKeys !== undefined ? { selectedKeys } : {}),
+      ...(defaultSelectedKeys !== undefined ? { defaultSelectedKeys } : {}),
+      ...(onSelectionChange ? { onSelectionChange } : {}),
+      ...(onAction ? { onAction } : {}),
+      disabledKeys,
+    },
+    state,
+    ref
+  );
+
+  return (
+    <ListContext.Provider value={{ isInteractive: true, state }}>
+      <ul {...listBoxProps} ref={ref} className={className}>
+        {Children.map(children, (child) => {
+          if (isValidElement<ListItemProps>(child)) {
+            return child;
+          }
+          return null;
+        })}
+      </ul>
+    </ListContext.Provider>
+  );
+});
+
+InteractiveList.displayName = "InteractiveList";
+
+// ─── ListItemHeadless ─────────────────────────────────────────────────────────
+
+/**
+ * Headless List Item (Layer 2).
+ *
+ * Renders an accessible list item:
+ * - **Static mode**: `<li role="listitem">`, not focusable
+ * - **Interactive mode**: `<li>` with `useOption` providing `role="option"`,
+ *   `aria-selected`, `aria-disabled`, and keyboard interaction
+ *
+ * @example
+ * ```tsx
+ * <ListItemHeadless value="wifi" headline="Wi-Fi" supportingText="Connected" />
+ * ```
+ */
+export const ListItemHeadless = forwardRef<HTMLLIElement, ListItemProps>(function ListItemHeadless(
+  { value, headline, supportingText, overline, className },
+  forwardedRef
+) {
+  const ctx = useListContext();
+
+  if (ctx) {
+    return (
+      <InteractiveListItem
+        ref={forwardedRef}
+        value={value}
+        headline={headline}
+        {...(supportingText !== undefined ? { supportingText } : {})}
+        {...(overline !== undefined ? { overline } : {})}
+        {...(className !== undefined ? { className } : {})}
+        state={ctx.state}
+      />
+    );
+  }
+
+  return (
+    <li ref={forwardedRef} role="listitem" className={className}>
+      {overline && <span>{overline}</span>}
+      <span>{headline}</span>
+      {supportingText && <span>{supportingText}</span>}
+    </li>
+  );
+});
+
+ListItemHeadless.displayName = "ListItemHeadless";
+
+// ─── InteractiveListItem (internal) ───────────────────────────────────────────
+
+interface InteractiveListItemInternalProps {
+  value: string | number;
+  headline: string;
+  supportingText?: string;
+  overline?: string;
+  className?: string;
+  state: ListState<object>;
+}
+
+const InteractiveListItem = forwardRef<HTMLLIElement, InteractiveListItemInternalProps>(
+  function InteractiveListItem(
+    { value, headline, supportingText, overline, className, state },
+    forwardedRef
+  ) {
+    const internalRef = useRef<HTMLLIElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLLIElement>;
+
+    const { optionProps, isSelected, isDisabled } = useOption({ key: value }, state, ref);
+
+    return (
+      <li
+        {...optionProps}
+        ref={ref}
+        className={className}
+        data-selected={isSelected || undefined}
+        data-disabled={isDisabled || undefined}
+      >
+        {overline && <span>{overline}</span>}
+        <span>{headline}</span>
+        {supportingText && <span>{supportingText}</span>}
+      </li>
+    );
+  }
+);
+
+InteractiveListItem.displayName = "InteractiveListItem";

--- a/packages/react/src/components/List/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem.tsx
@@ -184,7 +184,7 @@ const InteractiveStyledListItem = forwardRef<HTMLLIElement, InteractiveStyledLis
       >
         <div
           aria-hidden="true"
-          className="bg-on-surface pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-8"
+          className="bg-on-surface duration-short2 ease-standard pointer-events-none absolute inset-0 opacity-0 transition-opacity group-hover:opacity-8 group-active:opacity-12"
         />
         {ripples}
 

--- a/packages/react/src/components/List/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { forwardRef, useRef } from "react";
+import type React from "react";
+import { useOption } from "react-aria";
+import { mergeProps } from "@react-aria/utils";
+import type { ListState } from "react-stately";
+import { cn } from "../../utils/cn";
+import { useRipple } from "../../hooks/useRipple";
+import { Divider } from "../Divider";
+import { listItemVariants } from "./List.variants";
+import { ListItemLeading } from "./ListItemLeading";
+import { ListItemTrailing } from "./ListItemTrailing";
+import { ListItemText } from "./ListItemText";
+import { useListContext } from "./ListHeadless";
+import type { ListDensity, ListItemProps } from "./List.types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getDensity(overline?: string, supportingText?: string): ListDensity {
+  if (overline) return "three-line";
+  if (supportingText) return "two-line";
+  return "one-line";
+}
+
+// ─── ListItem (Layer 3: Styled) ───────────────────────────────────────────────
+
+/**
+ * Material Design 3 List Item (Layer 3: Styled)
+ *
+ * Renders an accessible list item with MD3 visual treatment:
+ * state layer, ripple, density-driven height, and slot-based layout.
+ *
+ * - **Interactive mode** (inside a `List` with `selectionMode` or `onAction`):
+ *   uses `useOption` for ARIA semantics, renders state layer + ripple.
+ * - **Static mode**: renders `<li role="listitem">` without interactive
+ *   affordances.
+ *
+ * Density is auto-derived from content:
+ * - one-line (56dp) — headline only
+ * - two-line (72dp) — headline + supportingText
+ * - three-line (88dp) — overline present
+ */
+export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(function ListItem(
+  {
+    value,
+    headline,
+    supportingText,
+    overline,
+    leadingSlot,
+    leadingType,
+    trailingSlot,
+    trailingType,
+    isDisabled = false,
+    insetDivider = false,
+    className,
+  },
+  forwardedRef
+) {
+  const ctx = useListContext();
+  const density = getDensity(overline, supportingText);
+
+  if (ctx) {
+    return (
+      <InteractiveStyledListItem
+        ref={forwardedRef}
+        value={value}
+        headline={headline}
+        {...(supportingText !== undefined ? { supportingText } : {})}
+        {...(overline !== undefined ? { overline } : {})}
+        {...(leadingSlot !== undefined ? { leadingSlot } : {})}
+        {...(leadingType !== undefined ? { leadingType } : {})}
+        {...(trailingSlot !== undefined ? { trailingSlot } : {})}
+        {...(trailingType !== undefined ? { trailingType } : {})}
+        density={density}
+        insetDivider={insetDivider}
+        {...(className !== undefined ? { className } : {})}
+        state={ctx.state}
+      />
+    );
+  }
+
+  return (
+    <li
+      ref={forwardedRef}
+      role="listitem"
+      className={cn(
+        listItemVariants({
+          density,
+          isSelected: false,
+          isDisabled,
+          isInteractive: false,
+        }),
+        className
+      )}
+    >
+      {leadingSlot && <ListItemLeading type={leadingType ?? "icon"}>{leadingSlot}</ListItemLeading>}
+      <ListItemText
+        headline={headline}
+        {...(supportingText !== undefined ? { supportingText } : {})}
+        {...(overline !== undefined ? { overline } : {})}
+      />
+      {trailingSlot && (
+        <ListItemTrailing type={trailingType ?? "icon"}>{trailingSlot}</ListItemTrailing>
+      )}
+      {insetDivider && (
+        <Divider
+          orientation="horizontal"
+          inset="start"
+          className="absolute right-0 bottom-0 left-0"
+        />
+      )}
+    </li>
+  );
+});
+
+ListItem.displayName = "ListItem";
+
+// ─── InteractiveStyledListItem (internal) ─────────────────────────────────────
+
+interface InteractiveStyledListItemInternalProps {
+  value: string | number;
+  headline: string;
+  supportingText?: string;
+  overline?: string;
+  leadingSlot?: React.ReactNode;
+  leadingType?: ListItemProps["leadingType"];
+  trailingSlot?: React.ReactNode;
+  trailingType?: ListItemProps["trailingType"];
+  density: ListDensity;
+  insetDivider: boolean;
+  className?: string;
+  state: ListState<object>;
+}
+
+/**
+ * Internal interactive list item — separated so `useOption` is always
+ * called unconditionally (Rules of Hooks).
+ */
+const InteractiveStyledListItem = forwardRef<HTMLLIElement, InteractiveStyledListItemInternalProps>(
+  function InteractiveStyledListItem(
+    {
+      value,
+      headline,
+      supportingText,
+      overline,
+      leadingSlot,
+      leadingType,
+      trailingSlot,
+      trailingType,
+      density,
+      insetDivider,
+      className,
+      state,
+    },
+    forwardedRef
+  ) {
+    const internalRef = useRef<HTMLLIElement>(null);
+    const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLLIElement>;
+
+    const { optionProps, isSelected, isDisabled } = useOption({ key: value }, state, ref);
+
+    const { onMouseDown: handleRipple, ripples } = useRipple({
+      disabled: isDisabled,
+    });
+
+    const mergedProps = mergeProps(optionProps, { onMouseDown: handleRipple });
+
+    return (
+      <li
+        {...mergedProps}
+        ref={ref}
+        className={cn(
+          listItemVariants({
+            density,
+            isSelected,
+            isDisabled,
+            isInteractive: true,
+          }),
+          className
+        )}
+        data-selected={isSelected || undefined}
+        data-disabled={isDisabled || undefined}
+      >
+        <div
+          aria-hidden="true"
+          className="bg-on-surface pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-8"
+        />
+        {ripples}
+
+        {leadingSlot && (
+          <ListItemLeading type={leadingType ?? "icon"}>{leadingSlot}</ListItemLeading>
+        )}
+        <ListItemText
+          headline={headline}
+          {...(supportingText !== undefined ? { supportingText } : {})}
+          {...(overline !== undefined ? { overline } : {})}
+        />
+        {trailingSlot && (
+          <ListItemTrailing type={trailingType ?? "icon"}>{trailingSlot}</ListItemTrailing>
+        )}
+        {insetDivider && (
+          <Divider
+            orientation="horizontal"
+            inset="start"
+            className="absolute right-0 bottom-0 left-0"
+          />
+        )}
+      </li>
+    );
+  }
+);
+
+InteractiveStyledListItem.displayName = "InteractiveStyledListItem";

--- a/packages/react/src/components/List/ListItemLeading.tsx
+++ b/packages/react/src/components/List/ListItemLeading.tsx
@@ -1,0 +1,41 @@
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import type { ListItemLeadingProps } from "./List.types";
+
+const typeClasses: Record<string, string> = {
+  icon: "size-6 text-on-surface-variant",
+  avatar: "size-10 overflow-hidden rounded-full",
+  checkbox: "",
+  radio: "",
+};
+
+/**
+ * MD3 ListItem leading slot.
+ *
+ * For `checkbox` and `radio` types the children are wrapped with
+ * `aria-hidden="true"` and `tabIndex={-1}` because the parent
+ * `ListItem`'s `useOption` already conveys selection state to
+ * assistive technology.
+ */
+export const ListItemLeading = forwardRef<HTMLDivElement, ListItemLeadingProps>(
+  function ListItemLeading({ type, children, className }, ref) {
+    const isControl = type === "checkbox" || type === "radio";
+
+    return (
+      <div
+        ref={ref}
+        className={cn("mr-4 flex shrink-0 items-center", typeClasses[type], className)}
+      >
+        {isControl ? (
+          <span aria-hidden="true" tabIndex={-1}>
+            {children}
+          </span>
+        ) : (
+          children
+        )}
+      </div>
+    );
+  }
+);
+
+ListItemLeading.displayName = "ListItemLeading";

--- a/packages/react/src/components/List/ListItemText.tsx
+++ b/packages/react/src/components/List/ListItemText.tsx
@@ -1,0 +1,25 @@
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import type { ListItemTextProps } from "./List.types";
+
+/**
+ * MD3 ListItem text block — overline + headline + supporting text.
+ *
+ * Uses `min-w-0` to allow text truncation inside flex containers.
+ */
+export const ListItemText = forwardRef<HTMLDivElement, ListItemTextProps>(function ListItemText(
+  { headline, supportingText, overline, className },
+  ref
+) {
+  return (
+    <div ref={ref} className={cn("min-w-0 flex-1", className)}>
+      {overline && <p className="text-on-surface-variant text-label-small">{overline}</p>}
+      <p className="text-on-surface text-body-large">{headline}</p>
+      {supportingText && (
+        <p className="text-on-surface-variant text-body-medium">{supportingText}</p>
+      )}
+    </div>
+  );
+});
+
+ListItemText.displayName = "ListItemText";

--- a/packages/react/src/components/List/ListItemTrailing.tsx
+++ b/packages/react/src/components/List/ListItemTrailing.tsx
@@ -1,0 +1,40 @@
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+import type { ListItemTrailingProps } from "./List.types";
+
+const typeClasses: Record<string, string> = {
+  icon: "size-6 text-on-surface-variant",
+  text: "text-on-surface-variant text-label-small",
+  checkbox: "",
+  radio: "",
+};
+
+/**
+ * MD3 ListItem trailing slot.
+ *
+ * For `checkbox` and `radio` types the children are wrapped with
+ * `aria-hidden="true"` and `tabIndex={-1}` — selection semantics
+ * come from the parent `ListItem`'s `useOption`.
+ */
+export const ListItemTrailing = forwardRef<HTMLDivElement, ListItemTrailingProps>(
+  function ListItemTrailing({ type, children, className }, ref) {
+    const isControl = type === "checkbox" || type === "radio";
+
+    return (
+      <div
+        ref={ref}
+        className={cn("ml-auto flex shrink-0 items-center", typeClasses[type], className)}
+      >
+        {isControl ? (
+          <span aria-hidden="true" tabIndex={-1}>
+            {children}
+          </span>
+        ) : (
+          children
+        )}
+      </div>
+    );
+  }
+);
+
+ListItemTrailing.displayName = "ListItemTrailing";

--- a/packages/react/src/components/List/index.ts
+++ b/packages/react/src/components/List/index.ts
@@ -1,5 +1,20 @@
+// Layer 3: MD3 Styled Components (most users use this)
+export { List } from "./List";
+export { ListItem } from "./ListItem";
+export { ListItemLeading } from "./ListItemLeading";
+export { ListItemTrailing } from "./ListItemTrailing";
+export { ListItemText } from "./ListItemText";
+
 // Layer 2: Headless Primitives (for advanced customization)
 export { ListHeadless, ListItemHeadless } from "./ListHeadless";
+
+// CVA Variants
+export {
+  listVariants,
+  listItemVariants,
+  type ListVariants,
+  type ListItemVariants,
+} from "./List.variants";
 
 // Types
 export type {

--- a/packages/react/src/components/List/index.ts
+++ b/packages/react/src/components/List/index.ts
@@ -1,0 +1,15 @@
+// Layer 2: Headless Primitives (for advanced customization)
+export { ListHeadless, ListItemHeadless } from "./ListHeadless";
+
+// Types
+export type {
+  ListDensity,
+  ListLeadingType,
+  ListTrailingType,
+  ListProps,
+  ListItemProps,
+  ListItemLeadingProps,
+  ListItemTrailingProps,
+  ListItemTextProps,
+  ListHeadlessProps,
+} from "./List.types";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -103,6 +103,7 @@ export {
 } from "./Card";
 export type {
   CardVariant,
+  CardVariants,
   CardProps,
   CardHeadlessProps,
   CardMediaProps,

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -206,3 +206,28 @@ export type {
   TooltipVariants,
   RichTooltipVariants,
 } from "./Tooltip";
+
+export {
+  List,
+  ListItem,
+  ListItemLeading,
+  ListItemTrailing,
+  ListItemText,
+  ListHeadless,
+  ListItemHeadless,
+  listVariants,
+  listItemVariants,
+} from "./List";
+export type {
+  ListDensity,
+  ListLeadingType,
+  ListTrailingType,
+  ListProps,
+  ListItemProps,
+  ListItemLeadingProps,
+  ListItemTrailingProps,
+  ListItemTextProps,
+  ListHeadlessProps,
+  ListVariants,
+  ListItemVariants,
+} from "./List";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -274,3 +274,28 @@ export type {
   TooltipVariants,
   RichTooltipVariants,
 } from "./components/Tooltip";
+
+export {
+  List,
+  ListItem,
+  ListItemLeading,
+  ListItemTrailing,
+  ListItemText,
+  ListHeadless,
+  ListItemHeadless,
+  listVariants,
+  listItemVariants,
+} from "./components/List";
+export type {
+  ListDensity,
+  ListLeadingType,
+  ListTrailingType,
+  ListProps,
+  ListItemProps,
+  ListItemLeadingProps,
+  ListItemTrailingProps,
+  ListItemTextProps,
+  ListHeadlessProps,
+  ListVariants,
+  ListItemVariants,
+} from "./components/List";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -171,6 +171,7 @@ export {
 } from "./components/Card";
 export type {
   CardVariant,
+  CardVariants,
   CardProps,
   CardHeadlessProps,
   CardMediaProps,


### PR DESCRIPTION
## Summary

Adds the MD3 List component to `@tinybigui/react`.

### What's included

- `List` — Container supporting static and interactive modes (`selectionMode`, `onAction`, `showDividers`)
- `ListItem` — Item with auto-density (one/two/three-line), `leadingSlot`, `trailingSlot`, `insetDivider`
- `ListItemLeading` — Leading slot (icon, avatar, checkbox, radio)
- `ListItemTrailing` — Trailing slot (icon, checkbox, radio, text)
- `ListItemText` — Text block (headline, supporting text, overline)
- `ListHeadless` — Headless primitives using `useListBox`/`useOption`
- Full TypeScript types
- 59 tests (foundation + styled + Divider integration)
- 21 Storybook stories including realistic Contact and Settings list examples

### MD3 Compliance

- One-line: `min-h-14` (56dp), Two-line: `min-h-18` (72dp), Three-line: `min-h-22` (88dp)
- Container: `bg-surface`, item padding: `px-4 py-2`
- Selected: `bg-secondary-container` with `transition-[background-color] duration-short4`
- State layer: `bg-on-surface opacity-8/12` with `transition-opacity duration-short2`
- Divider: `showDividers` (full-width between items), `insetDivider` (16dp leading inset at item bottom)

### Accessibility

- Static: `role="list"` / `role="listitem"`
- Interactive: `role="listbox"` / `role="option"` via React Aria
- Keyboard: Arrow Up/Down, Home, End, Enter/Space selection
- Leading/trailing checkbox/radio: `aria-hidden="true"` (selection via `aria-selected` on option)
- `aria-disabled` on disabled items
- WCAG 2.1 AA compliant

### Test results

- `pnpm lint` — ✅ zero errors
- `pnpm typecheck` — ✅ zero type errors
- `pnpm test` — ✅ all tests passing (no regressions)
- `pnpm build` — ✅ build successful