### PR TITLE
refactor(button): align styling with md3 specs and variants-vs-states architecture

### DIFF
--- a/.changeset/button-styling-refactor.md
+++ b/.changeset/button-styling-refactor.md
@@ -1,0 +1,6 @@
+---
+"@tinybigui/react": patch
+"@tinybigui/tokens": patch
+---
+
+Refactor Button, ButtonGroup, and IconButton to align with MD3 specs — adopt variants-vs-states architecture with data-attribute interaction layers, remove non-spec `color` prop, correct size heights and state layer opacities, and enhance ripple and focus ring behavior.

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
+import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./Button";
 
-// Sample icons for stories
 const IconAdd = (): React.ReactElement => (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
     <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
@@ -20,6 +20,12 @@ const IconFavorite = (): React.ReactElement => (
   </svg>
 );
 
+const IconDelete = (): React.ReactElement => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+  </svg>
+);
+
 const meta: Meta<typeof Button> = {
   title: "Components/Button",
   component: Button,
@@ -28,7 +34,7 @@ const meta: Meta<typeof Button> = {
     docs: {
       description: {
         component:
-          "Material Design 3 Button component with 5 variants, multiple colors, sizes, and full accessibility support.",
+          "Material Design 3 Button component with 5 strict MD3 variants, 3 sizes, and full accessibility support. Each variant uses its spec-defined color roles — no color override is needed.",
       },
     },
   },
@@ -37,17 +43,12 @@ const meta: Meta<typeof Button> = {
     variant: {
       control: "select",
       options: ["filled", "outlined", "tonal", "elevated", "text"],
-      description: "Button visual style variant",
-    },
-    color: {
-      control: "select",
-      options: ["primary", "secondary", "tertiary", "error"],
-      description: "Color scheme for the button",
+      description: "MD3 button variant — determines visual emphasis and color roles",
     },
     size: {
       control: "select",
       options: ["small", "medium", "large"],
-      description: "Button size",
+      description: "Button size (small=32dp, medium=40dp, large=56dp)",
     },
     isDisabled: {
       control: "boolean",
@@ -55,15 +56,15 @@ const meta: Meta<typeof Button> = {
     },
     loading: {
       control: "boolean",
-      description: "Show loading spinner",
+      description: "Show loading spinner (also disables the button)",
     },
     fullWidth: {
       control: "boolean",
-      description: "Make button full width",
+      description: "Span the full width of the container",
     },
     disableRipple: {
       control: "boolean",
-      description: "Disable ripple effect",
+      description: "Disable the ripple press effect",
     },
   },
 };
@@ -71,137 +72,84 @@ const meta: Meta<typeof Button> = {
 export default meta;
 type Story = StoryObj<typeof Button>;
 
-// Default Story
+// ─── DEFAULT ──────────────────────────────────────────────────────────────────
+
 export const Default: Story = {
   args: {
     children: "Button",
     variant: "filled",
-    color: "primary",
     size: "medium",
   },
 };
 
-// Variants
+// ─── VARIANTS ─────────────────────────────────────────────────────────────────
+
 export const Filled: Story = {
-  args: {
-    variant: "filled",
-    children: "Filled Button",
-  },
+  args: { variant: "filled", children: "Filled" },
 };
 
 export const Outlined: Story = {
-  args: {
-    variant: "outlined",
-    children: "Outlined Button",
-  },
+  args: { variant: "outlined", children: "Outlined" },
 };
 
 export const Tonal: Story = {
-  args: {
-    variant: "tonal",
-    children: "Tonal Button",
-  },
+  args: { variant: "tonal", children: "Tonal" },
 };
 
 export const Elevated: Story = {
-  args: {
-    variant: "elevated",
-    children: "Elevated Button",
-  },
+  args: { variant: "elevated", children: "Elevated" },
 };
 
 export const Text: Story = {
-  args: {
-    variant: "text",
-    children: "Text Button",
-  },
+  args: { variant: "text", children: "Text" },
 };
 
-// All Variants Showcase
 export const AllVariants: Story = {
   render: () => (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-wrap items-center gap-3">
       <Button variant="filled">Filled</Button>
-      <Button variant="outlined">Outlined</Button>
       <Button variant="tonal">Tonal</Button>
       <Button variant="elevated">Elevated</Button>
+      <Button variant="outlined">Outlined</Button>
       <Button variant="text">Text</Button>
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All 5 MD3 button variants ordered by visual emphasis (highest to lowest). Use at most one filled/elevated per surface.",
+      },
+    },
+  },
 };
 
-// Colors
-export const Colors: Story = {
-  render: () => (
-    <div className="flex flex-col gap-4">
-      <div className="flex gap-2">
-        <Button color="primary">Primary</Button>
-        <Button color="secondary">Secondary</Button>
-        <Button color="tertiary">Tertiary</Button>
-        <Button color="error">Error</Button>
-      </div>
-      <div className="flex gap-2">
-        <Button variant="outlined" color="primary">
-          Primary
-        </Button>
-        <Button variant="outlined" color="secondary">
-          Secondary
-        </Button>
-        <Button variant="outlined" color="tertiary">
-          Tertiary
-        </Button>
-        <Button variant="outlined" color="error">
-          Error
-        </Button>
-      </div>
-      <div className="flex gap-2">
-        <Button variant="tonal" color="primary">
-          Primary
-        </Button>
-        <Button variant="tonal" color="secondary">
-          Secondary
-        </Button>
-        <Button variant="tonal" color="tertiary">
-          Tertiary
-        </Button>
-        <Button variant="tonal" color="error">
-          Error
-        </Button>
-      </div>
-    </div>
-  ),
-};
+// ─── SIZES ────────────────────────────────────────────────────────────────────
 
-// Sizes
 export const Sizes: Story = {
   render: () => (
-    <div className="flex items-end gap-4">
-      <Button size="small">Small</Button>
-      <Button size="medium">Medium</Button>
-      <Button size="large">Large</Button>
+    <div className="flex flex-wrap items-end gap-3">
+      <Button size="small">Small (32dp)</Button>
+      <Button size="medium">Medium (40dp)</Button>
+      <Button size="large">Large (56dp)</Button>
     </div>
   ),
 };
 
-// With Icons
+// ─── ICONS ────────────────────────────────────────────────────────────────────
+
 export const WithLeadingIcon: Story = {
-  args: {
-    icon: <IconAdd />,
-    children: "Add Item",
-  },
+  args: { icon: <IconAdd />, children: "Add Item" },
 };
 
 export const WithTrailingIcon: Story = {
-  args: {
-    trailingIcon: <IconArrowForward />,
-    children: "Continue",
-  },
+  args: { trailingIcon: <IconArrowForward />, children: "Continue" },
 };
 
 export const IconExamples: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <Button icon={<IconAdd />}>Add</Button>
         <Button icon={<IconFavorite />} variant="outlined">
           Like
@@ -209,8 +157,14 @@ export const IconExamples: Story = {
         <Button icon={<IconAdd />} variant="tonal">
           Create
         </Button>
+        <Button icon={<IconAdd />} variant="elevated">
+          Elevated
+        </Button>
+        <Button icon={<IconFavorite />} variant="text">
+          Favorite
+        </Button>
       </div>
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <Button trailingIcon={<IconArrowForward />}>Next</Button>
         <Button trailingIcon={<IconArrowForward />} variant="outlined">
           Continue
@@ -219,80 +173,122 @@ export const IconExamples: Story = {
           Learn More
         </Button>
       </div>
-    </div>
-  ),
-};
-
-// States
-export const Disabled: Story = {
-  render: () => (
-    <div className="flex flex-col gap-4">
-      <div className="flex gap-2">
-        <Button isDisabled>Filled</Button>
-        <Button variant="outlined" isDisabled>
-          Outlined
+      <div className="flex flex-wrap gap-2">
+        <Button size="small" icon={<IconAdd />}>
+          Small
         </Button>
-        <Button variant="tonal" isDisabled>
-          Tonal
+        <Button size="medium" icon={<IconAdd />}>
+          Medium
         </Button>
-        <Button variant="elevated" isDisabled>
-          Elevated
-        </Button>
-        <Button variant="text" isDisabled>
-          Text
+        <Button size="large" icon={<IconAdd />}>
+          Large
         </Button>
       </div>
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "MD3 spec: icons must be 18×18px. Use the leading slot for action icons, trailing for directional/navigation icons.",
+      },
+    },
+  },
+};
+
+// ─── STATES ───────────────────────────────────────────────────────────────────
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Button isDisabled>Filled</Button>
+      <Button variant="outlined" isDisabled>
+        Outlined
+      </Button>
+      <Button variant="tonal" isDisabled>
+        Tonal
+      </Button>
+      <Button variant="elevated" isDisabled>
+        Elevated
+      </Button>
+      <Button variant="text" isDisabled>
+        Text
+      </Button>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Disabled state per MD3: container uses on-surface at 12% opacity, label uses on-surface at 38% opacity. Elevation is removed.",
+      },
+    },
+  },
 };
 
 export const Loading: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
-      <div className="flex gap-2">
-        <Button loading>Loading</Button>
+      <div className="flex flex-wrap gap-2">
+        <Button loading>Saving</Button>
         <Button variant="outlined" loading>
-          Loading
+          Saving
         </Button>
         <Button variant="tonal" loading>
-          Loading
+          Saving
+        </Button>
+        <Button variant="elevated" loading>
+          Saving
+        </Button>
+        <Button variant="text" loading>
+          Saving
         </Button>
       </div>
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <Button loading icon={<IconAdd />}>
           Creating
         </Button>
         <Button variant="outlined" loading icon={<IconFavorite />}>
-          Saving
+          Liking
         </Button>
       </div>
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Loading state: spinner replaces icon (layout stable — icon is invisible not hidden), button is disabled. data-loading attribute is set on root.",
+      },
+    },
+  },
 };
 
-// Full Width
+// ─── FULL WIDTH ───────────────────────────────────────────────────────────────
+
 export const FullWidth: Story = {
   render: () => (
-    <div className="flex w-80 flex-col gap-4">
-      <Button fullWidth>Full Width Button</Button>
+    <div className="flex w-80 flex-col gap-3">
+      <Button fullWidth>Full Width Filled</Button>
       <Button variant="outlined" fullWidth>
         Full Width Outlined
       </Button>
       <Button variant="tonal" fullWidth icon={<IconAdd />}>
-        Full Width With Icon
+        With Icon
       </Button>
     </div>
   ),
 };
 
-// Interactive Example
+// ─── INTERACTIVE ─────────────────────────────────────────────────────────────
+
 const InteractiveExample = (): React.ReactElement => {
   const [count, setCount] = React.useState(0);
   return (
     <div className="flex flex-col items-center gap-4">
-      <p className="text-lg">Count: {count}</p>
+      <p className="text-body-large text-on-surface">Count: {count}</p>
       <div className="flex gap-2">
-        <Button onPress={() => setCount(count + 1)} icon={<IconAdd />}>
+        <Button onPress={() => setCount((c) => c + 1)} icon={<IconAdd />}>
           Increment
         </Button>
         <Button variant="outlined" onPress={() => setCount(0)} isDisabled={count === 0}>
@@ -307,7 +303,8 @@ export const Interactive: Story = {
   render: () => <InteractiveExample />,
 };
 
-// Accessibility Example
+// ─── ACCESSIBILITY ────────────────────────────────────────────────────────────
+
 export const Accessibility: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
@@ -325,14 +322,14 @@ export const Accessibility: Story = {
   parameters: {
     docs: {
       description: {
-        story:
-          "Buttons support ARIA attributes for enhanced accessibility. Use aria-label, aria-pressed, aria-haspopup, etc.",
+        story: "Buttons support ARIA attributes for enhanced accessibility.",
       },
     },
   },
 };
 
-// Button Types
+// ─── BUTTON TYPES ─────────────────────────────────────────────────────────────
+
 export const ButtonTypes: Story = {
   render: () => (
     <form
@@ -361,26 +358,20 @@ export const ButtonTypes: Story = {
       </div>
     </form>
   ),
-  parameters: {
-    docs: {
-      description: {
-        story: "Buttons support different HTML button types: submit, reset, and button.",
-      },
-    },
-  },
 };
 
-// Complex Example
+// ─── COMPLEX EXAMPLE ─────────────────────────────────────────────────────────
+
 export const ComplexExample: Story = {
   render: () => (
-    <div className="bg-surface w-96 rounded-lg p-6">
-      <h2 className="mb-4 text-2xl font-bold">Confirm Action</h2>
-      <p className="text-on-surface-variant mb-6">
-        Are you sure you want to proceed with this action? This cannot be undone.
+    <div className="bg-surface shadow-elevation-2 w-96 rounded-lg p-6">
+      <h2 className="text-headline-small text-on-surface mb-2">Delete item?</h2>
+      <p className="text-body-medium text-on-surface-variant mb-6">
+        This will permanently remove the item. This action cannot be undone.
       </p>
       <div className="flex justify-end gap-2">
         <Button variant="text">Cancel</Button>
-        <Button variant="tonal" color="error">
+        <Button variant="filled" icon={<IconDelete />}>
           Delete
         </Button>
       </div>
@@ -389,18 +380,19 @@ export const ComplexExample: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Example of buttons in a dialog/modal context.",
+        story:
+          "Dialog footer pattern: text button for dismissive actions, filled for destructive/confirming actions.",
       },
     },
   },
 };
 
-// Playground
+// ─── PLAYGROUND ───────────────────────────────────────────────────────────────
+
 export const Playground: Story = {
   args: {
     children: "Customize Me",
     variant: "filled",
-    color: "primary",
     size: "medium",
     isDisabled: false,
     loading: false,
@@ -410,11 +402,8 @@ export const Playground: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Play around with all the button props to see how they work together.",
+        story: "Use the controls panel to explore all button props.",
       },
     },
   },
 };
-
-// Import React for Interactive story
-import React from "react";

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -15,20 +15,30 @@ describe("Button", () => {
 
     test("renders as button element by default", () => {
       render(<Button>Click me</Button>);
-      const button = screen.getByRole("button");
-      expect(button.tagName).toBe("BUTTON");
+      expect(screen.getByRole("button").tagName).toBe("BUTTON");
     });
 
     test("applies custom className", () => {
       render(<Button className="custom-class">Click me</Button>);
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("custom-class");
+      expect(screen.getByRole("button")).toHaveClass("custom-class");
     });
 
     test("forwards ref to button element", () => {
       const ref = { current: null };
       render(<Button ref={ref}>Click me</Button>);
       expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test("renders state layer span inside button", () => {
+      render(<Button>Button</Button>);
+      const button = screen.getByRole("button");
+      const stateLayer = button.querySelector('span[aria-hidden="true"]');
+      expect(stateLayer).toBeInTheDocument();
+    });
+
+    test("sets group/button class on root element", () => {
+      render(<Button>Button</Button>);
+      expect(screen.getByRole("button")).toHaveClass("group/button");
     });
   });
 
@@ -42,13 +52,13 @@ describe("Button", () => {
     test("renders outlined variant", () => {
       render(<Button variant="outlined">Outlined</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("border", "border-outline-variant");
+      expect(button).toHaveClass("border", "border-outline", "text-primary");
     });
 
     test("renders tonal variant", () => {
       render(<Button variant="tonal">Tonal</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-primary-container", "text-on-primary-container");
+      expect(button).toHaveClass("bg-secondary-container", "text-on-secondary-container");
     });
 
     test("renders elevated variant", () => {
@@ -62,32 +72,19 @@ describe("Button", () => {
       const button = screen.getByRole("button");
       expect(button).toHaveClass("bg-transparent", "text-primary");
     });
-  });
 
-  describe("Colors", () => {
-    test("renders primary color (default)", () => {
-      render(<Button color="primary">Primary</Button>);
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-primary", "text-on-primary");
+    test("sets data-variant attribute", () => {
+      render(<Button variant="filled">Filled</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("data-variant", "filled");
     });
 
-    test("renders secondary color", () => {
-      render(<Button color="secondary">Secondary</Button>);
-      const button = screen.getByRole("button");
-      // For filled variant with secondary color
-      expect(button).toHaveClass("bg-secondary", "text-on-secondary");
-    });
-
-    test("renders tertiary color", () => {
-      render(<Button color="tertiary">Tertiary</Button>);
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-tertiary", "text-on-tertiary");
-    });
-
-    test("renders error color", () => {
-      render(<Button color="error">Error</Button>);
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-error", "text-on-error");
+    test("sets data-variant for each variant", () => {
+      const variants = ["filled", "outlined", "tonal", "elevated", "text"] as const;
+      variants.forEach((variant) => {
+        const { unmount } = render(<Button variant={variant}>{variant}</Button>);
+        expect(screen.getByRole("button")).toHaveAttribute("data-variant", variant);
+        unmount();
+      });
     });
   });
 
@@ -107,7 +104,25 @@ describe("Button", () => {
     test("renders large size", () => {
       render(<Button size="large">Large</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("h-12", "px-8");
+      expect(button).toHaveClass("h-14", "px-8");
+    });
+
+    test("text variant uses reduced padding for medium", () => {
+      render(
+        <Button variant="text" size="medium">
+          Text
+        </Button>
+      );
+      expect(screen.getByRole("button")).toHaveClass("px-3");
+    });
+
+    test("text variant uses reduced padding for small", () => {
+      render(
+        <Button variant="text" size="small">
+          Text
+        </Button>
+      );
+      expect(screen.getByRole("button")).toHaveClass("px-3");
     });
   });
 
@@ -125,77 +140,145 @@ describe("Button", () => {
       expect(screen.getByTestId("trailing-icon")).toBeInTheDocument();
     });
 
-    test("icon appears before text", () => {
+    test("sets data-with-icon when leading icon is present", () => {
+      render(<Button icon={<svg>icon</svg>}>Icon</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("data-with-icon", "");
+    });
+
+    test("sets data-with-icon when trailing icon is present", () => {
+      render(<Button trailingIcon={<svg>icon</svg>}>Icon</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("data-with-icon", "");
+    });
+
+    test("does not set data-with-icon when no icon is present", () => {
+      render(<Button>No Icon</Button>);
+      expect(screen.getByRole("button")).not.toHaveAttribute("data-with-icon");
+    });
+
+    test("icon appears before label text in DOM order", () => {
       render(<Button icon={<span data-testid="icon">I</span>}>Text</Button>);
       const button = screen.getByRole("button");
       const icon = screen.getByTestId("icon");
-      const text = screen.getByText("Text");
+      const label = screen.getByText("Text");
 
-      // Icon should come before text in DOM order
-      // Get all children as array, excluding ripple container
-      const children = Array.from(button.childNodes).filter(
-        (node) => !(node as HTMLElement).hasAttribute?.("data-ripple-container")
-      );
-      expect(children[0]).toContainElement(icon);
-      expect(children[1]).toContainElement(text);
+      // Filter out ripple container and aria-hidden slots (state layer, focus ring)
+      const visibleChildren = Array.from(button.childNodes).filter((node) => {
+        const el = node as HTMLElement;
+        return (
+          !el.hasAttribute?.("data-ripple-container") && el.getAttribute?.("aria-hidden") !== "true"
+        );
+      });
+      expect(visibleChildren[0]).toContainElement(icon);
+      expect(visibleChildren[1]).toContainElement(label);
     });
 
-    test("trailing icon appears after text", () => {
+    test("trailing icon appears after label text in DOM order", () => {
       render(<Button trailingIcon={<span data-testid="trailing">I</span>}>Text</Button>);
       const button = screen.getByRole("button");
-      const text = screen.getByText("Text");
+      const label = screen.getByText("Text");
       const icon = screen.getByTestId("trailing");
 
-      // Text should come before trailing icon
-      // Get all children as array, excluding ripple container
-      const children = Array.from(button.childNodes).filter(
-        (node) => !(node as HTMLElement).hasAttribute?.("data-ripple-container")
-      );
-      expect(children[0]).toContainElement(text);
-      expect(children[1]).toContainElement(icon);
+      const visibleChildren = Array.from(button.childNodes).filter((node) => {
+        const el = node as HTMLElement;
+        return (
+          !el.hasAttribute?.("data-ripple-container") && el.getAttribute?.("aria-hidden") !== "true"
+        );
+      });
+      expect(visibleChildren[0]).toContainElement(label);
+      expect(visibleChildren[1]).toContainElement(icon);
     });
   });
 
   describe("States", () => {
-    test("handles disabled state", () => {
+    test("disabled button is not clickable", () => {
       render(<Button isDisabled>Disabled</Button>);
-      const button = screen.getByRole("button");
-      expect(button).toBeDisabled();
-      // MD3 spec: disabled state uses pointer-events-none, cursor-not-allowed, and removes shadows
-      expect(button).toHaveClass("pointer-events-none", "cursor-not-allowed", "shadow-none");
+      expect(screen.getByRole("button")).toBeDisabled();
     });
 
-    test("handles loading state", () => {
+    test("sets data-disabled attribute when disabled", () => {
+      render(<Button isDisabled>Disabled</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("data-disabled", "");
+    });
+
+    test("does not set data-disabled when enabled", () => {
+      render(<Button>Enabled</Button>);
+      expect(screen.getByRole("button")).not.toHaveAttribute("data-disabled");
+    });
+
+    test("loading button is also disabled", () => {
       render(<Button loading>Loading</Button>);
-      const button = screen.getByRole("button");
-      expect(button).toBeDisabled();
-      expect(button).toHaveClass("cursor-wait");
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    test("sets data-loading attribute when loading", () => {
+      render(<Button loading>Loading</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("data-loading", "");
+    });
+
+    test("does not set data-loading when not loading", () => {
+      render(<Button>Normal</Button>);
+      expect(screen.getByRole("button")).not.toHaveAttribute("data-loading");
     });
 
     test("shows loading spinner when loading", () => {
       render(<Button loading>Loading</Button>);
-      // Spinner should be present (we'll check for loading indicator)
-      const button = screen.getByRole("button");
-      expect(button.querySelector('[role="progressbar"]')).toBeInTheDocument();
+      expect(screen.getByRole("button").querySelector('[role="progressbar"]')).toBeInTheDocument();
     });
 
-    test("hides icon when loading", () => {
+    test("icon is invisible (not removed) when loading", () => {
       render(
         <Button loading icon={<svg data-testid="icon">icon</svg>}>
           Loading
         </Button>
       );
-      // Icon should be present but hidden when loading
       const icon = screen.getByTestId("icon");
       expect(icon).toBeInTheDocument();
-      // Check that parent span has invisible class
       expect(icon.parentElement).toHaveClass("invisible");
     });
 
     test("full width button spans container", () => {
       render(<Button fullWidth>Full Width</Button>);
+      expect(screen.getByRole("button")).toHaveClass("w-full");
+    });
+  });
+
+  describe("Interaction Data Attributes", () => {
+    test("sets data-hovered when pointer is over button", async () => {
+      const user = userEvent.setup();
+      render(<Button>Hover me</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("w-full");
+
+      await user.hover(button);
+      expect(button).toHaveAttribute("data-hovered", "");
+    });
+
+    test("removes data-hovered when pointer leaves button", async () => {
+      const user = userEvent.setup();
+      render(<Button>Hover me</Button>);
+      const button = screen.getByRole("button");
+
+      await user.hover(button);
+      await user.unhover(button);
+      expect(button).not.toHaveAttribute("data-hovered");
+    });
+
+    test("does not set data-hovered when disabled", async () => {
+      const user = userEvent.setup();
+      render(<Button isDisabled>Disabled</Button>);
+      const button = screen.getByRole("button");
+
+      await user.hover(button);
+      expect(button).not.toHaveAttribute("data-hovered");
+    });
+
+    test("sets data-pressed on press start", async () => {
+      const user = userEvent.setup();
+      render(<Button>Press me</Button>);
+      const button = screen.getByRole("button");
+
+      // Hold pointer down to see pressed state
+      await user.pointer({ target: button, keys: "[MouseLeft>]" });
+      expect(button).toHaveAttribute("data-pressed", "");
     });
   });
 
@@ -220,7 +303,6 @@ describe("Button", () => {
         </Button>
       );
       await user.click(screen.getByRole("button"));
-
       expect(handlePress).not.toHaveBeenCalled();
     });
 
@@ -234,7 +316,6 @@ describe("Button", () => {
         </Button>
       );
       await user.click(screen.getByRole("button"));
-
       expect(handlePress).not.toHaveBeenCalled();
     });
 
@@ -243,10 +324,8 @@ describe("Button", () => {
       const user = userEvent.setup();
 
       render(<Button onPress={handlePress}>Press Enter</Button>);
-      const button = screen.getByRole("button");
-      button.focus();
+      screen.getByRole("button").focus();
       await user.keyboard("{Enter}");
-
       expect(handlePress).toHaveBeenCalledTimes(1);
     });
 
@@ -255,10 +334,8 @@ describe("Button", () => {
       const user = userEvent.setup();
 
       render(<Button onPress={handlePress}>Press Space</Button>);
-      const button = screen.getByRole("button");
-      button.focus();
+      screen.getByRole("button").focus();
       await user.keyboard(" ");
-
       expect(handlePress).toHaveBeenCalledTimes(1);
     });
   });
@@ -283,14 +360,12 @@ describe("Button", () => {
   describe("Accessibility", () => {
     test("is keyboard accessible", () => {
       render(<Button>Accessible</Button>);
-      const button = screen.getByRole("button");
-      expect(isKeyboardAccessible(button)).toBe(true);
+      expect(isKeyboardAccessible(screen.getByRole("button"))).toBe(true);
     });
 
     test("has accessible label from children", () => {
       render(<Button>Click me</Button>);
-      const button = screen.getByRole("button");
-      expect(hasAccessibleLabel(button)).toBe(true);
+      expect(hasAccessibleLabel(screen.getByRole("button"))).toBe(true);
     });
 
     test("supports custom aria-label", () => {
@@ -328,15 +403,19 @@ describe("Button", () => {
       expect(screen.getByRole("button")).toHaveAttribute("tabIndex", "-1");
     });
 
-    test("shows focus indicator on focus", async () => {
+    test("receives focus on tab", async () => {
       const user = userEvent.setup();
       render(<Button>Focus me</Button>);
-      const button = screen.getByRole("button");
-
       await user.tab();
-      expect(button).toHaveFocus();
-      // Focus styles should be applied
-      expect(button).toHaveClass("focus-visible:outline-2");
+      expect(screen.getByRole("button")).toHaveFocus();
+    });
+
+    test("focus ring span is present for keyboard focus styling", () => {
+      render(<Button>Focus me</Button>);
+      const button = screen.getByRole("button");
+      // Multiple aria-hidden spans: state layer + focus ring
+      const hiddenSpans = button.querySelectorAll('span[aria-hidden="true"]');
+      expect(hiddenSpans.length).toBeGreaterThanOrEqual(2);
     });
   });
 
@@ -344,54 +423,18 @@ describe("Button", () => {
     test("renders ripple container by default", () => {
       render(<Button>Ripple</Button>);
       const button = screen.getByRole("button");
-      // Ripple container should exist
-      const rippleContainer = button.querySelector("[data-ripple-container]");
-      expect(rippleContainer).toBeInTheDocument();
+      expect(button.querySelector("[data-ripple-container]")).toBeInTheDocument();
     });
 
     test("does not render ripple when disableRipple is true", () => {
       render(<Button disableRipple>No Ripple</Button>);
       const button = screen.getByRole("button");
-      const rippleContainer = button.querySelector("[data-ripple-container]");
-      expect(rippleContainer).not.toBeInTheDocument();
-    });
-  });
-
-  describe("Variant + Color Combinations", () => {
-    test("outlined secondary button has correct classes", () => {
-      render(
-        <Button variant="outlined" color="secondary">
-          Outlined Secondary
-        </Button>
-      );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("border-outline-variant", "text-secondary");
-    });
-
-    test("tonal tertiary button has correct classes", () => {
-      render(
-        <Button variant="tonal" color="tertiary">
-          Tonal Tertiary
-        </Button>
-      );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-tertiary-container", "text-on-tertiary-container");
-    });
-
-    test("text error button has correct classes", () => {
-      render(
-        <Button variant="text" color="error">
-          Text Error
-        </Button>
-      );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("text-error");
+      expect(button.querySelector("[data-ripple-container]")).not.toBeInTheDocument();
     });
   });
 
   describe("Edge Cases", () => {
     test("handles empty children gracefully", () => {
-      // This should show a dev warning but still render
       const { container } = render(<Button>{""}</Button>);
       expect(container.querySelector("button")).toBeInTheDocument();
     });
@@ -407,7 +450,7 @@ describe("Button", () => {
       expect(screen.getByText("Part 2")).toBeInTheDocument();
     });
 
-    test("prevents event bubbling when disabled", async () => {
+    test("prevents press when disabled", async () => {
       const parentClick = vi.fn();
       const buttonPress = vi.fn();
       const user = userEvent.setup();
@@ -423,7 +466,6 @@ describe("Button", () => {
 
       await user.click(screen.getByRole("button"));
       expect(buttonPress).not.toHaveBeenCalled();
-      // Parent should also not receive click due to pointer-events-none
     });
   });
 
@@ -439,8 +481,8 @@ describe("Button", () => {
     });
   });
 
-  describe("data attributes for ButtonGroup integration", () => {
-    test("sets data-variant attribute matching the variant prop", () => {
+  describe("data-variant attribute for ButtonGroup integration", () => {
+    test("sets data-variant matching the variant prop", () => {
       render(<Button variant="filled">Test</Button>);
       expect(screen.getByRole("button")).toHaveAttribute("data-variant", "filled");
     });
@@ -460,29 +502,14 @@ describe("Button", () => {
       expect(screen.getByRole("button")).toHaveAttribute("data-variant", "text");
     });
 
-    test("sets data-color attribute matching the color prop", () => {
-      render(<Button color="primary">Test</Button>);
-      expect(screen.getByRole("button")).toHaveAttribute("data-color", "primary");
-    });
-
-    test("sets data-color for secondary", () => {
-      render(<Button color="secondary">Test</Button>);
-      expect(screen.getByRole("button")).toHaveAttribute("data-color", "secondary");
-    });
-
-    test("sets data-color for tertiary", () => {
-      render(<Button color="tertiary">Test</Button>);
-      expect(screen.getByRole("button")).toHaveAttribute("data-color", "tertiary");
-    });
-
-    test("sets data-color for error", () => {
-      render(<Button color="error">Test</Button>);
-      expect(screen.getByRole("button")).toHaveAttribute("data-color", "error");
+    test("sets data-variant for elevated", () => {
+      render(<Button variant="elevated">Test</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("data-variant", "elevated");
     });
   });
 
   describe("ButtonGroup context consumption", () => {
-    test("standalone Button renders normally without group context", () => {
+    test("standalone Button renders with rounded-full by default", () => {
       render(<Button>Standalone</Button>);
       const button = screen.getByRole("button");
       expect(button).toHaveClass("rounded-full");
@@ -497,9 +524,7 @@ describe("Button", () => {
           <Button>Two</Button>
         </ButtonGroup>
       );
-      const buttons = screen.getAllByRole("button");
-      // Inner radius (rounded-sm) overrides the default rounded-full
-      buttons.forEach((btn) => {
+      screen.getAllByRole("button").forEach((btn) => {
         expect(btn).toHaveClass("rounded-sm");
       });
     });
@@ -523,8 +548,7 @@ describe("Button", () => {
           <Button>Two</Button>
         </ButtonGroup>
       );
-      const buttons = screen.getAllByRole("button");
-      buttons.forEach((btn) => {
+      screen.getAllByRole("button").forEach((btn) => {
         expect(btn).toHaveClass("rounded-lg");
       });
     });
@@ -536,8 +560,7 @@ describe("Button", () => {
           <Button>Two</Button>
         </ButtonGroup>
       );
-      const buttons = screen.getAllByRole("button");
-      buttons.forEach((btn) => {
+      screen.getAllByRole("button").forEach((btn) => {
         expect(btn.className).toContain("rounded-[20px]");
       });
     });
@@ -554,15 +577,14 @@ describe("Button", () => {
       expect(buttons[0].className).toContain("last:rounded-e-sm");
     });
 
-    test("Button inside connected extra-small/small group has min-w-12", () => {
+    test("Button inside connected extra-small group has min-w-12", () => {
       render(
         <ButtonGroup variant="connected" size="extra-small" aria-label="Group">
           <Button>One</Button>
           <Button>Two</Button>
         </ButtonGroup>
       );
-      const buttons = screen.getAllByRole("button");
-      buttons.forEach((btn) => {
+      screen.getAllByRole("button").forEach((btn) => {
         expect(btn).toHaveClass("min-w-12");
       });
     });
@@ -613,6 +635,12 @@ describe("Button", () => {
 
     test("has no accessibility violations in loading state", async () => {
       const { container } = render(<Button loading>Saving</Button>);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations with icon", async () => {
+      const { container } = render(<Button icon={<svg aria-hidden="true" />}>With Icon</Button>);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -1,10 +1,19 @@
 "use client";
 
-import { forwardRef } from "react";
+import { forwardRef, useRef, useState, useCallback } from "react";
 import type React from "react";
+import { useHover, useFocusRing, mergeProps } from "react-aria";
 import { ButtonHeadless } from "./ButtonHeadless";
-import { buttonVariants, type ButtonVariants } from "./Button.variants";
+import {
+  buttonVariants,
+  buttonStateLayerVariants,
+  buttonFocusRingVariants,
+  buttonIconVariants,
+  buttonLabelVariants,
+  type ButtonVariants,
+} from "./Button.variants";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
 import { useOptionalButtonGroup } from "../ButtonGroup/ButtonGroupContext";
 import { getConnectedRadiusClasses } from "../ButtonGroup/ButtonGroup.utils";
@@ -17,7 +26,7 @@ const Spinner = (): React.ReactElement => (
   <svg
     role="progressbar"
     aria-label="Loading"
-    className="h-4 w-4 animate-spin"
+    className="relative z-10 h-[18px] w-[18px] animate-spin"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
@@ -35,58 +44,51 @@ const Spinner = (): React.ReactElement => (
  * Material Design 3 Button Component (Layer 3: Styled)
  *
  * Built on React Aria for world-class accessibility.
- * Uses CVA for type-safe variant management.
- * Styled with Tailwind CSS using MD3 design tokens.
+ * Implements the Variants-vs-States architecture: all interaction states are
+ * expressed as data-* attributes on the root and consumed by each slot via
+ * group-data-[x]/button Tailwind selectors — no state variants in CVA.
  *
  * Features:
  * - ✅ 5 MD3 variants: filled, outlined, tonal, elevated, text
- * - ✅ 4 color schemes: primary, secondary, tertiary, error
- * - ✅ 3 sizes: small, medium, large
+ * - ✅ 3 sizes: small (32dp), medium (40dp), large (56dp)
  * - ✅ Loading state with spinner
  * - ✅ Ripple effect (Material Design)
+ * - ✅ Proper MD3 state layer (hover 8%, focus 10%, pressed 10%)
  * - ✅ Full keyboard accessibility (via React Aria)
  * - ✅ Screen reader support (via React Aria)
  * - ✅ Focus management (via React Aria)
  * - ✅ ButtonGroup-aware: applies connected corner radii and min-width when inside a group
  *
  * MD3 Specifications:
- * - Height: 40dp (medium), 32dp (small), 48dp (large)
- * - Typography: Label Large (14px, 500 weight, +0.1px letter-spacing)
+ * - Height: 40dp (medium), 32dp (small), 56dp (large)
+ * - Typography: Label Large (medium), Label Medium (small), Title Medium (large)
  * - Icon size: 18px × 18px (per MD3 spec)
- * - State layers: 8% hover, 12% focus/pressed
- * - Elevation: Level 1 on hover (filled), Level 1→2 (elevated)
+ * - State layers: 8% hover, 10% focus/pressed
+ * - Elevation: Level 1 on hover (filled), Level 1 base → Level 2 hover (elevated)
  *
  * @example
  * ```tsx
  * // Basic usage
  * <Button>Click me</Button>
  *
- * // With variant and color
- * <Button variant="outlined" color="secondary">
- *   Secondary Action
- * </Button>
+ * // With variant
+ * <Button variant="outlined">Secondary Action</Button>
  *
- * // With icon (MD3 spec: icons should be 18px × 18px)
+ * // With icon (MD3 spec: icons are 18px × 18px)
  * <Button icon={<IconAdd className="h-[18px] w-[18px]" />}>
  *   Add Item
  * </Button>
  *
  * // Loading state
- * <Button loading>
- *   Saving...
- * </Button>
+ * <Button loading>Saving...</Button>
  *
  * // Disabled
- * <Button isDisabled>
- *   Disabled
- * </Button>
+ * <Button isDisabled>Disabled</Button>
  *
  * // Full width
- * <Button fullWidth>
- *   Full Width Button
- * </Button>
+ * <Button fullWidth>Full Width Button</Button>
  *
- * // Inside a connected ButtonGroup (corner radii applied automatically)
+ * // Inside a connected ButtonGroup
  * <ButtonGroup variant="connected" selectionMode="required" defaultValue="md">
  *   <Button value="sm">S</Button>
  *   <Button value="md">M</Button>
@@ -94,12 +96,11 @@ const Spinner = (): React.ReactElement => (
  * </ButtonGroup>
  * ```
  */
-export const Button = forwardRef<HTMLButtonElement, ButtonProps & Omit<ButtonVariants, "disabled">>(
+export const Button = forwardRef<HTMLButtonElement, ButtonProps & Omit<ButtonVariants, never>>(
   (
     {
       // Variant props (CVA)
       variant = "filled",
-      color = "primary",
       size = "medium",
       fullWidth = false,
 
@@ -116,33 +117,34 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & Omit<ButtonVar
       // Styling
       className,
 
-      // Other props
+      // Other button props
       tabIndex = 0,
       type = "button",
-      onPress,
+
+      // Passed through to ButtonHeadless → useButton
       ...props
     },
     ref
   ) => {
-    // ButtonGroup context — null when rendered outside a group (safe to call unconditionally)
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const resolvedRef = (ref ?? buttonRef) as React.RefObject<HTMLButtonElement>;
+
+    // ButtonGroup context — null when rendered outside a group
     const groupCtx = useOptionalButtonGroup();
     const isConnected = groupCtx?.variant === "connected";
 
-    // Development warnings
-    if (process.env.NODE_ENV === "development") {
-      if (!children) {
-        console.warn(
-          "[Button] Button should have text content. Use IconButton for icon-only buttons."
-        );
-      }
-
-      if (icon && trailingIcon) {
-        console.warn("[Button] Button should have either icon or trailingIcon, not both.");
-      }
-    }
-
-    // Combine disabled states
+    // Combined disabled state (loading also disables)
     const isButtonDisabled = isDisabled || loading;
+
+    // ── Interaction state tracking ───────────────────────────────────────────
+    // isPressed is tracked via onPressStart/onPressEnd forwarded to useButton,
+    // which avoids competing with ButtonHeadless's own useButton press handling.
+    const [isPressed, setIsPressed] = useState(false);
+    const handlePressStart = useCallback(() => setIsPressed(true), []);
+    const handlePressEnd = useCallback(() => setIsPressed(false), []);
+
+    const { isHovered, hoverProps } = useHover({ isDisabled: isButtonDisabled });
+    const { isFocusVisible, focusProps } = useFocusRing();
 
     // Ripple effect
     const { onMouseDown: handleRipple, ripples } = useRipple({
@@ -150,35 +152,67 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & Omit<ButtonVar
     });
 
     // Connected group radius + min-width overrides
+    const buttonValue = (props as { value?: string | undefined }).value;
+    const isGroupSelected =
+      isConnected && groupCtx && buttonValue ? groupCtx.selectedValues.has(buttonValue) : false;
+
     const connectedClasses =
       isConnected && groupCtx
         ? [
-            ...getConnectedRadiusClasses(groupCtx, props?.value),
+            ...getConnectedRadiusClasses(groupCtx, buttonValue),
             groupCtx.enforceMinWidth ? "min-w-12" : "",
           ]
         : [];
 
+    const hasIcon = !!icon || !!trailingIcon;
+
+    if (process.env.NODE_ENV === "development") {
+      if (!children) {
+        console.warn(
+          "[Button] Button should have text content. Use IconButton for icon-only buttons."
+        );
+      }
+    }
+
     return (
       <ButtonHeadless
-        {...props}
-        ref={ref}
+        {...mergeProps(
+          hoverProps,
+          focusProps,
+          // Track pressed state via useButton's press lifecycle callbacks,
+          // rather than a separate usePress hook, to avoid event handler conflicts.
+          { onPressStart: handlePressStart, onPressEnd: handlePressEnd },
+          props
+        )}
+        ref={resolvedRef}
         type={type}
         isDisabled={isButtonDisabled}
-        {...(onPress && { onPress })}
         tabIndex={tabIndex}
         onMouseDown={handleRipple}
+        // ── Interaction data attributes ──────────────────────────────────────
+        {...getInteractionDataAttributes({
+          isHovered,
+          isFocusVisible,
+          isPressed,
+          isDisabled: isButtonDisabled,
+        })}
+        // ── Content flags ────────────────────────────────────────────────────
         data-variant={variant}
-        data-color={color}
+        data-with-icon={hasIcon ? "" : undefined}
+        data-loading={loading ? "" : undefined}
+        // ── Connected group selection state ──────────────────────────────────
+        // Used to switch border-radius easing: expressive (select) vs decelerate (deselect).
+        // btn-transition-selected overrides --_btn-radius-easing to the bouncy spring only
+        // while the button is gaining the pill shape; removal restores safe decelerate easing
+        // for the pill→inner-radius return, eliminating the overshoot-to-0px flicker.
+        data-group-selected={isGroupSelected ? "" : undefined}
         className={cn(
-          // Apply CVA variants (includes rounded-full base)
-          buttonVariants({
-            variant,
-            color,
-            size,
-            fullWidth,
-            disabled: isButtonDisabled,
-            loading,
-          }),
+          buttonVariants({ variant, size, fullWidth }),
+          // group/button: enables group-data-[x]/button child selectors in all slots
+          // (added here, not in CVA, following the Switch pattern)
+          "group/button",
+          // Asymmetric border-radius easing: expressive when selected, decelerate when not
+          isGroupSelected ? "btn-transition-selected" : "",
           // Connected group overrides: inner radius + start/end outer radius + min-width
           ...connectedClasses,
           // User custom classes
@@ -188,28 +222,24 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & Omit<ButtonVar
         {/* Ripple effect */}
         {ripples}
 
-        {/* Leading icon (hidden when loading) */}
-        {icon && (
-          <span className={cn("relative z-10 inline-flex shrink-0", loading && "invisible")}>
-            {icon}
-          </span>
-        )}
+        {/* State layer — absolute overlay that transitions opacity on interaction */}
+        <span className={cn(buttonStateLayerVariants({ variant }))} aria-hidden="true" />
 
-        {/* Loading spinner (shown when loading, overlays icon position) */}
-        {loading && (
-          <span className="relative z-10">
-            <Spinner />
-          </span>
-        )}
+        {/* Focus ring — absolute overlay rendered above state layer */}
+        <span className={cn(buttonFocusRingVariants())} aria-hidden="true" />
 
-        {/* Content */}
-        <span className="relative z-10 inline-flex items-center">{children}</span>
+        {/* Leading icon (invisible, not hidden, when loading so layout is stable) */}
+        {icon && <span className={cn(buttonIconVariants({ hidden: loading }))}>{icon}</span>}
 
-        {/* Trailing icon (hidden when loading) */}
+        {/* Loading spinner (replaces icon position) */}
+        {loading && <Spinner />}
+
+        {/* Label */}
+        <span className={cn(buttonLabelVariants())}>{children}</span>
+
+        {/* Trailing icon (invisible when loading) */}
         {trailingIcon && (
-          <span className={cn("relative z-10 inline-flex shrink-0", loading && "invisible")}>
-            {trailingIcon}
-          </span>
+          <span className={cn(buttonIconVariants({ hidden: loading }))}>{trailingIcon}</span>
         )}
       </ButtonHeadless>
     );

--- a/packages/react/src/components/Button/Button.types.ts
+++ b/packages/react/src/components/Button/Button.types.ts
@@ -7,12 +7,7 @@ import type { AriaButtonProps } from "react-aria";
 export type ButtonVariant = "filled" | "outlined" | "tonal" | "elevated" | "text";
 
 /**
- * Button color schemes (Material Design 3 color roles)
- */
-export type ButtonColor = "primary" | "secondary" | "tertiary" | "error";
-
-/**
- * Button sizes
+ * Button sizes (Material Design 3)
  */
 export type ButtonSize = "small" | "medium" | "large";
 
@@ -20,35 +15,37 @@ export type ButtonSize = "small" | "medium" | "large";
  * Material Design 3 Button Component Props
  *
  * Built on React Aria for world-class accessibility.
- * Supports 5 variants: filled, outlined, tonal, elevated, text
- * Implementation uses CVA + Tailwind CSS classes mapped to MD3 tokens.
+ * Supports 5 strict MD3 variants: filled, outlined, tonal, elevated, text.
+ * Each variant uses its spec-defined color roles — no color override prop.
+ *
+ * Interaction states (hover, focus, press, disabled) are managed via
+ * React Aria hooks and expressed as data-* attributes on the root element,
+ * consumed by slot classes via group-data-[x]/button selectors.
  *
  * @example
  * ```tsx
- * // Filled button (default)
- * <Button variant="filled" color="primary">
- *   Click me
- * </Button>
+ * // Filled button (default, highest emphasis)
+ * <Button variant="filled">Save</Button>
  *
- * // With icon
- * <Button variant="tonal" icon={<IconAdd />}>
+ * // Outlined button (medium emphasis)
+ * <Button variant="outlined">Cancel</Button>
+ *
+ * // Tonal button (secondary emphasis)
+ * <Button variant="tonal">Learn more</Button>
+ *
+ * // With icon (MD3 spec: 18px × 18px)
+ * <Button variant="filled" icon={<IconAdd className="h-[18px] w-[18px]" />}>
  *   Add Item
  * </Button>
  *
  * // Loading state
- * <Button variant="elevated" loading>
- *   Saving...
- * </Button>
+ * <Button variant="elevated" loading>Saving...</Button>
  *
  * // Disabled
- * <Button variant="outlined" isDisabled>
- *   Disabled
- * </Button>
+ * <Button variant="outlined" isDisabled>Disabled</Button>
  *
  * // Headless version (custom styling)
- * <ButtonHeadless className="my-custom-styles">
- *   Click me
- * </ButtonHeadless>
+ * <ButtonHeadless className="my-custom-styles">Click me</ButtonHeadless>
  * ```
  */
 export interface ButtonProps
@@ -56,27 +53,23 @@ export interface ButtonProps
     AriaButtonProps,
     Omit<React.HTMLAttributes<HTMLButtonElement>, keyof AriaButtonProps | "children"> {
   /**
-   * Button variant
+   * Button variant (MD3 specification).
+   * Determines visual emphasis and color roles.
    * @default 'filled'
    */
   variant?: ButtonVariant;
 
   /**
-   * Color scheme
-   * @default 'primary'
-   */
-  color?: ButtonColor;
-
-  /**
-   * Size variant
+   * Size variant.
+   * MD3 heights: small=32dp, medium=40dp, large=56dp
    * @default 'medium'
    */
   size?: ButtonSize;
 
   /**
-   * Leading icon (before text)
+   * Leading icon (before label text).
    *
-   * MD3 Specification: Icons should be 18px × 18px
+   * MD3 Specification: Icons must be 18px × 18px.
    *
    * @example
    * ```tsx
@@ -88,9 +81,9 @@ export interface ButtonProps
   icon?: React.ReactNode;
 
   /**
-   * Trailing icon (after text)
+   * Trailing icon (after label text).
    *
-   * MD3 Specification: Icons should be 18px × 18px
+   * MD3 Specification: Icons must be 18px × 18px.
    *
    * @example
    * ```tsx
@@ -102,69 +95,70 @@ export interface ButtonProps
   trailingIcon?: React.ReactNode;
 
   /**
-   * Button content (text)
+   * Button label content.
    */
   children: React.ReactNode;
 
   /**
-   * Full width button (spans container)
+   * Full width button (spans container width).
    * @default false
    */
   fullWidth?: boolean;
 
   /**
-   * Loading state - shows spinner, disables interaction
+   * Loading state — shows spinner and disables interaction.
+   * The button remains in the DOM as disabled while loading.
    * @default false
    */
   loading?: boolean;
 
   /**
-   * Disable ripple effect
+   * Disable the ripple effect on press.
    * @default false
    */
   disableRipple?: boolean;
 
   /**
-   * Additional CSS classes (Tailwind)
+   * Additional Tailwind CSS classes applied to the root element.
    */
   className?: string;
 
   /**
-   * Tab index for keyboard navigation
+   * Tab index for keyboard navigation.
    * @default 0
    */
   tabIndex?: number;
 
   /**
-   * Button type attribute
+   * Button type attribute.
    * @default 'button'
    */
   type?: "button" | "submit" | "reset";
 }
 
 /**
- * Props for the headless Button component
- * Extends AriaButtonProps for accessibility
+ * Props for the headless Button component.
+ * Extends AriaButtonProps for accessibility primitives.
  */
 export interface ButtonHeadlessProps extends AriaButtonProps {
   /**
-   * Additional CSS classes
+   * Additional CSS classes.
    */
   className?: string;
 
   /**
-   * Button content
+   * Button content.
    */
   children: React.ReactNode;
 
   /**
-   * Tab index for keyboard navigation
+   * Tab index for keyboard navigation.
    * @default 0
    */
   tabIndex?: number;
 
   /**
-   * Mouse down handler (for ripple effect)
+   * Mouse down handler (for ripple effect).
    */
   onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }

--- a/packages/react/src/components/Button/Button.variants.ts
+++ b/packages/react/src/components/Button/Button.variants.ts
@@ -1,225 +1,308 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 Button Variants (CVA)
+ * Material Design 3 Button Variants
  *
- * Type-safe variant management for Button component.
- * Uses Tailwind CSS classes mapped to MD3 design tokens.
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no disabled/loading state variants).
+ * - All interaction states are driven by data-* attributes on the root via
+ *   group-data-[x]/button Tailwind selectors in each slot's base classes.
+ * - Content flags (data-with-icon, data-loading) are set explicitly by the component.
+ *
+ * Slot responsibilities:
+ *   buttonVariants           — root <button>; shape, color, elevation
+ *   buttonStateLayerVariants — hover/focus/press opacity ring (absolute inset overlay)
+ *   buttonFocusRingVariants  — keyboard focus outline, MUST NOT be inside overflow-hidden
+ *   buttonIconVariants       — leading/trailing icon wrapper
+ *   buttonLabelVariants      — label text slot
+ *
+ * MD3 Spec:
+ *   Shape: rounded-full (corner-full)
+ *   Height: 32dp small | 40dp medium | 56dp large
+ *   Padding: 16dp small | 24dp medium | 32dp large (12dp text variant)
+ *   Icon size: 18px × 18px
+ *   State-layer opacities: hover 8% | focus 10% | pressed 10%
+ *   Disabled: container 12% opacity, content 38% opacity
+ *
+ * Elevation per state (MD3 comp tokens):
+ *   Filled   base=0  hover=1  focus=0  pressed=0
+ *   Tonal    base=0  hover=1  focus=0  pressed=0
+ *   Elevated base=1  hover=2  focus=1  pressed=1
+ *   Outlined base=0  hover=0  focus=0  pressed=0
+ *   Text     base=0  hover=0  focus=0  pressed=0
+ */
+
+// ─── BUTTON ROOT / CONTAINER ─────────────────────────────────────────────────
+
+/**
+ * Root <button> element.
+ *
+ * IMPORTANT — overflow is intentionally NOT on the root.
+ * Overflow clipping is delegated to the ripple container and state layer
+ * via `overflow-hidden rounded-[inherit]` on those children. This lets the
+ * focus ring span (`inset-[-3px]`) extend outside the button boundary and
+ * remain fully visible — if overflow-hidden were on the root it would be
+ * clipped to zero width.
  */
 export const buttonVariants = cva(
   [
-    // Base classes (always applied)
-    "relative inline-flex items-center justify-center cursor-pointer",
-    "overflow-hidden rounded-full font-medium",
-    // Split MD3 transition: spatial (border-radius) uses expressive spring with overshoot;
-    // effects (color/bg/shadow) use standard effects spring — no overshoot allowed on color.
+    // Layout + shape — NO overflow-hidden here (see note above)
+    "relative inline-flex items-center justify-center",
+    "rounded-full cursor-pointer select-none",
+    // Split MD3 transition: spatial (border-radius) → expressive spring;
+    // effects (color/bg/shadow) → standard effects spring.
     "btn-transition",
-    "tracking-[0.1px]", // MD3 spec: +0.1px letter-spacing for label-large
-    "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
+    // Disabled — self-targeting data-[x]: selectors
+    "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
   ],
   {
     variants: {
       /**
-       * Button variant (MD3 specification)
+       * Button variant (MD3 specification — strict, no color override)
+       *
+       * Elevation per state follows _md-comp-*-button.scss tokens:
+       *   Filled/Tonal  hover→level-1, focus/pressed→level-0
+       *   Elevated      base→level-1, hover→level-2, focus/pressed→level-1
+       *   Outlined/Text no elevation
        */
       variant: {
-        filled: "shadow-none hover:shadow-elevation-1", // MD3: gains elevation on hover
-        outlined: "bg-transparent border border-outline-variant",
-        tonal: "",
-        elevated: "shadow-elevation-1 hover:shadow-elevation-2", // MD3: level 1 → level 2 on hover
-        text: "bg-transparent",
-      },
+        /**
+         * Filled — highest emphasis.
+         * MD3: container=primary, label=on-primary, state-layer=on-primary
+         * Elevation: 0 base → 1 hover → 0 focus → 0 pressed
+         */
+        filled: [
+          "bg-primary text-on-primary shadow-none",
+          // Hover: gains level-1 elevation
+          "group-data-[hovered]/button:shadow-elevation-1",
+          // Focus/pressed: shadow must explicitly return to level-0
+          // (doubled attribute selector → higher specificity than hover)
+          "group-data-[focus-visible]/button:shadow-none",
+          "group-data-[pressed]/button:group-data-[pressed]/button:shadow-none",
+          // Disabled overrides
+          "group-data-[disabled]/button:bg-on-surface/12",
+          "group-data-[disabled]/button:text-on-surface/38",
+          "group-data-[disabled]/button:shadow-none",
+        ],
 
-      /**
-       * Color scheme (MD3 color roles)
-       */
-      color: {
-        primary: "",
-        secondary: "",
-        tertiary: "",
-        error: "",
+        /**
+         * Outlined — medium emphasis. Transparent with border.
+         * MD3: container=transparent, outline=outline, label=primary, state-layer=primary
+         * Elevation: always 0
+         */
+        outlined: [
+          "bg-transparent border border-outline text-primary",
+          // Disabled overrides
+          "group-data-[disabled]/button:border-on-surface/12",
+          "group-data-[disabled]/button:text-on-surface/38",
+        ],
+
+        /**
+         * Tonal — secondary emphasis.
+         * MD3 name: "Filled tonal". container=secondary-container, label=on-secondary-container
+         * Elevation: 0 base → 1 hover → 0 focus → 0 pressed
+         */
+        tonal: [
+          "bg-secondary-container text-on-secondary-container shadow-none",
+          // Hover: gains level-1 elevation (same as filled)
+          "group-data-[hovered]/button:shadow-elevation-1",
+          // Focus/pressed: return to level-0
+          "group-data-[focus-visible]/button:shadow-none",
+          "group-data-[pressed]/button:group-data-[pressed]/button:shadow-none",
+          // Disabled overrides
+          "group-data-[disabled]/button:bg-on-surface/12",
+          "group-data-[disabled]/button:text-on-surface/38",
+          "group-data-[disabled]/button:shadow-none",
+        ],
+
+        /**
+         * Elevated — separation via shadow.
+         * MD3: container=surface-container-low, label=primary
+         * Elevation: 1 base → 2 hover → 1 focus → 1 pressed
+         */
+        elevated: [
+          "bg-surface-container-low text-primary shadow-elevation-1",
+          // Hover: gains extra elevation
+          "group-data-[hovered]/button:shadow-elevation-2",
+          // Focus/pressed: return to base level-1
+          // (doubled selector wins over single hover selector at same cascade position)
+          "group-data-[focus-visible]/button:shadow-elevation-1",
+          "group-data-[pressed]/button:group-data-[pressed]/button:shadow-elevation-1",
+          // Disabled overrides
+          "group-data-[disabled]/button:bg-on-surface/12",
+          "group-data-[disabled]/button:text-on-surface/38",
+          "group-data-[disabled]/button:shadow-none",
+        ],
+
+        /**
+         * Text — lowest emphasis.
+         * MD3: container=transparent, label=primary, state-layer=primary
+         * Elevation: always 0
+         */
+        text: [
+          "bg-transparent text-primary",
+          // Disabled overrides
+          "group-data-[disabled]/button:text-on-surface/38",
+        ],
       },
 
       /**
        * Button size
+       * MD3 spec: small=32dp, medium=40dp, large=56dp
+       * Padding: small=16dp, medium=24dp, large=32dp
+       * Text variant uses reduced padding: small=12dp, medium=12dp
        */
       size: {
-        small: "h-8 px-4 text-sm gap-2",
-        medium: "h-10 px-6 text-sm gap-2",
-        large: "h-12 px-8 text-base gap-3",
+        small: "h-8 px-4 gap-1 text-label-medium tracking-[0.1px]",
+        medium: "h-10 px-6 gap-2 text-label-large tracking-[0.1px]",
+        large: "h-14 px-8 gap-2 text-title-medium",
       },
 
       /**
-       * Full width variant
+       * Full width button (spans container)
        */
       fullWidth: {
         true: "w-full",
         false: "",
       },
-
-      /**
-       * Disabled state (MD3 spec: container 12% opacity, content 38% opacity)
-       */
-      disabled: {
-        true: [
-          "pointer-events-none cursor-not-allowed",
-          "bg-on-surface/12", // MD3: disabled container uses on-surface at 12%
-          "text-on-surface/38", // MD3: disabled text/icons use on-surface at 38%
-          "border-on-surface/12", // For outlined variant
-          "shadow-none", // Remove elevation when disabled
-        ],
-        false: "",
-      },
-
-      /**
-       * Loading state
-       */
-      loading: {
-        true: "cursor-wait",
-        false: "",
-      },
     },
 
     /**
-     * Compound variants - combinations of variant + color
+     * Compound variants for text variant reduced padding per size
+     * MD3: text buttons use 12dp padding (px-3) instead of standard padding
      */
     compoundVariants: [
-      // ====================
-      // FILLED VARIANTS
-      // ====================
-      {
-        variant: "filled",
-        color: "primary",
-        className: "bg-primary text-on-primary",
-      },
-      {
-        variant: "filled",
-        color: "secondary",
-        className: "bg-secondary text-on-secondary",
-      },
-      {
-        variant: "filled",
-        color: "tertiary",
-        className: "bg-tertiary text-on-tertiary",
-      },
-      {
-        variant: "filled",
-        color: "error",
-        className: "bg-error text-on-error",
-      },
-
-      // ====================
-      // OUTLINED VARIANTS
-      // ====================
-      {
-        variant: "outlined",
-        color: "primary",
-        className: "text-primary",
-      },
-      {
-        variant: "outlined",
-        color: "secondary",
-        className: "text-secondary",
-      },
-      {
-        variant: "outlined",
-        color: "tertiary",
-        className: "text-tertiary",
-      },
-      {
-        variant: "outlined",
-        color: "error",
-        className: "text-error",
-      },
-
-      // ====================
-      // TONAL VARIANTS
-      // ====================
-      {
-        variant: "tonal",
-        color: "primary",
-        className: "bg-primary-container text-on-primary-container",
-      },
-      {
-        variant: "tonal",
-        color: "secondary",
-        className: "bg-secondary-container text-on-secondary-container",
-      },
-      {
-        variant: "tonal",
-        color: "tertiary",
-        className: "bg-tertiary-container text-on-tertiary-container",
-      },
-      {
-        variant: "tonal",
-        color: "error",
-        className: "bg-error-container text-on-error-container",
-      },
-
-      // ====================
-      // ELEVATED VARIANTS
-      // ====================
-      {
-        variant: "elevated",
-        color: "primary",
-        className: "bg-surface-container-low text-primary",
-      },
-      {
-        variant: "elevated",
-        color: "secondary",
-        className: "bg-surface-container-low text-secondary",
-      },
-      {
-        variant: "elevated",
-        color: "tertiary",
-        className: "bg-surface-container-low text-tertiary",
-      },
-      {
-        variant: "elevated",
-        color: "error",
-        className: "bg-surface-container-low text-error",
-      },
-
-      // ====================
-      // TEXT VARIANTS
-      // ====================
-      {
-        variant: "text",
-        color: "primary",
-        className: "text-primary hover:bg-primary/[0.08]", // MD3: text buttons gain primary color at 8% opacity on hover
-      },
-      {
-        variant: "text",
-        color: "secondary",
-        className: "text-secondary hover:bg-secondary/[0.08]", // MD3: text buttons gain secondary color at 8% opacity on hover
-      },
-      {
-        variant: "text",
-        color: "tertiary",
-        className: "text-tertiary hover:bg-tertiary/[0.08]", // MD3: text buttons gain tertiary color at 8% opacity on hover
-      },
-      {
-        variant: "text",
-        color: "error",
-        className: "text-error hover:bg-error/[0.08]", // MD3: text buttons gain error color at 8% opacity on hover
-      },
+      { variant: "text", size: "small", className: "px-3" },
+      { variant: "text", size: "medium", className: "px-3" },
+      { variant: "text", size: "large", className: "px-4" },
     ],
 
-    /**
-     * Default variants
-     */
     defaultVariants: {
       variant: "filled",
-      color: "primary",
       size: "medium",
       fullWidth: false,
-      disabled: false,
-      loading: false,
     },
   }
 );
 
+// ─── STATE LAYER ─────────────────────────────────────────────────────────────
+
 /**
- * Extract variant prop types from CVA
+ * State layer — absolute inset overlay that transitions opacity on interaction.
+ *
+ * Color is variant-specific (uses the "on-container" role per MD3):
+ *   filled   → bg-on-primary
+ *   outlined → bg-primary
+ *   tonal    → bg-on-secondary-container
+ *   elevated → bg-primary
+ *   text     → bg-primary
+ *
+ * Opacity:
+ *   0 at rest
+ *   8% hover
+ *   10% focus/pressed
+ *   hidden when disabled
+ *
+ * Pressed (10%) must win over hover (8%) when both data attributes are set
+ * simultaneously. The doubled attribute selector for pressed gives it higher
+ * specificity than the singly-chained hover selector:
+ *   group-data-[hovered]/button:           → specificity (0,1,0) relative weight
+ *   group-data-[pressed]/button:group-...  → specificity (0,2,0) always wins
+ *
+ * overflow-hidden is placed HERE (not on the root button) so the state layer
+ * clips to the button shape while the focus ring span can extend outside.
  */
+export const buttonStateLayerVariants = cva(
+  [
+    "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+    // Effects transition for opacity — standard spring, no overshoot
+    "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Hover: 8%
+    "group-data-[hovered]/button:opacity-8",
+    // Focus: 10%
+    "group-data-[focus-visible]/button:opacity-10",
+    // Pressed: 10%, doubled selector wins over hover
+    "group-data-[pressed]/button:group-data-[pressed]/button:opacity-10",
+    // No state layer when disabled
+    "group-data-[disabled]/button:hidden",
+  ],
+  {
+    variants: {
+      variant: {
+        filled: "bg-on-primary",
+        outlined: "bg-primary",
+        tonal: "bg-on-secondary-container",
+        elevated: "bg-primary",
+        text: "bg-primary",
+      },
+    },
+    defaultVariants: { variant: "filled" },
+  }
+);
+
+// ─── FOCUS RING ───────────────────────────────────────────────────────────────
+
+/**
+ * Focus ring overlay.
+ *
+ * Rendered as an absolute `<span>` with `inset-[-3px]` so it extends 3px
+ * outside the button boundary. This REQUIRES that `overflow-hidden` is NOT
+ * on the root `<button>` element — overflow clipping is moved to the ripple
+ * container and state layer instead.
+ *
+ * The ring is always present in the DOM (opacity-0 at rest) and transitions
+ * to opacity-100 on keyboard/programmatic focus, which avoids layout shifts
+ * and allows the CSS transition to animate it smoothly.
+ */
+export const buttonFocusRingVariants = cva([
+  "pointer-events-none absolute inset-[-3px] rounded-full",
+  "outline outline-2 outline-offset-0 outline-secondary",
+  // Effects transition — opacity change must not overshoot
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/button:opacity-100",
+]);
+
+// ─── ICON ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Icon wrapper (leading or trailing).
+ *
+ * MD3 spec: icons inside buttons must be 18×18px.
+ * Color is inherited from the parent button's text color.
+ * `invisible` (not `hidden`) when loading — keeps layout stable so the
+ * spinner can take the same space without reflowing adjacent content.
+ */
+export const buttonIconVariants = cva(
+  [
+    "relative z-10 inline-flex shrink-0 items-center justify-center",
+    "size-[18px]",
+    // Color transition uses effects token (no spatial overshoot on color)
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  ],
+  {
+    variants: {
+      hidden: {
+        true: "invisible",
+        false: "",
+      },
+    },
+    defaultVariants: { hidden: false },
+  }
+);
+
+// ─── LABEL ────────────────────────────────────────────────────────────────────
+
+/**
+ * Label text wrapper.
+ * Typography + color are inherited from the root buttonVariants classes.
+ * z-10 keeps it above the state layer and ripple overlays.
+ */
+export const buttonLabelVariants = cva(["relative z-10 inline-flex items-center"]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
 export type ButtonVariants = VariantProps<typeof buttonVariants>;
+export type ButtonStateLayerVariants = VariantProps<typeof buttonStateLayerVariants>;
+export type ButtonIconVariants = VariantProps<typeof buttonIconVariants>;
+export type ButtonLabelVariants = VariantProps<typeof buttonLabelVariants>;

--- a/packages/react/src/components/Button/index.ts
+++ b/packages/react/src/components/Button/index.ts
@@ -4,14 +4,18 @@ export { Button } from "./Button";
 // Layer 2: Headless Component (for advanced customization)
 export { ButtonHeadless } from "./ButtonHeadless";
 
-// CVA Variants
-export { buttonVariants, type ButtonVariants } from "./Button.variants";
+// CVA Variants (for advanced customization)
+export {
+  buttonVariants,
+  buttonStateLayerVariants,
+  buttonFocusRingVariants,
+  buttonIconVariants,
+  buttonLabelVariants,
+  type ButtonVariants,
+  type ButtonStateLayerVariants,
+  type ButtonIconVariants,
+  type ButtonLabelVariants,
+} from "./Button.variants";
 
 // Types
-export type {
-  ButtonProps,
-  ButtonHeadlessProps,
-  ButtonVariant,
-  ButtonColor,
-  ButtonSize,
-} from "./Button.types";
+export type { ButtonProps, ButtonHeadlessProps, ButtonVariant, ButtonSize } from "./Button.types";

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "vitest-axe";
 import type React from "react";
-import { buttonGroupVariants } from "./ButtonGroup.variants";
+import { buttonGroupRootVariants, buttonGroupVariants } from "./ButtonGroup.variants";
 import { ButtonGroupContext, useButtonGroup, useOptionalButtonGroup } from "./ButtonGroupContext";
 import { ButtonGroupHeadless } from "./ButtonGroupHeadless";
 import { ButtonGroup } from "./ButtonGroup";
@@ -37,80 +37,107 @@ const ContextConsumer = ({ value }: { value: string }): React.ReactElement => {
 // 1. buttonGroupVariants (CVA) — class output
 // ---------------------------------------------------------------------------
 
-describe("buttonGroupVariants", () => {
+describe("buttonGroupRootVariants", () => {
   describe("standard variant", () => {
     test("default (standard, medium) has inline-flex", () => {
-      const cls = buttonGroupVariants({ variant: "standard", size: "medium" });
+      const cls = buttonGroupRootVariants({ variant: "standard", size: "medium" });
       expect(cls).toContain("inline-flex");
     });
 
     test("standard+extra-small has gap-[18px]", () => {
-      const cls = buttonGroupVariants({ variant: "standard", size: "extra-small" });
+      const cls = buttonGroupRootVariants({ variant: "standard", size: "extra-small" });
       expect(cls).toContain("gap-[18px]");
     });
 
     test("standard+small has gap-3", () => {
-      const cls = buttonGroupVariants({ variant: "standard", size: "small" });
+      const cls = buttonGroupRootVariants({ variant: "standard", size: "small" });
       expect(cls).toContain("gap-3");
     });
 
     test("standard+medium has gap-2", () => {
-      const cls = buttonGroupVariants({ variant: "standard", size: "medium" });
+      const cls = buttonGroupRootVariants({ variant: "standard", size: "medium" });
       expect(cls).toContain("gap-2");
     });
 
     test("standard+large has gap-2", () => {
-      const cls = buttonGroupVariants({ variant: "standard", size: "large" });
+      const cls = buttonGroupRootVariants({ variant: "standard", size: "large" });
       expect(cls).toContain("gap-2");
     });
 
     test("standard+extra-large has gap-2", () => {
-      const cls = buttonGroupVariants({ variant: "standard", size: "extra-large" });
+      const cls = buttonGroupRootVariants({ variant: "standard", size: "extra-large" });
       expect(cls).toContain("gap-2");
     });
   });
 
   describe("connected variant", () => {
     test("connected has flex and w-full", () => {
-      const cls = buttonGroupVariants({ variant: "connected", size: "medium" });
+      const cls = buttonGroupRootVariants({ variant: "connected", size: "medium" });
       expect(cls).toContain("flex");
       expect(cls).toContain("w-full");
     });
 
     test("connected+extra-small has gap-0.5", () => {
-      const cls = buttonGroupVariants({ variant: "connected", size: "extra-small" });
+      const cls = buttonGroupRootVariants({ variant: "connected", size: "extra-small" });
       expect(cls).toContain("gap-0.5");
     });
 
     test("connected+small has gap-0.5", () => {
-      const cls = buttonGroupVariants({ variant: "connected", size: "small" });
+      const cls = buttonGroupRootVariants({ variant: "connected", size: "small" });
       expect(cls).toContain("gap-0.5");
     });
 
     test("connected+medium has gap-0.5", () => {
-      const cls = buttonGroupVariants({ variant: "connected", size: "medium" });
+      const cls = buttonGroupRootVariants({ variant: "connected", size: "medium" });
       expect(cls).toContain("gap-0.5");
     });
 
     test("connected+large has gap-0.5", () => {
-      const cls = buttonGroupVariants({ variant: "connected", size: "large" });
+      const cls = buttonGroupRootVariants({ variant: "connected", size: "large" });
       expect(cls).toContain("gap-0.5");
     });
 
     test("connected+extra-large has gap-0.5", () => {
-      const cls = buttonGroupVariants({ variant: "connected", size: "extra-large" });
+      const cls = buttonGroupRootVariants({ variant: "connected", size: "extra-large" });
       expect(cls).toContain("gap-0.5");
     });
   });
 
+  describe("motion tokens", () => {
+    test("includes spatial transition for gap", () => {
+      const cls = buttonGroupRootVariants({ variant: "standard", size: "medium" });
+      expect(cls).toContain("transition-[gap]");
+      expect(cls).toContain("duration-spring-standard-fast-spatial");
+      expect(cls).toContain("ease-spring-standard-fast-spatial");
+    });
+  });
+
+  describe("disabled state styling", () => {
+    test("includes data-[disabled] pointer-events-none", () => {
+      const cls = buttonGroupRootVariants({ variant: "standard", size: "medium" });
+      expect(cls).toContain("data-[disabled]:pointer-events-none");
+    });
+
+    test("includes data-[disabled] opacity-38", () => {
+      const cls = buttonGroupRootVariants({ variant: "standard", size: "medium" });
+      expect(cls).toContain("data-[disabled]:opacity-38");
+    });
+  });
+
   test("default variant is standard", () => {
-    const cls = buttonGroupVariants({});
+    const cls = buttonGroupRootVariants({});
     expect(cls).toContain("inline-flex");
   });
 
   test("default size is md", () => {
-    const cls = buttonGroupVariants({ variant: "standard" });
+    const cls = buttonGroupRootVariants({ variant: "standard" });
     expect(cls).toContain("gap-2");
+  });
+});
+
+describe("buttonGroupVariants (backward compat)", () => {
+  test("is identical to buttonGroupRootVariants", () => {
+    expect(buttonGroupVariants).toBe(buttonGroupRootVariants);
   });
 });
 
@@ -126,6 +153,10 @@ describe("ButtonGroupContext", () => {
     selectionMode: undefined,
     selectedValues: new Set(),
     onSelectionChange: vi.fn(),
+    isDisabled: false,
+    connectedInnerRadius: "rounded-sm",
+    connectedOuterRadius: "rounded-full",
+    enforceMinWidth: false,
   };
 
   test("useButtonGroup throws when used outside a provider", () => {
@@ -996,5 +1027,178 @@ describe("ButtonGroup dev warnings (DOM-based)", () => {
         String(args[1]).includes("data-color")
     );
     expect(colorWarning).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Container data attributes
+// ---------------------------------------------------------------------------
+
+describe("ButtonGroup container data attributes", () => {
+  test("emits data-connected when variant is connected", () => {
+    render(
+      <ButtonGroup variant="connected" aria-label="Connected group">
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).toHaveAttribute("data-connected", "");
+  });
+
+  test("does NOT emit data-connected when variant is standard", () => {
+    render(
+      <ButtonGroup variant="standard" aria-label="Standard group">
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).not.toHaveAttribute("data-connected");
+  });
+
+  test("emits data-has-selection when selectedValues is non-empty", () => {
+    render(
+      <ButtonGroup
+        selectionMode="single"
+        selectedValues={new Set(["a"])}
+        onSelectionChange={vi.fn()}
+        aria-label="Selection group"
+      >
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).toHaveAttribute("data-has-selection", "");
+  });
+
+  test("does NOT emit data-has-selection when selectedValues is empty", () => {
+    render(
+      <ButtonGroup
+        selectionMode="single"
+        selectedValues={new Set()}
+        onSelectionChange={vi.fn()}
+        aria-label="Empty selection"
+      >
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).not.toHaveAttribute("data-has-selection");
+  });
+
+  test("emits data-has-selection when defaultValue is provided", () => {
+    render(
+      <ButtonGroup selectionMode="single" defaultValue="a" aria-label="Default value group">
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).toHaveAttribute("data-has-selection", "");
+  });
+
+  test("emits data-selection-mode with the mode value", () => {
+    render(
+      <ButtonGroup selectionMode="multi" aria-label="Multi group">
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).toHaveAttribute("data-selection-mode", "multi");
+  });
+
+  test("does NOT emit data-selection-mode when no selectionMode", () => {
+    render(
+      <ButtonGroup aria-label="Action group">
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).not.toHaveAttribute("data-selection-mode");
+  });
+
+  test("applies group/button-group class scope", () => {
+    render(
+      <ButtonGroup aria-label="Scoped group">
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).toHaveClass("group/button-group");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Disabled group state
+// ---------------------------------------------------------------------------
+
+describe("ButtonGroup disabled state", () => {
+  test("emits data-disabled when isDisabled is true", () => {
+    render(
+      <ButtonGroup isDisabled aria-label="Disabled group">
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).toHaveAttribute("data-disabled", "");
+  });
+
+  test("does NOT emit data-disabled when isDisabled is false", () => {
+    render(
+      <ButtonGroup aria-label="Enabled group">
+        <button>A</button>
+      </ButtonGroup>
+    );
+    expect(screen.getByRole("group")).not.toHaveAttribute("data-disabled");
+  });
+
+  test("disabled group prevents selection changes", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <ButtonGroup
+        isDisabled
+        selectionMode="single"
+        selectedValues={new Set<string>()}
+        onSelectionChange={onSelectionChange}
+        aria-label="Disabled toggle group"
+      >
+        <ContextConsumer value="a" />
+      </ButtonGroup>
+    );
+    await user.click(screen.getByText("a"));
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
+  test("provides isDisabled=true to children via context", () => {
+    const DisabledCapture = (): React.ReactElement => {
+      const ctx = useButtonGroup();
+      return <div data-testid="ctx-disabled" data-is-disabled={String(ctx.isDisabled)} />;
+    };
+
+    render(
+      <ButtonGroup isDisabled aria-label="Disabled context check">
+        <DisabledCapture />
+      </ButtonGroup>
+    );
+    expect(screen.getByTestId("ctx-disabled")).toHaveAttribute("data-is-disabled", "true");
+  });
+
+  test("provides isDisabled=false to children via context when not disabled", () => {
+    const DisabledCapture = (): React.ReactElement => {
+      const ctx = useButtonGroup();
+      return <div data-testid="ctx-disabled" data-is-disabled={String(ctx.isDisabled)} />;
+    };
+
+    render(
+      <ButtonGroup aria-label="Enabled context check">
+        <DisabledCapture />
+      </ButtonGroup>
+    );
+    expect(screen.getByTestId("ctx-disabled")).toHaveAttribute("data-is-disabled", "false");
+  });
+
+  test("accessibility: disabled group has no violations", async () => {
+    const { container } = render(
+      <ButtonGroup isDisabled aria-label="Disabled actions">
+        <button aria-pressed="false" disabled>
+          Bold
+        </button>
+        <button aria-pressed="false" disabled>
+          Italic
+        </button>
+      </ButtonGroup>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,19 +1,31 @@
 "use client";
 
-import { forwardRef, useCallback, useEffect, useRef } from "react";
+import { forwardRef, useCallback, useEffect, useRef, useMemo } from "react";
 import type React from "react";
 import { ButtonGroupHeadless } from "./ButtonGroupHeadless";
-import { buttonGroupVariants } from "./ButtonGroup.variants";
+import { buttonGroupRootVariants } from "./ButtonGroup.variants";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import type { ButtonGroupProps } from "./ButtonGroup.types";
 
 /**
  * Material Design 3 ButtonGroup Component (Layer 3: Styled)
  *
+ * Built on the Variants-vs-States architecture: interaction/selection states
+ * are expressed as data-* attributes on the root and consumed by child slots
+ * via group-data-[x]/button-group Tailwind selectors.
+ *
  * An invisible container that:
- * - Applies MD3-spec gap between child buttons
+ * - Applies MD3-spec gap between child buttons with spatial spring transitions
  * - Manages selection state (single / multi / required) across toggle buttons
- * - Passes shape, size, and variant metadata to children via React Context
+ * - Passes shape, size, variant, and disabled metadata to children via React Context
+ * - Emits container-level state attributes for CSS targeting
+ *
+ * Container data attributes:
+ * - `data-connected`      — variant is "connected"
+ * - `data-has-selection`  — at least one child button is selected
+ * - `data-selection-mode` — "single" | "required" | "multi"
+ * - `data-disabled`       — group is non-interactive (via getInteractionDataAttributes)
  *
  * Variants:
  * - `standard`: Buttons float independently. Gap is larger for xs/sm to preserve
@@ -25,6 +37,11 @@ import type { ButtonGroupProps } from "./ButtonGroup.types";
  * - `single`: At most one button selected; deselectable.
  * - `required`: Exactly one always selected; pressing the active button is a no-op.
  * - `multi`: Any number of buttons selected simultaneously.
+ *
+ * Motion:
+ * - Gap transitions use spring-standard-fast-spatial (350ms) for smooth layout changes
+ * - Border-radius morphing on child buttons uses expressive-fast-spatial (350ms, overshoot)
+ * - Color/opacity effects on children use spring-standard-fast-effects (150ms, no overshoot)
  *
  * @example
  * ```tsx
@@ -46,16 +63,10 @@ import type { ButtonGroupProps } from "./ButtonGroup.types";
  *   <Button value="16oz">16 oz</Button>
  * </ButtonGroup>
  *
- * // Controlled multi-select
- * <ButtonGroup
- *   variant="connected"
- *   selectionMode="multi"
- *   selectedValues={selected}
- *   onSelectionChange={setSelected}
- *   aria-label="Text formatting"
- * >
- *   <Button value="bold">Bold</Button>
- *   <Button value="italic">Italic</Button>
+ * // Disabled group
+ * <ButtonGroup variant="connected" isDisabled aria-label="Unavailable options">
+ *   <Button value="a">A</Button>
+ *   <Button value="b">B</Button>
  * </ButtonGroup>
  * ```
  */
@@ -69,16 +80,15 @@ export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
       selectedValues,
       onSelectionChange,
       defaultValue,
+      isDisabled = false,
       children,
       className,
       ...htmlProps
     },
     ref
   ) => {
-    // Internal ref used by dev-mode DOM inspection — separate from the forwarded ref
     const containerRef = useRef<HTMLDivElement>(null);
 
-    // Combine the internal ref with the consumer's forwarded ref
     const handleRef = useCallback(
       (node: HTMLDivElement | null) => {
         (containerRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
@@ -90,6 +100,15 @@ export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
       },
       [ref]
     );
+
+    // Compute whether the group has any active selection
+    const hasSelection = useMemo(() => {
+      if (selectedValues) return selectedValues.size > 0;
+      if (defaultValue) {
+        return Array.isArray(defaultValue) ? defaultValue.length > 0 : true;
+      }
+      return false;
+    }, [selectedValues, defaultValue]);
 
     // Development warnings — synchronous child-prop scan
     if (process.env.NODE_ENV === "development") {
@@ -117,7 +136,6 @@ export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
       if (process.env.NODE_ENV !== "development") return;
       if (variant !== "connected" || !containerRef.current) return;
 
-      // Warning: connected group with no toggle buttons
       const toggleButtons = containerRef.current.querySelectorAll("[aria-pressed]");
       if (toggleButtons.length === 0) {
         console.warn(
@@ -126,7 +144,6 @@ export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
         );
       }
 
-      // Warning: connected group with mixed child color styles
       const colorValues = new Set<string>();
       containerRef.current.querySelectorAll("[data-color]").forEach((el) => {
         const c = el.getAttribute("data-color");
@@ -139,7 +156,7 @@ export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
         );
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []); // Run once after mount
+    }, []);
 
     return (
       <ButtonGroupHeadless
@@ -152,7 +169,14 @@ export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
         selectedValues={selectedValues}
         onSelectionChange={onSelectionChange}
         defaultValue={defaultValue}
-        className={cn(buttonGroupVariants({ variant, size }), className)}
+        isDisabled={isDisabled}
+        className={cn(buttonGroupRootVariants({ variant, size }), "group/button-group", className)}
+        // ── Interaction data attributes (from component state) ─────────────
+        {...getInteractionDataAttributes({ isDisabled })}
+        // ── Container state attributes (describe group-level state) ────────
+        data-connected={variant === "connected" ? "" : undefined}
+        data-has-selection={hasSelection ? "" : undefined}
+        data-selection-mode={selectionMode ?? undefined}
       >
         {children}
       </ButtonGroupHeadless>

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.types.ts
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.types.ts
@@ -70,6 +70,14 @@ export interface ButtonGroupContextValue {
   onSelectionChange: (value: string) => void;
 
   /**
+   * Whether the entire group is disabled.
+   * When `true`, all child buttons should be non-interactive.
+   *
+   * @default false
+   */
+  isDisabled: boolean;
+
+  /**
    * Tailwind class for the inner (adjacent) corner radius in the connected variant.
    * Applied to all four corners of every button in a connected group.
    *
@@ -203,6 +211,15 @@ export interface ButtonGroupProps extends Omit<React.HTMLAttributes<HTMLDivEleme
    * @default new Set()
    */
   defaultValue?: string | string[] | undefined;
+
+  /**
+   * Whether the entire group and all child buttons are disabled.
+   * When `true`, the group container receives `data-disabled` and
+   * all children inherit the disabled state via context.
+   *
+   * @default false
+   */
+  isDisabled?: boolean;
 
   /**
    * Child buttons (Button, IconButton, or any element with a `value` prop).

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.variants.ts
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.variants.ts
@@ -1,27 +1,59 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 ButtonGroup Variants (CVA)
+ * Material Design 3 ButtonGroup Variants
  *
- * Type-safe variant management for the ButtonGroup container.
- * The container has no colour of its own — it only controls layout
- * (display, width) and the inner gap between child buttons.
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no interaction state variants).
+ * - All interaction/selection states are driven by data-* attributes on the root
+ *   via group-data-[x]/button-group Tailwind selectors.
+ * - Container-level state attributes:
+ *     data-connected      — variant is "connected"
+ *     data-has-selection  — at least one child button is selected
+ *     data-disabled       — entire group is non-interactive
+ *     data-selection-mode — "single" | "required" | "multi" (when applicable)
  *
- * MD3 Inner Gap Spec:
- * | Size        | standard   | connected |
- * |-------------|------------|-----------|
- * | extra-small | 18dp       | 2dp       |
- * | small       | 12dp       | 2dp       |
- * | medium      | 8dp        | 2dp       |
- * | large       | 8dp        | 2dp       |
- * | extra-large | 8dp        | 2dp       |
+ * Slot responsibilities:
+ *   buttonGroupRootVariants  — layout container; gap, alignment, motion, disabled state
+ *
+ * MD3 Spec (Inner Gap):
+ *   | Size        | standard   | connected |
+ *   |-------------|------------|-----------|
+ *   | extra-small | 18dp       | 2dp       |
+ *   | small       | 12dp       | 2dp       |
+ *   | medium      | 8dp        | 2dp       |
+ *   | large       | 8dp        | 2dp       |
+ *   | extra-large | 8dp        | 2dp       |
+ *
+ * Motion:
+ *   Gap is a spatial property — uses spring-standard-fast-spatial (350ms, no overshoot
+ *   for gap since CSS gap cannot visually overshoot). This ensures smooth transitions
+ *   when the size prop changes or buttons are added/removed.
  *
  * Note: xs/sm standard gaps are intentionally large to preserve 48dp touch targets.
  * Connected gap is always 2dp (`gap-0.5`) regardless of size.
  */
-export const buttonGroupVariants = cva(
-  // Base classes applied to every ButtonGroup container
-  ["items-center"],
+
+// ─── ROOT ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Root container element — carries `group/button-group` scope via the styled layer.
+ *
+ * Handles:
+ * - Flexbox layout (inline-flex or flex)
+ * - Gap between child buttons (per variant × size)
+ * - Spatial motion for gap transitions
+ * - Disabled state (opacity + pointer-events)
+ */
+export const buttonGroupRootVariants = cva(
+  [
+    // Layout
+    "items-center",
+    // Spatial motion for gap changes — standard spring (calm, utility UI)
+    "transition-[gap] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+    // Disabled state — self-targeting data-[x]: selector on root
+    "data-[disabled]:pointer-events-none data-[disabled]:opacity-38",
+  ],
   {
     variants: {
       /**
@@ -74,7 +106,41 @@ export const buttonGroupVariants = cva(
   }
 );
 
+// ─── FOCUS RING ───────────────────────────────────────────────────────────────
+
 /**
- * Extract variant prop types from CVA
+ * Focus ring overlay for the group container.
+ *
+ * Visible only when the group itself receives keyboard focus (rare — typically
+ * focus goes to child buttons). Included for completeness and edge cases where
+ * the group container might receive programmatic focus.
+ *
+ * Uses the same pattern as Switch/Button focus rings:
+ * - Always in DOM (opacity-0)
+ * - Transitions to opacity-100 on group-data-[focus-visible]
  */
-export type ButtonGroupVariants = VariantProps<typeof buttonGroupVariants>;
+export const buttonGroupFocusRingVariants = cva([
+  "pointer-events-none absolute inset-[-3px] rounded-[inherit]",
+  "outline outline-2 outline-offset-0 outline-secondary",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/button-group:opacity-100",
+]);
+
+// ─── BACKWARD COMPAT ──────────────────────────────────────────────────────────
+
+/**
+ * @deprecated Use `buttonGroupRootVariants` instead.
+ * Kept for backward compatibility during migration.
+ */
+export const buttonGroupVariants = buttonGroupRootVariants;
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
+export type ButtonGroupRootVariants = VariantProps<typeof buttonGroupRootVariants>;
+export type ButtonGroupFocusRingVariants = VariantProps<typeof buttonGroupFocusRingVariants>;
+
+/**
+ * @deprecated Use `ButtonGroupRootVariants` instead.
+ */
+export type ButtonGroupVariants = ButtonGroupRootVariants;

--- a/packages/react/src/components/ButtonGroup/ButtonGroupHeadless.tsx
+++ b/packages/react/src/components/ButtonGroup/ButtonGroupHeadless.tsx
@@ -45,6 +45,7 @@ export const ButtonGroupHeadless = forwardRef<HTMLDivElement, ButtonGroupProps>(
       size = "medium",
       shape = "round",
       selectionMode,
+      isDisabled = false,
 
       // Selection — controlled
       selectedValues: controlledValues,
@@ -83,7 +84,7 @@ export const ButtonGroupHeadless = forwardRef<HTMLDivElement, ButtonGroupProps>(
      * Computes the new Set according to the selectionMode and notifies the parent.
      */
     const handleSelectionChange = (value: string): void => {
-      if (!selectionMode) return;
+      if (!selectionMode || isDisabled) return;
 
       let nextValues: Set<string>;
 
@@ -129,6 +130,7 @@ export const ButtonGroupHeadless = forwardRef<HTMLDivElement, ButtonGroupProps>(
             selectionMode,
             selectedValues,
             onSelectionChange: handleSelectionChange,
+            isDisabled,
             connectedInnerRadius: getInnerRadius(size),
             connectedOuterRadius: getOuterRadius(shape, size),
             enforceMinWidth:

--- a/packages/react/src/components/ButtonGroup/index.ts
+++ b/packages/react/src/components/ButtonGroup/index.ts
@@ -4,7 +4,15 @@ export { ButtonGroup } from "./ButtonGroup";
 // Layer 2: Headless Component (for advanced customization)
 export { ButtonGroupHeadless } from "./ButtonGroupHeadless";
 
-// CVA Variants
+// CVA Variants (slot-based naming)
+export {
+  buttonGroupRootVariants,
+  buttonGroupFocusRingVariants,
+  type ButtonGroupRootVariants,
+  type ButtonGroupFocusRingVariants,
+} from "./ButtonGroup.variants";
+
+// CVA Variants (backward compat — deprecated)
 export { buttonGroupVariants, type ButtonGroupVariants } from "./ButtonGroup.variants";
 
 // Context + hooks (for child button components)

--- a/packages/react/src/components/IconButton/IconButton.test.tsx
+++ b/packages/react/src/components/IconButton/IconButton.test.tsx
@@ -422,9 +422,7 @@ describe("IconButton", () => {
   });
 
   describe("Ripple Effect", () => {
-    test("shows ripple effect by default", async () => {
-      const user = userEvent.setup();
-
+    test("shows ripple container by default", () => {
       render(
         <IconButton aria-label="Delete">
           <IconDelete />
@@ -432,10 +430,7 @@ describe("IconButton", () => {
       );
 
       const button = screen.getByRole("button");
-      await user.click(button);
-
-      // Ripple container should be present
-      expect(button.querySelector(".animate-ripple")).toBeInTheDocument();
+      expect(button.querySelector("[data-ripple-container]")).toBeInTheDocument();
     });
 
     test("disables ripple when disableRipple is true", () => {
@@ -446,15 +441,10 @@ describe("IconButton", () => {
       );
 
       const button = screen.getByRole("button");
-
-      // With disableRipple, no initial ripples should exist
-      const ripples = button.querySelectorAll(".animate-ripple");
-      expect(ripples.length).toBe(0);
+      expect(button.querySelector("[data-ripple-container]")).not.toBeInTheDocument();
     });
 
-    test("does not show ripple when disabled", async () => {
-      const user = userEvent.setup();
-
+    test("does not show ripple when disabled", () => {
       render(
         <IconButton aria-label="Delete" isDisabled>
           <IconDelete />
@@ -462,10 +452,7 @@ describe("IconButton", () => {
       );
 
       const button = screen.getByRole("button");
-      await user.click(button);
-
-      // No ripple when disabled
-      expect(button.querySelector(".animate-ripple")).not.toBeInTheDocument();
+      expect(button.querySelector("[data-ripple-container]")).not.toBeInTheDocument();
     });
   });
 

--- a/packages/react/src/components/IconButton/IconButton.tsx
+++ b/packages/react/src/components/IconButton/IconButton.tsx
@@ -118,6 +118,9 @@ export const IconButton = forwardRef<
     });
 
     // Connected group radius + min-width overrides (pass value for selection-aware shape morph)
+    const isGroupSelected =
+      isConnected && groupCtx && value ? groupCtx.selectedValues.has(value) : false;
+
     const connectedClasses =
       isConnected && groupCtx
         ? [
@@ -130,23 +133,14 @@ export const IconButton = forwardRef<
       <IconButtonHeadless
         ref={ref}
         className={cn(
-          // Base classes
-          "relative inline-flex items-center justify-center",
-          "overflow-hidden rounded-full", // Circular shape (overridden by connected group classes)
-          // Spatial (border-radius, transform): expressive fast spring — 350ms, visible overshoot
-          "duration-expressive-fast-spatial ease-expressive-fast-spatial transition-all",
-          "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
-
-          // State layers (hover, focus, active) — effects token: opacity, no overshoot
-          "before:absolute before:inset-0 before:rounded-[inherit]",
-          "before:duration-spring-standard-fast-effects before:ease-spring-standard-fast-effects before:transition-opacity",
-          "before:bg-current before:opacity-0",
-          "hover:before:opacity-8",
-          "focus-visible:before:opacity-12",
-          "active:before:opacity-12",
-
-          // CVA variants
+          // CVA variants — includes btn-transition for asymmetric border-radius easing
           iconButtonVariants({ variant, color, size, selected: selected ?? false, isDisabled }),
+
+          // Asymmetric border-radius easing: expressive when selected, decelerate when not.
+          // btn-transition-selected overrides --_btn-radius-easing to the bouncy spring while
+          // the button is gaining the pill shape; removal restores decelerate for the return
+          // path, preventing the overshoot-to-0px sharp-corner flash.
+          isGroupSelected ? "btn-transition-selected" : "",
 
           // Connected group overrides: inner radius + start/end outer radius + min-width
           ...connectedClasses,
@@ -157,6 +151,8 @@ export const IconButton = forwardRef<
         aria-label={ariaLabel}
         data-variant={variant}
         data-color={color}
+        // Connected group selection state — mirrors btn-transition-selected for CSS targeting
+        data-group-selected={isGroupSelected ? "" : undefined}
         {...(selected !== undefined && { selected })}
         {...(title && { title })}
         {...mergedPropsValue}

--- a/packages/react/src/components/IconButton/IconButton.variants.ts
+++ b/packages/react/src/components/IconButton/IconButton.variants.ts
@@ -17,11 +17,13 @@ export const iconButtonVariants = cva(
     // Base classes (always applied)
     "relative inline-flex items-center justify-center cursor-pointer",
     "overflow-hidden rounded-full", // Circular shape
-    // Spatial (border-radius, transform): expressive fast spring — 350ms, visible overshoot
-    "transition-all duration-expressive-fast-spatial ease-expressive-fast-spatial",
+    // Split MD3 transition: btn-transition handles spatial (border-radius) with asymmetric
+    // easing (decelerate by default, switched to expressive via btn-transition-selected when
+    // the button is group-selected) and effects (color/bg/shadow) with standard spring.
+    "btn-transition",
     "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
 
-    // State layers — effects token: opacity only, no overshoot
+    // State layers — effects token: opacity only, no overshoot (separate ::before pseudo-element)
     "before:absolute before:inset-0 before:rounded-[inherit]",
     "before:transition-opacity before:duration-spring-standard-fast-effects before:ease-spring-standard-fast-effects",
     "before:bg-current before:opacity-0",

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -2,7 +2,7 @@ export { AppBar, AppBarHeadless } from "./AppBar";
 export type { AppBarProps, AppBarHeadlessProps, AppBarVariant } from "./AppBar";
 
 export { Button } from "./Button";
-export type { ButtonProps, ButtonVariant, ButtonColor, ButtonSize } from "./Button";
+export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button";
 
 export { IconButton, IconButtonHeadless } from "./IconButton";
 export type {

--- a/packages/react/src/hooks/useRipple.tsx
+++ b/packages/react/src/hooks/useRipple.tsx
@@ -1,4 +1,5 @@
 import { useRef, useCallback, useState, useEffect, type MouseEvent } from "react";
+import { useReducedMotion } from "./useReducedMotion";
 
 /**
  * Ripple state for tracking individual ripple animations
@@ -26,17 +27,25 @@ interface UseRippleOptions {
   color?: string;
 
   /**
-   * Duration of ripple animation in ms
+   * Duration of ripple animation in ms.
+   * Must match the `--animate-md-ripple` token duration (450ms).
    * @default 450
    */
   duration?: number;
 }
 
 /**
- * Hook for Material Design 3 ripple effect
+ * Hook for Material Design 3 ripple effect.
  *
- * Creates a ripple animation that emanates from the click/touch point.
- * The ripple is bounded to the container and follows MD3 motion specs.
+ * Creates a ripple animation that emanates from the pointer-down origin,
+ * expanding to cover the entire container element. Uses the `animate-md-ripple`
+ * composite token (md-ripple keyframe + 450ms emphasized spatial curve) so
+ * the animation is always in sync with the MD3 motion system.
+ *
+ * Automatically respects `prefers-reduced-motion`: when the OS/browser
+ * requests reduced motion the ripple is fully suppressed (no DOM nodes are
+ * created, no JS timers fire). This is a non-negotiable accessibility
+ * requirement per `md3-motion.mdc`.
  *
  * @example
  * ```tsx
@@ -58,6 +67,11 @@ export function useRipple(options: UseRippleOptions = {}): {
 } {
   const { disabled = false, color = "currentColor", duration = 450 } = options;
 
+  // MD3 motion rule: JS-driven animations must gate on useReducedMotion().
+  // When reduced motion is preferred, suppress the ripple entirely —
+  // do not just shorten it (shortened motion can still cause discomfort).
+  const prefersReducedMotion = useReducedMotion();
+
   const [ripples, setRipples] = useState<Ripple[]>([]);
   const rippleKeyCounter = useRef(0);
   const timersRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
@@ -69,64 +83,69 @@ export function useRipple(options: UseRippleOptions = {}): {
   }, []);
 
   /**
-   * Create ripple on mouse down
+   * Create ripple on pointer down (mouse or touch)
    */
   const onMouseDown = useCallback(
     (event: MouseEvent<HTMLElement>) => {
-      if (disabled) return;
+      if (disabled || prefersReducedMotion) return;
 
       const element = event.currentTarget;
       const rect = element.getBoundingClientRect();
 
-      // Calculate ripple position relative to element
+      // Position relative to the element's own coordinate system
       const x = event.clientX - rect.left;
       const y = event.clientY - rect.top;
 
-      // Calculate ripple size (diameter that covers entire element)
+      // Diameter that guarantees coverage of all four corners
       const sizeX = Math.max(x, rect.width - x);
       const sizeY = Math.max(y, rect.height - y);
       const size = Math.sqrt(sizeX ** 2 + sizeY ** 2) * 2;
 
       const key = rippleKeyCounter.current++;
 
-      // Add new ripple
       setRipples((prev) => [...prev, { key, x, y, size }]);
 
-      // Remove ripple after animation completes
+      // Remove after animation completes so DOM stays clean
       const timer = setTimeout(() => {
         setRipples((prev) => prev.filter((r) => r.key !== key));
         timersRef.current = timersRef.current.filter((t) => t !== timer);
       }, duration);
       timersRef.current.push(timer);
     },
-    [disabled, duration]
+    [disabled, duration, prefersReducedMotion]
   );
 
   /**
-   * Ripple elements to render
+   * Ripple container and individual ripple elements.
+   *
+   * animate-md-ripple   — MD3 composite token: md-ripple keyframe + 450ms
+   *                       cubic-bezier(0.2, 0, 0, 1) (emphasized spatial)
+   * opacity-12          — MD3 press state layer opacity for ripple fill
+   * rounded-full        — circular ripple shape
    */
-  const rippleElements = disabled ? null : (
-    <span
-      data-ripple-container
-      className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
-    >
-      {ripples.map((ripple) => (
-        <span
-          key={ripple.key}
-          className="animate-ripple absolute rounded-full opacity-12"
-          style={{
-            left: ripple.x,
-            top: ripple.y,
-            width: ripple.size,
-            height: ripple.size,
-            transform: "translate(-50%, -50%) scale(0)",
-            backgroundColor: color,
-            animationDuration: `${duration}ms`,
-          }}
-        />
-      ))}
-    </span>
-  );
+  const rippleElements =
+    disabled || prefersReducedMotion ? null : (
+      <span
+        data-ripple-container
+        className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
+      >
+        {ripples.map((ripple) => (
+          <span
+            key={ripple.key}
+            className="animate-md-ripple absolute rounded-full opacity-12"
+            style={{
+              left: ripple.x,
+              top: ripple.y,
+              width: ripple.size,
+              height: ripple.size,
+              transform: "translate(-50%, -50%) scale(0)",
+              backgroundColor: color,
+              animationDuration: `${duration}ms`,
+            }}
+          />
+        ))}
+      </span>
+    );
 
   return {
     onMouseDown,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -45,11 +45,13 @@ export { AppBar, AppBarHeadless } from "./components/AppBar";
 export type { AppBarProps, AppBarHeadlessProps, AppBarVariant } from "./components/AppBar";
 
 export { Button } from "./components/Button";
-export type { ButtonProps, ButtonVariant, ButtonColor, ButtonSize } from "./components/Button";
+export type { ButtonProps, ButtonVariant, ButtonSize } from "./components/Button";
 
 export {
   ButtonGroup,
   ButtonGroupHeadless,
+  buttonGroupRootVariants,
+  buttonGroupFocusRingVariants,
   buttonGroupVariants,
   ButtonGroupContext,
   useButtonGroup,
@@ -63,6 +65,8 @@ export type {
   ButtonGroupShape,
   ButtonGroupSelectionMode,
   ButtonGroupContextValue,
+  ButtonGroupRootVariants,
+  ButtonGroupFocusRingVariants,
 } from "./components/ButtonGroup";
 
 export { IconButton, IconButtonHeadless } from "./components/IconButton";

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -91,16 +91,54 @@
  * btn-transition — use on all Button and IconButton elements inside connected
  * groups where border-radius morphs on selection.
  *
- * Spatial  (border-radius):         expressive-fast-spatial  350ms, overshoot ok
+ * Spatial  (border-radius):  driven by --_btn-radius-easing (see below)
  * Effects  (color / bg / shadow):   standard-fast-effects    150ms, no overshoot
+ *
+ * Border-radius easing is asymmetric by design:
+ *
+ *   Deselecting (pill → inner radius):  emphasized-decelerate   cubic-bezier(0.05, 0.7, 0.1, 1)
+ *     → No overshoot. Prevents the "sharp corner flash" that occurs when the
+ *       expressive spring overshoots below 0px from a large radius.
+ *
+ *   Selecting   (inner → pill):         expressive-fast-spatial cubic-bezier(0.42, 1.67, 0.21, 0.9)
+ *     → Overshoot is safe (can't go past fully-round). Applied via
+ *       `btn-transition-selected` class added when the button is group-selected.
+ *
+ * CSS transitions use the easing active on the element AFTER the state change,
+ * so toggling `btn-transition-selected` in the same render cycle that changes
+ * the radius class correctly applies the right easing for each direction.
  */
 @utility btn-transition {
+  /* Default easing for border-radius: decelerate (no overshoot) for deselect path */
+  --_btn-radius-easing: var(--md-sys-motion-easing-emphasized-decelerate);
+
   transition:
-    border-radius var(--md-sys-motion-expressive-fast-spatial-duration),
-    color var(--md-sys-motion-standard-fast-effects-duration),
-    background-color var(--md-sys-motion-standard-fast-effects-duration),
-    border-color var(--md-sys-motion-standard-fast-effects-duration),
-    opacity var(--md-sys-motion-standard-fast-effects-duration),
-    box-shadow var(--md-sys-motion-standard-fast-effects-duration),
-    outline-color var(--md-sys-motion-standard-fast-effects-duration);
+    /* Spatial — shape morphing; easing is directional via --_btn-radius-easing */
+    border-radius var(--md-sys-motion-expressive-fast-spatial-duration) var(--_btn-radius-easing),
+    /* Effects — no overshoot on color/opacity/shadow changes */ color
+      var(--md-sys-motion-standard-fast-effects-duration)
+      var(--md-sys-motion-standard-fast-effects-easing),
+    background-color var(--md-sys-motion-standard-fast-effects-duration)
+      var(--md-sys-motion-standard-fast-effects-easing),
+    border-color var(--md-sys-motion-standard-fast-effects-duration)
+      var(--md-sys-motion-standard-fast-effects-easing),
+    opacity var(--md-sys-motion-standard-fast-effects-duration)
+      var(--md-sys-motion-standard-fast-effects-easing),
+    box-shadow var(--md-sys-motion-standard-fast-effects-duration)
+      var(--md-sys-motion-standard-fast-effects-easing),
+    outline-color var(--md-sys-motion-standard-fast-effects-duration)
+      var(--md-sys-motion-standard-fast-effects-easing);
+}
+
+/**
+ * btn-transition-selected — apply alongside `btn-transition` when a button is
+ * currently selected inside a connected group.
+ *
+ * Switches the border-radius easing to expressive-fast-spatial so that the
+ * inner-radius → pill animation gains the intentional overshoot bounce.
+ * Removed when the button is deselected, leaving `btn-transition`'s default
+ * emphasized-decelerate easing for the pill → inner-radius return path.
+ */
+@utility btn-transition-selected {
+  --_btn-radius-easing: var(--md-sys-motion-expressive-fast-spatial-easing);
 }


### PR DESCRIPTION
## Summary

- Refactor Button, ButtonGroup, and IconButton to adopt the variants-vs-states architecture (data-attribute interaction layers via `group-data-[x]/button` selectors)
- Remove non-MD3 `color` prop — each variant now uses its spec-defined color roles
- Correct MD3 size heights (small 32dp, medium 40dp, large 56dp) and state layer opacities (8% hover, 10% focus/pressed)
- Enhance ripple and focus ring behavior; update stories and tests

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 1939 tests pass
- [ ] Visual review in Storybook (Button, ButtonGroup, IconButton stories)