### PR TITLE
fix(time-picker): clear buffer timeout on unmount for stable ci

### DIFF
--- a/packages/react/src/components/TimePicker/TimeInputField.tsx
+++ b/packages/react/src/components/TimePicker/TimeInputField.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { TimeInputFieldProps } from "./TimePicker.types";
 
@@ -39,6 +39,14 @@ export function TimeInputField({
   const [isInvalid, setIsInvalid] = useState(false);
   const bufferRef = useRef<string>("");
   const bufferTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (bufferTimerRef.current !== null) {
+        clearTimeout(bufferTimerRef.current);
+      }
+    };
+  }, []);
 
   const label = field === "hour" ? "Hour" : "Minute";
 


### PR DESCRIPTION
## Summary

- Clear the TimeInputField digit-buffer timeout on unmount to prevent `window is not defined` unhandled errors in CI after tests complete

## Test plan

- [x] TimePicker tests pass (125/125)