### PR TITLE
fix(tokens): add reference palette layer and semantic theme wrapper for storybook

### DIFF
--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -1,10 +1,31 @@
-import type { Preview } from "@storybook/react-vite";
+import type { Preview, ReactRenderer } from "@storybook/react-vite";
+import type { DecoratorFunction } from "storybook/internal/types";
 import { withThemeByClassName } from "@storybook/addon-themes";
 import "../src/styles.css"; // Import MD3 tokens and Tailwind
 
+/**
+ * Wraps every story in a surface-colored container so that the active MD3
+ * theme (light or dark) is visually apparent from the canvas background.
+ * Uses semantic token utilities so the color automatically follows the
+ * `.dark` / `.light` class applied by withThemeByClassName.
+ */
+const withThemeWrapper: DecoratorFunction<ReactRenderer> = (Story) => (
+  <div className="bg-surface text-on-surface duration-medium2 min-h-[100px] w-full p-6 transition-colors">
+    <Story />
+  </div>
+);
+
 const preview: Preview = {
+  /**
+   * Pre-seed the `theme` global so the addon-themes toolbar renders its
+   * initial label ("light theme") without waiting for the first story render.
+   */
+  initialGlobals: {
+    theme: "light",
+  },
   decorators: [
-    withThemeByClassName({
+    withThemeWrapper,
+    withThemeByClassName<ReactRenderer>({
       themes: {
         light: "light",
         dark: "dark",
@@ -26,21 +47,6 @@ const preview: Preview = {
     // Configure actions
     actions: {
       argTypesRegex: "^on[A-Z].*", // Auto-detect event handlers
-    },
-
-    // Configure backgrounds for light/dark mode testing
-    backgrounds: {
-      default: "light",
-      values: [
-        {
-          name: "light",
-          value: "#fef7ff", // MD3 surface light
-        },
-        {
-          name: "dark",
-          value: "#1c1b1f", // MD3 surface dark
-        },
-      ],
     },
 
     // Configure viewport presets

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -25,6 +25,7 @@
   "type": "module",
   "exports": {
     "./tokens.css": "./dist/tokens.css",
+    "./palette.css": "./dist/palette.css",
     "./color.css": "./dist/color.css",
     "./typography.css": "./dist/typography.css",
     "./shape.css": "./dist/shape.css",

--- a/packages/tokens/src/color.css
+++ b/packages/tokens/src/color.css
@@ -4,6 +4,10 @@
  * Complete set of semantic color roles for light and dark themes.
  *
  * Token prefix: --md-sys-color-*
+ *
+ * All values are references to the reference palette tokens (--md-ref-palette-*)
+ * defined in palette.css. Raw hex values live only in palette.css.
+ * To re-theme, override the --md-ref-palette-* variables, not these tokens.
  */
 
 :root {
@@ -11,81 +15,81 @@
      PRIMARY
      ========================================================================== */
 
-  --md-sys-color-primary: #6750a4;
-  --md-sys-color-on-primary: #ffffff;
-  --md-sys-color-primary-container: #eaddff;
-  --md-sys-color-on-primary-container: #21005d;
+  --md-sys-color-primary: var(--md-ref-palette-primary40);
+  --md-sys-color-on-primary: var(--md-ref-palette-primary100);
+  --md-sys-color-primary-container: var(--md-ref-palette-primary90);
+  --md-sys-color-on-primary-container: var(--md-ref-palette-primary10);
 
   /* ==========================================================================
      SECONDARY
      ========================================================================== */
 
-  --md-sys-color-secondary: #625b71;
-  --md-sys-color-on-secondary: #ffffff;
-  --md-sys-color-secondary-container: #e8def8;
-  --md-sys-color-on-secondary-container: #1d192b;
+  --md-sys-color-secondary: var(--md-ref-palette-secondary40);
+  --md-sys-color-on-secondary: var(--md-ref-palette-secondary100);
+  --md-sys-color-secondary-container: var(--md-ref-palette-secondary90);
+  --md-sys-color-on-secondary-container: var(--md-ref-palette-secondary10);
 
   /* ==========================================================================
      TERTIARY
      ========================================================================== */
 
-  --md-sys-color-tertiary: #7d5260;
-  --md-sys-color-on-tertiary: #ffffff;
-  --md-sys-color-tertiary-container: #ffd8e4;
-  --md-sys-color-on-tertiary-container: #31111d;
+  --md-sys-color-tertiary: var(--md-ref-palette-tertiary40);
+  --md-sys-color-on-tertiary: var(--md-ref-palette-tertiary100);
+  --md-sys-color-tertiary-container: var(--md-ref-palette-tertiary90);
+  --md-sys-color-on-tertiary-container: var(--md-ref-palette-tertiary10);
 
   /* ==========================================================================
      ERROR
      ========================================================================== */
 
-  --md-sys-color-error: #b3261e;
-  --md-sys-color-on-error: #ffffff;
-  --md-sys-color-error-container: #f9dedc;
-  --md-sys-color-on-error-container: #410e0b;
+  --md-sys-color-error: var(--md-ref-palette-error40);
+  --md-sys-color-on-error: var(--md-ref-palette-error100);
+  --md-sys-color-error-container: var(--md-ref-palette-error90);
+  --md-sys-color-on-error-container: var(--md-ref-palette-error10);
 
   /* ==========================================================================
      SURFACE
      ========================================================================== */
 
-  --md-sys-color-surface: #fffbfe;
-  --md-sys-color-on-surface: #1c1b1f;
-  --md-sys-color-surface-variant: #e7e0ec;
-  --md-sys-color-on-surface-variant: #49454f;
+  --md-sys-color-surface: var(--md-ref-palette-neutral99);
+  --md-sys-color-on-surface: var(--md-ref-palette-neutral10);
+  --md-sys-color-surface-variant: var(--md-ref-palette-neutral-variant90);
+  --md-sys-color-on-surface-variant: var(--md-ref-palette-neutral-variant30);
 
   /* Surface containers (MD3 elevation system) */
-  --md-sys-color-surface-container-lowest: #ffffff;
-  --md-sys-color-surface-container-low: #f7f2fa;
-  --md-sys-color-surface-container: #f3edf7;
-  --md-sys-color-surface-container-high: #ece6f0;
-  --md-sys-color-surface-container-highest: #e6e0e9;
+  --md-sys-color-surface-container-lowest: var(--md-ref-palette-neutral100);
+  --md-sys-color-surface-container-low: var(--md-ref-palette-neutral96);
+  --md-sys-color-surface-container: var(--md-ref-palette-neutral94);
+  --md-sys-color-surface-container-high: var(--md-ref-palette-neutral92);
+  --md-sys-color-surface-container-highest: var(--md-ref-palette-neutral87);
 
   /* ==========================================================================
      OUTLINE
      ========================================================================== */
 
-  --md-sys-color-outline: #79747e;
-  --md-sys-color-outline-variant: #cac4d0;
+  --md-sys-color-outline: var(--md-ref-palette-neutral-variant50);
+  --md-sys-color-outline-variant: var(--md-ref-palette-neutral-variant80);
 
   /* ==========================================================================
      BACKGROUND
      ========================================================================== */
 
-  --md-sys-color-background: #fffbfe;
-  --md-sys-color-on-background: #1c1b1f;
+  --md-sys-color-background: var(--md-ref-palette-neutral99);
+  --md-sys-color-on-background: var(--md-ref-palette-neutral10);
 
   /* ==========================================================================
      SCRIM
      ========================================================================== */
 
-  --md-sys-color-scrim: #000000;
+  --md-sys-color-scrim: var(--md-ref-palette-neutral0);
 
   /* ==========================================================================
      INVERSE
      ========================================================================== */
 
-  --md-sys-color-inverse-surface: #313033;
-  --md-sys-color-inverse-on-surface: #f4eff4;
-  --md-sys-color-inverse-primary: #d0bcff;
+  --md-sys-color-inverse-surface: var(--md-ref-palette-neutral20);
+  --md-sys-color-inverse-on-surface: var(--md-ref-palette-neutral95);
+  --md-sys-color-inverse-primary: var(--md-ref-palette-primary80);
 }
 
 /* ==========================================================================
@@ -93,48 +97,48 @@
    ========================================================================== */
 
 .dark {
-  --md-sys-color-primary: #d0bcff;
-  --md-sys-color-on-primary: #381e72;
-  --md-sys-color-primary-container: #4f378b;
-  --md-sys-color-on-primary-container: #eaddff;
+  --md-sys-color-primary: var(--md-ref-palette-primary80);
+  --md-sys-color-on-primary: var(--md-ref-palette-primary20);
+  --md-sys-color-primary-container: var(--md-ref-palette-primary30);
+  --md-sys-color-on-primary-container: var(--md-ref-palette-primary90);
 
-  --md-sys-color-secondary: #ccc2dc;
-  --md-sys-color-on-secondary: #332d41;
-  --md-sys-color-secondary-container: #4a4458;
-  --md-sys-color-on-secondary-container: #e8def8;
+  --md-sys-color-secondary: var(--md-ref-palette-secondary80);
+  --md-sys-color-on-secondary: var(--md-ref-palette-secondary20);
+  --md-sys-color-secondary-container: var(--md-ref-palette-secondary30);
+  --md-sys-color-on-secondary-container: var(--md-ref-palette-secondary90);
 
-  --md-sys-color-tertiary: #efb8c8;
-  --md-sys-color-on-tertiary: #492532;
-  --md-sys-color-tertiary-container: #633b48;
-  --md-sys-color-on-tertiary-container: #ffd8e4;
+  --md-sys-color-tertiary: var(--md-ref-palette-tertiary80);
+  --md-sys-color-on-tertiary: var(--md-ref-palette-tertiary20);
+  --md-sys-color-tertiary-container: var(--md-ref-palette-tertiary30);
+  --md-sys-color-on-tertiary-container: var(--md-ref-palette-tertiary90);
 
-  --md-sys-color-error: #f2b8b5;
-  --md-sys-color-on-error: #601410;
-  --md-sys-color-error-container: #8c1d18;
-  --md-sys-color-on-error-container: #f9dedc;
+  --md-sys-color-error: var(--md-ref-palette-error80);
+  --md-sys-color-on-error: var(--md-ref-palette-error20);
+  --md-sys-color-error-container: var(--md-ref-palette-error30);
+  --md-sys-color-on-error-container: var(--md-ref-palette-error90);
 
-  --md-sys-color-surface: #1c1b1f;
-  --md-sys-color-on-surface: #e6e1e5;
-  --md-sys-color-surface-variant: #49454f;
-  --md-sys-color-on-surface-variant: #cac4d0;
+  --md-sys-color-surface: var(--md-ref-palette-neutral10);
+  --md-sys-color-on-surface: var(--md-ref-palette-neutral90);
+  --md-sys-color-surface-variant: var(--md-ref-palette-neutral-variant30);
+  --md-sys-color-on-surface-variant: var(--md-ref-palette-neutral-variant80);
 
-  --md-sys-color-surface-container-lowest: #0f0d13;
-  --md-sys-color-surface-container-low: #1d1b20;
-  --md-sys-color-surface-container: #211f26;
-  --md-sys-color-surface-container-high: #2b2930;
-  --md-sys-color-surface-container-highest: #36343b;
+  --md-sys-color-surface-container-lowest: var(--md-ref-palette-neutral4);
+  --md-sys-color-surface-container-low: var(--md-ref-palette-neutral6);
+  --md-sys-color-surface-container: var(--md-ref-palette-neutral12);
+  --md-sys-color-surface-container-high: var(--md-ref-palette-neutral17);
+  --md-sys-color-surface-container-highest: var(--md-ref-palette-neutral22);
 
-  --md-sys-color-outline: #938f99;
-  --md-sys-color-outline-variant: #49454f;
+  --md-sys-color-outline: var(--md-ref-palette-neutral-variant60);
+  --md-sys-color-outline-variant: var(--md-ref-palette-neutral-variant30);
 
-  --md-sys-color-background: #1c1b1f;
-  --md-sys-color-on-background: #e6e1e5;
+  --md-sys-color-background: var(--md-ref-palette-neutral10);
+  --md-sys-color-on-background: var(--md-ref-palette-neutral90);
 
-  --md-sys-color-scrim: #000000;
+  --md-sys-color-scrim: var(--md-ref-palette-neutral0);
 
-  --md-sys-color-inverse-surface: #e6e1e5;
-  --md-sys-color-inverse-on-surface: #313033;
-  --md-sys-color-inverse-primary: #6750a4;
+  --md-sys-color-inverse-surface: var(--md-ref-palette-neutral90);
+  --md-sys-color-inverse-on-surface: var(--md-ref-palette-neutral20);
+  --md-sys-color-inverse-primary: var(--md-ref-palette-primary40);
 }
 
 /* ==========================================================================
@@ -143,47 +147,47 @@
 
 @media (prefers-color-scheme: dark) {
   :root:not(.light) {
-    --md-sys-color-primary: #d0bcff;
-    --md-sys-color-on-primary: #381e72;
-    --md-sys-color-primary-container: #4f378b;
-    --md-sys-color-on-primary-container: #eaddff;
+    --md-sys-color-primary: var(--md-ref-palette-primary80);
+    --md-sys-color-on-primary: var(--md-ref-palette-primary20);
+    --md-sys-color-primary-container: var(--md-ref-palette-primary30);
+    --md-sys-color-on-primary-container: var(--md-ref-palette-primary90);
 
-    --md-sys-color-secondary: #ccc2dc;
-    --md-sys-color-on-secondary: #332d41;
-    --md-sys-color-secondary-container: #4a4458;
-    --md-sys-color-on-secondary-container: #e8def8;
+    --md-sys-color-secondary: var(--md-ref-palette-secondary80);
+    --md-sys-color-on-secondary: var(--md-ref-palette-secondary20);
+    --md-sys-color-secondary-container: var(--md-ref-palette-secondary30);
+    --md-sys-color-on-secondary-container: var(--md-ref-palette-secondary90);
 
-    --md-sys-color-tertiary: #efb8c8;
-    --md-sys-color-on-tertiary: #492532;
-    --md-sys-color-tertiary-container: #633b48;
-    --md-sys-color-on-tertiary-container: #ffd8e4;
+    --md-sys-color-tertiary: var(--md-ref-palette-tertiary80);
+    --md-sys-color-on-tertiary: var(--md-ref-palette-tertiary20);
+    --md-sys-color-tertiary-container: var(--md-ref-palette-tertiary30);
+    --md-sys-color-on-tertiary-container: var(--md-ref-palette-tertiary90);
 
-    --md-sys-color-error: #f2b8b5;
-    --md-sys-color-on-error: #601410;
-    --md-sys-color-error-container: #8c1d18;
-    --md-sys-color-on-error-container: #f9dedc;
+    --md-sys-color-error: var(--md-ref-palette-error80);
+    --md-sys-color-on-error: var(--md-ref-palette-error20);
+    --md-sys-color-error-container: var(--md-ref-palette-error30);
+    --md-sys-color-on-error-container: var(--md-ref-palette-error90);
 
-    --md-sys-color-surface: #1c1b1f;
-    --md-sys-color-on-surface: #e6e1e5;
-    --md-sys-color-surface-variant: #49454f;
-    --md-sys-color-on-surface-variant: #cac4d0;
+    --md-sys-color-surface: var(--md-ref-palette-neutral10);
+    --md-sys-color-on-surface: var(--md-ref-palette-neutral90);
+    --md-sys-color-surface-variant: var(--md-ref-palette-neutral-variant30);
+    --md-sys-color-on-surface-variant: var(--md-ref-palette-neutral-variant80);
 
-    --md-sys-color-surface-container-lowest: #0f0d13;
-    --md-sys-color-surface-container-low: #1d1b20;
-    --md-sys-color-surface-container: #211f26;
-    --md-sys-color-surface-container-high: #2b2930;
-    --md-sys-color-surface-container-highest: #36343b;
+    --md-sys-color-surface-container-lowest: var(--md-ref-palette-neutral4);
+    --md-sys-color-surface-container-low: var(--md-ref-palette-neutral6);
+    --md-sys-color-surface-container: var(--md-ref-palette-neutral12);
+    --md-sys-color-surface-container-high: var(--md-ref-palette-neutral17);
+    --md-sys-color-surface-container-highest: var(--md-ref-palette-neutral22);
 
-    --md-sys-color-outline: #938f99;
-    --md-sys-color-outline-variant: #49454f;
+    --md-sys-color-outline: var(--md-ref-palette-neutral-variant60);
+    --md-sys-color-outline-variant: var(--md-ref-palette-neutral-variant30);
 
-    --md-sys-color-background: #1c1b1f;
-    --md-sys-color-on-background: #e6e1e5;
+    --md-sys-color-background: var(--md-ref-palette-neutral10);
+    --md-sys-color-on-background: var(--md-ref-palette-neutral90);
 
-    --md-sys-color-scrim: #000000;
+    --md-sys-color-scrim: var(--md-ref-palette-neutral0);
 
-    --md-sys-color-inverse-surface: #e6e1e5;
-    --md-sys-color-inverse-on-surface: #313033;
-    --md-sys-color-inverse-primary: #6750a4;
+    --md-sys-color-inverse-surface: var(--md-ref-palette-neutral90);
+    --md-sys-color-inverse-on-surface: var(--md-ref-palette-neutral20);
+    --md-sys-color-inverse-primary: var(--md-ref-palette-primary40);
   }
 }

--- a/packages/tokens/src/palette.css
+++ b/packages/tokens/src/palette.css
@@ -1,0 +1,154 @@
+/**
+ * @tinybigui/tokens — Reference Palette Tokens
+ * Material Design 3 tonal palette — raw hex values at each tonal stop.
+ *
+ * Token prefix: --md-ref-palette-*
+ *
+ * These are Layer 1 (reference) tokens. They are NOT consumed by components
+ * directly. Components use the system color tokens (--md-sys-color-*) defined
+ * in color.css, which reference these palette tokens.
+ *
+ * Standard tonal stops: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100
+ * Extended neutral stops: 4, 6, 12, 17, 22 (dark surface containers)
+ *                         87, 92, 94, 96   (light surface containers)
+ *
+ * Values sourced from:
+ *   https://github.com/material-foundation/material-tokens/blob/main/css/palette.css
+ * Extended neutral stops derived from the default MD3 baseline purple seed (#6750A4).
+ */
+
+:root {
+  /* ==========================================================================
+     PRIMARY
+     ========================================================================== */
+
+  --md-ref-palette-primary0: #000000;
+  --md-ref-palette-primary10: #21005d;
+  --md-ref-palette-primary20: #381e72;
+  --md-ref-palette-primary30: #4f378b;
+  --md-ref-palette-primary40: #6750a4;
+  --md-ref-palette-primary50: #7f67be;
+  --md-ref-palette-primary60: #9a82db;
+  --md-ref-palette-primary70: #b69df8;
+  --md-ref-palette-primary80: #d0bcff;
+  --md-ref-palette-primary90: #eaddff;
+  --md-ref-palette-primary95: #f6edff;
+  --md-ref-palette-primary99: #fffbfe;
+  --md-ref-palette-primary100: #ffffff;
+
+  /* ==========================================================================
+     SECONDARY
+     ========================================================================== */
+
+  --md-ref-palette-secondary0: #000000;
+  --md-ref-palette-secondary10: #1d192b;
+  --md-ref-palette-secondary20: #332d41;
+  --md-ref-palette-secondary30: #4a4458;
+  --md-ref-palette-secondary40: #625b71;
+  --md-ref-palette-secondary50: #7a7289;
+  --md-ref-palette-secondary60: #958da5;
+  --md-ref-palette-secondary70: #b0a7c0;
+  --md-ref-palette-secondary80: #ccc2dc;
+  --md-ref-palette-secondary90: #e8def8;
+  --md-ref-palette-secondary95: #f6edff;
+  --md-ref-palette-secondary99: #fffbfe;
+  --md-ref-palette-secondary100: #ffffff;
+
+  /* ==========================================================================
+     TERTIARY
+     ========================================================================== */
+
+  --md-ref-palette-tertiary0: #000000;
+  --md-ref-palette-tertiary10: #31111d;
+  --md-ref-palette-tertiary20: #492532;
+  --md-ref-palette-tertiary30: #633b48;
+  --md-ref-palette-tertiary40: #7d5260;
+  --md-ref-palette-tertiary50: #986977;
+  --md-ref-palette-tertiary60: #b58392;
+  --md-ref-palette-tertiary70: #d29dac;
+  --md-ref-palette-tertiary80: #efb8c8;
+  --md-ref-palette-tertiary90: #ffd8e4;
+  --md-ref-palette-tertiary95: #ffecf1;
+  --md-ref-palette-tertiary99: #fffbfa;
+  --md-ref-palette-tertiary100: #ffffff;
+
+  /* ==========================================================================
+     ERROR
+     ========================================================================== */
+
+  --md-ref-palette-error0: #000000;
+  --md-ref-palette-error10: #410e0b;
+  --md-ref-palette-error20: #601410;
+  --md-ref-palette-error30: #8c1d18;
+  --md-ref-palette-error40: #b3261e;
+  --md-ref-palette-error50: #dc362e;
+  --md-ref-palette-error60: #e46962;
+  --md-ref-palette-error70: #ec928e;
+  --md-ref-palette-error80: #f2b8b5;
+  --md-ref-palette-error90: #f9dedc;
+  --md-ref-palette-error95: #fceeee;
+  --md-ref-palette-error99: #fffbf9;
+  --md-ref-palette-error100: #ffffff;
+
+  /* ==========================================================================
+     NEUTRAL
+     Standard stops + extended stops for surface container elevation system.
+     ========================================================================== */
+
+  --md-ref-palette-neutral0: #000000;
+  /* Extended: dark surface-container-lowest */
+  --md-ref-palette-neutral4: #0f0d13;
+  /* Extended: dark surface-container-low */
+  --md-ref-palette-neutral6: #1d1b20;
+  --md-ref-palette-neutral10: #1c1b1f;
+  /* Extended: dark surface-container */
+  --md-ref-palette-neutral12: #211f26;
+  /* Extended: dark surface-container-high */
+  --md-ref-palette-neutral17: #2b2930;
+  --md-ref-palette-neutral20: #313033;
+  /* Extended: dark surface-container-highest */
+  --md-ref-palette-neutral22: #36343b;
+  --md-ref-palette-neutral30: #484649;
+  --md-ref-palette-neutral40: #605d62;
+  --md-ref-palette-neutral50: #787579;
+  --md-ref-palette-neutral60: #939094;
+  --md-ref-palette-neutral70: #aeaaae;
+  --md-ref-palette-neutral80: #c9c5ca;
+  --md-ref-palette-neutral90: #e6e1e5;
+  --md-ref-palette-neutral95: #f4eff4;
+  /* Extended: light surface-container-highest */
+  --md-ref-palette-neutral87: #e6e0e9;
+  /* Extended: light surface-container-high */
+  --md-ref-palette-neutral92: #ece6f0;
+  /* Extended: light surface-container */
+  --md-ref-palette-neutral94: #f3edf7;
+  /* Extended: light surface-container-low */
+  --md-ref-palette-neutral96: #f7f2fa;
+  --md-ref-palette-neutral99: #fffbfe;
+  --md-ref-palette-neutral100: #ffffff;
+
+  /* ==========================================================================
+     NEUTRAL VARIANT
+     ========================================================================== */
+
+  --md-ref-palette-neutral-variant0: #000000;
+  --md-ref-palette-neutral-variant10: #1d1a22;
+  --md-ref-palette-neutral-variant20: #322f37;
+  --md-ref-palette-neutral-variant30: #49454f;
+  --md-ref-palette-neutral-variant40: #605d66;
+  --md-ref-palette-neutral-variant50: #79747e;
+  --md-ref-palette-neutral-variant60: #938f99;
+  --md-ref-palette-neutral-variant70: #aea9b4;
+  --md-ref-palette-neutral-variant80: #cac4d0;
+  --md-ref-palette-neutral-variant90: #e7e0ec;
+  --md-ref-palette-neutral-variant95: #f5eefa;
+  --md-ref-palette-neutral-variant99: #fffbfe;
+  --md-ref-palette-neutral-variant100: #ffffff;
+
+  /* ==========================================================================
+     BLACK / WHITE — explicit aliases
+     ========================================================================== */
+
+  --md-ref-palette-black: #000000;
+  --md-ref-palette-white: #ffffff;
+}

--- a/packages/tokens/src/tokens.css
+++ b/packages/tokens/src/tokens.css
@@ -6,7 +6,8 @@
  * file that consumers (and packages/react/src/styles.css) should import.
  *
  * Partial breakdown:
- *   color.css      — MD3 color roles + light/dark mode
+ *   palette.css    — MD3 reference palette tokens (--md-ref-palette-*)
+ *   color.css      — MD3 color roles + light/dark mode (references palette)
  *   typography.css — MD3 type scale (display → label)
  *   shape.css      — MD3 corner radius scale
  *   elevation.css  — MD3 elevation levels (box shadows)
@@ -18,6 +19,7 @@
 @import "tailwindcss";
 
 /* MD3 token partials */
+@import "./palette.css";
 @import "./color.css";
 @import "./typography.css";
 @import "./shape.css";


### PR DESCRIPTION
## Summary

- Extract MD3 reference palette tokens (`--md-ref-palette-*`) into a dedicated `palette.css` layer so `color.css` can reference them instead of duplicating raw hex values
- Export `palette.css` as a standalone entry point from `@tinybigui/tokens`
- Replace Storybook's hardcoded `#hex` background config with a `withThemeWrapper` decorator that uses `bg-surface`/`text-on-surface` tokens, so the canvas background automatically follows the active light/dark theme class
- Pre-seed `initialGlobals.theme` so the addon-themes toolbar renders its initial label immediately

## Changes

| File | Change |
|---|---|
| `packages/tokens/src/palette.css` | New — reference palette token definitions |
| `packages/tokens/src/color.css` | Refactored to consume palette tokens |
| `packages/tokens/src/tokens.css` | Add `@import "./palette.css"` |
| `packages/tokens/package.json` | Expose `./palette.css` export |
| `packages/react/.storybook/preview.tsx` | Semantic theme wrapper + `initialGlobals` |

## Test plan

- [ ] Storybook canvas background changes with light/dark toggle
- [ ] Existing component stories show no color regressions
- [ ] `import '@tinybigui/tokens/palette.css'` resolves without errors