### PR TITLE
fix(switch): align styling with md3 specs and refactor variant system

### DIFF
--- a/.changeset/switch-component-fix.md
+++ b/.changeset/switch-component-fix.md
@@ -1,0 +1,6 @@
+---
+"@tinybigui/react": patch
+"@tinybigui/tokens": patch
+---
+
+Fix Switch component styling to match MD3 specs — correct track alignment, refactor variant system to reduce CVA combinatorial explosion, and add shared interaction state utilities for consistent hover/focus/pressed styling.

--- a/packages/react/src/components/Switch/Switch.test.tsx
+++ b/packages/react/src/components/Switch/Switch.test.tsx
@@ -54,8 +54,8 @@ describe("Switch", () => {
     test("renders disabled state", () => {
       render(<Switch isDisabled>Disabled</Switch>);
       const label = screen.getByText("Disabled").closest("label");
-      expect(label).toHaveClass("opacity-38");
-      expect(label).toHaveClass("pointer-events-none");
+      // Disabled state expressed via data attribute (Variants vs States architecture)
+      expect(label).toHaveAttribute("data-disabled", "");
     });
 
     test("renders readonly state", () => {
@@ -116,7 +116,7 @@ describe("Switch", () => {
       const switchElement = screen.getByRole("switch");
       const label = screen.getByText("Disabled").closest("label");
 
-      expect(label).toHaveClass("opacity-38");
+      expect(label).toHaveAttribute("data-disabled", "");
       expect(switchElement).not.toBeChecked();
     });
 
@@ -286,22 +286,24 @@ describe("Switch", () => {
   });
 
   describe("Disabled", () => {
-    test("applies disabled styling", () => {
+    test("applies disabled styling via data attribute", () => {
       render(<Switch isDisabled>Disabled</Switch>);
       const label = screen.getByText("Disabled").closest("label");
-      expect(label).toHaveClass("opacity-38");
+      // New architecture: disabled state is a data attribute; CSS classes are applied
+      // by Tailwind's data-[disabled]: selectors rather than hard-coded class names.
+      expect(label).toHaveAttribute("data-disabled", "");
     });
 
     test("switch has disabled visual state", () => {
       render(<Switch isDisabled>Disabled</Switch>);
       const label = screen.getByText("Disabled").closest("label");
-      expect(label).toHaveClass("pointer-events-none");
+      expect(label).toHaveAttribute("data-disabled", "");
     });
 
     test("does not respond to interactions when disabled", () => {
       render(<Switch isDisabled>Disabled</Switch>);
       const label = screen.getByText("Disabled").closest("label");
-      expect(label).toHaveClass("pointer-events-none");
+      expect(label).toHaveAttribute("data-disabled", "");
     });
   });
 
@@ -427,6 +429,69 @@ describe("Switch", () => {
       switchElement.focus();
       await user.keyboard(" ");
       expect(handleSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Data Attributes (Variants vs States architecture)", () => {
+    test("sets data-disabled attribute when disabled", () => {
+      render(<Switch isDisabled>Disabled</Switch>);
+      const label = screen.getByText("Disabled").closest("label");
+      expect(label).toHaveAttribute("data-disabled", "");
+    });
+
+    test("does not set data-disabled when enabled", () => {
+      render(<Switch>Enabled</Switch>);
+      const label = screen.getByText("Enabled").closest("label");
+      expect(label).not.toHaveAttribute("data-disabled");
+    });
+
+    test("sets data-selected attribute when selected", () => {
+      render(<Switch isSelected>Selected</Switch>);
+      const label = screen.getByText("Selected").closest("label");
+      expect(label).toHaveAttribute("data-selected", "");
+    });
+
+    test("does not set data-selected when unselected", () => {
+      render(<Switch>Unselected</Switch>);
+      const label = screen.getByText("Unselected").closest("label");
+      expect(label).not.toHaveAttribute("data-selected");
+    });
+
+    test("updates data-selected on toggle", async () => {
+      const user = userEvent.setup();
+      render(<Switch>Toggle</Switch>);
+      const switchElement = screen.getByRole("switch");
+      const label = screen.getByText("Toggle").closest("label");
+
+      expect(label).not.toHaveAttribute("data-selected");
+      await user.click(switchElement);
+      expect(label).toHaveAttribute("data-selected", "");
+      await user.click(switchElement);
+      expect(label).not.toHaveAttribute("data-selected");
+    });
+
+    test("sets data-with-icon when icon prop is provided", () => {
+      render(<Switch icon={<span>X</span>}>With icon</Switch>);
+      const label = screen.getByText("With icon").closest("label");
+      expect(label).toHaveAttribute("data-with-icon", "");
+    });
+
+    test("sets data-with-icon when selectedIcon prop is provided", () => {
+      render(<Switch selectedIcon={<span>✓</span>}>With icon</Switch>);
+      const label = screen.getByText("With icon").closest("label");
+      expect(label).toHaveAttribute("data-with-icon", "");
+    });
+
+    test("does not set data-with-icon when no icons are provided", () => {
+      render(<Switch>No icon</Switch>);
+      const label = screen.getByText("No icon").closest("label");
+      expect(label).not.toHaveAttribute("data-with-icon");
+    });
+
+    test("sets data-readonly attribute when readonly", () => {
+      render(<Switch isReadOnly>Readonly</Switch>);
+      const label = screen.getByText("Readonly").closest("label");
+      expect(label).toHaveAttribute("data-readonly", "");
     });
   });
 

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -146,31 +146,38 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
           <input {...mergeProps(inputProps, focusProps)} ref={ref} id={htmlId} />
         </VisuallyHidden>
 
-        {/* Visual track */}
-        <div role="presentation" className={cn(switchTrackVariants())}>
-          {/* Focus ring — outside overflow-hidden, replaces animate-pulse */}
+        {/*
+         * Relative wrapper — gives the focus ring an absolute positioning
+         * context that is outside the track's overflow-hidden, so the ring
+         * is never clipped.
+         */}
+        <div role="presentation" className="relative">
+          {/* Focus ring — sibling of track div, not clipped by overflow-hidden */}
           <div className={cn(switchFocusRingVariants())} aria-hidden="true" />
 
-          {/* Handle container — movement only (translate-x) */}
-          <div
-            role="presentation"
-            className={cn(switchHandleContainerVariants())}
-            onMouseDown={handleRipple}
-          >
-            {/* Ripple */}
-            {ripples}
+          {/* Track — overflow-hidden clips the state layer to the pill shape */}
+          <div className={cn(switchTrackVariants())}>
+            {/* Handle container — movement only (translate-x) */}
+            <div
+              role="presentation"
+              className={cn(switchHandleContainerVariants())}
+              onMouseDown={handleRipple}
+            >
+              {/* Ripple */}
+              {ripples}
 
-            {/* State layer — hover/focus/pressed opacity ring */}
-            <span className={cn(switchStateLayerVariants())} aria-hidden="true" />
+              {/* State layer — hover/focus/pressed opacity ring */}
+              <span className={cn(switchStateLayerVariants())} aria-hidden="true" />
 
-            {/* Handle — size + color only */}
-            <div className={cn(switchHandleVariants())} aria-hidden="true">
-              {/* Unselected icon */}
-              {!isSelected && icon && <span className={cn(switchIconVariants())}>{icon}</span>}
-              {/* Selected icon */}
-              {isSelected && selectedIcon && (
-                <span className={cn(switchIconVariants())}>{selectedIcon}</span>
-              )}
+              {/* Handle — size + color only */}
+              <div className={cn(switchHandleVariants())} aria-hidden="true">
+                {/* Icon when unselected */}
+                {!isSelected && icon && <span className={cn(switchIconVariants())}>{icon}</span>}
+                {/* Icon when selected */}
+                {isSelected && selectedIcon && (
+                  <span className={cn(switchIconVariants())}>{selectedIcon}</span>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -2,14 +2,17 @@
 
 import { forwardRef, useRef } from "react";
 import type React from "react";
-import { useSwitch, useFocusRing, mergeProps, VisuallyHidden } from "react-aria";
+import { useSwitch, useFocusRing, useHover, mergeProps, VisuallyHidden } from "react-aria";
 import { useToggleState } from "react-stately";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
 import {
-  switchVariants,
+  switchRootVariants,
   switchTrackVariants,
+  switchFocusRingVariants,
   switchHandleContainerVariants,
+  switchStateLayerVariants,
   switchHandleVariants,
   switchIconVariants,
   switchLabelVariants,
@@ -20,8 +23,9 @@ import type { SwitchProps } from "./Switch.types";
  * Material Design 3 Switch Component (Layer 3: Styled)
  *
  * Built on React Aria for world-class accessibility.
- * Uses CVA for type-safe variant management.
- * Styled with Tailwind CSS using MD3 design tokens.
+ * Implements the Variants-vs-States architecture: all interaction/selection
+ * states are expressed as data-* attributes on the root and consumed by each
+ * slot via group-data-[x]/switch Tailwind selectors — no state variants in CVA.
  *
  * Features:
  * - ✅ 2 states: on/off (not selection like checkbox)
@@ -33,11 +37,11 @@ import type { SwitchProps } from "./Switch.types";
  * - ✅ Form integration (name, value props)
  *
  * MD3 Specifications:
- * - Track: 52x32dp (border-radius 16dp)
- * - Handle: 16x16dp (unselected), 24x24dp (selected), 28x28dp (pressed)
- * - Touch target: 48x48dp minimum
- * - State layers: 8% hover, 12% focus/pressed
- * - Disabled: 12% container, 38% content opacity
+ * - Track: 52×32dp (border-radius 16dp)
+ * - Handle: 16dp (unselected) | 24dp (selected / with-icon) | 28dp (pressed)
+ * - State-layer container: 40dp centered on handle
+ * - State-layer opacities: hover 8% | focus 10% | pressed 10%
+ * - Disabled: container 12% | content 38% opacity
  * - Label spacing: 16px (ml-4)
  *
  * @example
@@ -65,179 +69,114 @@ import type { SwitchProps } from "./Switch.types";
 export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
   (
     {
-      // Content props
       children,
       icon,
       selectedIcon,
-
-      // State props
       disableRipple = false,
       isDisabled = false,
-
-      // Styling
       className,
-
-      // Other props
       ...props
     },
     forwardedRef
   ) => {
-    // Internal ref for React Aria
     const internalRef = useRef<HTMLInputElement>(null);
-
-    // Merge internal ref with forwarded ref
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLInputElement>;
 
-    // Extract data-testid and other HTML attributes
+    // Extract passthrough HTML attributes that React Aria doesn't understand
     const htmlAttrs = props as Record<string, unknown>;
     const dataTestId = htmlAttrs["data-testid"] as string | undefined;
     const htmlId = htmlAttrs.id as string | undefined;
     const htmlTitle = htmlAttrs.title as string | undefined;
 
-    // Remove HTML attributes from props for React Aria
     const {
       "data-testid": _dataTestId,
       id: _htmlId,
       title: _htmlTitle,
-      ...restPropsWithoutHtmlAttrs
+      ...ariaProps
     } = props as Record<string, unknown>;
 
-    // State management using React Stately
-    const state = useToggleState(restPropsWithoutHtmlAttrs as Parameters<typeof useToggleState>[0]);
+    // React Stately — toggle state
+    const state = useToggleState(ariaProps as Parameters<typeof useToggleState>[0]);
 
-    // React Aria hooks - pass props without HTML attributes
+    // React Aria hooks
     const { inputProps, labelProps, isPressed } = useSwitch(
-      restPropsWithoutHtmlAttrs as Parameters<typeof useSwitch>[0],
+      ariaProps as Parameters<typeof useSwitch>[0],
       state,
       ref
     );
     const { isFocusVisible, focusProps } = useFocusRing();
+    const { isHovered, hoverProps } = useHover({ isDisabled });
 
-    // Get selected state
     const isSelected = state.isSelected;
+    const hasIcon = !!icon || !!selectedIcon;
 
-    // Ripple effect
+    // Ripple effect on the handle container
     const { onMouseDown: handleRipple, ripples } = useRipple({
       disabled: isDisabled || disableRipple,
     });
 
-    // Development warnings
     if (process.env.NODE_ENV === "development") {
-      const ariaProps = restPropsWithoutHtmlAttrs as {
-        "aria-label"?: string;
-        "aria-labelledby"?: string;
-      };
-      if (!children && !ariaProps["aria-label"] && !ariaProps["aria-labelledby"]) {
-        console.warn(
-          "[Switch] Switch should have a label (children) or aria-label for accessibility."
-        );
+      const a = ariaProps as { "aria-label"?: string; "aria-labelledby"?: string };
+      if (!children && !a["aria-label"] && !a["aria-labelledby"]) {
+        console.warn("[Switch] Provide a label via children or aria-label for accessibility.");
       }
     }
 
     return (
       <label
-        {...labelProps}
-        className={cn(
-          switchVariants({
-            disabled: isDisabled,
-          }),
-          className
-        )}
+        {...mergeProps(labelProps, hoverProps)}
+        className={cn(switchRootVariants(), "group/switch", className)}
         data-testid={dataTestId}
         title={htmlTitle}
+        // ── Interaction data attributes (from React Aria state) ──────────
+        {...getInteractionDataAttributes({
+          isHovered,
+          isFocusVisible,
+          isPressed,
+          isSelected,
+          isDisabled,
+          // isReadOnly can be undefined; ?? false satisfies exactOptionalPropertyTypes
+          isReadOnly: (ariaProps as { isReadOnly?: boolean }).isReadOnly ?? false,
+        })}
+        // ── Content flag (describes structure, NOT interaction state) ────
+        data-with-icon={hasIcon ? "" : undefined}
       >
-        {/* Visually hidden native input for accessibility */}
+        {/* Visually hidden native input — handles all accessibility */}
         <VisuallyHidden>
           <input {...mergeProps(inputProps, focusProps)} ref={ref} id={htmlId} />
         </VisuallyHidden>
 
-        {/* Visual switch container */}
-        <div
-          role="presentation"
-          className={cn(
-            switchTrackVariants({
-              selected: isSelected,
-              disabled: isDisabled,
-            })
-          )}
-        >
-          {/* Focus ring (keyboard focus indicator) */}
-          {isFocusVisible && (
-            <div
-              className="border-primary absolute inset-[-4px] animate-pulse rounded-full border-2"
-              aria-hidden="true"
-            />
-          )}
+        {/* Visual track */}
+        <div role="presentation" className={cn(switchTrackVariants())}>
+          {/* Focus ring — outside overflow-hidden, replaces animate-pulse */}
+          <div className={cn(switchFocusRingVariants())} aria-hidden="true" />
 
-          {/* Handle container (with state layers and ripple) */}
+          {/* Handle container — movement only (translate-x) */}
           <div
-            className={cn(
-              switchHandleContainerVariants({
-                selected: isSelected,
-                pressed: isPressed,
-                disabled: isDisabled,
-              })
-            )}
-            onMouseDown={handleRipple}
             role="presentation"
+            className={cn(switchHandleContainerVariants())}
+            onMouseDown={handleRipple}
           >
-            {/* Ripple effect */}
+            {/* Ripple */}
             {ripples}
 
-            {/* Handle (thumb) */}
-            <div
-              className={cn(
-                switchHandleVariants({
-                  selected: isSelected,
-                  pressed: isPressed,
-                  disabled: isDisabled,
-                  withIcon: !!icon || !!selectedIcon,
-                })
-              )}
-            >
-              {/* Icon when OFF */}
-              {!isSelected && icon && (
-                <div
-                  className={cn(
-                    switchIconVariants({
-                      visible: !isSelected,
-                      disabled: isDisabled,
-                    })
-                  )}
-                >
-                  {icon}
-                </div>
-              )}
+            {/* State layer — hover/focus/pressed opacity ring */}
+            <span className={cn(switchStateLayerVariants())} aria-hidden="true" />
 
-              {/* Icon when ON */}
+            {/* Handle — size + color only */}
+            <div className={cn(switchHandleVariants())} aria-hidden="true">
+              {/* Unselected icon */}
+              {!isSelected && icon && <span className={cn(switchIconVariants())}>{icon}</span>}
+              {/* Selected icon */}
               {isSelected && selectedIcon && (
-                <div
-                  className={cn(
-                    switchIconVariants({
-                      visible: isSelected,
-                      disabled: isDisabled,
-                    })
-                  )}
-                >
-                  {selectedIcon}
-                </div>
+                <span className={cn(switchIconVariants())}>{selectedIcon}</span>
               )}
             </div>
           </div>
         </div>
 
-        {/* Label text */}
-        {children && (
-          <span
-            className={cn(
-              switchLabelVariants({
-                disabled: isDisabled,
-              })
-            )}
-          >
-            {children}
-          </span>
-        )}
+        {/* Text label */}
+        {children && <span className={cn(switchLabelVariants())}>{children}</span>}
       </label>
     );
   }

--- a/packages/react/src/components/Switch/Switch.types.ts
+++ b/packages/react/src/components/Switch/Switch.types.ts
@@ -6,7 +6,7 @@ import type { AriaSwitchProps } from "react-aria";
  *
  * Built on React Aria for world-class accessibility.
  * Represents on/off states (not selection like checkbox).
- * Implementation uses CVA + Tailwind CSS classes mapped to MD3 tokens.
+ * Styled via the Variants-vs-States architecture: CVA slots + data-* attributes.
  *
  * @example
  * ```tsx
@@ -41,52 +41,58 @@ export interface SwitchProps
     AriaSwitchProps,
     Omit<React.HTMLAttributes<HTMLLabelElement>, keyof AriaSwitchProps | "children"> {
   /**
-   * Switch label content
+   * Switch label content.
    */
   children?: React.ReactNode;
 
   /**
-   * Icon to display inside handle when switch is OFF
+   * Icon displayed inside the handle when the switch is OFF.
+   * Presence of this prop also sets `data-with-icon` on the root,
+   * expanding the handle to 24dp (same as selected) for visual balance.
+   *
    * @default undefined
    */
   icon?: React.ReactNode;
 
   /**
-   * Icon to display inside handle when switch is ON
+   * Icon displayed inside the handle when the switch is ON.
+   * Presence of this prop also sets `data-with-icon` on the root.
+   *
    * @default undefined
    */
   selectedIcon?: React.ReactNode;
 
   /**
-   * Disable ripple effect
+   * Disable the ripple effect on press.
+   *
    * @default false
    */
   disableRipple?: boolean;
 
   /**
-   * Additional CSS classes (Tailwind)
+   * Additional Tailwind CSS classes applied to the root label element.
    */
   className?: string;
 }
 
 /**
- * Props for the headless Switch component
- * Extends AriaSwitchProps for accessibility
+ * Props for the headless Switch component.
+ * Extends AriaSwitchProps for accessibility primitives.
  */
 export interface SwitchHeadlessProps extends AriaSwitchProps {
   /**
-   * Additional CSS classes for the label wrapper
+   * Additional CSS classes for the label wrapper.
    */
   className?: string;
 
   /**
-   * Switch label content
+   * Switch label content.
    */
   children?: React.ReactNode;
 
   /**
-   * Render prop for custom switch visual
-   * Receives state information
+   * Render prop for custom switch visual.
+   * Receives the current interaction/selection state.
    */
   renderSwitch?: (state: {
     isSelected: boolean;

--- a/packages/react/src/components/Switch/Switch.variants.ts
+++ b/packages/react/src/components/Switch/Switch.variants.ts
@@ -58,7 +58,7 @@ export const switchRootVariants = cva([
  * overflow-hidden clips the state-layer ring to the pill shape.
  */
 export const switchTrackVariants = cva([
-  "relative flex items-center w-13 h-8 rounded-full border-2 overflow-hidden",
+  "relative flex items-center w-13 h-8 rounded-full border-2",
   // Effects transition (color — no spatial overshoot)
   "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
   // Unselected (base)
@@ -95,14 +95,14 @@ export const switchFocusRingVariants = cva([
  * position. Translates horizontally via group-data-[selected].
  *
  * Geometry:
- *   -left-1 → container left edge at –4px from track inner-left.
+ *   -left-1.5 → container left edge at –6px from track inner-left. (2dp border + 4px gap)
  *   Container center (40dp/2=20) at –4+20 = 16px from track inner-left.
  *   Handle 16dp: center at 16px (symmetric gap of ~0px from inner-left arc) ✓
  *   translate-x-5 (+20px): center at 36px from inner-left.
  *   Handle 24dp: edges at 24–48px (inner track spans 0–48px) ✓
  */
 export const switchHandleContainerVariants = cva([
-  "absolute top-1/2 -translate-y-1/2 -left-1 size-10",
+  "absolute top-1/2 -translate-y-1/2 -left-1.5 size-10",
   "flex items-center justify-center rounded-full",
   // Spatial transition for movement (position is spatial, not an effect)
   "transition-transform duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",

--- a/packages/react/src/components/Switch/Switch.variants.ts
+++ b/packages/react/src/components/Switch/Switch.variants.ts
@@ -1,320 +1,217 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 Switch Variants (CVA)
+ * Material Design 3 Switch Variants
  *
- * Type-safe variant management for Switch component.
- * Uses Tailwind CSS classes mapped to MD3 design tokens.
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no state variants, no state compoundVariants).
+ * - All interaction/selection states are driven by data-* attributes on the root via
+ *   group-data-[x]/switch Tailwind selectors in each slot's base classes.
+ * - Content flags (data-with-icon) are set explicitly by the component, not via helper.
+ * - The root element sets inherited CSS variables for dynamic geometry.
  *
- * MD3 Specifications:
- * - Track: 52x32dp, border-radius 16dp (full)
- * - Handle: 16x16dp (unselected), 24x24dp (selected), 28x28dp (pressed)
- * - Touch target: 48x48dp minimum
- * - State layers: 8% hover, 12% focus/pressed (on handle)
- * - Disabled: 12% container opacity, 38% content opacity
- * - Label spacing: 16px (ml-4)
+ * Slot responsibilities:
+ *   switchRootVariants        — label wrapper; carries `group/switch`; sets --switch-handle-size
+ *   switchTrackVariants       — 52×32dp pill background; owns color/border
+ *   switchHandleContainerVariants — movement only (translate-x); hosts state layer
+ *   switchStateLayerVariants  — hover/focus/pressed opacity ring
+ *   switchHandleVariants      — size + color only (no positioning)
+ *   switchIconVariants        — icon container inside handle
+ *   switchLabelVariants       — text label next to track
+ *
+ * MD3 Spec:
+ *   Track: 52×32dp, border-radius 16dp (full), 2dp border
+ *   Handle: 16dp unselected | 24dp selected / with-icon | 28dp pressed
+ *   State-layer container: 40dp, centered on handle
+ *   State-layer opacities: hover 8% | focus 10% | pressed 10% | dragged 16%
+ *   Disabled: container 12% opacity, content 38% opacity
  */
+
+// ─── ROOT ─────────────────────────────────────────────────────────────────────
 
 /**
- * Switch wrapper/label variants (main container)
+ * Root label wrapper — carries `group/switch` and handle geometry variables.
+ *
+ * Sets --switch-handle-size as an inherited CSS variable so both the container
+ * and the handle slot can consume it without coupling. Priority order (last wins
+ * in CSS cascade at equal specificity): base → selected → with-icon → pressed.
  */
-export const switchVariants = cva(
-  [
-    // Base classes (always applied to label wrapper)
-    "relative inline-flex items-center cursor-pointer select-none",
-    "transition-opacity duration-200",
-  ],
-  {
-    variants: {
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "opacity-38 cursor-not-allowed pointer-events-none",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      disabled: false,
-    },
-  }
-);
+export const switchRootVariants = cva([
+  "relative inline-flex items-center cursor-pointer select-none",
+  // Interaction states are styled via group-data on children.
+  // Root's own disabled state must use self-targeting data-[x]: selectors.
+  "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+  "data-[disabled]:opacity-38",
+  // ── Handle size CSS variable ──────────────────────────────────────────────
+  // Set via self-referential data-[x]: so all child slots inherit the value.
+  "[--switch-handle-size:1rem]", // 16dp base
+  "data-[selected]:[--switch-handle-size:1.5rem]", // 24dp selected
+  "data-[with-icon]:[--switch-handle-size:1.5rem]", // 24dp with icon
+  "data-[pressed]:[--switch-handle-size:1.75rem]", // 28dp pressed (last = wins)
+]);
+
+// ─── TRACK ────────────────────────────────────────────────────────────────────
 
 /**
- * Switch track variants (the 52x32dp background rail)
+ * Track — the 52×32dp pill background rail.
+ * Owns background color, border color, and focus outline.
+ * overflow-hidden clips the state-layer ring to the pill shape.
  */
-export const switchTrackVariants = cva(
-  [
-    // Base classes for track
-    "relative flex items-center",
-    "w-13 h-8", // MD3 spec: 52x32dp
-    "rounded-full", // MD3 spec: border-radius 16dp (full)
-    "transition-all duration-200",
-    "border-2 border-outline", // MD3 spec: outline border
-  ],
-  {
-    variants: {
-      /**
-       * Switch state (determines track color)
-       */
-      selected: {
-        true: "bg-primary border-primary", // MD3: selected track
-        false: "bg-surface-container-highest", // MD3: unselected track
-      },
+export const switchTrackVariants = cva([
+  "relative flex items-center w-13 h-8 rounded-full border-2 overflow-hidden",
+  // Effects transition (color — no spatial overshoot)
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Unselected (base)
+  "bg-surface-container-highest border-outline",
+  // Selected
+  "group-data-[selected]/switch:bg-primary group-data-[selected]/switch:border-primary",
+  // Disabled (overrides selected via higher cascade position + same specificity)
+  "group-data-[disabled]/switch:bg-on-surface/12 group-data-[disabled]/switch:border-on-surface/12",
+]);
 
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "bg-on-surface/12 border-on-surface/12", // MD3: 12% opacity for disabled
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Disabled state overrides normal colors
-      {
-        selected: true,
-        disabled: true,
-        className: "bg-on-surface/12",
-      },
-      {
-        selected: false,
-        disabled: true,
-        className: "bg-on-surface/12",
-      },
-    ],
-    defaultVariants: {
-      selected: false,
-      disabled: false,
-    },
-  }
-);
+// ─── FOCUS RING ───────────────────────────────────────────────────────────────
 
 /**
- * Switch handle container variants (the movable thumb with state layers)
+ * Focus ring overlay (sibling of the track, outside overflow-hidden).
+ * Renders as an absolutely-positioned outline so it sits above the track
+ * border without being clipped.
+ *
+ * Replaces the non-MD3 animate-pulse ring from the previous implementation.
  */
-export const switchHandleContainerVariants = cva(
-  [
-    // Base classes for handle container (includes state layer)
-    "absolute flex items-center justify-center",
-    "rounded-full",
-    "transition-all duration-200",
+export const switchFocusRingVariants = cva([
+  "pointer-events-none absolute inset-[-3px] rounded-full",
+  "outline outline-2 outline-offset-0 outline-primary",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/switch:opacity-100",
+]);
 
-    // State layer (hover, focus, active) - MD3 spec: 8%/12%/12% opacity
-    "before:absolute before:inset-0 before:rounded-full before:transition-opacity before:duration-200",
-    "before:bg-current before:opacity-0",
-    "hover:before:opacity-8",
-    "active:before:opacity-12",
-  ],
-  {
-    variants: {
-      /**
-       * Switch state (determines handle position and size)
-       */
-      selected: {
-        true: [
-          "left-[22px]", // Position when ON (52px - 24px = 28px)
-          "text-primary", // State layer color
-        ],
-        false: [
-          "left-1.5", // Position when OFF (centered in left half)
-          "text-on-surface-variant", // State layer color
-        ],
-      },
-
-      /**
-       * Pressed state (increases handle size)
-       */
-      pressed: {
-        true: "size-7 left-[20px]", // MD3: 28dp when pressed
-        false: "",
-      },
-
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "pointer-events-none",
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Size depends on selected + pressed state
-      {
-        selected: true,
-        pressed: false,
-        className: "size-6", // MD3: 24dp when selected
-      },
-      {
-        selected: false,
-        pressed: false,
-        className: "size-4", // MD3: 16dp when unselected
-      },
-    ],
-    defaultVariants: {
-      selected: false,
-      pressed: false,
-      disabled: false,
-    },
-  }
-);
+// ─── HANDLE CONTAINER ────────────────────────────────────────────────────────
 
 /**
- * Switch handle (the actual thumb visual)
+ * Handle container — movement only.
+ *
+ * Fixed 40dp circle (MD3 state-layer size), absolutely centred on the handle
+ * position. Translates horizontally via group-data-[selected].
+ *
+ * Geometry:
+ *   -left-1 → container left edge at –4px from track inner-left.
+ *   Container center (40dp/2=20) at –4+20 = 16px from track inner-left.
+ *   Handle 16dp: center at 16px (symmetric gap of ~0px from inner-left arc) ✓
+ *   translate-x-5 (+20px): center at 36px from inner-left.
+ *   Handle 24dp: edges at 24–48px (inner track spans 0–48px) ✓
  */
-export const switchHandleVariants = cva(
-  [
-    // Base classes for the handle
-    "relative z-10 rounded-full flex-shrink-0",
-    "transition-all duration-200",
-    "flex items-center justify-center",
-  ],
-  {
-    variants: {
-      /**
-       * Switch state (determines handle color and size)
-       */
-      selected: {
-        true: "bg-on-primary", // MD3: on-primary when selected
-        false: "bg-outline", // MD3: outline when unselected
-      },
+export const switchHandleContainerVariants = cva([
+  "absolute top-1/2 -translate-y-1/2 -left-1 size-10",
+  "flex items-center justify-center rounded-full",
+  // Spatial transition for movement (position is spatial, not an effect)
+  "transition-transform duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+  // Travel to selected position
+  "group-data-[selected]/switch:translate-x-5",
+]);
 
-      /**
-       * Pressed state
-       */
-      pressed: {
-        true: "size-7", // MD3: 28dp when pressed
-        false: "",
-      },
-
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "bg-on-surface/38", // MD3: 38% opacity for disabled
-        false: "",
-      },
-
-      /**
-       * HOvered state
-       */
-      hovered: {
-        true: "bg-on-primary/8", // MD3: 8% opacity hover state
-        false: "",
-      },
-
-      /**
-       * With icon state
-       */
-      withIcon: {
-        true: "size-7", // MD3: 28dp when handle has icon (to accommodate icon size)
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Size depends on selected + pressed state
-      {
-        selected: true,
-        pressed: false,
-        className: "size-6", // MD3: 24dp when selected
-      },
-      {
-        selected: false,
-        pressed: false,
-        withIcon: true,
-        className: "size-6", // MD3: 24dp when unselected
-      },
-
-      {
-        selected: false,
-        pressed: false,
-        withIcon: false,
-        className: "size-4", // MD3: 16dp when unselected
-      },
-      // Disabled state overrides normal colors
-      {
-        selected: true,
-        disabled: true,
-        className: "bg-on-surface/38",
-      },
-      {
-        selected: false,
-        disabled: true,
-        className: "bg-on-surface/38",
-      },
-    ],
-    defaultVariants: {
-      selected: false,
-      pressed: false,
-      disabled: false,
-    },
-  }
-);
+// ─── STATE LAYER ─────────────────────────────────────────────────────────────
 
 /**
- * Switch icon variants (icons inside handle)
+ * State layer — the 40dp semi-transparent ring inside the handle container.
+ *
+ * Color: on-surface (unselected) → primary (selected).
+ * Opacity: 0 at rest, 8% hover, 10% focus/pressed, hidden when disabled.
  */
-export const switchIconVariants = cva(
-  [
-    // Base classes for icons
-    "size-5", // MD3: 16x16dp icon size
-    "transition-all duration-200",
-    "flex items-center justify-center flex-shrink-0",
-  ],
-  {
-    variants: {
-      /**
-       * Icon visibility based on state
-       */
-      visible: {
-        true: "opacity-100", // MD3: fully visible with appropriate color
-        false: "opacity-0", // MD3: invisible but still takes space (for smooth transitions)
-      },
+export const switchStateLayerVariants = cva([
+  "absolute inset-0 rounded-full pointer-events-none opacity-0",
+  // Base state-layer color (unselected)
+  "bg-on-surface",
+  // Effects transition for opacity
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Selected state-layer color
+  "group-data-[selected]/switch:bg-primary",
+  // Interaction opacities (MD3: hover 8%, focus/pressed 10%)
+  "group-data-[hovered]/switch:opacity-8",
+  "group-data-[focus-visible]/switch:opacity-10",
+  "group-data-[pressed]/switch:opacity-10",
+  // No state layer when disabled
+  "group-data-[disabled]/switch:hidden",
+]);
 
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "opacity-38",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      visible: true,
-      disabled: false,
-    },
-  }
-);
+// ─── HANDLE ───────────────────────────────────────────────────────────────────
 
 /**
- * Switch label text variants
+ * Handle (thumb) — size and color only, no positioning.
+ *
+ * Size: inherited from --switch-handle-size CSS variable set on root.
+ *   16dp unselected → 24dp selected/icon → 28dp pressed.
+ *
+ * Color progression (singly-chained rules come first; doubly-chained win by
+ * higher specificity; disabled rules placed last win by cascade order within
+ * equal specificity):
+ *   base:            outline
+ *   selected:        on-primary
+ *   unselected+int:  on-surface-variant  (singly-chained)
+ *   selected+int:    primary-container   (doubly-chained → higher specificity)
+ *   disabled:        on-surface/38       (singly-chained, placed last → cascade wins)
+ *   disabled+sel:    surface             (doubly-chained → highest for this combo)
  */
-export const switchLabelVariants = cva(
-  [
-    "text-sm", // MD3: Body Medium (14px)
-    "text-on-surface",
-    "select-none",
-    "ml-4", // 16px spacing between switch and label (MD3 standard)
-  ],
-  {
-    variants: {
-      disabled: {
-        true: "",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      disabled: false,
-    },
-  }
-);
+export const switchHandleVariants = cva([
+  "relative z-10 rounded-full flex items-center justify-center flex-shrink-0",
+  // Size via inherited CSS variable
+  "size-[var(--switch-handle-size,1rem)]",
+  // Spatial transition for size changes + effects for color
+  "transition-[width,height,background-color] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+  // ── Colors ────────────────────────────────────────────────────────────────
+  // Base (unselected, enabled, no interaction)
+  "bg-outline",
+  // Selected
+  "group-data-[selected]/switch:bg-on-primary",
+  // Unselected + interaction (singly-chained — overrides base by cascade order)
+  "group-data-[hovered]/switch:bg-on-surface-variant",
+  "group-data-[focus-visible]/switch:bg-on-surface-variant",
+  "group-data-[pressed]/switch:bg-on-surface-variant",
+  // Selected + interaction (doubly-chained → higher specificity; wins over singly-chained above)
+  "group-data-[selected]/switch:group-data-[hovered]/switch:bg-primary-container",
+  "group-data-[selected]/switch:group-data-[focus-visible]/switch:bg-primary-container",
+  "group-data-[selected]/switch:group-data-[pressed]/switch:bg-primary-container",
+  // Disabled — placed last so cascade wins at equal specificity vs interaction colors
+  "group-data-[disabled]/switch:bg-on-surface/38",
+  // Disabled + selected — doubly-chained wins over singly-chained disabled
+  "group-data-[selected]/switch:group-data-[disabled]/switch:bg-surface",
+]);
+
+// ─── ICON ─────────────────────────────────────────────────────────────────────
 
 /**
- * Extract variant prop types from CVA
+ * Icon container inside the handle.
+ *
+ * Color follows the MD3 spec:
+ *   unselected: surface-container-highest (icon blends with track bg)
+ *   selected:   on-primary-container
+ *   disabled:   on-surface/38
  */
-export type SwitchVariants = VariantProps<typeof switchVariants>;
+export const switchIconVariants = cva([
+  "size-4 flex items-center justify-center flex-shrink-0",
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Unselected icon color (matches track bg, visually "hidden" at rest)
+  "text-surface-container-highest",
+  // Selected icon color
+  "group-data-[selected]/switch:text-on-primary-container",
+  // Disabled
+  "group-data-[disabled]/switch:text-on-surface/38",
+]);
+
+// ─── LABEL ────────────────────────────────────────────────────────────────────
+
+/**
+ * Text label next to the track.
+ * Disabled opacity is inherited from the root's data-[disabled]:opacity-38.
+ */
+export const switchLabelVariants = cva(["text-body-medium text-on-surface select-none ml-4"]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
+export type SwitchRootVariants = VariantProps<typeof switchRootVariants>;
 export type SwitchTrackVariants = VariantProps<typeof switchTrackVariants>;
 export type SwitchHandleContainerVariants = VariantProps<typeof switchHandleContainerVariants>;
+export type SwitchStateLayerVariants = VariantProps<typeof switchStateLayerVariants>;
 export type SwitchHandleVariants = VariantProps<typeof switchHandleVariants>;
 export type SwitchIconVariants = VariantProps<typeof switchIconVariants>;
 export type SwitchLabelVariants = VariantProps<typeof switchLabelVariants>;

--- a/packages/react/src/components/Switch/Switch.variants.ts
+++ b/packages/react/src/components/Switch/Switch.variants.ts
@@ -44,10 +44,13 @@ export const switchRootVariants = cva([
   "data-[disabled]:opacity-38",
   // ── Handle size CSS variable ──────────────────────────────────────────────
   // Set via self-referential data-[x]: so all child slots inherit the value.
+  // "data-[selected]" and "data-[with-icon]" have specificity (0,1,0).
+  // "data-[pressed]:data-[pressed]:" doubles the attribute selector → (0,2,0),
+  // guaranteeing it always wins regardless of Tailwind's CSS output order.
   "[--switch-handle-size:1rem]", // 16dp base
   "data-[selected]:[--switch-handle-size:1.5rem]", // 24dp selected
   "data-[with-icon]:[--switch-handle-size:1.5rem]", // 24dp with icon
-  "data-[pressed]:[--switch-handle-size:1.75rem]", // 28dp pressed (last = wins)
+  "data-[pressed]:data-[pressed]:[--switch-handle-size:1.75rem]", // 28dp pressed — doubled for higher specificity
 ]);
 
 // ─── TRACK ────────────────────────────────────────────────────────────────────
@@ -79,8 +82,10 @@ export const switchTrackVariants = cva([
  * Replaces the non-MD3 animate-pulse ring from the previous implementation.
  */
 export const switchFocusRingVariants = cva([
+  // Sits outside the track's overflow-hidden by being rendered as a sibling,
+  // not a child — see Switch.tsx for the relative wrapper structure.
   "pointer-events-none absolute inset-[-3px] rounded-full",
-  "outline outline-2 outline-offset-0 outline-primary",
+  "outline outline-2 outline-offset-0 outline-secondary",
   "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
   "opacity-0",
   "group-data-[focus-visible]/switch:opacity-100",

--- a/packages/react/src/components/Switch/index.ts
+++ b/packages/react/src/components/Switch/index.ts
@@ -12,17 +12,20 @@ export type { SwitchProps, SwitchHeadlessProps } from "./Switch.types";
 
 // Variants (for advanced customization)
 export {
-  switchVariants,
+  switchRootVariants,
   switchTrackVariants,
+  switchFocusRingVariants,
   switchHandleContainerVariants,
+  switchStateLayerVariants,
   switchHandleVariants,
   switchIconVariants,
   switchLabelVariants,
 } from "./Switch.variants";
 export type {
-  SwitchVariants,
+  SwitchRootVariants,
   SwitchTrackVariants,
   SwitchHandleContainerVariants,
+  SwitchStateLayerVariants,
   SwitchHandleVariants,
   SwitchIconVariants,
   SwitchLabelVariants,

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -24,6 +24,9 @@ export {
   type Theme,
 } from "./colors";
 
+// Interaction state utilities
+export { getInteractionDataAttributes, type InteractionStates } from "./interactionStates";
+
 // Typography utilities
 export {
   getTypographyToken,

--- a/packages/react/src/utils/interactionStates.ts
+++ b/packages/react/src/utils/interactionStates.ts
@@ -1,0 +1,106 @@
+/**
+ * Interaction States Utility
+ *
+ * Shared helper for converting React Aria interaction/selection state booleans
+ * into presence-based `data-*` attributes for `group-data-[x]/<name>` Tailwind
+ * CSS selectors.
+ *
+ * This covers **interaction and selection states only**. Content flags such as
+ * `data-with-icon` or `data-with-label` describe structural composition and
+ * must be set explicitly by the component — never via this helper.
+ *
+ * @example
+ * ```tsx
+ * const { isHovered, hoverProps } = useHover({ isDisabled })
+ * const { isFocusVisible, focusProps } = useFocusRing()
+ *
+ * <label
+ *   className="group/switch"
+ *   {...mergeProps(labelProps, hoverProps, focusProps)}
+ *   {...getInteractionDataAttributes({ isHovered, isFocusVisible, isSelected, isDisabled })}
+ *   data-with-icon={(!!icon) ? "" : undefined}
+ * />
+ * ```
+ */
+
+/**
+ * Subset of React Aria interaction states that map to `data-*` attributes.
+ * All fields are optional — omit states not relevant to a given component.
+ */
+export interface InteractionStates {
+  /**
+   * Pointer is hovering over the component.
+   * Source: `useHover` → `isHovered`
+   */
+  isHovered?: boolean;
+  /**
+   * Keyboard or programmatic focus is visible (not pointer-initiated).
+   * Source: `useFocusRing` → `isFocusVisible`
+   */
+  isFocusVisible?: boolean;
+  /**
+   * Component is actively being pressed.
+   * Source: React Aria interaction → `isPressed`
+   */
+  isPressed?: boolean;
+  /**
+   * Component is in the ON / checked / active selection state.
+   * Source: toggle/select state → `isSelected`
+   */
+  isSelected?: boolean;
+  /**
+   * Component is non-interactive.
+   * Source: `isDisabled` prop
+   */
+  isDisabled?: boolean;
+  /**
+   * Component value cannot be changed.
+   * Source: `isReadOnly` prop
+   */
+  isReadOnly?: boolean;
+  /**
+   * Component value fails validation.
+   * Source: `isInvalid` prop
+   */
+  isInvalid?: boolean;
+  /**
+   * Component is partially selected (checkbox indeterminate state).
+   * Source: `isIndeterminate` prop
+   */
+  isIndeterminate?: boolean;
+}
+
+/**
+ * Converts interaction/selection states into presence-based `data-*` attributes.
+ *
+ * Attributes are set to `""` (present) when true and `undefined` (absent) when
+ * false/undefined, so Tailwind `data-[x]` and `group-data-[x]/<name>` selectors
+ * match purely on attribute presence — no value comparison needed.
+ *
+ * Uses explicit ternaries (`s.isHovered ? "" : undefined`) rather than
+ * `s.isHovered || undefined` to avoid incorrect attribute removal on falsy
+ * non-boolean values.
+ *
+ * @param s - The component's current interaction/selection state
+ * @returns A record of `data-*` attribute names to `""` or `undefined`
+ *
+ * @example
+ * ```tsx
+ * <label
+ *   className="group/switch"
+ *   {...getInteractionDataAttributes({ isHovered, isFocusVisible, isSelected, isDisabled })}
+ * />
+ * ```
+ */
+export function getInteractionDataAttributes(s: InteractionStates): Record<string, "" | undefined> {
+  return {
+    "data-hovered": s.isHovered ? "" : undefined,
+    "data-focus-visible": s.isFocusVisible ? "" : undefined,
+    "data-pressed": s.isPressed ? "" : undefined,
+    "data-selected": s.isSelected ? "" : undefined,
+    "data-disabled": s.isDisabled ? "" : undefined,
+    "data-readonly": s.isReadOnly ? "" : undefined,
+    "data-invalid": s.isInvalid ? "" : undefined,
+    "data-indeterminate": s.isIndeterminate ? "" : undefined,
+  };
+}

--- a/packages/tokens/src/theme.css
+++ b/packages/tokens/src/theme.css
@@ -325,11 +325,13 @@
   --spacing-dialog-max: 35rem; /* 560px */
 
   /* ── OPACITY (MD3 state layer values) ─────────────────────────────────────
-     Usage: opacity-8, opacity-12, opacity-32, opacity-38
+     Usage: opacity-8, opacity-10, opacity-12, opacity-16, opacity-32, opacity-38
      ──────────────────────────────────────────────────────────────────────── */
 
   --opacity-8: 0.08;
+  --opacity-10: 0.1;
   --opacity-12: 0.12;
+  --opacity-16: 0.16;
   --opacity-32: 0.32;
   --opacity-38: 0.38;
 


### PR DESCRIPTION
## Summary

- Refactor Switch CVA variants to reduce combinatorial explosion via shared `interactionStates` utilities
- Fix track alignment and MD3 styling (track, handle, state layer, focus ring)
- Update Switch public exports (`switchRootVariants`, `switchStateLayerVariants`, etc.)
- Add changeset for patch release

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Switch tests pass (50/50)
- [x] Changeset added for `@tinybigui/react` and `@tinybigui/tokens` patch bump