### PR TITLE
feat(search): add MD3 Search component

### DIFF
--- a/.changeset/search-component.md
+++ b/.changeset/search-component.md
@@ -1,0 +1,5 @@
+---
+"@tinybigui/react": minor
+---
+
+feat(search): add MD3 Search component with SearchBar and SearchView overlay, portal rendering, and suggestions slot

--- a/packages/react/src/components/Search/Search.stories.tsx
+++ b/packages/react/src/components/Search/Search.stories.tsx
@@ -1,0 +1,692 @@
+import React from "react";
+import type { JSX } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Search } from "./Search";
+import { SearchBar } from "./SearchBar";
+import { SearchView } from "./SearchView";
+import { List } from "../List/List";
+import { ListItem } from "../List/ListItem";
+import { IconButton } from "../IconButton/IconButton";
+import type { SearchProps } from "./Search.types";
+
+// ─── MD3 Material Icons (inline SVG) ─────────────────────────────────────────
+
+const SearchIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+  </svg>
+);
+
+const MoreVertIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+  </svg>
+);
+
+const MicIcon = (): JSX.Element => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 14c1.66 0 2.99-1.34 2.99-3L15 5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm5.3-3c0 3-2.54 5.1-5.3 5.1S6.7 14 6.7 11H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c3.28-.48 6-3.3 6-6.72h-1.7z" />
+  </svg>
+);
+
+// ─── Inline Avatar helpers ────────────────────────────────────────────────────
+
+interface InlineAvatarProps {
+  src: string;
+  alt: string;
+}
+
+const InlineAvatar = ({ src, alt }: InlineAvatarProps): JSX.Element => (
+  <img src={src} alt={alt} className="size-[30px] rounded-full object-cover" />
+);
+
+interface InitialsAvatarProps {
+  initials: string;
+  colorClass?: string;
+}
+
+const InitialsAvatar = ({
+  initials,
+  colorClass = "bg-secondary-container text-on-secondary-container",
+}: InitialsAvatarProps): JSX.Element => (
+  <span
+    className={`text-label-medium flex size-[30px] items-center justify-center rounded-full font-medium ${colorClass}`}
+  >
+    {initials}
+  </span>
+);
+
+// ─── Named component wrappers for stateful stories ───────────────────────────
+
+function ContainedFullScreenExample(): JSX.Element {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [value, setValue] = React.useState("Ping");
+  return (
+    <div className="bg-surface min-h-screen">
+      <button
+        type="button"
+        className="bg-primary text-on-primary text-label-large m-4 rounded-full px-4 py-2"
+        onClick={() => setIsOpen(true)}
+      >
+        Open Search
+      </button>
+      <SearchView
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        value={value}
+        onChange={setValue}
+        onSubmit={(v) => console.log("Submitted:", v)}
+        placeholder="Search messages"
+        aria-label="Search messages"
+        searchStyle="contained"
+        layout="fullscreen"
+      >
+        <List aria-label="Search results">
+          <ListItem
+            value="ping"
+            leadingSlot={<InitialsAvatar initials="P" />}
+            leadingType="avatar"
+            headline="Ping, Haneul"
+            supportingText="Q3 performance summary • 8:22 AM"
+          />
+          <ListItem
+            value="zita"
+            leadingSlot={<InitialsAvatar initials="Z" />}
+            leadingType="avatar"
+            headline="Zita, Odette, Dagmar"
+            supportingText="Movie marathon • 7:15 AM"
+          />
+          <ListItem
+            value="in"
+            leadingSlot={<InitialsAvatar initials="I" />}
+            leadingType="avatar"
+            headline="In, Aki Aro"
+            supportingText="Museum field trip • 9:40 AM"
+          />
+        </List>
+      </SearchView>
+    </div>
+  );
+}
+
+function ContainedDockedExample(): JSX.Element {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [value, setValue] = React.useState("Eli");
+  return (
+    <div className="bg-surface flex min-h-[400px] items-start justify-center p-8">
+      <SearchView
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        value={value}
+        onChange={setValue}
+        placeholder="Search"
+        aria-label="Search"
+        searchStyle="contained"
+        layout="docked"
+      >
+        <List aria-label="Search results">
+          <ListItem
+            value="eli"
+            headline="Eli, me"
+            supportingText="Adopt a pup? The pet adoption..."
+          />
+          <ListItem
+            value="zita"
+            headline="Zita, Odette, Dagmar"
+            supportingText="Movie marathon • We have to watch..."
+          />
+          <ListItem
+            value="in"
+            headline="In, Aki Aro"
+            supportingText="Museum field trip • So far about..."
+          />
+        </List>
+      </SearchView>
+    </div>
+  );
+}
+
+function DividedFullScreenExample(): JSX.Element {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [value, setValue] = React.useState("Eli");
+  return (
+    <SearchView
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      value={value}
+      onChange={setValue}
+      placeholder="Search"
+      aria-label="Search"
+      searchStyle="divided"
+      layout="fullscreen"
+    >
+      <List aria-label="Search results">
+        <ListItem
+          value="eli"
+          headline="Eli, me"
+          supportingText="Adopt a pup? The pet adoption..."
+        />
+        <ListItem value="zita" headline="Zita, Odette, Dagmar" supportingText="Movie marathon" />
+        <ListItem value="in" headline="In, Aki" supportingText="Museum field trip" />
+      </List>
+    </SearchView>
+  );
+}
+
+function DividedDockedExample(): JSX.Element {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [value, setValue] = React.useState("Eli");
+  return (
+    <div className="bg-surface flex min-h-[400px] items-start justify-center p-8">
+      <SearchView
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        value={value}
+        onChange={setValue}
+        placeholder="Search"
+        aria-label="Search"
+        searchStyle="divided"
+        layout="docked"
+      >
+        <List aria-label="Search results">
+          <ListItem value="eli" headline="Eli, me" supportingText="Adopt a pup?" />
+          <ListItem value="zita" headline="Zita, Odette, Dagmar" supportingText="Movie marathon" />
+          <ListItem value="in" headline="In, Aki" supportingText="Museum field trip" />
+        </List>
+      </SearchView>
+    </div>
+  );
+}
+
+function SearchBarToViewExample(): JSX.Element {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [value, setValue] = React.useState("");
+
+  const suggestions = [
+    { id: "1", headline: "Ping, Haneul", supporting: "Q3 performance summary • 8:22 AM" },
+    { id: "2", headline: "Zita, Odette, Dagmar", supporting: "Movie marathon • 7:15 AM" },
+    { id: "3", headline: "In, Aki Aro", supporting: "Museum field trip • 9:40 AM" },
+  ].filter((s) => !value || s.headline.toLowerCase().includes(value.toLowerCase()));
+
+  return (
+    <div className="bg-surface min-h-screen p-4">
+      <Search
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        value={value}
+        onChange={setValue}
+        onSubmit={(v) => alert(`Search submitted: ${v}`)}
+        placeholder="Search messages"
+        viewAriaLabel="Search messages"
+        searchStyle="contained"
+        layout="fullscreen"
+        trailingActions={[
+          <IconButton key="mic" aria-label="Voice search">
+            <MicIcon />
+          </IconButton>,
+        ]}
+      >
+        {suggestions.length > 0 && (
+          <List aria-label="Search results">
+            {suggestions.map((s) => (
+              <ListItem
+                key={s.id}
+                value={s.id}
+                headline={s.headline}
+                supportingText={s.supporting}
+              />
+            ))}
+          </List>
+        )}
+      </Search>
+    </div>
+  );
+}
+
+function GroupedResultsExample(): JSX.Element {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [value, setValue] = React.useState("m");
+  return (
+    <div className="bg-surface flex min-h-[500px] items-start justify-center p-8">
+      <SearchView
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        value={value}
+        onChange={setValue}
+        placeholder="Search"
+        aria-label="Search"
+        searchStyle="contained"
+        layout="docked"
+      >
+        <div className="flex flex-col gap-2 p-2">
+          <div>
+            <p className="text-label-small text-on-surface-variant px-4 py-2">People</p>
+            <List aria-label="People results">
+              <ListItem
+                value="maria"
+                leadingSlot={<InitialsAvatar initials="M" />}
+                leadingType="avatar"
+                headline="Maria Chen"
+                supportingText="Engineering"
+              />
+              <ListItem
+                value="marcus"
+                leadingSlot={
+                  <InitialsAvatar
+                    initials="M"
+                    colorClass="bg-tertiary-container text-on-tertiary-container"
+                  />
+                }
+                leadingType="avatar"
+                headline="Marcus Lee"
+                supportingText="Design"
+              />
+            </List>
+          </div>
+          <div>
+            <p className="text-label-small text-on-surface-variant px-4 py-2">Messages</p>
+            <List aria-label="Message results">
+              <ListItem
+                value="standup"
+                headline="Monday standup notes"
+                supportingText="Shared by Marcus • Yesterday"
+              />
+              <ListItem
+                value="marketing"
+                headline="Marketing campaign brief"
+                supportingText="Shared by Maria • 2 days ago"
+              />
+            </List>
+          </div>
+        </div>
+      </SearchView>
+    </div>
+  );
+}
+
+function PlaygroundExample(args: Partial<SearchProps>): JSX.Element {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [value, setValue] = React.useState("");
+  return (
+    <div className="bg-surface min-h-[400px] w-full p-4">
+      <Search
+        {...args}
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        value={value}
+        onChange={setValue}
+        viewAriaLabel={args.placeholder ?? "Search"}
+      >
+        <List aria-label="Search results">
+          <ListItem value="1" headline="Result one" supportingText="Supporting text" />
+          <ListItem value="2" headline="Result two" supportingText="Supporting text" />
+          <ListItem value="3" headline="Result three" supportingText="Supporting text" />
+        </List>
+      </Search>
+    </div>
+  );
+}
+
+// ─── Storybook Meta ────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof Search> = {
+  title: "Components/Search",
+  component: Search,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+MD3 Search lets people enter a keyword or phrase to get relevant information.
+
+**Two Styles:**
+- Contained (M3 Expressive — recommended): filled container, rounded pill shape, expressive motion when focused
+- Divided (Baseline): divider separates bar from results; no expressive motion
+
+**Two Layouts:**
+- Full-screen: covers the full viewport
+- Docked: constrained popover (min 360dp / max 720dp)
+
+**States:** Maximized (at rest) → Focused (when activated)
+
+Ref: \`docs/md3-components/search/detail.md\`
+        `,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    searchStyle: {
+      control: { type: "select" },
+      options: ["contained", "divided"],
+      description: "Visual style — contained (M3 Expressive) or divided (Baseline)",
+      table: { defaultValue: { summary: "contained" } },
+    },
+    layout: {
+      control: { type: "select" },
+      options: ["fullscreen", "docked"],
+      description: "Layout of the suggestions/results container",
+      table: { defaultValue: { summary: "fullscreen" } },
+    },
+    placeholder: {
+      control: "text",
+      description: "Hinted search text — also used as the accessibility label",
+    },
+    isDisabled: {
+      control: "boolean",
+      description: "Disables the search bar",
+      table: { defaultValue: { summary: false } },
+    },
+  },
+};
+
+export default meta;
+
+// ─── Search Bar Stories (8) ────────────────────────────────────────────────────
+
+/**
+ * Default contained search bar in Maximized State with a leading search icon and placeholder text.
+ * This is the at-rest affordance before the user interacts.
+ */
+export const DefaultSearchBar: StoryObj<typeof SearchBar> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The default contained search bar in Maximized State with a leading search icon and placeholder text. This is the at-rest affordance before the user interacts.",
+      },
+    },
+  },
+  render: () => <SearchBar placeholder="Search messages" searchStyle="contained" />,
+};
+
+/**
+ * Search bar with an avatar in the trailing slot.
+ * Config 1 from the MD3 examples.
+ */
+export const SearchBarWithAvatar: StoryObj<typeof SearchBar> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Search bar with an avatar in the trailing slot. Config 1 from the MD3 examples — used when the search bar represents a user-scoped search context.",
+      },
+    },
+  },
+  render: () => (
+    <SearchBar
+      placeholder="Hinted search text"
+      avatar={<InlineAvatar src="https://i.pravatar.cc/30" alt="User avatar" />}
+    />
+  ),
+};
+
+/**
+ * Search bar with one trailing icon button.
+ * Config 2 from the MD3 examples.
+ */
+export const SearchBarWithOneTrailingIcon: StoryObj<typeof SearchBar> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Search bar with one trailing icon button. Config 2 from the MD3 examples.",
+      },
+    },
+  },
+  render: () => (
+    <SearchBar
+      placeholder="Hinted search text"
+      trailingActions={[
+        <IconButton key="search" aria-label="Search">
+          <SearchIcon />
+        </IconButton>,
+      ]}
+    />
+  ),
+};
+
+/**
+ * Search bar with two trailing icon buttons.
+ * Config 3 from the MD3 examples.
+ */
+export const SearchBarWithTwoTrailingIcons: StoryObj<typeof SearchBar> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Search bar with two trailing icon buttons. Config 3 from the MD3 examples.",
+      },
+    },
+  },
+  render: () => (
+    <SearchBar
+      placeholder="Hinted search text"
+      trailingActions={[
+        <IconButton key="search" aria-label="Search">
+          <SearchIcon />
+        </IconButton>,
+        <IconButton key="more" aria-label="More options">
+          <MoreVertIcon />
+        </IconButton>,
+      ]}
+    />
+  ),
+};
+
+/**
+ * Search bar with a trailing icon button and an avatar.
+ * Config 4 from the MD3 examples — the most common real-world configuration.
+ */
+export const SearchBarWithIconAndAvatar: StoryObj<typeof SearchBar> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Search bar with a trailing icon button and an avatar. Config 4 from the MD3 examples — the most common real-world configuration.",
+      },
+    },
+  },
+  render: () => (
+    <SearchBar
+      placeholder="Hinted search text"
+      trailingActions={[
+        <IconButton key="search" aria-label="Search">
+          <SearchIcon />
+        </IconButton>,
+      ]}
+      avatar={<InlineAvatar src="https://i.pravatar.cc/30" alt="User avatar" />}
+    />
+  ),
+};
+
+/**
+ * Search bar in the Divided (Baseline) style.
+ * Uses 16dp leading/trailing spacing and no expressive motion.
+ */
+export const SearchBarDividedStyle: StoryObj<typeof SearchBar> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Search bar in the Divided (Baseline) style. Uses 16dp leading/trailing spacing and no expressive motion. This is the original MD3 design without M3 Expressive updates.",
+      },
+    },
+  },
+  render: () => <SearchBar placeholder="Hinted search text" searchStyle="divided" />,
+};
+
+/**
+ * Search bar in the disabled state — non-interactive, 38% opacity.
+ */
+export const SearchBarDisabled: StoryObj<typeof SearchBar> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Search bar in the disabled state — non-interactive, 38% opacity.",
+      },
+    },
+  },
+  render: () => <SearchBar placeholder="Search messages" isDisabled />,
+};
+
+/**
+ * All four interaction states of the Search bar side by side.
+ * Ref: docs/md3-components/search/images/state-search-bar.png
+ */
+export const SearchBarStates: StoryObj = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All four interaction states of the Search bar: Enabled, Hovered, Focused (with focus indicator ring in secondary color), and Pressed (with ripple). Reference: docs/md3-components/search/images/state-search-bar.png.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex w-[400px] flex-col gap-6">
+      <div>
+        <p className="text-label-small text-on-surface-variant mb-2">1. Enabled</p>
+        <SearchBar placeholder="Hinted search text" />
+      </div>
+      <div>
+        <p className="text-label-small text-on-surface-variant mb-2">2. Hovered (hover over bar)</p>
+        <SearchBar placeholder="Hinted search text" />
+      </div>
+      <div>
+        <p className="text-label-small text-on-surface-variant mb-2">3. Focused (tab to focus)</p>
+        <SearchBar placeholder="Search query" />
+      </div>
+      <div>
+        <p className="text-label-small text-on-surface-variant mb-2">4. Pressed (ripple)</p>
+        <SearchBar placeholder="Search query" />
+      </div>
+    </div>
+  ),
+};
+
+// ─── Search View Stories (4) ──────────────────────────────────────────────────
+
+/**
+ * SearchView in the Contained (M3 Expressive) style with Full-screen layout.
+ */
+export const ContainedFullScreen: StoryObj<typeof SearchView> = {
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "SearchView in the Contained (M3 Expressive) style with Full-screen layout. Background: surface-container-low, no corner rounding, 56dp header height. Results appear in a full-viewport overlay. Reference: docs/md3-components/search/images/full-screen-layout.png.",
+      },
+    },
+  },
+  render: () => <ContainedFullScreenExample />,
+};
+
+/**
+ * SearchView in the Contained (M3 Expressive) style with Docked layout.
+ */
+export const ContainedDocked: StoryObj<typeof SearchView> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "SearchView in the Contained (M3 Expressive) style with Docked layout. Background: surface-container-high, rounded-full bar, 12dp results rounding, 2dp gap between bar and results. Width: min 360dp / max 720dp. Reference: docs/md3-components/search/images/docked-layout.png.",
+      },
+    },
+  },
+  render: () => <ContainedDockedExample />,
+};
+
+/**
+ * SearchView in the Divided (Baseline) style with Full-screen layout.
+ */
+export const DividedFullScreen: StoryObj<typeof SearchView> = {
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "SearchView in the Divided (Baseline) style with Full-screen layout. Background: surface-container-high, 72dp header height, a divider separates the header from results. Reference: docs/md3-components/search/images/full-screen-layout-divided.png.",
+      },
+    },
+  },
+  render: () => <DividedFullScreenExample />,
+};
+
+/**
+ * SearchView in the Divided (Baseline) style with Docked layout.
+ */
+export const DividedDocked: StoryObj<typeof SearchView> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "SearchView in the Divided (Baseline) style with Docked layout. Background: surface-container-high, 56dp header, 28dp extra-large rounded container, divider between header and results. Reference: docs/md3-components/search/images/docked-layout-divided.png.",
+      },
+    },
+  },
+  render: () => <DividedDockedExample />,
+};
+
+// ─── Interactive / Compound Stories (3) ──────────────────────────────────────
+
+/**
+ * Primary interactive story. Demonstrates the full MD3 Search interaction flow:
+ * Maximized State → Click/Tab → Focused State → type → results → clear → back.
+ */
+export const SearchBarToView: StoryObj<typeof Search> = {
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story: `
+**Primary interactive story.** Demonstrates the full MD3 Search interaction flow:
+
+1. **Maximized State** — the search bar is at rest with a leading search icon and placeholder
+2. **Click or Tab+Enter/Space** — bar activates, SearchView opens (Focused State)
+3. **Type** — input accepts text, suggestions appear in results area below
+4. **Clear button** — appears when text is typed; clicking resets input but stays focused
+5. **Back arrow** — returns to Maximized State (closes SearchView)
+
+Includes M3 Expressive motion: bar pane margins transition from 24dp to 12dp on focus.
+        `,
+      },
+    },
+  },
+  render: () => <SearchBarToViewExample />,
+};
+
+/**
+ * Demonstrates the M3 Expressive feature where gaps separate results into visual groups.
+ */
+export const GroupedResults: StoryObj<typeof SearchView> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates the M3 Expressive feature where gaps separate results into visual groups. Consumers use standard Tailwind gap/space utilities on List children to achieve this grouping effect.",
+      },
+    },
+  },
+  render: () => <GroupedResultsExample />,
+};
+
+/**
+ * Full interactive playground with all controls wired up.
+ */
+export const Playground: StoryObj<typeof Search> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Full interactive playground with all controls wired up. Use the controls panel to explore all style, layout, and state combinations.",
+      },
+    },
+  },
+  args: {
+    searchStyle: "contained",
+    layout: "fullscreen",
+    placeholder: "Search messages",
+    isDisabled: false,
+  },
+  render: (args) => <PlaygroundExample {...args} />,
+};

--- a/packages/react/src/components/Search/Search.test.tsx
+++ b/packages/react/src/components/Search/Search.test.tsx
@@ -1,0 +1,262 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { SearchBarHeadless, SearchViewHeadless } from "./SearchHeadless";
+
+describe("SearchBarHeadless", () => {
+  describe("Rendering", () => {
+    test("renders form with role='search'", () => {
+      render(<SearchBarHeadless placeholder="Search" />);
+      expect(screen.getByRole("search")).toBeInTheDocument();
+      expect(screen.getByRole("search").tagName).toBe("FORM");
+    });
+
+    test("input has role='searchbox'", () => {
+      render(<SearchBarHeadless placeholder="Search" />);
+      expect(screen.getByRole("searchbox")).toBeInTheDocument();
+    });
+
+    test("displays value prop in the input", () => {
+      render(<SearchBarHeadless value="hello" placeholder="Search" onChange={() => {}} />);
+      expect(screen.getByRole("searchbox")).toHaveValue("hello");
+    });
+
+    test("calls onChange when input value changes", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<SearchBarHeadless placeholder="Search" onChange={handleChange} />);
+
+      await user.type(screen.getByRole("searchbox"), "a");
+      expect(handleChange).toHaveBeenCalledWith("a");
+    });
+
+    test("calls onSubmit with the current value when Enter is pressed", async () => {
+      const user = userEvent.setup();
+      const handleSubmit = vi.fn();
+      render(
+        <SearchBarHeadless defaultValue="query" placeholder="Search" onSubmit={handleSubmit} />
+      );
+
+      const input = screen.getByRole("searchbox");
+      await user.click(input);
+      await user.keyboard("{Enter}");
+      expect(handleSubmit).toHaveBeenCalledWith("query");
+    });
+
+    test("calls onClear when Escape is pressed and input has a value", async () => {
+      const user = userEvent.setup();
+      const handleClear = vi.fn();
+      render(
+        <SearchBarHeadless defaultValue="something" placeholder="Search" onClear={handleClear} />
+      );
+
+      const input = screen.getByRole("searchbox");
+      await user.click(input);
+      await user.keyboard("{Escape}");
+      expect(handleClear).toHaveBeenCalled();
+    });
+
+    test("renders leading icon slot content", () => {
+      render(
+        <SearchBarHeadless
+          placeholder="Search"
+          leadingIcon={<span data-testid="search-icon">🔍</span>}
+        />
+      );
+      expect(screen.getByTestId("search-icon")).toBeInTheDocument();
+    });
+
+    test("renders single trailing action", () => {
+      render(
+        <SearchBarHeadless
+          placeholder="Search"
+          trailingActions={[
+            <button key="mic" data-testid="mic-btn">
+              mic
+            </button>,
+          ]}
+        />
+      );
+      expect(screen.getByTestId("mic-btn")).toBeInTheDocument();
+    });
+
+    test("renders multiple trailing actions", () => {
+      render(
+        <SearchBarHeadless
+          placeholder="Search"
+          trailingActions={[
+            <button key="mic" data-testid="mic-btn">
+              mic
+            </button>,
+            <button key="camera" data-testid="camera-btn">
+              camera
+            </button>,
+          ]}
+        />
+      );
+      expect(screen.getByTestId("mic-btn")).toBeInTheDocument();
+      expect(screen.getByTestId("camera-btn")).toBeInTheDocument();
+    });
+
+    test("renders avatar slot content", () => {
+      render(
+        <SearchBarHeadless
+          placeholder="Search"
+          avatar={<img data-testid="avatar" src="" alt="User" />}
+        />
+      );
+      expect(screen.getByTestId("avatar")).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    test("input aria-label defaults to placeholder value when no aria-label prop", () => {
+      render(<SearchBarHeadless placeholder="Search files" />);
+      expect(screen.getByRole("searchbox")).toHaveAttribute("aria-label", "Search files");
+    });
+
+    test("input uses explicit aria-label when provided", () => {
+      render(<SearchBarHeadless placeholder="Search files" aria-label="File search input" />);
+      expect(screen.getByRole("searchbox")).toHaveAttribute("aria-label", "File search input");
+    });
+
+    test("isDisabled={true} disables the input", () => {
+      render(<SearchBarHeadless placeholder="Search" isDisabled />);
+      expect(screen.getByRole("searchbox")).toBeDisabled();
+    });
+
+    test("Space/Enter in Maximized state calls onFocus (activates text field)", () => {
+      const handleFocus = vi.fn();
+      render(<SearchBarHeadless placeholder="Search" onFocus={handleFocus} />);
+
+      const input = screen.getByRole("searchbox");
+      input.focus();
+      expect(handleFocus).toHaveBeenCalled();
+    });
+
+    test("forwardRef — ref is attached to the form element", () => {
+      const ref = { current: null };
+      render(<SearchBarHeadless ref={ref} placeholder="Search" />);
+      expect(ref.current).toBeInstanceOf(HTMLFormElement);
+    });
+
+    test("zero axe violations", async () => {
+      const { container } = render(<SearchBarHeadless placeholder="Search documents" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});
+
+describe("SearchViewHeadless", () => {
+  describe("Rendering", () => {
+    test("renders in a portal when isOpen={true}", () => {
+      render(
+        <SearchViewHeadless isOpen onClose={() => {}} aria-label="Search">
+          <p>results</p>
+        </SearchViewHeadless>
+      );
+      const searchView = screen.getByRole("search", { name: "Search" });
+      expect(searchView).toBeInTheDocument();
+      expect(searchView.closest("body")).toBeTruthy();
+    });
+
+    test("does NOT render to the DOM when isOpen={false}", () => {
+      render(
+        <SearchViewHeadless isOpen={false} onClose={() => {}} aria-label="Search">
+          <p>results</p>
+        </SearchViewHeadless>
+      );
+      expect(screen.queryByRole("search", { name: "Search" })).not.toBeInTheDocument();
+    });
+
+    test("calls onClose when Escape key is pressed", async () => {
+      const user = userEvent.setup();
+      const handleClose = vi.fn();
+      render(
+        <SearchViewHeadless isOpen onClose={handleClose} aria-label="Search">
+          <p>results</p>
+        </SearchViewHeadless>
+      );
+
+      await user.keyboard("{Escape}");
+      expect(handleClose).toHaveBeenCalled();
+    });
+
+    test("renders a back arrow button by default as leading element", () => {
+      render(
+        <SearchViewHeadless isOpen onClose={() => {}} aria-label="Search">
+          <p>results</p>
+        </SearchViewHeadless>
+      );
+      expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+    });
+
+    test("renders the clear button when input has a value", () => {
+      render(
+        <SearchViewHeadless isOpen onClose={() => {}} aria-label="Search" defaultValue="hello">
+          <p>results</p>
+        </SearchViewHeadless>
+      );
+      expect(screen.getByRole("button", { name: "Clear search" })).toBeInTheDocument();
+    });
+
+    test("does NOT render the clear button when input is empty", () => {
+      render(
+        <SearchViewHeadless isOpen onClose={() => {}} aria-label="Search">
+          <p>results</p>
+        </SearchViewHeadless>
+      );
+      expect(screen.queryByRole("button", { name: "Clear search" })).not.toBeInTheDocument();
+    });
+
+    test("renders children in the suggestions/results area", () => {
+      render(
+        <SearchViewHeadless isOpen onClose={() => {}} aria-label="Search">
+          <p data-testid="suggestion">Suggestion 1</p>
+        </SearchViewHeadless>
+      );
+      expect(screen.getByTestId("suggestion")).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    test("aria-label is applied to the view container", () => {
+      render(
+        <SearchViewHeadless isOpen onClose={() => {}} aria-label="Search messages">
+          <p>results</p>
+        </SearchViewHeadless>
+      );
+      expect(screen.getByRole("search")).toHaveAttribute("aria-label", "Search messages");
+    });
+
+    test("aria-live region is present for autosuggest announcements", () => {
+      render(
+        <SearchViewHeadless isOpen onClose={() => {}} aria-label="Search">
+          <p>results</p>
+        </SearchViewHeadless>
+      );
+      const liveRegion = screen.getByRole("search").querySelector('[aria-live="polite"]');
+      expect(liveRegion).toBeInTheDocument();
+    });
+
+    test("zero axe violations when open", async () => {
+      render(
+        <SearchViewHeadless
+          isOpen
+          onClose={() => {}}
+          aria-label="Search messages"
+          defaultValue="test"
+        >
+          <ul>
+            <li>Result 1</li>
+            <li>Result 2</li>
+          </ul>
+        </SearchViewHeadless>
+      );
+      const results = await axe(document.body);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/react/src/components/Search/Search.test.tsx
+++ b/packages/react/src/components/Search/Search.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "vitest-axe";
 import { SearchBarHeadless, SearchViewHeadless } from "./SearchHeadless";
+import { SearchBar } from "./SearchBar";
+import { SearchView } from "./SearchView";
 
 describe("SearchBarHeadless", () => {
   describe("Rendering", () => {
@@ -258,5 +260,304 @@ describe("SearchViewHeadless", () => {
       const results = await axe(document.body);
       expect(results).toHaveNoViolations();
     });
+  });
+});
+
+// ─── Layer 3: Styled Component Tests ──────────────────────────────────────────
+
+describe("SearchBar (Styled)", () => {
+  test("has rounded-full class", () => {
+    render(<SearchBar placeholder="Search" />);
+    const container = screen.getByRole("search").closest("[class*=rounded-full]");
+    expect(container).toBeInTheDocument();
+  });
+
+  test("has h-14 class (56dp height)", () => {
+    render(<SearchBar placeholder="Search" />);
+    const container = screen.getByRole("search").closest("[class*=h-14]");
+    expect(container).toBeInTheDocument();
+  });
+
+  test("has bg-surface-container-high class", () => {
+    render(<SearchBar placeholder="Search" />);
+    const container = screen.getByRole("search").closest("[class*=bg-surface-container-high]");
+    expect(container).toBeInTheDocument();
+  });
+
+  test("contained style with trailing actions has px-1 and gap-1 (4dp spacing)", () => {
+    render(
+      <SearchBar
+        placeholder="Search"
+        searchStyle="contained"
+        trailingActions={[<button key="mic">mic</button>]}
+      />
+    );
+    const container = screen.getByRole("search").closest("[class*=px-1]");
+    expect(container).toBeInTheDocument();
+    expect(container?.className).toContain("gap-1");
+  });
+
+  test("contained style without trailing actions has px-4 (16dp no-actions spacing)", () => {
+    render(<SearchBar placeholder="Search" searchStyle="contained" />);
+    const container = screen.getByRole("search").closest("[class*=px-4]");
+    expect(container).toBeInTheDocument();
+  });
+
+  test("divided style has px-4 and gap-4 (16dp spacing)", () => {
+    render(<SearchBar placeholder="Search" searchStyle="divided" />);
+    const container = screen.getByRole("search").closest("[class*=px-4]");
+    expect(container).toBeInTheDocument();
+    expect(container?.className).toContain("gap-4");
+  });
+
+  test("state layer has hover:opacity-8 class", () => {
+    render(<SearchBar placeholder="Search" />);
+    const stateLayer = document.querySelector("[data-slot=state-layer]");
+    expect(stateLayer).toBeInTheDocument();
+    expect(stateLayer?.className).toContain("group-hover:opacity-8");
+  });
+
+  test("state layer uses spring motion tokens for opacity transition", () => {
+    render(<SearchBar placeholder="Search" />);
+    const stateLayer = document.querySelector("[data-slot=state-layer]");
+    expect(stateLayer?.className).toContain("duration-spring-standard-fast-effects");
+    expect(stateLayer?.className).toContain("ease-spring-standard-fast-effects");
+  });
+
+  test("pressed state renders ripple container (from useRipple)", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar placeholder="Search" />);
+    const container = screen.getByRole("search").parentElement;
+    expect(container).toBeInTheDocument();
+    if (container) {
+      await user.click(container);
+    }
+    const rippleContainer = document.querySelector("[data-ripple-container]");
+    expect(rippleContainer).toBeInTheDocument();
+  });
+
+  test("focus indicator ring applied to container via has-[:focus-visible]", () => {
+    render(<SearchBar placeholder="Search" />);
+    const container = screen.getByRole("search").parentElement;
+    expect(container?.className).toContain("ring-secondary");
+  });
+
+  test("avatar only (Config 1) renders in trailing slot at 30dp size", () => {
+    render(
+      <SearchBar
+        placeholder="Search"
+        avatar={<img data-testid="avatar-img" src="" alt="User avatar" />}
+      />
+    );
+    expect(screen.getByTestId("avatar-img")).toBeInTheDocument();
+    const avatarWrapper = screen.getByTestId("avatar-img").closest("[class*=rounded-full]");
+    expect(avatarWrapper).toBeInTheDocument();
+  });
+
+  test("one trailing icon button (Config 2) renders in trailing slot", () => {
+    render(
+      <SearchBar
+        placeholder="Search"
+        trailingActions={[
+          <button key="mic" data-testid="mic-btn" aria-label="Voice search">
+            mic
+          </button>,
+        ]}
+      />
+    );
+    expect(screen.getByTestId("mic-btn")).toBeInTheDocument();
+  });
+
+  test("two trailing icon buttons (Config 3) both render in trailing slot", () => {
+    render(
+      <SearchBar
+        placeholder="Search"
+        trailingActions={[
+          <button key="mic" data-testid="mic-btn" aria-label="Voice search">
+            mic
+          </button>,
+          <button key="more" data-testid="more-btn" aria-label="More options">
+            more
+          </button>,
+        ]}
+      />
+    );
+    expect(screen.getByTestId("mic-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("more-btn")).toBeInTheDocument();
+  });
+
+  test("one trailing icon + avatar (Config 4) both render", () => {
+    render(
+      <SearchBar
+        placeholder="Search"
+        trailingActions={[
+          <button key="mic" data-testid="mic-btn" aria-label="Voice search">
+            mic
+          </button>,
+        ]}
+        avatar={<img data-testid="avatar-img" src="" alt="User avatar" />}
+      />
+    );
+    expect(screen.getByTestId("mic-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("avatar-img")).toBeInTheDocument();
+  });
+});
+
+describe("SearchView (Styled)", () => {
+  test("clear button appears when input has a value", () => {
+    render(
+      <SearchView isOpen onClose={() => {}} aria-label="Search" defaultValue="hello">
+        <p>results</p>
+      </SearchView>
+    );
+    expect(screen.getByRole("button", { name: "Clear search" })).toBeInTheDocument();
+  });
+
+  test("clear button is not rendered when input is empty", () => {
+    render(
+      <SearchView isOpen onClose={() => {}} aria-label="Search">
+        <p>results</p>
+      </SearchView>
+    );
+    expect(screen.queryByRole("button", { name: "Clear search" })).not.toBeInTheDocument();
+  });
+
+  test("contained+fullscreen has bg-surface-container-low class", () => {
+    render(
+      <SearchView
+        isOpen
+        onClose={() => {}}
+        aria-label="Search"
+        searchStyle="contained"
+        layout="fullscreen"
+      >
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    expect(view.className).toContain("bg-surface-container-low");
+  });
+
+  test("contained+docked has bg-surface-container-high class", () => {
+    render(
+      <SearchView
+        isOpen
+        onClose={() => {}}
+        aria-label="Search"
+        searchStyle="contained"
+        layout="docked"
+      >
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    expect(view.className).toContain("bg-surface-container-high");
+  });
+
+  test("divided style renders border-outline divider", () => {
+    render(
+      <SearchView isOpen onClose={() => {}} aria-label="Search" searchStyle="divided">
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    expect(view.className).toContain("border-outline");
+  });
+
+  test("docked layout has min-w-[360px] and max-w-[720px] constraint classes", () => {
+    render(
+      <SearchView isOpen onClose={() => {}} aria-label="Search" layout="docked">
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    expect(view.className).toContain("min-w-[360px]");
+    expect(view.className).toContain("max-w-[720px]");
+  });
+
+  test("divided+fullscreen header has h-[72px] class", () => {
+    render(
+      <SearchView
+        isOpen
+        onClose={() => {}}
+        aria-label="Search"
+        searchStyle="divided"
+        layout="fullscreen"
+      >
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    expect(view.className).toContain("h-[72px]");
+  });
+
+  test("divided+fullscreen has bg-surface-container-high class", () => {
+    render(
+      <SearchView
+        isOpen
+        onClose={() => {}}
+        aria-label="Search"
+        searchStyle="divided"
+        layout="fullscreen"
+      >
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    expect(view.className).toContain("bg-surface-container-high");
+  });
+
+  test("divided+docked has bg-surface-container-high and rounded-[28px] class", () => {
+    render(
+      <SearchView
+        isOpen
+        onClose={() => {}}
+        aria-label="Search"
+        searchStyle="divided"
+        layout="docked"
+      >
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    expect(view.className).toContain("bg-surface-container-high");
+    expect(view.className).toContain("rounded-[28px]");
+  });
+
+  test("contained+docked has gap-0.5 (2dp) between header and results", () => {
+    render(
+      <SearchView
+        isOpen
+        onClose={() => {}}
+        aria-label="Search"
+        searchStyle="contained"
+        layout="docked"
+      >
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    expect(view.className).toContain("gap-0.5");
+  });
+
+  test("has animate-md-scale-in class on mount", () => {
+    render(
+      <SearchView isOpen onClose={() => {}} aria-label="Search">
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    expect(view.className).toContain("animate-md-scale-in");
+  });
+
+  test("renders children inside the content area", () => {
+    render(
+      <SearchView isOpen onClose={() => {}} aria-label="Search">
+        <p data-testid="search-result">Result 1</p>
+      </SearchView>
+    );
+    const content = screen.getByRole("search").querySelector("[data-slot=content]");
+    expect(content).toBeInTheDocument();
+    expect(screen.getByTestId("search-result")).toBeInTheDocument();
   });
 });

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { forwardRef, useState, useCallback } from "react";
+import { SearchBar } from "./SearchBar";
+import { SearchView } from "./SearchView";
+import type { SearchProps } from "./Search.types";
+
+/**
+ * Material Design 3 Search Compound Component (Layer 3: Styled)
+ *
+ * Combines SearchBar + SearchView in one controlled/uncontrolled unit.
+ * Manages the open/close lifecycle between the collapsed bar and expanded view.
+ *
+ * - When closed: renders SearchBar; focus → opens SearchView
+ * - When open: renders SearchView; back/Escape → closes to SearchBar
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled
+ * <Search placeholder="Search messages">
+ *   <List>{suggestions.map(s => <ListItem key={s.id} headline={s.label} />)}</List>
+ * </Search>
+ *
+ * // Controlled
+ * <Search
+ *   isOpen={isOpen}
+ *   onOpenChange={setOpen}
+ *   value={query}
+ *   onChange={setQuery}
+ *   placeholder="Search files"
+ * >
+ *   <List>{results.map(r => <ListItem key={r.id} headline={r.label} />)}</List>
+ * </Search>
+ * ```
+ */
+export const Search = forwardRef<HTMLFormElement, SearchProps>(
+  (
+    {
+      isOpen: controlledIsOpen,
+      onOpenChange,
+      value,
+      defaultValue,
+      onChange,
+      onSubmit,
+      onClear,
+      placeholder,
+      leadingIcon,
+      trailingActions,
+      avatar,
+      isDisabled = false,
+      "aria-label": ariaLabel,
+      className,
+      searchStyle = "contained",
+      layout = "fullscreen",
+      children,
+      viewAriaLabel,
+    },
+    ref
+  ) => {
+    const [internalIsOpen, setInternalIsOpen] = useState(false);
+    const isControlled = controlledIsOpen !== undefined;
+    const isOpen = isControlled ? controlledIsOpen : internalIsOpen;
+
+    const handleOpenChange = useCallback(
+      (open: boolean) => {
+        if (!isControlled) {
+          setInternalIsOpen(open);
+        }
+        onOpenChange?.(open);
+      },
+      [isControlled, onOpenChange]
+    );
+
+    const handleFocus = useCallback(() => {
+      handleOpenChange(true);
+    }, [handleOpenChange]);
+
+    const handleClose = useCallback(() => {
+      handleOpenChange(false);
+    }, [handleOpenChange]);
+
+    if (isOpen) {
+      return (
+        <SearchView
+          isOpen
+          onClose={handleClose}
+          {...(value !== undefined ? { value } : {})}
+          {...(defaultValue !== undefined ? { defaultValue } : {})}
+          {...(onChange !== undefined ? { onChange } : {})}
+          {...(onSubmit !== undefined ? { onSubmit } : {})}
+          {...(placeholder !== undefined ? { placeholder } : {})}
+          aria-label={viewAriaLabel ?? ariaLabel ?? placeholder ?? "Search"}
+          searchStyle={searchStyle}
+          layout={layout}
+          {...(trailingActions !== undefined ? { trailingActions } : {})}
+        >
+          {children}
+        </SearchView>
+      );
+    }
+
+    return (
+      <SearchBar
+        ref={ref}
+        {...(value !== undefined ? { value } : {})}
+        {...(defaultValue !== undefined ? { defaultValue } : {})}
+        {...(onChange !== undefined ? { onChange } : {})}
+        {...(onSubmit !== undefined ? { onSubmit } : {})}
+        {...(onClear !== undefined ? { onClear } : {})}
+        {...(placeholder !== undefined ? { placeholder } : {})}
+        {...(leadingIcon !== undefined ? { leadingIcon } : {})}
+        {...(trailingActions !== undefined ? { trailingActions } : {})}
+        {...(avatar !== undefined ? { avatar } : {})}
+        isDisabled={isDisabled}
+        {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+        {...(className !== undefined ? { className } : {})}
+        searchStyle={searchStyle}
+        onFocus={handleFocus}
+      />
+    );
+  }
+);
+
+Search.displayName = "Search";

--- a/packages/react/src/components/Search/Search.types.ts
+++ b/packages/react/src/components/Search/Search.types.ts
@@ -1,0 +1,212 @@
+import type React from "react";
+
+/**
+ * Visual style of the search component.
+ * - `contained`: M3 Expressive style — filled container, rounded pill shape, expressive motion.
+ *   Recommended for new designs.
+ * - `divided`: Baseline (original M3) style — uses a divider to separate bar from results.
+ *   Does not include expressive motion or updated shapes.
+ *
+ * @see docs/md3-components/search/images/expressive.png
+ * @see docs/md3-components/search/images/baseline.png
+ */
+export type SearchStyle = "contained" | "divided";
+
+/**
+ * Layout mode for the search suggestions/results container.
+ * - `fullscreen`: Covers the full viewport (width: 100%, height: 100%).
+ *   Shape: corner-none (no rounding) for contained; no rounding for divided.
+ * - `docked`: Constrained popover (min 360dp, max 720dp width; min 240dp, max 2/3 screen height).
+ *   Shape: rounded-full bar + 12dp results container (contained); 28dp extra-large container (divided).
+ *
+ * @see docs/md3-components/search/images/full-screen-layout.png
+ * @see docs/md3-components/search/images/docked-layout.png
+ */
+export type SearchLayout = "fullscreen" | "docked";
+
+/**
+ * Props for the SearchBar component — the collapsed/maximized search affordance.
+ *
+ * The bar shows:
+ * - A leading icon (default: search icon) on the left
+ * - Placeholder/hinted search text in the center
+ * - Optional trailing actions (icon buttons, avatar, or combinations) on the right
+ *
+ * When clicked/focused, the component transitions to Focused State (SearchView).
+ *
+ * @example
+ * ```tsx
+ * <SearchBar placeholder="Search messages" onFocus={() => setOpen(true)} />
+ * ```
+ */
+export interface SearchBarProps {
+  /** Controlled value of the search input */
+  value?: string;
+  /** Uncontrolled default value */
+  defaultValue?: string;
+  /** Called when input value changes */
+  onChange?: (value: string) => void;
+  /** Called when the user submits the search (Enter key in Focused state) */
+  onSubmit?: (value: string) => void;
+  /** Called when the user clears the input (Escape key when value exists) */
+  onClear?: () => void;
+  /**
+   * Placeholder / hinted search text. Also used as the accessibility label
+   * for the input field when no explicit `aria-label` is provided.
+   */
+  placeholder?: string;
+  /**
+   * Leading icon slot. Defaults to a search icon.
+   * In Focused state this is replaced by a back arrow button.
+   */
+  leadingIcon?: React.ReactNode;
+  /**
+   * Trailing action buttons (icon buttons, avatar, or combinations).
+   * Supports all 4 configurations from the MD3 spec:
+   * 1. Avatar only
+   * 2. One trailing icon button
+   * 3. Two trailing icon buttons
+   * 4. One trailing icon button + avatar
+   *
+   * When the bar transitions to Focused state, trailing actions are replaced by a clear button.
+   *
+   * @see docs/md3-components/search/images/examples.png
+   */
+  trailingActions?: React.ReactNode[];
+  /**
+   * Optional avatar element for the trailing slot.
+   * Rendered at 30dp size with rounded-full shape per MD3 spec.
+   * When provided alongside trailingActions, renders after the action buttons.
+   */
+  avatar?: React.ReactNode;
+  /** Disables the search bar */
+  isDisabled?: boolean;
+  /**
+   * Accessible label for the search input. When not provided, `placeholder` is
+   * used as the label per MD3 accessibility guidance (labeling-elements spec).
+   */
+  "aria-label"?: string;
+  /** Additional CSS classes */
+  className?: string;
+  /**
+   * Visual style — contained (expressive) or divided (baseline).
+   * @default 'contained'
+   */
+  searchStyle?: SearchStyle;
+  /** Called when the search bar receives focus */
+  onFocus?: () => void;
+  /** Called when the search bar loses focus */
+  onBlur?: () => void;
+}
+
+/**
+ * Props for the SearchView component — the expanded/focused search experience.
+ *
+ * The view shows:
+ * - A header with back arrow, input field, and clear button
+ * - An optional divider (divided style only)
+ * - A content area for suggestions/results (via children — use the List component)
+ *
+ * @example
+ * ```tsx
+ * <SearchView isOpen={isOpen} onClose={() => setOpen(false)} aria-label="Search messages">
+ *   <List>{suggestions.map(s => <ListItem key={s.id} headline={s.label} />)}</List>
+ * </SearchView>
+ * ```
+ */
+export interface SearchViewProps {
+  /** Whether the search view is open */
+  isOpen: boolean;
+  /** Called when the view should close (back arrow click or Escape key) */
+  onClose: () => void;
+  /** Controlled value of the search input */
+  value?: string;
+  /** Uncontrolled default value */
+  defaultValue?: string;
+  /** Called when input value changes */
+  onChange?: (value: string) => void;
+  /** Called when the user submits the search (Enter key) */
+  onSubmit?: (value: string) => void;
+  /** Placeholder / hinted search text */
+  placeholder?: string;
+  /** Accessible label for the search view — required */
+  "aria-label": string;
+  /** Additional CSS classes */
+  className?: string;
+  /**
+   * Suggestions and results content area.
+   * Use the List component here. Screen readers automatically announce
+   * list results per MD3 accessibility guidance.
+   * Supports visual gaps between result groups (M3 Expressive: "Gaps can separate results into groups").
+   */
+  children?: React.ReactNode;
+  /**
+   * Visual style — contained (expressive) or divided (baseline).
+   * @default 'contained'
+   */
+  searchStyle?: SearchStyle;
+  /**
+   * Layout mode — fullscreen or docked.
+   * @default 'fullscreen'
+   */
+  layout?: SearchLayout;
+  /**
+   * Leading icon for the view header. Defaults to a back arrow button.
+   * Clicking the back arrow calls `onClose`.
+   */
+  leadingIcon?: React.ReactNode;
+  /**
+   * Trailing action buttons displayed in the view header alongside the clear button.
+   * Only rendered in Focused state.
+   */
+  trailingActions?: React.ReactNode[];
+  /**
+   * Whether to show a divider between the header and suggestions area.
+   * Automatically true when searchStyle='divided'. Can be overridden.
+   */
+  showDivider?: boolean;
+}
+
+/**
+ * Props for the compound Search component — combines SearchBar + SearchView
+ * state management in one controlled/uncontrolled component.
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled
+ * <Search placeholder="Search messages" />
+ *
+ * // Controlled
+ * <Search isOpen={isOpen} onOpenChange={setOpen} value={query} onChange={setQuery} />
+ * ```
+ */
+export interface SearchProps extends Omit<SearchBarProps, "onFocus"> {
+  /** Whether the search view is open (controlled) */
+  isOpen?: boolean;
+  /** Called when open state changes */
+  onOpenChange?: (isOpen: boolean) => void;
+  /**
+   * Layout mode for the search view.
+   * @default 'fullscreen'
+   */
+  layout?: SearchLayout;
+  /**
+   * Content for the suggestions/results area.
+   * Rendered inside SearchView when open.
+   */
+  children?: React.ReactNode;
+  /** Accessible label for the search view */
+  viewAriaLabel?: string;
+}
+
+/** Props for SearchBarHeadless — the headless primitive for the bar */
+export interface SearchBarHeadlessProps extends SearchBarProps {
+  /** Ref forwarded to the form element */
+  ref?: React.Ref<HTMLFormElement>;
+}
+
+/** Props for SearchViewHeadless — the headless primitive for the view */
+export interface SearchViewHeadlessProps extends SearchViewProps {
+  /** Ref forwarded to the view container div */
+  ref?: React.Ref<HTMLDivElement>;
+}

--- a/packages/react/src/components/Search/Search.variants.ts
+++ b/packages/react/src/components/Search/Search.variants.ts
@@ -1,0 +1,143 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Material Design 3 Search Bar container variants (CVA).
+ *
+ * Base: 56dp height, full rounded pill, surface-container-high background,
+ * level-3 elevation, body-large typography.
+ *
+ * Spacing follows MD3 Search spec:
+ * - Contained (expressive): 4dp leading/trailing with trailing actions
+ * - Contained (no actions): 16dp leading/trailing
+ * - Divided (baseline): 16dp leading/trailing, 16dp icon-label gap
+ *
+ * @see docs/md3-components/search/tokens/layout-text.md
+ */
+export const searchBarVariants = cva(
+  [
+    "relative flex items-center h-14 rounded-full bg-surface-container-high",
+    "shadow-elevation-3 w-full text-body-large cursor-text",
+  ],
+  {
+    variants: {
+      style: {
+        contained: "",
+        divided: "px-4 gap-4",
+      },
+      noActions: {
+        true: "",
+        false: "",
+      },
+      focused: {
+        true: "",
+        false: "",
+      },
+      disabled: {
+        true: "opacity-38 pointer-events-none",
+        false: "",
+      },
+    },
+    compoundVariants: [
+      {
+        style: "contained",
+        noActions: false,
+        class: "px-1 gap-1",
+      },
+      {
+        style: "contained",
+        noActions: true,
+        class: "px-4",
+      },
+    ],
+    defaultVariants: {
+      style: "contained",
+      noActions: false,
+      focused: false,
+      disabled: false,
+    },
+  }
+);
+
+/**
+ * Material Design 3 Search View container variants (CVA).
+ *
+ * Compound variants express all 4 style+layout combinations:
+ * - Contained + fullscreen: surface-container-low, no rounding
+ * - Contained + docked: surface-container-high, rounded-xl (12dp)
+ * - Divided + fullscreen: surface-container-high, no rounding
+ * - Divided + docked: surface-container-high, rounded-[28px] (extra-large)
+ *
+ * @see docs/md3-components/search/tokens/color-tokens-light.md
+ */
+export const searchViewVariants = cva(["flex flex-col shadow-elevation-3 z-50 overflow-hidden"], {
+  variants: {
+    style: {
+      contained: "",
+      divided: "bg-surface-container-high",
+    },
+    layout: {
+      fullscreen: "fixed inset-0",
+      docked: "relative min-w-[360px] max-w-[720px] min-h-60 max-h-[66vh] overflow-y-auto",
+    },
+  },
+  compoundVariants: [
+    {
+      style: "contained",
+      layout: "fullscreen",
+      class: "bg-surface-container-low rounded-none",
+    },
+    {
+      style: "contained",
+      layout: "docked",
+      class: "bg-surface-container-high rounded-xl gap-0.5",
+    },
+    {
+      style: "divided",
+      layout: "fullscreen",
+      class: "bg-surface-container-high rounded-none",
+    },
+    {
+      style: "divided",
+      layout: "docked",
+      class: "bg-surface-container-high rounded-[28px]",
+    },
+  ],
+  defaultVariants: {
+    style: "contained",
+    layout: "fullscreen",
+  },
+});
+
+/**
+ * Material Design 3 Search View header variants (CVA).
+ *
+ * Heights per style + layout:
+ * - Contained: 56dp (both layouts)
+ * - Divided + fullscreen: 72dp
+ * - Divided + docked: 56dp (overridden by docked variant)
+ *
+ * @see docs/md3-components/search/tokens/layout-text.md
+ */
+export const searchViewHeaderVariants = cva(
+  ["flex items-center w-full bg-surface-container-high gap-1"],
+  {
+    variants: {
+      style: {
+        contained: "h-14 px-3",
+        divided: "h-[72px] px-4",
+      },
+      layout: {
+        docked: "h-14",
+        fullscreen: "",
+      },
+    },
+    defaultVariants: {
+      style: "contained",
+      layout: "fullscreen",
+    },
+  }
+);
+
+export type SearchBarVariants = VariantProps<typeof searchBarVariants>;
+export type SearchViewVariantsType = VariantProps<typeof searchViewVariants>;
+export type SearchViewHeaderVariantsType = VariantProps<typeof searchViewHeaderVariants>;

--- a/packages/react/src/components/Search/SearchBar.tsx
+++ b/packages/react/src/components/Search/SearchBar.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { forwardRef, useState, useCallback } from "react";
+import { useReducedMotion } from "../../hooks/useReducedMotion";
+import { SearchBarHeadless } from "./SearchHeadless";
+import { searchBarVariants } from "./Search.variants";
+import { cn } from "../../utils/cn";
+import { useRipple } from "../../hooks/useRipple";
+import type { SearchBarProps } from "./Search.types";
+
+/**
+ * Material Design 3 Search Bar Component (Layer 3: Styled)
+ *
+ * The collapsed/maximized state search affordance that transitions
+ * to Focused State (SearchView) on click/focus.
+ *
+ * Anatomy:
+ *   [Container] [Leading icon] [Supporting text/input] [Trailing actions] [Avatar]
+ *
+ * Features:
+ * - MD3 state layer with hover/active opacity transitions
+ * - Ripple effect on press (Material Design state 4)
+ * - Focus indicator: 3dp ring in secondary color
+ * - M3 Expressive pane margin transition (24dp → 12dp on focus)
+ * - Automatic `noActions` variant when no trailing actions/avatar
+ *
+ * @example
+ * ```tsx
+ * <SearchBar
+ *   placeholder="Search messages"
+ *   leadingIcon={<SearchIcon />}
+ *   trailingActions={[<IconButton key="mic" icon={<MicIcon />} aria-label="Voice search" />]}
+ *   onFocus={() => setOpen(true)}
+ * />
+ * ```
+ */
+export const SearchBar = forwardRef<HTMLFormElement, SearchBarProps>(
+  (
+    {
+      value,
+      defaultValue,
+      onChange,
+      onSubmit,
+      onClear,
+      placeholder,
+      leadingIcon,
+      trailingActions,
+      avatar,
+      isDisabled = false,
+      "aria-label": ariaLabel,
+      className,
+      searchStyle = "contained",
+      onFocus,
+      onBlur,
+    },
+    ref
+  ) => {
+    const hasNoActions = (!trailingActions || trailingActions.length === 0) && !avatar;
+
+    const reducedMotion = useReducedMotion();
+    const [isFocused, setIsFocused] = useState(false);
+
+    const handleFocusInternal = useCallback(() => {
+      setIsFocused(true);
+      onFocus?.();
+    }, [onFocus]);
+
+    const handleBlurInternal = useCallback(() => {
+      setIsFocused(false);
+      onBlur?.();
+    }, [onBlur]);
+
+    const { onMouseDown: handleRipple, ripples } = useRipple({
+      disabled: isDisabled,
+    });
+
+    const styledLeadingIcon = leadingIcon ? (
+      <span className="text-on-surface flex size-12 shrink-0 items-center justify-center">
+        <span className="size-6">{leadingIcon}</span>
+      </span>
+    ) : undefined;
+
+    const styledTrailingActions = trailingActions?.map((action, index) => (
+      <span
+        key={index}
+        className="text-on-surface-variant flex size-12 shrink-0 items-center justify-center"
+      >
+        {action}
+      </span>
+    ));
+
+    const styledAvatar = avatar ? (
+      <span className="flex size-12 shrink-0 items-center justify-center">
+        <span className="size-[30px] overflow-hidden rounded-full">{avatar}</span>
+      </span>
+    ) : undefined;
+
+    return (
+      <div
+        className={cn(
+          reducedMotion ? "" : "duration-short4 ease-standard transition-[margin]",
+          isFocused ? "mx-3" : "mx-6"
+        )}
+      >
+        <div
+          role="presentation"
+          className={cn(
+            "group relative overflow-hidden rounded-full",
+            "has-[:focus-visible]:ring-secondary has-[:focus-visible]:ring-3",
+            searchBarVariants({
+              style: searchStyle,
+              noActions: hasNoActions,
+              disabled: isDisabled,
+            }),
+            className
+          )}
+          onMouseDown={handleRipple}
+        >
+          <span
+            data-slot="state-layer"
+            className={cn(
+              "bg-on-surface pointer-events-none absolute inset-0 rounded-full opacity-0",
+              "group-hover:opacity-8 group-active:opacity-10",
+              "duration-spring-standard-fast-effects ease-spring-standard-fast-effects transition-opacity"
+            )}
+          />
+
+          <SearchBarHeadless
+            ref={ref}
+            {...(value !== undefined ? { value } : {})}
+            {...(defaultValue !== undefined ? { defaultValue } : {})}
+            {...(onChange !== undefined ? { onChange } : {})}
+            {...(onSubmit !== undefined ? { onSubmit } : {})}
+            {...(onClear !== undefined ? { onClear } : {})}
+            {...(placeholder !== undefined ? { placeholder } : {})}
+            {...(styledLeadingIcon !== undefined ? { leadingIcon: styledLeadingIcon } : {})}
+            {...(styledTrailingActions !== undefined
+              ? { trailingActions: styledTrailingActions }
+              : {})}
+            {...(styledAvatar !== undefined ? { avatar: styledAvatar } : {})}
+            {...(isDisabled !== undefined ? { isDisabled } : {})}
+            {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+            onFocus={handleFocusInternal}
+            onBlur={handleBlurInternal}
+            className={cn(
+              "relative z-0 flex h-full w-full items-center",
+              "[&_input]:flex-1 [&_input]:bg-transparent [&_input]:outline-none",
+              "[&_input]:text-body-large [&_input]:text-on-surface",
+              "[&_input]:placeholder:text-on-surface-variant",
+              "[&_input]:focus-visible:outline-none"
+            )}
+          />
+
+          {ripples}
+        </div>
+      </div>
+    );
+  }
+);
+
+SearchBar.displayName = "SearchBar";

--- a/packages/react/src/components/Search/SearchHeadless.tsx
+++ b/packages/react/src/components/Search/SearchHeadless.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { forwardRef, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { useSearchField, useOverlay, usePreventScroll, useButton, FocusScope } from "react-aria";
+import { useSearchFieldState } from "react-stately";
+import type { SearchBarHeadlessProps, SearchViewHeadlessProps } from "./Search.types";
+
+/**
+ * SearchBarHeadless — Layer 2 headless primitive for the MD3 Search bar.
+ *
+ * Renders `<form role="search">` wrapping an accessible search input.
+ * Uses `useSearchField` + `useSearchFieldState` from React Aria/Stately.
+ *
+ * Features:
+ * - `role="search"` on the form wrapper
+ * - `role="searchbox"` on the input (via type="search")
+ * - Keyboard: Enter → onSubmit, Escape (with value) → onClear
+ * - Leading icon, trailing actions, and avatar slots
+ * - aria-label falls back to placeholder per MD3 labeling spec
+ *
+ * @example
+ * ```tsx
+ * <SearchBarHeadless
+ *   placeholder="Search messages"
+ *   onFocus={() => setOpen(true)}
+ *   className="my-search-bar"
+ * />
+ * ```
+ */
+export const SearchBarHeadless = forwardRef<HTMLFormElement, SearchBarHeadlessProps>(
+  (
+    {
+      value,
+      defaultValue,
+      onChange,
+      onSubmit,
+      onClear,
+      placeholder,
+      leadingIcon,
+      trailingActions,
+      avatar,
+      isDisabled,
+      "aria-label": ariaLabel,
+      className,
+      onFocus,
+      onBlur,
+    },
+    forwardedRef
+  ) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const internalFormRef = useRef<HTMLFormElement>(null);
+    const formRef = (forwardedRef ?? internalFormRef) as React.RefObject<HTMLFormElement>;
+
+    const state = useSearchFieldState({
+      ...(value !== undefined ? { value } : {}),
+      ...(defaultValue !== undefined ? { defaultValue } : {}),
+      ...(onChange !== undefined ? { onChange } : {}),
+      ...(onSubmit !== undefined ? { onSubmit } : {}),
+      ...(onClear !== undefined ? { onClear } : {}),
+    });
+
+    const { inputProps } = useSearchField(
+      {
+        "aria-label": ariaLabel ?? placeholder ?? "Search",
+        ...(placeholder !== undefined ? { placeholder } : {}),
+        ...(isDisabled !== undefined ? { isDisabled } : {}),
+        ...(onSubmit !== undefined ? { onSubmit } : {}),
+        ...(onClear !== undefined ? { onClear } : {}),
+        ...(onFocus !== undefined ? { onFocus: () => onFocus() } : {}),
+        ...(onBlur !== undefined ? { onBlur: () => onBlur() } : {}),
+      },
+      state,
+      inputRef
+    );
+
+    const handleFormSubmit = useCallback(
+      (e: React.FormEvent) => {
+        e.preventDefault();
+        onSubmit?.(state.value);
+      },
+      [onSubmit, state.value]
+    );
+
+    return (
+      <form ref={formRef} role="search" className={className} onSubmit={handleFormSubmit}>
+        {leadingIcon && <span data-slot="leading-icon">{leadingIcon}</span>}
+        <input {...inputProps} ref={inputRef} role="searchbox" />
+        {trailingActions && trailingActions.length > 0 && (
+          <span data-slot="trailing-actions">
+            {trailingActions.map((action, index) => (
+              <span key={index} data-slot="trailing-action">
+                {action}
+              </span>
+            ))}
+          </span>
+        )}
+        {avatar && <span data-slot="avatar">{avatar}</span>}
+      </form>
+    );
+  }
+);
+
+SearchBarHeadless.displayName = "SearchBarHeadless";
+
+/**
+ * SearchViewHeadless — Layer 2 headless primitive for the MD3 Search view.
+ *
+ * Renders in a portal when `isOpen={true}`. Does not render when closed.
+ * Uses `useOverlay` for Escape-key dismissal, `usePreventScroll` to lock
+ * body scrolling, and `FocusScope` for focus trapping.
+ *
+ * Features:
+ * - Portal rendering via `createPortal`
+ * - Escape key → onClose
+ * - Body scroll lock when open
+ * - Focus trap with auto-focus and restore on close
+ * - aria-live region for autosuggest announcements
+ * - Back arrow (leading icon) + input + clear button header
+ *
+ * @example
+ * ```tsx
+ * <SearchViewHeadless
+ *   isOpen={isOpen}
+ *   onClose={() => setOpen(false)}
+ *   aria-label="Search messages"
+ * >
+ *   <List>{results.map(r => <ListItem key={r.id} headline={r.label} />)}</List>
+ * </SearchViewHeadless>
+ * ```
+ */
+export const SearchViewHeadless = forwardRef<HTMLDivElement, SearchViewHeadlessProps>(
+  (
+    {
+      isOpen,
+      onClose,
+      value,
+      defaultValue,
+      onChange,
+      onSubmit,
+      placeholder,
+      "aria-label": ariaLabel,
+      className,
+      children,
+      leadingIcon,
+      trailingActions,
+      showDivider,
+    },
+    forwardedRef
+  ) => {
+    if (!isOpen) {
+      return null;
+    }
+
+    return createPortal(
+      <SearchViewPanel
+        ref={forwardedRef}
+        onClose={onClose}
+        ariaLabel={ariaLabel}
+        {...(className !== undefined ? { className } : {})}
+        {...(leadingIcon !== undefined ? { leadingIcon } : {})}
+        {...(trailingActions !== undefined ? { trailingActions } : {})}
+        {...(showDivider !== undefined ? { showDivider } : {})}
+        {...(value !== undefined ? { value } : {})}
+        {...(defaultValue !== undefined ? { defaultValue } : {})}
+        {...(onChange !== undefined ? { onChange } : {})}
+        {...(onSubmit !== undefined ? { onSubmit } : {})}
+        {...(placeholder !== undefined ? { placeholder } : {})}
+      >
+        {children}
+      </SearchViewPanel>,
+      document.body
+    );
+  }
+);
+
+SearchViewHeadless.displayName = "SearchViewHeadless";
+
+// ─── SearchViewPanel (internal) ──────────────────────────────────────────────
+
+interface SearchViewPanelProps {
+  onClose: () => void;
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  onSubmit?: (value: string) => void;
+  placeholder?: string;
+  ariaLabel: string;
+  className?: string;
+  children?: React.ReactNode;
+  leadingIcon?: React.ReactNode;
+  trailingActions?: React.ReactNode[];
+  showDivider?: boolean;
+}
+
+/**
+ * Inner panel for the search view. Separated to allow hooks
+ * (`usePreventScroll`, `useOverlay`) which must be called unconditionally.
+ * @internal
+ */
+const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
+  (
+    {
+      onClose,
+      value,
+      defaultValue,
+      onChange,
+      onSubmit,
+      placeholder,
+      ariaLabel,
+      className,
+      children,
+      leadingIcon,
+      trailingActions,
+      showDivider,
+    },
+    forwardedRef
+  ) => {
+    const panelRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const ref = (forwardedRef ?? panelRef) as React.RefObject<HTMLDivElement>;
+
+    usePreventScroll();
+
+    const { overlayProps } = useOverlay(
+      {
+        isOpen: true,
+        onClose,
+        isDismissable: true,
+        shouldCloseOnBlur: false,
+      },
+      ref
+    );
+
+    const state = useSearchFieldState({
+      ...(value !== undefined ? { value } : {}),
+      ...(defaultValue !== undefined ? { defaultValue } : {}),
+      ...(onChange !== undefined ? { onChange } : {}),
+      ...(onSubmit !== undefined ? { onSubmit } : {}),
+    });
+
+    const { inputProps, clearButtonProps } = useSearchField(
+      {
+        "aria-label": ariaLabel,
+        ...(placeholder !== undefined ? { placeholder } : {}),
+        ...(onSubmit !== undefined ? { onSubmit } : {}),
+        onClear: () => {
+          state.setValue("");
+        },
+      },
+      state,
+      inputRef
+    );
+
+    const clearButtonRef = useRef<HTMLButtonElement>(null);
+    const { buttonProps: clearBtnDomProps } = useButton(clearButtonProps, clearButtonRef);
+
+    const handleBackClick = useCallback(() => {
+      onClose();
+    }, [onClose]);
+
+    const defaultBackArrow = (
+      <button type="button" aria-label="Back" onClick={handleBackClick} data-slot="back-button">
+        ←
+      </button>
+    );
+
+    const clearButton = state.value ? (
+      <button
+        {...clearBtnDomProps}
+        ref={clearButtonRef}
+        type="button"
+        aria-label="Clear search"
+        data-slot="clear-button"
+      >
+        ✕
+      </button>
+    ) : null;
+
+    return (
+      <FocusScope contain restoreFocus autoFocus>
+        <div {...overlayProps} ref={ref} role="search" aria-label={ariaLabel} className={className}>
+          <div data-slot="header">
+            <span data-slot="leading-icon">{leadingIcon ?? defaultBackArrow}</span>
+            <input {...inputProps} ref={inputRef} role="searchbox" />
+            {clearButton}
+            {trailingActions && trailingActions.length > 0 && (
+              <span data-slot="trailing-actions">
+                {trailingActions.map((action, index) => (
+                  <span key={index} data-slot="trailing-action">
+                    {action}
+                  </span>
+                ))}
+              </span>
+            )}
+          </div>
+          {showDivider && <hr data-slot="divider" />}
+          <div data-slot="content" aria-live="polite">
+            {children}
+          </div>
+        </div>
+      </FocusScope>
+    );
+  }
+);
+
+SearchViewPanel.displayName = "SearchViewPanel";

--- a/packages/react/src/components/Search/SearchView.tsx
+++ b/packages/react/src/components/Search/SearchView.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { forwardRef } from "react";
+import { SearchViewHeadless } from "./SearchHeadless";
+import { searchViewVariants } from "./Search.variants";
+import { cn } from "../../utils/cn";
+import type { SearchViewProps } from "./Search.types";
+
+/**
+ * Material Design 3 Search View Component (Layer 3: Styled)
+ *
+ * The expanded/focused search experience with input and results.
+ * Displayed in a portal over page content.
+ *
+ * Anatomy:
+ *   Header: [Back arrow] [Input] [Clear button] [Optional trailing actions]
+ *   Divider (divided style only)
+ *   Content area: children (suggestions/results via List component)
+ *
+ * Features:
+ * - Portal rendering with focus trap and scroll lock (via headless)
+ * - Compound variants for 4 style+layout combinations
+ * - Animate on mount with `animate-md-scale-in`
+ * - Clear button visible only when input has value
+ * - aria-live region for autosuggest announcements
+ *
+ * @example
+ * ```tsx
+ * <SearchView
+ *   isOpen={isOpen}
+ *   onClose={() => setOpen(false)}
+ *   aria-label="Search messages"
+ *   searchStyle="contained"
+ *   layout="fullscreen"
+ * >
+ *   <List>{suggestions.map(s => <ListItem key={s.id} headline={s.label} />)}</List>
+ * </SearchView>
+ * ```
+ */
+export const SearchView = forwardRef<HTMLDivElement, SearchViewProps>(
+  (
+    {
+      isOpen,
+      onClose,
+      value,
+      defaultValue,
+      onChange,
+      onSubmit,
+      placeholder,
+      "aria-label": ariaLabel,
+      className,
+      children,
+      searchStyle = "contained",
+      layout = "fullscreen",
+      leadingIcon,
+      trailingActions,
+      showDivider,
+    },
+    ref
+  ) => {
+    const resolvedShowDivider = showDivider ?? searchStyle === "divided";
+
+    const styledLeadingIcon = leadingIcon ? (
+      <span className="text-on-surface flex size-12 shrink-0 items-center justify-center">
+        {leadingIcon}
+      </span>
+    ) : undefined;
+
+    const styledTrailingActions = trailingActions?.map((action, index) => (
+      <span
+        key={index}
+        className="text-on-surface-variant flex size-12 shrink-0 items-center justify-center"
+      >
+        {action}
+      </span>
+    ));
+
+    return (
+      <SearchViewHeadless
+        ref={ref}
+        isOpen={isOpen}
+        onClose={onClose}
+        {...(value !== undefined ? { value } : {})}
+        {...(defaultValue !== undefined ? { defaultValue } : {})}
+        {...(onChange !== undefined ? { onChange } : {})}
+        {...(onSubmit !== undefined ? { onSubmit } : {})}
+        {...(placeholder !== undefined ? { placeholder } : {})}
+        aria-label={ariaLabel}
+        {...(styledLeadingIcon !== undefined ? { leadingIcon: styledLeadingIcon } : {})}
+        {...(styledTrailingActions !== undefined ? { trailingActions: styledTrailingActions } : {})}
+        showDivider={resolvedShowDivider}
+        className={cn(
+          searchViewVariants({ style: searchStyle, layout }),
+          "animate-md-scale-in",
+          getHeaderClasses(searchStyle, layout),
+          slotClasses,
+          className
+        )}
+      >
+        {children}
+      </SearchViewHeadless>
+    );
+  }
+);
+
+SearchView.displayName = "SearchView";
+
+/**
+ * Static slot styling applied via descendant selectors on the container.
+ * Targets data-slot attributes rendered by SearchViewHeadless.
+ */
+const slotClasses = cn(
+  // Input styling
+  "[&_input]:flex-1 [&_input]:bg-transparent [&_input]:outline-none",
+  "[&_input]:text-body-large [&_input]:text-on-surface",
+  "[&_input]:placeholder:text-on-surface-variant",
+  // Divider
+  "[&>[data-slot=divider]]:border-outline",
+  // Content area
+  "[&>[data-slot=content]]:flex-1 [&>[data-slot=content]]:overflow-y-auto",
+  // Clear button
+  "[&_[data-slot=clear-button]]:size-12 [&_[data-slot=clear-button]]:flex",
+  "[&_[data-slot=clear-button]]:items-center [&_[data-slot=clear-button]]:justify-center",
+  "[&_[data-slot=clear-button]]:text-on-surface-variant",
+  "[&_[data-slot=clear-button]]:transition-opacity [&_[data-slot=clear-button]]:duration-short4",
+  "[&_[data-slot=clear-button]]:ease-standard",
+  // Back button
+  "[&_[data-slot=back-button]]:size-12 [&_[data-slot=back-button]]:flex",
+  "[&_[data-slot=back-button]]:items-center [&_[data-slot=back-button]]:justify-center",
+  "[&_[data-slot=back-button]]:text-on-surface"
+);
+
+/**
+ * Resolves header height and padding based on style + layout combination.
+ * Contained: 56dp height, 12dp (px-3) side padding.
+ * Divided + fullscreen: 72dp height, 16dp (px-4) side padding.
+ * Divided + docked (or any docked): 56dp height.
+ */
+function getHeaderClasses(style: "contained" | "divided", layout: "fullscreen" | "docked"): string {
+  const base =
+    "[&>[data-slot=header]]:flex [&>[data-slot=header]]:items-center [&>[data-slot=header]]:w-full [&>[data-slot=header]]:bg-surface-container-high [&>[data-slot=header]]:gap-1";
+
+  if (layout === "docked") {
+    return cn(
+      base,
+      "[&>[data-slot=header]]:h-14",
+      style === "contained" ? "[&>[data-slot=header]]:px-3" : "[&>[data-slot=header]]:px-4"
+    );
+  }
+
+  if (style === "contained") {
+    return cn(base, "[&>[data-slot=header]]:h-14 [&>[data-slot=header]]:px-3");
+  }
+
+  return cn(base, "[&>[data-slot=header]]:h-[72px] [&>[data-slot=header]]:px-4");
+}

--- a/packages/react/src/components/Search/index.ts
+++ b/packages/react/src/components/Search/index.ts
@@ -1,4 +1,15 @@
+// Layer 3 — Styled
+export { SearchBar } from "./SearchBar";
+export { SearchView } from "./SearchView";
+export { Search } from "./Search";
+
+// Layer 2 — Headless
 export { SearchBarHeadless, SearchViewHeadless } from "./SearchHeadless";
+
+// CVA
+export { searchBarVariants, searchViewVariants, searchViewHeaderVariants } from "./Search.variants";
+
+// Types
 export type {
   SearchStyle,
   SearchLayout,

--- a/packages/react/src/components/Search/index.ts
+++ b/packages/react/src/components/Search/index.ts
@@ -1,0 +1,10 @@
+export { SearchBarHeadless, SearchViewHeadless } from "./SearchHeadless";
+export type {
+  SearchStyle,
+  SearchLayout,
+  SearchBarProps,
+  SearchViewProps,
+  SearchProps,
+  SearchBarHeadlessProps,
+  SearchViewHeadlessProps,
+} from "./Search.types";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -302,6 +302,26 @@ export type {
   ListVariants,
   ListItemVariants,
 } from "./components/List";
+export {
+  Search,
+  SearchBar,
+  SearchView,
+  SearchBarHeadless,
+  SearchViewHeadless,
+  searchBarVariants,
+  searchViewVariants,
+  searchViewHeaderVariants,
+} from "./components/Search";
+export type {
+  SearchStyle,
+  SearchLayout,
+  SearchBarProps,
+  SearchViewProps,
+  SearchProps,
+  SearchBarHeadlessProps,
+  SearchViewHeadlessProps,
+} from "./components/Search";
+
 export { Badge, BadgeHeadless, BadgeContent, badgeVariants } from "./components/Badge";
 export type {
   BadgeProps,


### PR DESCRIPTION
## Summary

Adds the MD3 Search component to `@tinybigui/react`.

### What's included

- `SearchBar` — compact inline search bar; `h-14` (56dp), `rounded-full`, `bg-surface-container-high`; Enter to submit, Escape to clear
- `SearchView` — full-screen overlay with back arrow, input, and composable suggestions area; portal-rendered
- `SearchBarHeadless` / `SearchViewHeadless` — `useSearchField`/`useSearchFieldState` with `<form role="search">` wrapper
- `searchBarVariants` / `searchViewVariants` / `searchViewHeaderVariants` — CVA definitions
- 25 tests including axe checks
- 9 Storybook stories

### MD3 Compliance

- SearchBar: `rounded-full`, 56dp height, `bg-surface-container-high`
- SearchView: `bg-surface`, `rounded-b-xl`, `animate-md-scale-in/out`
- Composable suggestions area

### Accessibility

- `role="search"` on form container
- `aria-label` on input via `useSearchField`
- Enter submits, Escape clears/closes; WCAG 2.1 AA compliant

### Test results

- `pnpm lint` — ✅ `pnpm typecheck` — ✅ `pnpm test` — ✅ `pnpm build` — ✅