### PR TITLE
chore: sync dev with button test fix for v0.4.1 release

### DIFF
--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -42,7 +42,7 @@ describe("Button", () => {
     test("renders outlined variant", () => {
       render(<Button variant="outlined">Outlined</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("border", "border-outline");
+      expect(button).toHaveClass("border", "border-outline-variant");
     });
 
     test("renders tonal variant", () => {
@@ -365,7 +365,7 @@ describe("Button", () => {
         </Button>
       );
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("border-outline", "text-secondary");
+      expect(button).toHaveClass("border-outline-variant", "text-secondary");
     });
 
     test("tonal tertiary button has correct classes", () => {


### PR DESCRIPTION
## Summary

- Fix stale Button test assertions (`border-outline` → `border-outline-variant`) to unblock the v0.4.1 release CI publish step

## Test plan

- [x] Button tests pass (74/74)