### PR TITLE
feat(icon-button): M3 Expressive sizing, variants-vs-states architecture

### DIFF
--- a/.changeset/icon-button-expressive-refactor.md
+++ b/.changeset/icon-button-expressive-refactor.md
@@ -1,0 +1,30 @@
+---
+"@tinybigui/react": minor
+---
+
+refactor(icon-button): M3 Expressive sizing system, Variants-vs-States architecture, press shape-morph
+
+**Breaking changes:**
+
+- `size` prop values renamed to the M3 Expressive 5-tier system. Map your existing values as follows:
+  - old `small` (32dp) → new `xsmall`
+  - old `medium` (40dp) → new `small`
+  - old `large` (48dp) → new `medium`
+  - new `large` (96dp) and `xlarge` (136dp) are added
+
+**New props:**
+
+- `width: 'narrow' | 'default' | 'wide'` — adjusts container width relative to height (default: `'default'`)
+- `shape: 'round' | 'square'` — `round` = circular (default); `square` = MD3 size-tiered corner radius
+- `selectedIcon: React.ReactNode` — icon shown when a toggle button (`selected` prop defined) is in the ON state
+
+**Improvements:**
+
+- Migrated to the Variants-vs-States architecture (same pattern as `Switch`): all interaction and selection states are driven by `data-*` attributes emitted by `IconButtonHeadless` and consumed by slot CVA classes via `group-data-[x]/icon-button` selectors — no state variants in CVA
+- `IconButtonHeadless` now runs `useHover` + `useFocusRing` and emits `data-hovered`, `data-focus-visible`, `data-pressed`, `data-selected`, `data-disabled`, `data-toggle` via `getInteractionDataAttributes`
+- MD3-correct state layers: per-variant overlay color via `--ib-sl` CSS variable, hover 8% / focus-visible 10% / pressed 10% opacity
+- MD3-correct disabled: icon content `text-on-surface/38`; filled/tonal containers collapse to `bg-on-surface/12`; outlined border collapses to `border-on-surface/12`
+- Press shape-morph: `round` shape springs to size-tiered square corners on press via `data-[pressed]:rounded-[var(--ib-radius-press)]` + expressive-fast-spatial easing
+- Toggle-off filled/tonal: correct `surface-container-highest` background per MD3 Flutter spec
+- Slot-based CVA with CSS role variables (`--ib-bg`, `--ib-bg-off`, `--ib-bg-on`, `--ib-fg`, `--ib-fg-off`, `--ib-fg-on`, `--ib-sl`, `--ib-border`, `--ib-radius`, `--ib-radius-press`) for clean variant × state separation
+- New exports: `iconButtonRootVariants`, `iconButtonStateLayerVariants`, `iconButtonIconVariants`, `IconButtonWidth`, `IconButtonShape`

--- a/packages/react/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/react/src/components/IconButton/IconButton.stories.tsx
@@ -2,36 +2,51 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { IconButton } from "./IconButton";
 import React from "react";
 
-// Sample icons for stories (using SVG)
+// ─── Icon helpers ─────────────────────────────────────────────────────────────
+
 const IconDelete = (): React.ReactElement => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
   </svg>
 );
 
 const IconEdit = (): React.ReactElement => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
   </svg>
 );
 
-const IconFavorite = (): React.ReactElement => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-  </svg>
-);
-
 const IconFavoriteOutline = (): React.ReactElement => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M16.5 3c-1.74 0-3.41.81-4.5 2.09C10.91 3.81 9.24 3 7.5 3 4.42 3 2 5.42 2 8.5c0 3.78 3.4 6.86 8.55 11.54L12 21.35l1.45-1.32C18.6 15.36 22 12.28 22 8.5 22 5.42 19.58 3 16.5 3zm-4.4 15.55l-.1.1-.1-.1C7.14 14.24 4 11.39 4 8.5 4 6.5 5.5 5 7.5 5c1.54 0 3.04.99 3.57 2.36h1.87C13.46 5.99 14.96 5 16.5 5c2 0 3.5 1.5 3.5 3.5 0 2.89-3.14 5.74-7.9 10.05z" />
   </svg>
 );
 
+const IconFavoriteFilled = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+  </svg>
+);
+
 const IconClose = (): React.ReactElement => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
   </svg>
 );
+
+const IconSettings = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19.14,12.94c0.04-0.3,0.06-0.61,0.06-0.94c0-0.32-0.02-0.64-0.07-0.94l2.03-1.58c0.18-0.14,0.23-0.41,0.12-0.61 l-1.92-3.32c-0.12-0.22-0.37-0.29-0.59-0.22l-2.39,0.96c-0.5-0.38-1.03-0.7-1.62-0.94L14.4,2.81c-0.04-0.24-0.24-0.41-0.48-0.41 h-3.84c-0.24,0-0.43,0.17-0.47,0.41L9.25,5.35C8.66,5.59,8.12,5.92,7.63,6.29L5.24,5.33c-0.22-0.08-0.47,0-0.59,0.22L2.74,8.87 C2.62,9.08,2.66,9.34,2.86,9.48l2.03,1.58C4.84,11.36,4.8,11.69,4.8,12s0.02,0.64,0.07,0.94l-2.03,1.58 c-0.18,0.14-0.23,0.41-0.12,0.61l1.92,3.32c0.12,0.22,0.37,0.29,0.59,0.22l2.39-0.96c0.5,0.38,1.03,0.7,1.62,0.94l0.36,2.54 c0.05,0.24,0.24,0.41,0.48,0.41h3.84c0.24,0,0.44-0.17,0.47-0.41l0.36-2.54c0.59-0.24,1.13-0.56,1.62-0.94l2.39,0.96 c0.22,0.08,0.47,0,0.59-0.22l1.92-3.32c0.12-0.22,0.07-0.47-0.12-0.61L19.14,12.94z M12,15.6c-1.98,0-3.6-1.62-3.6-3.6 s1.62-3.6,3.6-3.6s3.6,1.62,3.6,3.6S13.98,15.6,12,15.6z" />
+  </svg>
+);
+
+const IconAdd = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+  </svg>
+);
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
 
 const meta: Meta<typeof IconButton> = {
   title: "Components/IconButton",
@@ -40,8 +55,17 @@ const meta: Meta<typeof IconButton> = {
     layout: "centered",
     docs: {
       description: {
-        component:
-          "Material Design 3 IconButton component with 4 variants and mandatory accessibility support. Icon-only circular buttons for compact actions.",
+        component: `
+Material Design 3 Expressive IconButton.
+
+**Key features:**
+- 5 sizes (xsmall → xlarge), 3 widths (narrow/default/wide), 2 shapes (round/square)
+- Press shape-morph: round shape springs into square corners on press
+- Toggle support with optional \`selectedIcon\`
+- 4 variants × 4 color roles
+- MD3-correct state layers (per-variant overlay color, 8%/10%/10% opacities)
+- MD3-correct disabled (content opacity-38, container on-surface/12)
+        `,
       },
     },
   },
@@ -50,17 +74,27 @@ const meta: Meta<typeof IconButton> = {
     variant: {
       control: "select",
       options: ["standard", "filled", "tonal", "outlined"],
-      description: "Button visual style variant",
+      description: "MD3 button style variant",
     },
     color: {
       control: "select",
       options: ["primary", "secondary", "tertiary", "error"],
-      description: "Color scheme for the button",
+      description: "MD3 color role",
     },
     size: {
       control: "select",
-      options: ["small", "medium", "large"],
-      description: "Button size",
+      options: ["xsmall", "small", "medium", "large", "xlarge"],
+      description: "M3 Expressive 5-tier size (container height)",
+    },
+    width: {
+      control: "select",
+      options: ["narrow", "default", "wide"],
+      description: "Container width relative to height",
+    },
+    shape: {
+      control: "select",
+      options: ["round", "square"],
+      description: "Corner shape (round = circular; square = tiered MD3 radius)",
     },
     isDisabled: {
       control: "boolean",
@@ -68,7 +102,7 @@ const meta: Meta<typeof IconButton> = {
     },
     selected: {
       control: "boolean",
-      description: "Toggle selected state",
+      description: "Toggle selected state (enables toggle behaviour when defined)",
     },
     disableRipple: {
       control: "boolean",
@@ -80,158 +114,251 @@ const meta: Meta<typeof IconButton> = {
 export default meta;
 type Story = StoryObj<typeof IconButton>;
 
-// Default Story
+// ─── Default ──────────────────────────────────────────────────────────────────
+
 export const Default: Story = {
   args: {
     "aria-label": "Delete",
     variant: "standard",
     color: "primary",
     size: "medium",
+    width: "default",
+    shape: "round",
     children: <IconDelete />,
   },
 };
 
-// Variants
-export const Standard: Story = {
-  args: {
-    "aria-label": "Delete",
-    variant: "standard",
-    children: <IconDelete />,
-  },
-};
+// ─── Variants ─────────────────────────────────────────────────────────────────
 
-export const Filled: Story = {
-  args: {
-    "aria-label": "Favorite",
-    variant: "filled",
-    children: <IconFavorite />,
-  },
-};
-
-export const Tonal: Story = {
-  args: {
-    "aria-label": "Edit",
-    variant: "tonal",
-    children: <IconEdit />,
-  },
-};
-
-export const Outlined: Story = {
-  args: {
-    "aria-label": "Close",
-    variant: "outlined",
-    children: <IconClose />,
-  },
-};
-
-// All Variants Showcase
-export const AllVariants: Story = {
+export const Variants: Story = {
   render: () => (
-    <div className="flex flex-col gap-4">
-      <IconButton aria-label="Delete" variant="standard">
+    <div className="flex items-center gap-4">
+      <IconButton aria-label="Standard" variant="standard">
         <IconDelete />
       </IconButton>
-      <IconButton aria-label="Favorite" variant="filled">
-        <IconFavorite />
+      <IconButton aria-label="Filled" variant="filled">
+        <IconFavoriteFilled />
       </IconButton>
-      <IconButton aria-label="Edit" variant="tonal">
+      <IconButton aria-label="Tonal" variant="tonal">
         <IconEdit />
       </IconButton>
-      <IconButton aria-label="Close" variant="outlined">
+      <IconButton aria-label="Outlined" variant="outlined">
         <IconClose />
       </IconButton>
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story: "All four MD3 icon button variants: standard, filled, tonal, outlined.",
+      },
+    },
+  },
 };
 
-// Colors
+// ─── Colors ───────────────────────────────────────────────────────────────────
+
 export const Colors: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
-      <div className="flex gap-2">
-        <IconButton aria-label="Primary" color="primary">
-          <IconFavorite />
-        </IconButton>
-        <IconButton aria-label="Secondary" color="secondary">
-          <IconFavorite />
-        </IconButton>
-        <IconButton aria-label="Tertiary" color="tertiary">
-          <IconFavorite />
-        </IconButton>
-        <IconButton aria-label="Error" color="error">
-          <IconFavorite />
-        </IconButton>
-      </div>
-      <div className="flex gap-2">
-        <IconButton aria-label="Primary" variant="filled" color="primary">
-          <IconFavorite />
-        </IconButton>
-        <IconButton aria-label="Secondary" variant="filled" color="secondary">
-          <IconFavorite />
-        </IconButton>
-        <IconButton aria-label="Tertiary" variant="filled" color="tertiary">
-          <IconFavorite />
-        </IconButton>
-        <IconButton aria-label="Error" variant="filled" color="error">
-          <IconFavorite />
-        </IconButton>
-      </div>
+      {(["standard", "filled", "tonal", "outlined"] as const).map((variant) => (
+        <div key={variant} className="flex items-center gap-2">
+          {(["primary", "secondary", "tertiary", "error"] as const).map((color) => (
+            <IconButton
+              key={color}
+              aria-label={`${variant} ${color}`}
+              variant={variant}
+              color={color}
+            >
+              <IconFavoriteFilled />
+            </IconButton>
+          ))}
+        </div>
+      ))}
     </div>
   ),
+  parameters: {
+    docs: {
+      description: { story: "All variant × color combinations (4 × 4 = 16 buttons)." },
+    },
+  },
 };
 
-// Sizes
+// ─── Sizes ────────────────────────────────────────────────────────────────────
+
 export const Sizes: Story = {
   render: () => (
     <div className="flex items-end gap-4">
-      <IconButton aria-label="Small" size="small">
-        <IconFavorite />
-      </IconButton>
-      <IconButton aria-label="Medium" size="medium">
-        <IconFavorite />
-      </IconButton>
-      <IconButton aria-label="Large" size="large">
-        <IconFavorite />
-      </IconButton>
+      {(["xsmall", "small", "medium", "large", "xlarge"] as const).map((size) => (
+        <div key={size} className="flex flex-col items-center gap-2">
+          <IconButton aria-label={size} variant="filled" size={size}>
+            <IconSettings />
+          </IconButton>
+          <span className="text-label-small text-on-surface-variant">{size}</span>
+        </div>
+      ))}
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "M3 Expressive 5-tier sizes: xsmall (32dp), small (40dp), medium (56dp), large (96dp), xlarge (136dp).",
+      },
+    },
+  },
 };
 
-// States
-export const Disabled: Story = {
+// ─── Widths ───────────────────────────────────────────────────────────────────
+
+export const Widths: Story = {
   render: () => (
-    <div className="flex gap-4">
-      <IconButton aria-label="Delete" isDisabled>
-        <IconDelete />
-      </IconButton>
-      <IconButton aria-label="Favorite" variant="filled" isDisabled>
-        <IconFavorite />
-      </IconButton>
-      <IconButton aria-label="Edit" variant="tonal" isDisabled>
-        <IconEdit />
-      </IconButton>
-      <IconButton aria-label="Close" variant="outlined" isDisabled>
-        <IconClose />
-      </IconButton>
+    <div className="flex flex-col gap-6">
+      {(["xsmall", "small", "medium", "large"] as const).map((size) => (
+        <div key={size} className="flex items-center gap-3">
+          <span className="text-label-small text-on-surface-variant w-14">{size}</span>
+          {(["narrow", "default", "wide"] as const).map((width) => (
+            <div key={width} className="flex flex-col items-center gap-1">
+              <IconButton aria-label={`${size} ${width}`} variant="tonal" size={size} width={width}>
+                <IconAdd />
+              </IconButton>
+              <span className="text-label-small text-on-surface-variant">{width}</span>
+            </div>
+          ))}
+        </div>
+      ))}
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Width variants adjust container width: narrow (slimmer), default (square), wide (wider than height).",
+      },
+    },
+  },
 };
 
-// Toggle Button
+// ─── Shapes ───────────────────────────────────────────────────────────────────
+
+export const Shapes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {(["filled", "tonal", "outlined"] as const).map((variant) => (
+        <div key={variant} className="flex items-center gap-4">
+          <span className="text-label-small text-on-surface-variant w-16">{variant}</span>
+          <div className="flex items-center gap-3">
+            <div className="flex flex-col items-center gap-1">
+              <IconButton aria-label={`${variant} round`} variant={variant} shape="round">
+                <IconSettings />
+              </IconButton>
+              <span className="text-label-small text-on-surface-variant">round</span>
+            </div>
+            <div className="flex flex-col items-center gap-1">
+              <IconButton aria-label={`${variant} square`} variant={variant} shape="square">
+                <IconSettings />
+              </IconButton>
+              <span className="text-label-small text-on-surface-variant">square</span>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shape variants: `round` = circular; `square` = size-tiered corner radius (12/16/28dp per size).",
+      },
+    },
+  },
+};
+
+// ─── Press Shape Morph ────────────────────────────────────────────────────────
+
+export const ShapeMorphDemo: Story = {
+  render: () => (
+    <div className="flex flex-col items-center gap-4">
+      <p className="text-body-medium text-on-surface-variant">
+        Press and hold each button to see the shape morph.
+      </p>
+      <div className="flex items-end gap-4">
+        {(["xsmall", "small", "medium", "large"] as const).map((size) => (
+          <div key={size} className="flex flex-col items-center gap-2">
+            <IconButton aria-label={`${size} morph`} variant="filled" size={size} shape="round">
+              <IconAdd />
+            </IconButton>
+            <span className="text-label-small text-on-surface-variant">{size}</span>
+          </div>
+        ))}
+      </div>
+      <p className="text-body-small text-on-surface-variant max-w-xs text-center">
+        Round shape springs into square corners (MD3 Expressive press morph). Square shape has no
+        morph.
+      </p>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "M3 Expressive press shape-morph: the circular container morphs to the size-tiered square corner radius on press, then springs back. Driven by CSS `data-[pressed]:rounded-[var(--ib-radius-press)]` and expressive-fast-spatial easing.",
+      },
+    },
+  },
+};
+
+// ─── Toggle ───────────────────────────────────────────────────────────────────
+
+const ToggleVariant = ({
+  variant,
+}: {
+  variant: "standard" | "filled" | "tonal" | "outlined";
+}): React.ReactElement => {
+  const [sel, setSel] = React.useState(false);
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <IconButton
+        aria-label={sel ? "Remove favorite" : "Add favorite"}
+        variant={variant}
+        selected={sel}
+        onPress={() => setSel(!sel)}
+        selectedIcon={<IconFavoriteFilled />}
+      >
+        <IconFavoriteOutline />
+      </IconButton>
+      <span className="text-label-small text-on-surface-variant">{variant}</span>
+    </div>
+  );
+};
+
 const ToggleExample = (): React.ReactElement => {
   const [isFavorite, setIsFavorite] = React.useState(false);
 
   return (
-    <div className="flex flex-col items-center gap-4">
-      <IconButton
-        aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
-        variant="standard"
-        selected={isFavorite}
-        onPress={() => setIsFavorite(!isFavorite)}
-      >
-        {isFavorite ? <IconFavorite /> : <IconFavoriteOutline />}
-      </IconButton>
-      <p className="text-sm">{isFavorite ? "Favorited" : "Not favorited"}</p>
+    <div className="flex flex-col items-center gap-6">
+      <div className="flex items-end gap-4">
+        <ToggleVariant variant="standard" />
+        <ToggleVariant variant="filled" />
+        <ToggleVariant variant="tonal" />
+        <ToggleVariant variant="outlined" />
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <IconButton
+          aria-label={isFavorite ? "Remove favorite" : "Add favorite"}
+          variant="filled"
+          size="large"
+          selected={isFavorite}
+          onPress={() => setIsFavorite(!isFavorite)}
+          selectedIcon={<IconFavoriteFilled />}
+        >
+          <IconFavoriteOutline />
+        </IconButton>
+        <span className="text-body-medium text-on-surface-variant">
+          {isFavorite ? "Favorited" : "Not favorited"}
+        </span>
+      </div>
     </div>
   );
 };
@@ -242,29 +369,148 @@ export const Toggle: Story = {
     docs: {
       description: {
         story:
-          "IconButton supports toggle mode with the `selected` prop. Use aria-pressed for accessibility. Change the icon based on state for better UX.",
+          "Toggle behaviour is activated by passing the `selected` prop (even as `false`). Provide `selectedIcon` to swap the icon on selection. `aria-pressed` is set automatically.",
       },
     },
   },
 };
 
-// Interactive Example
-const InteractiveExample = (): React.ReactElement => {
+// ─── States ───────────────────────────────────────────────────────────────────
+
+export const States: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      {/* Enabled */}
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">Enabled</p>
+        <div className="flex items-center gap-3">
+          {(["standard", "filled", "tonal", "outlined"] as const).map((v) => (
+            <IconButton key={v} aria-label={v} variant={v}>
+              <IconDelete />
+            </IconButton>
+          ))}
+        </div>
+      </div>
+
+      {/* Disabled */}
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">Disabled</p>
+        <div className="flex items-center gap-3">
+          {(["standard", "filled", "tonal", "outlined"] as const).map((v) => (
+            <IconButton key={v} aria-label={v} variant={v} isDisabled>
+              <IconDelete />
+            </IconButton>
+          ))}
+        </div>
+      </div>
+
+      {/* Selected */}
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">Selected (toggle ON)</p>
+        <div className="flex items-center gap-3">
+          {(["standard", "filled", "tonal", "outlined"] as const).map((v) => (
+            <IconButton
+              key={v}
+              aria-label={v}
+              variant={v}
+              selected
+              selectedIcon={<IconFavoriteFilled />}
+            >
+              <IconFavoriteOutline />
+            </IconButton>
+          ))}
+        </div>
+      </div>
+
+      {/* Toggle unselected */}
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">
+          Toggle unselected (filled/tonal toggle-off uses surface-container-highest)
+        </p>
+        <div className="flex items-center gap-3">
+          {(["standard", "filled", "tonal", "outlined"] as const).map((v) => (
+            <IconButton
+              key={v}
+              aria-label={v}
+              variant={v}
+              selected={false}
+              selectedIcon={<IconFavoriteFilled />}
+            >
+              <IconFavoriteOutline />
+            </IconButton>
+          ))}
+        </div>
+      </div>
+
+      {/* Disabled + selected */}
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">Disabled + selected</p>
+        <div className="flex items-center gap-3">
+          {(["standard", "filled", "tonal", "outlined"] as const).map((v) => (
+            <IconButton
+              key={v}
+              aria-label={v}
+              variant={v}
+              selected
+              isDisabled
+              selectedIcon={<IconFavoriteFilled />}
+            >
+              <IconFavoriteOutline />
+            </IconButton>
+          ))}
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All interaction states: enabled, disabled, selected (toggle ON), toggle unselected, disabled+selected.",
+      },
+    },
+  },
+};
+
+// ─── Playground ───────────────────────────────────────────────────────────────
+
+export const Playground: Story = {
+  args: {
+    "aria-label": "Icon button",
+    children: <IconFavoriteFilled />,
+    variant: "filled",
+    color: "primary",
+    size: "medium",
+    width: "default",
+    shape: "round",
+    isDisabled: false,
+    disableRipple: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Explore all props interactively via the Controls panel.",
+      },
+    },
+  },
+};
+
+// ─── Interactive ──────────────────────────────────────────────────────────────
+
+const CounterExample = (): React.ReactElement => {
   const [count, setCount] = React.useState(0);
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <p className="text-lg">Clicks: {count}</p>
+      <p className="text-headline-small text-on-surface">Clicks: {count}</p>
       <div className="flex gap-2">
         <IconButton
           aria-label="Add one"
           variant="filled"
           color="primary"
-          onPress={() => setCount(count + 1)}
+          onPress={() => setCount((c) => c + 1)}
         >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-          </svg>
+          <IconAdd />
         </IconButton>
         <IconButton
           aria-label="Reset"
@@ -273,9 +519,7 @@ const InteractiveExample = (): React.ReactElement => {
           onPress={() => setCount(0)}
           isDisabled={count === 0}
         >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z" />
-          </svg>
+          <IconClose />
         </IconButton>
       </div>
     </div>
@@ -283,26 +527,5 @@ const InteractiveExample = (): React.ReactElement => {
 };
 
 export const Interactive: Story = {
-  render: () => <InteractiveExample />,
-};
-
-// Playground
-export const Playground: Story = {
-  args: {
-    "aria-label": "Icon button",
-    children: <IconFavorite />,
-    variant: "standard",
-    color: "primary",
-    size: "medium",
-    selected: false,
-    isDisabled: false,
-    disableRipple: false,
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: "Play around with all the icon button props to see how they work together.",
-      },
-    },
-  },
+  render: () => <CounterExample />,
 };

--- a/packages/react/src/components/IconButton/IconButton.test.tsx
+++ b/packages/react/src/components/IconButton/IconButton.test.tsx
@@ -12,6 +12,7 @@ import { isKeyboardAccessible, hasAccessibleLabel } from "../../../test/helpers"
 // Mock icons for testing
 const IconDelete = (): React.ReactElement => <svg data-testid="icon-delete" />;
 const IconFavorite = (): React.ReactElement => <svg data-testid="icon-favorite" />;
+const IconFavoriteSelected = (): React.ReactElement => <svg data-testid="icon-favorite-selected" />;
 const IconEdit = (): React.ReactElement => <svg data-testid="icon-edit" />;
 
 describe("IconButton", () => {
@@ -42,7 +43,7 @@ describe("IconButton", () => {
         </IconButton>
       );
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-transparent");
+      expect(button).toHaveAttribute("data-variant", "standard");
     });
 
     test("renders filled variant", () => {
@@ -51,8 +52,7 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-primary", "text-on-primary");
+      expect(screen.getByRole("button")).toHaveAttribute("data-variant", "filled");
     });
 
     test("renders tonal variant", () => {
@@ -61,8 +61,7 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-secondary-container", "text-on-secondary-container");
+      expect(screen.getByRole("button")).toHaveAttribute("data-variant", "tonal");
     });
 
     test("renders outlined variant", () => {
@@ -71,8 +70,7 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-transparent", "border", "border-outline");
+      expect(screen.getByRole("button")).toHaveAttribute("data-variant", "outlined");
     });
 
     test("renders with primary color", () => {
@@ -81,8 +79,7 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-primary");
+      expect(screen.getByRole("button")).toHaveAttribute("data-color", "primary");
     });
 
     test("renders with secondary color", () => {
@@ -91,8 +88,7 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-secondary");
+      expect(screen.getByRole("button")).toHaveAttribute("data-color", "secondary");
     });
 
     test("renders with tertiary color", () => {
@@ -101,8 +97,7 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-tertiary");
+      expect(screen.getByRole("button")).toHaveAttribute("data-color", "tertiary");
     });
 
     test("renders with error color", () => {
@@ -111,48 +106,19 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-error");
+      expect(screen.getByRole("button")).toHaveAttribute("data-color", "error");
     });
 
-    test("renders small size", () => {
-      render(
-        <IconButton aria-label="Delete" size="small">
-          <IconDelete />
-        </IconButton>
-      );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("h-8", "w-8"); // 32px
-    });
-
-    test("renders medium size by default", () => {
+    test("renders with circular shape by default", () => {
       render(
         <IconButton aria-label="Delete">
           <IconDelete />
         </IconButton>
       );
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("h-10", "w-10"); // 40px
-    });
-
-    test("renders large size", () => {
-      render(
-        <IconButton aria-label="Delete" size="large">
-          <IconDelete />
-        </IconButton>
-      );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("h-12", "w-12"); // 48px
-    });
-
-    test("renders with circular shape", () => {
-      render(
-        <IconButton aria-label="Delete">
-          <IconDelete />
-        </IconButton>
-      );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("rounded-full");
+      // Round shape uses CSS variable [--ib-radius:9999px] rather than rounded-full
+      expect(button).toHaveAttribute("data-shape", "round");
+      expect(button.className).toContain("[--ib-radius:9999px]");
     });
 
     test("merges custom className", () => {
@@ -161,8 +127,7 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("custom-class");
+      expect(screen.getByRole("button")).toHaveClass("custom-class");
     });
 
     test("applies title attribute", () => {
@@ -171,13 +136,130 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
+      expect(screen.getByRole("button")).toHaveAttribute("title", "Delete item");
+    });
+
+    test("renders state layer span", () => {
+      render(
+        <IconButton aria-label="Delete">
+          <IconDelete />
+        </IconButton>
+      );
       const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("title", "Delete item");
+      expect(button.querySelector("[data-state-layer]")).toBeInTheDocument();
+    });
+
+    test("renders icon slot span", () => {
+      render(
+        <IconButton aria-label="Delete">
+          <IconDelete />
+        </IconButton>
+      );
+      const button = screen.getByRole("button");
+      expect(button.querySelector("[data-icon-slot]")).toBeInTheDocument();
     });
   });
 
-  describe("States", () => {
-    test("handles disabled state", () => {
+  describe("Sizes — M3 Expressive 5-tier", () => {
+    test("renders xsmall size", () => {
+      render(
+        <IconButton aria-label="Delete" size="xsmall">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).toHaveAttribute("data-size", "xsmall");
+    });
+
+    test("renders small size", () => {
+      render(
+        <IconButton aria-label="Delete" size="small">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).toHaveAttribute("data-size", "small");
+    });
+
+    test("renders medium size by default", () => {
+      render(
+        <IconButton aria-label="Delete">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).toHaveAttribute("data-size", "medium");
+    });
+
+    test("renders large size", () => {
+      render(
+        <IconButton aria-label="Delete" size="large">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).toHaveAttribute("data-size", "large");
+    });
+
+    test("renders xlarge size", () => {
+      render(
+        <IconButton aria-label="Delete" size="xlarge">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).toHaveAttribute("data-size", "xlarge");
+    });
+  });
+
+  describe("Width variants", () => {
+    test("renders with default width by default", () => {
+      render(
+        <IconButton aria-label="Delete">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).toHaveAttribute("data-width", "default");
+    });
+
+    test("renders with narrow width", () => {
+      render(
+        <IconButton aria-label="Delete" width="narrow">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).toHaveAttribute("data-width", "narrow");
+    });
+
+    test("renders with wide width", () => {
+      render(
+        <IconButton aria-label="Delete" width="wide">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).toHaveAttribute("data-width", "wide");
+    });
+  });
+
+  describe("Shape variants", () => {
+    test("renders with round shape by default", () => {
+      render(
+        <IconButton aria-label="Delete">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).toHaveAttribute("data-shape", "round");
+    });
+
+    test("renders with square shape", () => {
+      render(
+        <IconButton aria-label="Delete" shape="square">
+          <IconDelete />
+        </IconButton>
+      );
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("data-shape", "square");
+      expect(button).not.toHaveClass("rounded-full");
+    });
+  });
+
+  describe("Interaction state attributes", () => {
+    test("sets data-disabled when disabled", () => {
       render(
         <IconButton aria-label="Delete" isDisabled>
           <IconDelete />
@@ -185,21 +267,19 @@ describe("IconButton", () => {
       );
       const button = screen.getByRole("button");
       expect(button).toBeDisabled();
-      expect(button).toHaveClass("opacity-38", "pointer-events-none");
+      expect(button).toHaveAttribute("data-disabled", "");
     });
 
-    test("renders unselected state by default", () => {
+    test("does not set data-disabled when enabled", () => {
       render(
-        <IconButton aria-label="Favorite">
-          <IconFavorite />
+        <IconButton aria-label="Delete">
+          <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      // When selected is not provided, aria-pressed should not be set
-      expect(button).not.toHaveAttribute("aria-pressed");
+      expect(screen.getByRole("button")).not.toHaveAttribute("data-disabled");
     });
 
-    test("renders selected state", () => {
+    test("sets data-selected when selected is true", () => {
       render(
         <IconButton aria-label="Favorite" selected>
           <IconFavorite />
@@ -207,9 +287,10 @@ describe("IconButton", () => {
       );
       const button = screen.getByRole("button");
       expect(button).toHaveAttribute("aria-pressed", "true");
+      expect(button).toHaveAttribute("data-selected", "");
     });
 
-    test("renders unselected state explicitly", () => {
+    test("does not set data-selected when selected is false", () => {
       render(
         <IconButton aria-label="Favorite" selected={false}>
           <IconFavorite />
@@ -217,36 +298,75 @@ describe("IconButton", () => {
       );
       const button = screen.getByRole("button");
       expect(button).toHaveAttribute("aria-pressed", "false");
+      expect(button).not.toHaveAttribute("data-selected");
     });
 
-    test("applies selected styles for standard variant", () => {
+    test("sets data-toggle when selected prop is defined", () => {
       render(
-        <IconButton aria-label="Favorite" variant="standard" selected>
+        <IconButton aria-label="Favorite" selected={false}>
           <IconFavorite />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("text-primary");
+      expect(screen.getByRole("button")).toHaveAttribute("data-toggle", "");
     });
 
-    test("applies selected styles for filled variant", () => {
+    test("does not set data-toggle when selected prop is undefined", () => {
       render(
-        <IconButton aria-label="Favorite" variant="filled" color="primary" selected>
+        <IconButton aria-label="Delete">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).not.toHaveAttribute("data-toggle");
+      expect(screen.getByRole("button")).not.toHaveAttribute("aria-pressed");
+    });
+  });
+
+  describe("Toggle behaviour", () => {
+    test("shows selectedIcon when selected is true", () => {
+      render(
+        <IconButton aria-label="Favorite" selected selectedIcon={<IconFavoriteSelected />}>
           <IconFavorite />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-primary-container", "text-on-primary-container");
+      expect(screen.getByTestId("icon-favorite-selected")).toBeInTheDocument();
+      expect(screen.queryByTestId("icon-favorite")).not.toBeInTheDocument();
     });
 
-    test("applies selected styles for outlined variant", () => {
+    test("shows children icon when selected is false", () => {
       render(
-        <IconButton aria-label="Favorite" variant="outlined" selected>
+        <IconButton aria-label="Favorite" selected={false} selectedIcon={<IconFavoriteSelected />}>
           <IconFavorite />
         </IconButton>
       );
+      expect(screen.getByTestId("icon-favorite")).toBeInTheDocument();
+      expect(screen.queryByTestId("icon-favorite-selected")).not.toBeInTheDocument();
+    });
+
+    test("supports controlled toggle behavior", async () => {
+      const user = userEvent.setup();
+      const TestComponent = (): React.ReactElement => {
+        const [selected, setSelected] = React.useState(false);
+        return (
+          <IconButton
+            aria-label={selected ? "Remove favorite" : "Add favorite"}
+            selected={selected}
+            onPress={() => setSelected(!selected)}
+            selectedIcon={<IconFavoriteSelected />}
+          >
+            <IconFavorite />
+          </IconButton>
+        );
+      };
+
+      render(<TestComponent />);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-inverse-surface", "text-inverse-on-surface");
+      expect(button).toHaveAttribute("aria-pressed", "false");
+
+      await user.click(button);
+      expect(button).toHaveAttribute("aria-pressed", "true");
+
+      await user.click(button);
+      expect(button).toHaveAttribute("aria-pressed", "false");
     });
   });
 
@@ -332,31 +452,19 @@ describe("IconButton", () => {
       expect(button).toHaveFocus();
     });
 
-    test("supports toggle behavior", async () => {
+    test("handles rapid clicks", async () => {
       const user = userEvent.setup();
-      const TestComponent = (): React.ReactElement => {
-        const [selected, setSelected] = React.useState(false);
-        return (
-          <IconButton
-            aria-label={selected ? "Remove favorite" : "Add favorite"}
-            selected={selected}
-            onPress={() => setSelected(!selected)}
-          >
-            <IconFavorite />
-          </IconButton>
-        );
-      };
+      const onPress = vi.fn();
 
-      render(<TestComponent />);
+      render(
+        <IconButton aria-label="Delete" onPress={onPress}>
+          <IconDelete />
+        </IconButton>
+      );
 
       const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("aria-pressed", "false");
-
-      await user.click(button);
-      expect(button).toHaveAttribute("aria-pressed", "true");
-
-      await user.click(button);
-      expect(button).toHaveAttribute("aria-pressed", "false");
+      await user.tripleClick(button);
+      expect(onPress).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -377,8 +485,7 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveAccessibleName("Delete");
+      expect(screen.getByRole("button")).toHaveAccessibleName("Delete");
     });
 
     test("supports aria-pressed for toggle buttons", () => {
@@ -387,8 +494,16 @@ describe("IconButton", () => {
           <IconFavorite />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+    });
+
+    test("does not set aria-pressed when not a toggle button", () => {
+      render(
+        <IconButton aria-label="Delete">
+          <IconDelete />
+        </IconButton>
+      );
+      expect(screen.getByRole("button")).not.toHaveAttribute("aria-pressed");
     });
 
     test("has proper button role", () => {
@@ -400,24 +515,13 @@ describe("IconButton", () => {
       expect(screen.getByRole("button")).toBeInTheDocument();
     });
 
-    test("includes icon in accessibility tree", () => {
-      render(
-        <IconButton aria-label="Delete item">
-          <IconDelete />
-        </IconButton>
-      );
-      // Icon should be present but decorative (label comes from aria-label)
-      expect(screen.getByTestId("icon-delete")).toBeInTheDocument();
-    });
-
-    test("disabled button has aria-disabled", () => {
+    test("disabled button is properly disabled", () => {
       render(
         <IconButton aria-label="Delete" isDisabled>
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("disabled");
+      expect(screen.getByRole("button")).toHaveAttribute("disabled");
     });
   });
 
@@ -428,9 +532,9 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-
-      const button = screen.getByRole("button");
-      expect(button.querySelector("[data-ripple-container]")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button").querySelector("[data-ripple-container]")
+      ).toBeInTheDocument();
     });
 
     test("disables ripple when disableRipple is true", () => {
@@ -439,9 +543,9 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-
-      const button = screen.getByRole("button");
-      expect(button.querySelector("[data-ripple-container]")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button").querySelector("[data-ripple-container]")
+      ).not.toBeInTheDocument();
     });
 
     test("does not show ripple when disabled", () => {
@@ -450,9 +554,9 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-
-      const button = screen.getByRole("button");
-      expect(button.querySelector("[data-ripple-container]")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button").querySelector("[data-ripple-container]")
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -463,8 +567,7 @@ describe("IconButton", () => {
           <IconDelete />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("type", "button");
+      expect(screen.getByRole("button")).toHaveAttribute("type", "button");
     });
 
     test("supports submit type", () => {
@@ -473,8 +576,7 @@ describe("IconButton", () => {
           <IconEdit />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("type", "submit");
+      expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
     });
 
     test("supports reset type", () => {
@@ -483,12 +585,11 @@ describe("IconButton", () => {
           <IconEdit />
         </IconButton>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("type", "reset");
+      expect(screen.getByRole("button")).toHaveAttribute("type", "reset");
     });
   });
 
-  describe("Variant Combinations", () => {
+  describe("Variant combinations", () => {
     test("renders all variant and color combinations", () => {
       const variants = ["standard", "filled", "tonal", "outlined"] as const;
       const colors = ["primary", "secondary", "tertiary", "error"] as const;
@@ -505,12 +606,38 @@ describe("IconButton", () => {
       });
     });
 
-    test("renders all size variations", () => {
-      const sizes = ["small", "medium", "large"] as const;
+    test("renders all 5 size variations", () => {
+      const sizes = ["xsmall", "small", "medium", "large", "xlarge"] as const;
 
       sizes.forEach((size) => {
         const { container } = render(
           <IconButton aria-label={`${size} button`} size={size}>
+            <IconDelete />
+          </IconButton>
+        );
+        expect(container.querySelector("button")).toBeInTheDocument();
+      });
+    });
+
+    test("renders all width variations", () => {
+      const widths = ["narrow", "default", "wide"] as const;
+
+      widths.forEach((width) => {
+        const { container } = render(
+          <IconButton aria-label={`${width} button`} width={width}>
+            <IconDelete />
+          </IconButton>
+        );
+        expect(container.querySelector("button")).toBeInTheDocument();
+      });
+    });
+
+    test("renders both shape variations", () => {
+      const shapes = ["round", "square"] as const;
+
+      shapes.forEach((shape) => {
+        const { container } = render(
+          <IconButton aria-label={`${shape} button`} shape={shape}>
             <IconDelete />
           </IconButton>
         );
@@ -525,19 +652,6 @@ describe("IconButton", () => {
       expect(screen.getByRole("button")).toBeInTheDocument();
     });
 
-    test("handles multiple icons (uses last one)", () => {
-      render(
-        <IconButton aria-label="Multiple">
-          <IconDelete />
-          <IconFavorite />
-        </IconButton>
-      );
-      const button = screen.getByRole("button");
-      expect(button).toBeInTheDocument();
-      expect(screen.getByTestId("icon-delete")).toBeInTheDocument();
-      expect(screen.getByTestId("icon-favorite")).toBeInTheDocument();
-    });
-
     test("forwards ref correctly", () => {
       const ref = React.createRef<HTMLButtonElement>();
       render(
@@ -547,68 +661,9 @@ describe("IconButton", () => {
       );
       expect(ref.current).toBeInstanceOf(HTMLButtonElement);
     });
-
-    test("handles rapid clicks", async () => {
-      const user = userEvent.setup();
-      const onPress = vi.fn();
-
-      render(
-        <IconButton aria-label="Delete" onPress={onPress}>
-          <IconDelete />
-        </IconButton>
-      );
-
-      const button = screen.getByRole("button");
-      await user.tripleClick(button);
-      expect(onPress).toHaveBeenCalledTimes(3);
-    });
   });
 
-  describe("Development Warnings", () => {
-    const originalEnv = process.env.NODE_ENV;
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    afterEach(() => {
-      process.env.NODE_ENV = originalEnv;
-      consoleError.mockClear();
-      consoleWarn.mockClear();
-    });
-
-    test("warns when icon is missing in development", () => {
-      process.env.NODE_ENV = "development";
-
-      render(<IconButton aria-label="Empty">{null}</IconButton>);
-
-      expect(consoleWarn).toHaveBeenCalledWith(
-        "[IconButton] IconButton should have an icon as children."
-      );
-    });
-  });
-
-  describe("Axe Accessibility", () => {
-    test("has no accessibility violations", async () => {
-      const { container } = render(
-        <IconButton aria-label="Delete">
-          <IconDelete />
-        </IconButton>
-      );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
-    });
-
-    test("has no accessibility violations when disabled", async () => {
-      const { container } = render(
-        <IconButton aria-label="Delete" isDisabled>
-          <IconDelete />
-        </IconButton>
-      );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
-    });
-  });
-
-  describe("data attributes for ButtonGroup integration", () => {
+  describe("data attributes for styling and ButtonGroup integration", () => {
     test("sets data-variant attribute matching the variant prop", () => {
       render(
         <IconButton aria-label="Test" variant="filled">
@@ -616,33 +671,6 @@ describe("IconButton", () => {
         </IconButton>
       );
       expect(screen.getByRole("button")).toHaveAttribute("data-variant", "filled");
-    });
-
-    test("sets data-variant for standard", () => {
-      render(
-        <IconButton aria-label="Test" variant="standard">
-          <IconDelete />
-        </IconButton>
-      );
-      expect(screen.getByRole("button")).toHaveAttribute("data-variant", "standard");
-    });
-
-    test("sets data-variant for tonal", () => {
-      render(
-        <IconButton aria-label="Test" variant="tonal">
-          <IconDelete />
-        </IconButton>
-      );
-      expect(screen.getByRole("button")).toHaveAttribute("data-variant", "tonal");
-    });
-
-    test("sets data-variant for outlined", () => {
-      render(
-        <IconButton aria-label="Test" variant="outlined">
-          <IconDelete />
-        </IconButton>
-      );
-      expect(screen.getByRole("button")).toHaveAttribute("data-variant", "outlined");
     });
 
     test("sets data-color attribute matching the color prop", () => {
@@ -654,31 +682,31 @@ describe("IconButton", () => {
       expect(screen.getByRole("button")).toHaveAttribute("data-color", "primary");
     });
 
-    test("sets data-color for secondary", () => {
+    test("sets data-size attribute", () => {
       render(
-        <IconButton aria-label="Test" variant="filled" color="secondary">
+        <IconButton aria-label="Test" size="large">
           <IconDelete />
         </IconButton>
       );
-      expect(screen.getByRole("button")).toHaveAttribute("data-color", "secondary");
+      expect(screen.getByRole("button")).toHaveAttribute("data-size", "large");
     });
 
-    test("sets data-color for tertiary", () => {
+    test("sets data-shape attribute", () => {
       render(
-        <IconButton aria-label="Test" variant="filled" color="tertiary">
+        <IconButton aria-label="Test" shape="square">
           <IconDelete />
         </IconButton>
       );
-      expect(screen.getByRole("button")).toHaveAttribute("data-color", "tertiary");
+      expect(screen.getByRole("button")).toHaveAttribute("data-shape", "square");
     });
 
-    test("sets data-color for error", () => {
+    test("sets data-width attribute", () => {
       render(
-        <IconButton aria-label="Test" variant="filled" color="error">
+        <IconButton aria-label="Test" width="wide">
           <IconDelete />
         </IconButton>
       );
-      expect(screen.getByRole("button")).toHaveAttribute("data-color", "error");
+      expect(screen.getByRole("button")).toHaveAttribute("data-width", "wide");
     });
   });
 
@@ -690,7 +718,9 @@ describe("IconButton", () => {
         </IconButton>
       );
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("rounded-full");
+      // Round shape uses CSS variable rather than rounded-full
+      expect(button).toHaveAttribute("data-shape", "round");
+      expect(button.className).toContain("[--ib-radius:9999px]");
       expect(button).not.toHaveClass("rounded-xs");
       expect(button).not.toHaveClass("rounded-sm");
     });
@@ -826,9 +856,63 @@ describe("IconButton", () => {
         </ButtonGroup>
       );
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("rounded-full");
+      // Round shape uses CSS variable rather than rounded-full
+      expect(button).toHaveAttribute("data-shape", "round");
+      expect(button.className).toContain("[--ib-radius:9999px]");
       expect(button).not.toHaveClass("rounded-sm");
       expect(button).not.toHaveClass("min-w-12");
+    });
+  });
+
+  describe("Development Warnings", () => {
+    const originalEnv = process.env.NODE_ENV;
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+      consoleWarn.mockClear();
+    });
+
+    test("warns when icon is missing in development", () => {
+      process.env.NODE_ENV = "development";
+
+      render(<IconButton aria-label="Empty">{null}</IconButton>);
+
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "[IconButton] IconButton should have an icon as children."
+      );
+    });
+  });
+
+  describe("Axe Accessibility", () => {
+    test("has no accessibility violations", async () => {
+      const { container } = render(
+        <IconButton aria-label="Delete">
+          <IconDelete />
+        </IconButton>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations when disabled", async () => {
+      const { container } = render(
+        <IconButton aria-label="Delete" isDisabled>
+          <IconDelete />
+        </IconButton>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations in toggle mode", async () => {
+      const { container } = render(
+        <IconButton aria-label="Favorite" selected={false}>
+          <IconFavorite />
+        </IconButton>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
     });
   });
 });

--- a/packages/react/src/components/IconButton/IconButton.test.tsx
+++ b/packages/react/src/components/IconButton/IconButton.test.tsx
@@ -116,9 +116,9 @@ describe("IconButton", () => {
         </IconButton>
       );
       const button = screen.getByRole("button");
-      // Round shape uses CSS variable [--ib-radius:9999px] rather than rounded-full
+      // Round shape sets --ib-radius to half the container height (medium = 1.75rem = 28px)
       expect(button).toHaveAttribute("data-shape", "round");
-      expect(button.className).toContain("[--ib-radius:9999px]");
+      expect(button.className).toContain("[--ib-radius:1.75rem]");
     });
 
     test("merges custom className", () => {
@@ -718,9 +718,9 @@ describe("IconButton", () => {
         </IconButton>
       );
       const button = screen.getByRole("button");
-      // Round shape uses CSS variable rather than rounded-full
+      // Round shape sets --ib-radius to half the container height (medium = 1.75rem = 28px)
       expect(button).toHaveAttribute("data-shape", "round");
-      expect(button.className).toContain("[--ib-radius:9999px]");
+      expect(button.className).toContain("[--ib-radius:1.75rem]");
       expect(button).not.toHaveClass("rounded-xs");
       expect(button).not.toHaveClass("rounded-sm");
     });
@@ -856,9 +856,9 @@ describe("IconButton", () => {
         </ButtonGroup>
       );
       const button = screen.getByRole("button");
-      // Round shape uses CSS variable rather than rounded-full
+      // Round shape sets --ib-radius to half the container height (medium = 1.75rem = 28px)
       expect(button).toHaveAttribute("data-shape", "round");
-      expect(button.className).toContain("[--ib-radius:9999px]");
+      expect(button.className).toContain("[--ib-radius:1.75rem]");
       expect(button).not.toHaveClass("rounded-sm");
       expect(button).not.toHaveClass("min-w-12");
     });

--- a/packages/react/src/components/IconButton/IconButton.tsx
+++ b/packages/react/src/components/IconButton/IconButton.tsx
@@ -3,7 +3,11 @@
 import { forwardRef } from "react";
 import type React from "react";
 import { IconButtonHeadless } from "./IconButtonHeadless";
-import { iconButtonVariants, type IconButtonVariants } from "./IconButton.variants";
+import {
+  iconButtonRootVariants,
+  iconButtonStateLayerVariants,
+  iconButtonIconVariants,
+} from "./IconButton.variants";
 import { cn } from "../../utils/cn";
 import { useRipple } from "../../hooks/useRipple";
 import { mergeProps } from "@react-aria/utils";
@@ -12,19 +16,27 @@ import { getConnectedRadiusClasses } from "../ButtonGroup/ButtonGroup.utils";
 import type { IconButtonProps } from "./IconButton.types";
 
 /**
- * Material Design 3 IconButton Component
+ * Material Design 3 Expressive — IconButton Component (Layer 3: Styled)
  *
- * Icon-only button component following MD3 specifications.
- * Supports 4 variants, toggle mode, and enforces accessibility.
+ * Built on React Aria for world-class accessibility. Implements the
+ * Variants-vs-States architecture: all interaction/selection states are
+ * expressed as data-* attributes (emitted by IconButtonHeadless) and consumed
+ * by each slot via group-data-[x]/icon-button Tailwind selectors — no state
+ * variants in CVA.
  *
- * **Key Features:**
- * - 4 variants: standard, filled, tonal, outlined
- * - Circular shape (MD3 specification)
- * - Mandatory `aria-label` for accessibility
- * - Toggle support with `selected` prop
- * - Ripple effect on interaction
- * - 48×48px minimum touch target
- * - ButtonGroup-aware: applies connected corner radii and min-width when inside a group
+ * Features:
+ * - ✅ M3 Expressive 5-tier sizes: xsmall, small, medium, large, xlarge
+ * - ✅ 3 width options: narrow, default, wide
+ * - ✅ 2 shapes: round (circular), square (MD3 corner scale)
+ * - ✅ Press shape-morph (round shape springs into square corner on press)
+ * - ✅ 4 variants: standard, filled, tonal, outlined
+ * - ✅ 4 color roles: primary, secondary, tertiary, error
+ * - ✅ Toggle support (selected + selectedIcon)
+ * - ✅ MD3-correct state layer: per-variant color, opacity-8/10/10
+ * - ✅ MD3-correct disabled: content opacity-38 + container on-surface/12
+ * - ✅ Ripple effect on press
+ * - ✅ ButtonGroup-aware: connected corner radii + min-width
+ * - ✅ Mandatory aria-label for accessibility
  *
  * @example
  * ```tsx
@@ -33,45 +45,45 @@ import type { IconButtonProps } from "./IconButton.types";
  *   <IconDelete />
  * </IconButton>
  *
- * // Filled with color
- * <IconButton aria-label="Favorite" variant="filled" color="error">
+ * // Filled with color, large
+ * <IconButton aria-label="Favorite" variant="filled" color="error" size="large">
  *   <IconHeart />
  * </IconButton>
  *
- * // Toggle button
+ * // Toggle button with selectedIcon
  * <IconButton
  *   aria-label={selected ? "Remove favorite" : "Add favorite"}
  *   selected={selected}
  *   onPress={() => setSelected(!selected)}
+ *   selectedIcon={<IconStarFilled />}
  * >
- *   {selected ? <IconStarFilled /> : <IconStarOutline />}
+ *   <IconStarOutline />
  * </IconButton>
  *
- * // Inside a connected ButtonGroup (corner radii applied automatically)
- * <ButtonGroup variant="connected" selectionMode="multi" aria-label="Quick settings">
- *   <IconButton aria-label="Bluetooth"><BluetoothIcon /></IconButton>
- *   <IconButton aria-label="Wi-Fi"><WifiIcon /></IconButton>
- * </ButtonGroup>
+ * // Square shape, wide width
+ * <IconButton aria-label="Menu" shape="square" width="wide" size="medium">
+ *   <IconMenu />
+ * </IconButton>
  * ```
  */
-export const IconButton = forwardRef<
-  HTMLButtonElement,
-  IconButtonProps & Omit<IconButtonVariants, "isDisabled" | "selected">
->(
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     {
-      // Variant props (CVA)
+      // Variant props (CVA / design-time)
       variant = "standard",
       color = "primary",
       size = "medium",
+      width = "default",
+      shape = "round",
       // IconButton specific props
       children,
+      selectedIcon,
       value,
       selected,
       disableRipple = false,
       className,
       // React Aria props
-      isDisabled: propIsDisabled = false,
+      isDisabled = false,
       onPress,
       onMouseDown,
       "aria-label": ariaLabel,
@@ -80,7 +92,7 @@ export const IconButton = forwardRef<
     },
     ref
   ) => {
-    // ButtonGroup context — null when rendered outside a group (safe to call unconditionally)
+    // ButtonGroup context — null when rendered outside a group
     const groupCtx = useOptionalButtonGroup();
     const isConnected = groupCtx?.variant === "connected";
 
@@ -91,21 +103,20 @@ export const IconButton = forwardRef<
           "[IconButton] aria-label is required for IconButton. Icon-only buttons need accessible labels for screen readers."
         );
       }
-
       if (!children) {
         console.warn("[IconButton] IconButton should have an icon as children.");
       }
     }
 
-    // Combine disabled states
-    const isDisabled = propIsDisabled;
+    // Toggle behaviour: `selected` being defined (even as false) signals a toggle button
+    const isToggle = selected !== undefined;
+    const isSelected = isToggle ? (selected ?? false) : false;
 
     // Ripple effect
     const { onMouseDown: handleRipple, ripples } = useRipple({
       disabled: isDisabled || disableRipple,
     });
 
-    // Merge user's onMouseDown with ripple handler
     const mergedOnMouseDown = (e: React.MouseEvent<HTMLButtonElement>): void => {
       onMouseDown?.(e);
       handleRipple(e);
@@ -117,7 +128,7 @@ export const IconButton = forwardRef<
       isDisabled,
     });
 
-    // Connected group radius + min-width overrides (pass value for selection-aware shape morph)
+    // ButtonGroup connected-variant radius + min-width overrides
     const isGroupSelected =
       isConnected && groupCtx && value ? groupCtx.selectedValues.has(value) : false;
 
@@ -129,39 +140,48 @@ export const IconButton = forwardRef<
           ]
         : [];
 
+    // Determine which icon to render
+    const iconNode = isToggle && isSelected && selectedIcon ? selectedIcon : children;
+
     return (
       <IconButtonHeadless
         ref={ref}
         className={cn(
-          // CVA variants — includes btn-transition for asymmetric border-radius easing
-          iconButtonVariants({ variant, color, size, selected: selected ?? false, isDisabled }),
-
-          // Asymmetric border-radius easing: expressive when selected, decelerate when not.
-          // btn-transition-selected overrides --_btn-radius-easing to the bouncy spring while
-          // the button is gaining the pill shape; removal restores decelerate for the return
-          // path, preventing the overshoot-to-0px sharp-corner flash.
+          // Root CVA — sets CSS role variables, dimensions, shape, transitions
+          iconButtonRootVariants({ variant, color, size, width, shape }),
+          // Group scope for child slot selectors
+          "group/icon-button",
+          // ButtonGroup asymmetric border-radius easing (connected selection morph)
           isGroupSelected ? "btn-transition-selected" : "",
-
-          // Connected group overrides: inner radius + start/end outer radius + min-width
+          // Connected group corner radius + min-width overrides
           ...connectedClasses,
-
-          // User custom classes
+          // Consumer custom classes
           className
         )}
         aria-label={ariaLabel}
+        isSelected={isSelected}
+        isToggle={isToggle}
+        // Data attributes for external CSS targeting + Storybook/test assertions
         data-variant={variant}
         data-color={color}
-        // Connected group selection state — mirrors btn-transition-selected for CSS targeting
+        data-size={size}
+        data-width={width}
+        data-shape={shape}
+        // ButtonGroup selection shape-morph targeting
         data-group-selected={isGroupSelected ? "" : undefined}
-        {...(selected !== undefined && { selected })}
         {...(title && { title })}
         {...mergedPropsValue}
       >
+        {/* State layer — hover/focus/pressed opacity ring */}
+        <span className={iconButtonStateLayerVariants()} aria-hidden="true" data-state-layer="" />
+
         {/* Ripple effect */}
         {ripples}
 
-        {/* Icon content */}
-        <span className="relative z-10 inline-flex shrink-0">{children}</span>
+        {/* Icon slot */}
+        <span className={iconButtonIconVariants({ size })} data-icon-slot="" aria-hidden="true">
+          {iconNode}
+        </span>
       </IconButtonHeadless>
     );
   }

--- a/packages/react/src/components/IconButton/IconButton.types.ts
+++ b/packages/react/src/components/IconButton/IconButton.types.ts
@@ -7,27 +7,48 @@ import type React from "react";
 export type IconButtonVariant = "standard" | "filled" | "tonal" | "outlined";
 
 /**
- * Color scheme
+ * Color scheme (MD3 color roles)
  */
 export type IconButtonColor = "primary" | "secondary" | "tertiary" | "error";
 
 /**
- * IconButton sizes (square dimensions)
+ * Icon button sizes — M3 Expressive 5-tier system.
+ *
+ * Container heights (dp → px):
+ * - xsmall: 32dp
+ * - small:  40dp
+ * - medium: 56dp (default)
+ * - large:  96dp
+ * - xlarge: 136dp
  */
-export type IconButtonSize = "small" | "medium" | "large";
+export type IconButtonSize = "xsmall" | "small" | "medium" | "large" | "xlarge";
 
 /**
- * Material Design 3 IconButton Component Props
+ * Width variant — adjusts container width relative to height.
+ * - narrow: narrower than height
+ * - default: same width as height (square container)
+ * - wide: wider than height
+ */
+export type IconButtonWidth = "narrow" | "default" | "wide";
+
+/**
+ * Shape variant — controls corner rounding.
+ * - round: fully circular (rounded-full)
+ * - square: size-tiered corner radius (MD3 shape scale)
+ */
+export type IconButtonShape = "round" | "square";
+
+/**
+ * Material Design 3 Expressive IconButton Component Props
  *
- * Icon-only button component with 4 variants and mandatory accessibility.
- *
- * **Key Features:**
+ * Icon-only button component following the M3 Expressive spec with:
+ * - 5 sizes: xsmall, small, medium (default), large, xlarge
+ * - 3 width options: narrow, default, wide
+ * - 2 shapes: round (circular), square (corner-radius scale)
+ * - Press shape-morph: corners tighten on press when `shape="round"`
+ * - Toggle support: `selected` + `selectedIcon`
  * - 4 variants: standard, filled, tonal, outlined
- * - Icon only (no text content)
- * - Circular shape (MD3 specification)
  * - Mandatory `aria-label` for accessibility
- * - Toggle support with `selected` prop
- * - 48×48px minimum touch target
  *
  * @example
  * ```tsx
@@ -41,13 +62,19 @@ export type IconButtonSize = "small" | "medium" | "large";
  *   <IconHeart />
  * </IconButton>
  *
- * // Toggle button
+ * // Toggle button with selectedIcon
  * <IconButton
  *   aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
  *   selected={isFavorite}
  *   onPress={() => setIsFavorite(!isFavorite)}
+ *   selectedIcon={<IconStarFilled />}
  * >
- *   {isFavorite ? <IconStarFilled /> : <IconStarOutline />}
+ *   <IconStarOutline />
+ * </IconButton>
+ *
+ * // Large square shape
+ * <IconButton aria-label="Settings" size="large" shape="square">
+ *   <IconSettings />
  * </IconButton>
  *
  * // Disabled
@@ -70,23 +97,53 @@ export interface IconButtonProps extends AriaButtonProps {
   color?: IconButtonColor;
 
   /**
-   * Size variant
+   * Size tier (M3 Expressive 5-tier system)
    * @default 'medium'
    */
   size?: IconButtonSize;
 
   /**
-   * Icon content (React node). Recommended size:
-   * - small: 20×20px
-   * - medium: 24×24px
-   * - large: 28×28px
+   * Container width relative to height.
+   * - `narrow`: slimmer than the container height
+   * - `default`: square container (width = height)
+   * - `wide`: wider than the container height
+   *
+   * @default 'default'
+   */
+  width?: IconButtonWidth;
+
+  /**
+   * Corner shape.
+   * - `round`: fully circular (pill-shaped)
+   * - `square`: size-tiered corner radius from the MD3 shape scale
+   *
+   * Applies a press shape-morph (corners tighten on press, spring back on release).
+   *
+   * @default 'round'
+   */
+  shape?: IconButtonShape;
+
+  /**
+   * Icon content. Recommended icon sizes per container size:
+   * - xsmall: 20×20px
+   * - small / medium: 24×24px
+   * - large: 32×32px
+   * - xlarge: 40×40px
    */
   children: React.ReactNode;
 
   /**
-   * Toggle state (for toggle buttons)
-   * When true, button shows selected state
-   * @default false
+   * Icon to display when `selected` is `true`.
+   * When provided with a `selected` prop the button becomes a toggle button.
+   * If omitted, `children` is shown in both states.
+   */
+  selectedIcon?: React.ReactNode;
+
+  /**
+   * Toggle state.
+   * When defined (even as `false`) the button behaves as a toggle button and
+   * `aria-pressed` is set.
+   * @default undefined
    */
   selected?: boolean;
 
@@ -109,8 +166,8 @@ export interface IconButtonProps extends AriaButtonProps {
   value?: string;
 
   /**
-   * HTML title attribute for tooltip
-   * Recommended for better UX on desktop
+   * HTML title attribute for tooltip.
+   * Recommended for better UX on desktop.
    */
   title?: string;
 
@@ -120,13 +177,13 @@ export interface IconButtonProps extends AriaButtonProps {
   onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 
   /**
-   * REQUIRED: Accessible label for screen readers
-   * Since IconButton has no visible text, this is mandatory
+   * REQUIRED: Accessible label for screen readers.
+   * Since IconButton has no visible text, this is mandatory.
    *
    * @example
    * aria-label="Delete item"
    * aria-label="Add to favorites"
    * aria-label="Close dialog"
    */
-  "aria-label": string; // Make it required by removing the optional marker
+  "aria-label": string;
 }

--- a/packages/react/src/components/IconButton/IconButton.variants.ts
+++ b/packages/react/src/components/IconButton/IconButton.variants.ts
@@ -1,50 +1,153 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 IconButton Variants (CVA)
+ * Material Design 3 Expressive — IconButton Variants (slot-based CVA)
  *
- * Type-safe variant management for IconButton component.
- * Uses Tailwind CSS classes mapped to MD3 design tokens.
+ * Architecture: Variants vs States
+ * ─────────────────────────────────
+ * - CVA holds design-time choices only (variant, color, size, width, shape).
+ * - All interaction/selection states are driven by data-* attributes on the
+ *   root via group-data-[x]/icon-button Tailwind selectors in each slot's base
+ *   classes — no state variants in CVA.
+ * - compoundVariants = variant × color (and size × shape) only.
  *
- * Key differences from Button:
- * - Circular shape (not pill-shaped)
- * - Fixed square dimensions
- * - No text content support
- * - 'standard' variant instead of 'elevated'
+ * CSS role-variable technique
+ * ────────────────────────────
+ * Per-variant colors are set as CSS custom properties via compoundVariants so
+ * the state selectors in base classes only need to read the variable — they
+ * never need to know the current variant/color.
+ *
+ *   --ib-bg            container background (at rest, non-toggleable)
+ *   --ib-bg-off        container background when toggleable + unselected
+ *   --ib-bg-on         container background when selected
+ *   --ib-fg            icon/text color (at rest)
+ *   --ib-fg-off        icon/text color when toggleable + unselected
+ *   --ib-fg-on         icon/text color when selected
+ *   --ib-sl            state layer color
+ *   --ib-border        border color (outlined unselected)
+ *   --ib-radius        corner radius at rest
+ *   --ib-radius-press  corner radius when pressed (shape-morph)
+ *
+ * Slot responsibilities
+ * ──────────────────────
+ *   iconButtonRootVariants      — root button; carries group/icon-button, cursor,
+ *                                 overflow, corner radius + transitions, min touch target
+ *   iconButtonStateLayerVariants — hover/focus/pressed opacity ring (absolute overlay)
+ *   iconButtonIconVariants       — icon wrapper; color + size only
+ *
+ * M3 Expressive Sizes (container height × icon size)
+ * ───────────────────────────────────────────────────
+ *   xsmall:  32dp / 20dp icon   → h-8  / icon size-5
+ *   small:   40dp / 24dp icon   → h-10 / icon size-6
+ *   medium:  56dp / 24dp icon   → h-14 / icon size-6  (default)
+ *   large:   96dp / 32dp icon   → h-24 / icon size-8
+ *   xlarge: 136dp / 40dp icon   → h-34 / icon size-10
+ *
+ * Width variants (narrow / default / wide) adjust container width per size:
+ *   xsmall:  narrow 24dp / default 32dp / wide 40dp
+ *   small:   narrow 32dp / default 40dp / wide 52dp
+ *   medium:  narrow 48dp / default 56dp / wide 72dp
+ *   large:   narrow 72dp / default 96dp / wide 128dp
+ *   xlarge: narrow 96dp / default 136dp / wide 168dp
+ *
+ * Shape:
+ *   round  → rounded-full  (press morphs to size-tiered corner)
+ *   square → size-tiered corner at rest (no morph)
+ *
+ * Press shape morph (round only): on data-[pressed] the radius shrinks to the
+ * same scale as the square shape for that size, giving the Expressive spring feel.
+ * Driven by [--ib-radius-press] CSS variable consumed by the root.
+ *
+ * MD3 state-layer opacities:
+ *   hover        opacity-8  (8%)
+ *   focus-visible opacity-10 (10%)
+ *   pressed      opacity-10 (10%)
+ *   disabled container  bg-on-surface/12
+ *   disabled content    text-on-surface/38
  */
-export const iconButtonVariants = cva(
-  [
-    // Base classes (always applied)
-    "relative inline-flex items-center justify-center cursor-pointer",
-    "overflow-hidden rounded-full", // Circular shape
-    // Split MD3 transition: btn-transition handles spatial (border-radius) with asymmetric
-    // easing (decelerate by default, switched to expressive via btn-transition-selected when
-    // the button is group-selected) and effects (color/bg/shadow) with standard spring.
-    "btn-transition",
-    "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
 
-    // State layers — effects token: opacity only, no overshoot (separate ::before pseudo-element)
-    "before:absolute before:inset-0 before:rounded-[inherit]",
-    "before:transition-opacity before:duration-spring-standard-fast-effects before:ease-spring-standard-fast-effects",
-    "before:bg-current before:opacity-0",
-    "hover:before:opacity-8",
-    "focus-visible:before:opacity-12",
-    "active:before:opacity-12",
+// ─── SHAPE CORNER RADIUS LOOKUP ───────────────────────────────────────────────
+// MD3 square shape corner radii per size tier:
+//   xsmall / small: 12dp → rounded-xl (not in theme — use rounded-md = 12px)
+//   medium:         16dp → rounded-lg
+//   large / xlarge: 28dp → rounded-xl
+// Press morph target for round shape matches the square radius for that size.
+
+// ─── ROOT ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Root button element.
+ *
+ * Carries:
+ * - `group/icon-button` for child slot selectors
+ * - Container dimensions (height × width per size × width-variant)
+ * - Corner radius via --ib-radius CSS variable + shape-morph on press
+ * - Background, border, text color consumed from --ib-* role variables
+ * - Focus ring via group-data-[focus-visible]
+ * - MD3-correct disabled (content opacity, not blanket opacity)
+ */
+export const iconButtonRootVariants = cva(
+  [
+    // Layout
+    "relative inline-flex items-center justify-center",
+    "cursor-pointer select-none",
+    "overflow-hidden",
+
+    // Corner radius driven by CSS variable — lets compoundVariants set the
+    // correct value per shape×size without repeating transitions.
+    "rounded-[var(--ib-radius,9999px)]",
+
+    // Spatial transition: border-radius (shape morph on press/toggle)
+    "transition-[border-radius,background-color,border-color,color,opacity]",
+    "duration-expressive-fast-spatial ease-expressive-fast-spatial",
+
+    // Background + border + text driven from CSS role variables
+    "bg-[var(--ib-bg,transparent)]",
+    "border border-[var(--ib-border,transparent)]",
+    "text-[var(--ib-fg,currentColor)]",
+
+    // Toggle: off state (data-toggle present but data-selected absent)
+    // Uses doubly-chained selector to beat single-chain specificity of defaults
+    "data-[toggle]:bg-[var(--ib-bg-off,var(--ib-bg,transparent))]",
+    "data-[toggle]:text-[var(--ib-fg-off,var(--ib-fg,currentColor))]",
+
+    // Selected state
+    "data-[selected]:bg-[var(--ib-bg-on,var(--ib-bg,transparent))]",
+    "data-[selected]:text-[var(--ib-fg-on,var(--ib-fg,currentColor))]",
+    "data-[selected]:border-transparent",
+
+    // Press shape-morph: radius collapses to --ib-radius-press on press
+    // (only has visual effect when --ib-radius-press differs from --ib-radius)
+    "data-[pressed]:rounded-[var(--ib-radius-press,var(--ib-radius,9999px))]",
+
+    // Focus ring (outline, not a state layer — stays outside overflow-hidden
+    // because it's drawn as outline on the root element itself)
+    "outline-none",
+    "group-data-[focus-visible]/icon-button:outline-2",
+    "group-data-[focus-visible]/icon-button:outline-offset-2",
+    "group-data-[focus-visible]/icon-button:outline-secondary",
+
+    // Disabled — content opacity 38%, container handled per variant via CSS vars
+    "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+    "data-[disabled]:text-on-surface/38",
+    // Filled/tonal/outlined-selected backgrounds collapse to on-surface/12 — set
+    // via compoundVariants on the root for variants that have a container.
+    // For variants with transparent bg (standard, outlined-unselected) we do nothing.
   ],
   {
     variants: {
       /**
-       * Button variant (MD3 specification)
+       * Visual style variant (MD3 icon button types)
        */
       variant: {
-        standard: "bg-transparent", // No background
-        filled: "shadow-none", // Solid background
-        tonal: "", // Container background
-        outlined: "bg-transparent border border-outline",
+        standard: "",
+        filled: "data-[disabled]:bg-on-surface/12",
+        tonal: "data-[disabled]:bg-on-surface/12",
+        outlined: "",
       },
 
       /**
-       * Color scheme (MD3 color roles)
+       * Color scheme — sets CSS role variables via compoundVariants.
        */
       color: {
         primary: "",
@@ -54,175 +157,413 @@ export const iconButtonVariants = cva(
       },
 
       /**
-       * Button size (square dimensions)
+       * Size tier (M3 Expressive 5-tier)
        */
       size: {
-        small: "h-8 w-8", // 32×32px
-        medium: "h-10 w-10", // 40×40px (default)
-        large: "h-12 w-12", // 48×48px
+        xsmall: "h-8",
+        small: "h-10",
+        medium: "h-14",
+        large: "h-24",
+        xlarge: "h-[8.5rem]",
       },
 
       /**
-       * Selected state (for toggle buttons)
+       * Width variant — adjusts container width
        */
-      selected: {
-        true: "",
-        false: "",
+      width: {
+        narrow: "",
+        default: "",
+        wide: "",
       },
 
       /**
-       * Disabled state
+       * Shape — sets --ib-radius and --ib-radius-press
        */
-      isDisabled: {
-        true: "pointer-events-none cursor-not-allowed opacity-38",
-        false: "",
+      shape: {
+        round: [
+          "[--ib-radius:9999px]",
+          // Press morph: round → md3 square radius for that size
+          // (overridden per size in compoundVariants below)
+          "[--ib-radius-press:9999px]",
+        ],
+        square: [
+          // Base square radius set per size in compoundVariants
+        ],
       },
     },
 
-    /**
-     * Compound variants - combinations of variant + color + selected
-     */
     compoundVariants: [
-      // ====================
-      // STANDARD VARIANTS
-      // ====================
+      // ══════════════════════════════════════════════════════════════════════
+      // SIZE × WIDTH — container width
+      // ══════════════════════════════════════════════════════════════════════
+      { size: "xsmall", width: "narrow", className: "w-6" },
+      { size: "xsmall", width: "default", className: "w-8" },
+      { size: "xsmall", width: "wide", className: "w-10" },
+
+      { size: "small", width: "narrow", className: "w-8" },
+      { size: "small", width: "default", className: "w-10" },
+      { size: "small", width: "wide", className: "w-13" },
+
+      { size: "medium", width: "narrow", className: "w-12" },
+      { size: "medium", width: "default", className: "w-14" },
+      { size: "medium", width: "wide", className: "w-18" },
+
+      { size: "large", width: "narrow", className: "w-18" },
+      { size: "large", width: "default", className: "w-24" },
+      { size: "large", width: "wide", className: "w-32" },
+
+      { size: "xlarge", width: "narrow", className: "w-24" },
+      { size: "xlarge", width: "default", className: "w-[8.5rem]" },
+      { size: "xlarge", width: "wide", className: "w-42" },
+
+      // ══════════════════════════════════════════════════════════════════════
+      // SHAPE × SIZE — square corner radii + round press-morph targets
+      // ══════════════════════════════════════════════════════════════════════
+
+      // square: xsmall / small → 12dp corner (rounded-md = 12px)
+      { shape: "square", size: "xsmall", className: "[--ib-radius:0.75rem]" },
+      { shape: "square", size: "small", className: "[--ib-radius:0.75rem]" },
+      // square: medium → 16dp corner (rounded-lg token = 16px)
+      { shape: "square", size: "medium", className: "[--ib-radius:1rem]" },
+      // square: large / xlarge → 28dp corner (rounded-xl token = 28px)
+      { shape: "square", size: "large", className: "[--ib-radius:1.75rem]" },
+      { shape: "square", size: "xlarge", className: "[--ib-radius:1.75rem]" },
+
+      // round press-morph: shrink to the square value for that size on press
+      { shape: "round", size: "xsmall", className: "[--ib-radius-press:0.75rem]" },
+      { shape: "round", size: "small", className: "[--ib-radius-press:0.75rem]" },
+      { shape: "round", size: "medium", className: "[--ib-radius-press:1rem]" },
+      { shape: "round", size: "large", className: "[--ib-radius-press:1.75rem]" },
+      { shape: "round", size: "xlarge", className: "[--ib-radius-press:1.75rem]" },
+
+      // ══════════════════════════════════════════════════════════════════════
+      // VARIANT × COLOR — CSS role variable assignments
+      // Only variant × color (design-time decisions); no state variants here.
+      // ══════════════════════════════════════════════════════════════════════
+
+      // ── STANDARD ──────────────────────────────────────────────────────────
+      // Non-toggle standard: transparent bg, on-surface-variant fg
+      // Selected: primary fg
+      // State layer: on-surface-variant (unselected) / primary (selected)
       {
         variant: "standard",
-        selected: false,
-        className: "text-on-surface-variant",
+        color: "primary",
+        className: [
+          "[--ib-bg:transparent]",
+          "[--ib-fg:var(--color-on-surface-variant)]",
+          "[--ib-fg-on:var(--color-primary)]",
+          "[--ib-sl:var(--color-on-surface-variant)]",
+          // toggle-off same as non-toggle
+          "[--ib-bg-off:transparent]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          // toggle-on: selected
+          "[--ib-bg-on:transparent]",
+        ],
       },
       {
         variant: "standard",
-        selected: true,
-        className: "text-primary",
+        color: "secondary",
+        className: [
+          "[--ib-bg:transparent]",
+          "[--ib-fg:var(--color-on-surface-variant)]",
+          "[--ib-fg-on:var(--color-secondary)]",
+          "[--ib-sl:var(--color-on-surface-variant)]",
+          "[--ib-bg-off:transparent]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:transparent]",
+        ],
+      },
+      {
+        variant: "standard",
+        color: "tertiary",
+        className: [
+          "[--ib-bg:transparent]",
+          "[--ib-fg:var(--color-on-surface-variant)]",
+          "[--ib-fg-on:var(--color-tertiary)]",
+          "[--ib-sl:var(--color-on-surface-variant)]",
+          "[--ib-bg-off:transparent]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:transparent]",
+        ],
+      },
+      {
+        variant: "standard",
+        color: "error",
+        className: [
+          "[--ib-bg:transparent]",
+          "[--ib-fg:var(--color-on-surface-variant)]",
+          "[--ib-fg-on:var(--color-error)]",
+          "[--ib-sl:var(--color-on-surface-variant)]",
+          "[--ib-bg-off:transparent]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:transparent]",
+        ],
       },
 
-      // ====================
-      // FILLED VARIANTS (UNSELECTED)
-      // ====================
+      // ── FILLED ────────────────────────────────────────────────────────────
+      // Non-toggle: bg primary / fg on-primary
+      // Toggle off: bg surface-container-highest / fg primary
+      // Toggle on (selected): bg primary / fg on-primary
+      // State layer: on-primary (non-toggle / selected), primary (toggle-off)
       {
         variant: "filled",
         color: "primary",
-        selected: false,
-        className: "bg-primary text-on-primary",
+        className: [
+          "[--ib-bg:var(--color-primary)]",
+          "[--ib-fg:var(--color-on-primary)]",
+          "[--ib-sl:var(--color-on-primary)]",
+          "[--ib-bg-off:var(--color-surface-container-highest)]",
+          "[--ib-fg-off:var(--color-primary)]",
+          "[--ib-bg-on:var(--color-primary)]",
+          "[--ib-fg-on:var(--color-on-primary)]",
+        ],
       },
       {
         variant: "filled",
         color: "secondary",
-        selected: false,
-        className: "bg-secondary text-on-secondary",
+        className: [
+          "[--ib-bg:var(--color-secondary)]",
+          "[--ib-fg:var(--color-on-secondary)]",
+          "[--ib-sl:var(--color-on-secondary)]",
+          "[--ib-bg-off:var(--color-surface-container-highest)]",
+          "[--ib-fg-off:var(--color-secondary)]",
+          "[--ib-bg-on:var(--color-secondary)]",
+          "[--ib-fg-on:var(--color-on-secondary)]",
+        ],
       },
       {
         variant: "filled",
         color: "tertiary",
-        selected: false,
-        className: "bg-tertiary text-on-tertiary",
+        className: [
+          "[--ib-bg:var(--color-tertiary)]",
+          "[--ib-fg:var(--color-on-tertiary)]",
+          "[--ib-sl:var(--color-on-tertiary)]",
+          "[--ib-bg-off:var(--color-surface-container-highest)]",
+          "[--ib-fg-off:var(--color-tertiary)]",
+          "[--ib-bg-on:var(--color-tertiary)]",
+          "[--ib-fg-on:var(--color-on-tertiary)]",
+        ],
       },
       {
         variant: "filled",
         color: "error",
-        selected: false,
-        className: "bg-error text-on-error",
+        className: [
+          "[--ib-bg:var(--color-error)]",
+          "[--ib-fg:var(--color-on-error)]",
+          "[--ib-sl:var(--color-on-error)]",
+          "[--ib-bg-off:var(--color-surface-container-highest)]",
+          "[--ib-fg-off:var(--color-error)]",
+          "[--ib-bg-on:var(--color-error)]",
+          "[--ib-fg-on:var(--color-on-error)]",
+        ],
       },
 
-      // ====================
-      // FILLED VARIANTS (SELECTED - uses container colors)
-      // ====================
-      {
-        variant: "filled",
-        color: "primary",
-        selected: true,
-        className: "bg-primary-container text-on-primary-container",
-      },
-      {
-        variant: "filled",
-        color: "secondary",
-        selected: true,
-        className: "bg-secondary-container text-on-secondary-container",
-      },
-      {
-        variant: "filled",
-        color: "tertiary",
-        selected: true,
-        className: "bg-tertiary-container text-on-tertiary-container",
-      },
-      {
-        variant: "filled",
-        color: "error",
-        selected: true,
-        className: "bg-error-container text-on-error-container",
-      },
-
-      // ====================
-      // TONAL VARIANTS (UNSELECTED)
-      // ====================
+      // ── TONAL ─────────────────────────────────────────────────────────────
+      // Non-toggle: bg secondary-container / fg on-secondary-container
+      // Toggle off: bg surface-container-highest / fg on-surface-variant
+      // Toggle on (selected): bg secondary-container / fg on-secondary-container
       {
         variant: "tonal",
         color: "primary",
-        selected: false,
-        className: "bg-secondary-container text-on-secondary-container",
+        className: [
+          "[--ib-bg:var(--color-secondary-container)]",
+          "[--ib-fg:var(--color-on-secondary-container)]",
+          "[--ib-sl:var(--color-on-secondary-container)]",
+          "[--ib-bg-off:var(--color-surface-container-highest)]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:var(--color-secondary-container)]",
+          "[--ib-fg-on:var(--color-on-secondary-container)]",
+        ],
       },
       {
         variant: "tonal",
         color: "secondary",
-        selected: false,
-        className: "bg-secondary-container text-on-secondary-container",
+        className: [
+          "[--ib-bg:var(--color-secondary-container)]",
+          "[--ib-fg:var(--color-on-secondary-container)]",
+          "[--ib-sl:var(--color-on-secondary-container)]",
+          "[--ib-bg-off:var(--color-surface-container-highest)]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:var(--color-secondary-container)]",
+          "[--ib-fg-on:var(--color-on-secondary-container)]",
+        ],
       },
       {
         variant: "tonal",
         color: "tertiary",
-        selected: false,
-        className: "bg-tertiary-container text-on-tertiary-container",
+        className: [
+          "[--ib-bg:var(--color-tertiary-container)]",
+          "[--ib-fg:var(--color-on-tertiary-container)]",
+          "[--ib-sl:var(--color-on-tertiary-container)]",
+          "[--ib-bg-off:var(--color-surface-container-highest)]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:var(--color-tertiary-container)]",
+          "[--ib-fg-on:var(--color-on-tertiary-container)]",
+        ],
       },
       {
         variant: "tonal",
         color: "error",
-        selected: false,
-        className: "bg-error-container text-on-error-container",
+        className: [
+          "[--ib-bg:var(--color-error-container)]",
+          "[--ib-fg:var(--color-on-error-container)]",
+          "[--ib-sl:var(--color-on-error-container)]",
+          "[--ib-bg-off:var(--color-surface-container-highest)]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:var(--color-error-container)]",
+          "[--ib-fg-on:var(--color-on-error-container)]",
+        ],
       },
 
-      // ====================
-      // TONAL VARIANTS (SELECTED - uses tertiary container)
-      // ====================
-      {
-        variant: "tonal",
-        selected: true,
-        className: "bg-tertiary-container text-on-tertiary-container",
-      },
-
-      // ====================
-      // OUTLINED VARIANTS (UNSELECTED)
-      // ====================
+      // ── OUTLINED ──────────────────────────────────────────────────────────
+      // Non-toggle: transparent bg, border-outline, on-surface-variant fg
+      // Toggle off: same as non-toggle
+      // Toggle on (selected): inverse-surface bg, inverse-on-surface fg, no border
+      // Disabled: border becomes on-surface/12 (set via Tailwind utility on root)
       {
         variant: "outlined",
-        selected: false,
-        className: "text-on-surface-variant",
+        color: "primary",
+        className: [
+          "[--ib-bg:transparent]",
+          "[--ib-fg:var(--color-on-surface-variant)]",
+          "[--ib-sl:var(--color-on-surface-variant)]",
+          "[--ib-border:var(--color-outline)]",
+          "[--ib-bg-off:transparent]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:var(--color-inverse-surface)]",
+          "[--ib-fg-on:var(--color-inverse-on-surface)]",
+          // Disabled outlined border
+          "data-[disabled]:border-on-surface/12",
+        ],
       },
-
-      // ====================
-      // OUTLINED VARIANTS (SELECTED - uses inverse colors)
-      // ====================
       {
         variant: "outlined",
-        selected: true,
-        className: "bg-inverse-surface text-inverse-on-surface border-transparent",
+        color: "secondary",
+        className: [
+          "[--ib-bg:transparent]",
+          "[--ib-fg:var(--color-on-surface-variant)]",
+          "[--ib-sl:var(--color-on-surface-variant)]",
+          "[--ib-border:var(--color-outline)]",
+          "[--ib-bg-off:transparent]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:var(--color-inverse-surface)]",
+          "[--ib-fg-on:var(--color-inverse-on-surface)]",
+          "data-[disabled]:border-on-surface/12",
+        ],
+      },
+      {
+        variant: "outlined",
+        color: "tertiary",
+        className: [
+          "[--ib-bg:transparent]",
+          "[--ib-fg:var(--color-on-surface-variant)]",
+          "[--ib-sl:var(--color-on-surface-variant)]",
+          "[--ib-border:var(--color-outline)]",
+          "[--ib-bg-off:transparent]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:var(--color-inverse-surface)]",
+          "[--ib-fg-on:var(--color-inverse-on-surface)]",
+          "data-[disabled]:border-on-surface/12",
+        ],
+      },
+      {
+        variant: "outlined",
+        color: "error",
+        className: [
+          "[--ib-bg:transparent]",
+          "[--ib-fg:var(--color-on-surface-variant)]",
+          "[--ib-sl:var(--color-on-surface-variant)]",
+          "[--ib-border:var(--color-outline)]",
+          "[--ib-bg-off:transparent]",
+          "[--ib-fg-off:var(--color-on-surface-variant)]",
+          "[--ib-bg-on:var(--color-inverse-surface)]",
+          "[--ib-fg-on:var(--color-inverse-on-surface)]",
+          "data-[disabled]:border-on-surface/12",
+        ],
       },
     ],
 
-    /**
-     * Default variants
-     */
     defaultVariants: {
       variant: "standard",
       color: "primary",
       size: "medium",
-      selected: false,
-      isDisabled: false,
+      width: "default",
+      shape: "round",
     },
   }
 );
 
+// ─── STATE LAYER ─────────────────────────────────────────────────────────────
+
 /**
- * Extract variant prop types from CVA
+ * State layer — absolute overlay inside the button container.
+ *
+ * Color driven from --ib-sl CSS variable set by the root.
+ * Opacity: 0 at rest, 8% hover, 10% focus-visible, 10% pressed.
+ * Hidden when disabled (no state layer on disabled MD3 components).
+ *
+ * Uses `group-data-[x]/icon-button` to react to the root's data attributes.
+ * Note: the root itself is the group — it carries `group/icon-button`.
+ * However, since this is a child element, we read `group-data-[x]/icon-button`
+ * from the parent's group. But the root is the button, not a wrapper div.
+ * Therefore we use `data-[x]:` selectors directly (self-referential) for the
+ * root and emit `group/icon-button` on the root so the state layer can read
+ * via `group-data-[x]/icon-button`.
  */
-export type IconButtonVariants = VariantProps<typeof iconButtonVariants>;
+export const iconButtonStateLayerVariants = cva([
+  "absolute inset-0 rounded-[inherit] pointer-events-none opacity-0",
+  "bg-[var(--ib-sl,currentColor)]",
+  // Effects transition (opacity — no spatial overshoot)
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Interaction opacities (MD3: hover 8%, focus/pressed 10%)
+  "group-data-[hovered]/icon-button:opacity-8",
+  "group-data-[focus-visible]/icon-button:opacity-10",
+  "group-data-[pressed]/icon-button:opacity-10",
+  // No state layer when disabled
+  "group-data-[disabled]/icon-button:hidden",
+]);
+
+// ─── ICON SLOT ────────────────────────────────────────────────────────────────
+
+/**
+ * Icon wrapper — size and color only, no positioning.
+ *
+ * Sizes match M3 Expressive icon sizes per container tier.
+ * Color transitions via effects token (no spatial overshoot on color).
+ *
+ * Since this is inside the root (the group), we use group-data selectors.
+ * Icon color inherits from the root's `text-[var(--ib-fg)]` — no need to
+ * duplicate the full variable chain here; CSS `currentColor` flows through.
+ */
+export const iconButtonIconVariants = cva(
+  [
+    "relative z-10 inline-flex shrink-0 items-center justify-center",
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  ],
+  {
+    variants: {
+      size: {
+        xsmall: "size-5", // 20dp
+        small: "size-6", // 24dp
+        medium: "size-6", // 24dp
+        large: "size-8", // 32dp
+        xlarge: "size-10", // 40dp
+      },
+    },
+    defaultVariants: {
+      size: "medium",
+    },
+  }
+);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
+export type IconButtonRootVariants = VariantProps<typeof iconButtonRootVariants>;
+export type IconButtonStateLayerVariants = VariantProps<typeof iconButtonStateLayerVariants>;
+export type IconButtonIconVariants = VariantProps<typeof iconButtonIconVariants>;
+
+/**
+ * Combined variants type for the IconButton component surface.
+ * Excludes `isDisabled` and `selected` — those are driven by data attributes.
+ */
+export type IconButtonVariants = IconButtonRootVariants;

--- a/packages/react/src/components/IconButton/IconButton.variants.ts
+++ b/packages/react/src/components/IconButton/IconButton.variants.ts
@@ -51,12 +51,17 @@ import { cva, type VariantProps } from "class-variance-authority";
  *   xlarge: narrow 96dp / default 136dp / wide 168dp
  *
  * Shape:
- *   round  → rounded-full  (press morphs to size-tiered corner)
- *   square → size-tiered corner at rest (no morph)
+ *   round  → per-size half-height radius (true circle: xsmall 16px … xlarge 68px)
+ *            Press morphs to the size-tiered square corner (e.g. medium 28px → 16px).
+ *            Using exact half-height (not 9999px) keeps the morph distance small so
+ *            emphasized-decelerate produces a smooth transition with no overshoot clamp.
+ *   square → size-tiered corner at rest; no press morph.
  *
- * Press shape morph (round only): on data-[pressed] the radius shrinks to the
- * same scale as the square shape for that size, giving the Expressive spring feel.
- * Driven by [--ib-radius-press] CSS variable consumed by the root.
+ * Press shape morph (round only): on data-[pressed] the radius shrinks to
+ * --ib-radius-press (= MD3 square corner for that size tier).
+ * Smooth because btn-transition uses emphasized-decelerate (no overshoot) for
+ * border-radius. The old 9999px radius caused the spring to overshoot below 0,
+ * producing a sharp-corner flash before settling.
  *
  * MD3 state-layer opacities:
  *   hover        opacity-8  (8%)
@@ -66,12 +71,18 @@ import { cva, type VariantProps } from "class-variance-authority";
  *   disabled content    text-on-surface/38
  */
 
-// ─── SHAPE CORNER RADIUS LOOKUP ───────────────────────────────────────────────
-// MD3 square shape corner radii per size tier:
-//   xsmall / small: 12dp → rounded-xl (not in theme — use rounded-md = 12px)
-//   medium:         16dp → rounded-lg
-//   large / xlarge: 28dp → rounded-xl
-// Press morph target for round shape matches the square radius for that size.
+// ─── SHAPE CORNER RADIUS REFERENCE ───────────────────────────────────────────
+// Round rest radius (half container height → true circle):
+//   xsmall (32dp) → 16px = 1rem
+//   small  (40dp) → 20px = 1.25rem
+//   medium (56dp) → 28px = 1.75rem
+//   large  (96dp) → 48px = 3rem
+//   xlarge(136dp) → 68px = 4.25rem
+//
+// Square rest radius / round press-morph target (MD3 shape scale):
+//   xsmall / small → 12px = 0.75rem
+//   medium         → 16px = 1rem
+//   large / xlarge → 28px = 1.75rem
 
 // ─── ROOT ─────────────────────────────────────────────────────────────────────
 
@@ -93,13 +104,17 @@ export const iconButtonRootVariants = cva(
     "cursor-pointer select-none",
     "overflow-hidden",
 
-    // Corner radius driven by CSS variable — lets compoundVariants set the
-    // correct value per shape×size without repeating transitions.
+    // Corner radius driven by CSS variable — set per shape×size in compoundVariants.
+    // Fallback 9999px is only reached if both shape and size props are absent,
+    // which cannot happen in normal usage.
     "rounded-[var(--ib-radius,9999px)]",
 
-    // Spatial transition: border-radius (shape morph on press/toggle)
-    "transition-[border-radius,background-color,border-color,color,opacity]",
-    "duration-expressive-fast-spatial ease-expressive-fast-spatial",
+    // Split MD3 transition via the existing btn-transition utility:
+    //   border-radius  → emphasized-decelerate (no overshoot, no sharp-corner flash)
+    //   color/bg/border/opacity → standard-fast-effects (no overshoot on effects)
+    // This is identical to the approach used by Button/connected ButtonGroup and is
+    // the standard fix for the 9999px overshoot problem documented in styles.css.
+    "btn-transition",
 
     // Background + border + text driven from CSS role variables
     "bg-[var(--ib-bg,transparent)]",
@@ -177,18 +192,19 @@ export const iconButtonRootVariants = cva(
       },
 
       /**
-       * Shape — sets --ib-radius and --ib-radius-press
+       * Shape — base values only; per-size radii set via compoundVariants below.
+       *
+       * round:  --ib-radius = half the container height (true circle), set per size.
+       *         --ib-radius-press = square corner for that size (set per size).
+       *         Morph distance is small (e.g. 28px → 16px for medium), so the
+       *         emphasized-decelerate curve from btn-transition produces a smooth,
+       *         non-overshooting transition. The old 9999px fallback caused the
+       *         spring to overshoot below 0 = sharp-corner flash.
+       * square: --ib-radius = size-tiered MD3 corner, set per size. No press morph.
        */
       shape: {
-        round: [
-          "[--ib-radius:9999px]",
-          // Press morph: round → md3 square radius for that size
-          // (overridden per size in compoundVariants below)
-          "[--ib-radius-press:9999px]",
-        ],
-        square: [
-          // Base square radius set per size in compoundVariants
-        ],
+        round: [],
+        square: [],
       },
     },
 
@@ -217,24 +233,45 @@ export const iconButtonRootVariants = cva(
       { size: "xlarge", width: "wide", className: "w-42" },
 
       // ══════════════════════════════════════════════════════════════════════
-      // SHAPE × SIZE — square corner radii + round press-morph targets
+      // SHAPE × SIZE — corner radii for both round and square shapes
       // ══════════════════════════════════════════════════════════════════════
+      //
+      // Round rest radius = half container height (true circle).
+      // Using the exact half-height keeps the morph distance small, so the
+      // no-overshoot emphasized-decelerate curve in btn-transition produces a
+      // smooth animation. Using 9999px was the original cause of the sharp-
+      // corner flash (the spring overshoots below 0 before settling).
+      //
+      //   xsmall h-8  = 32px  → half = 16px = 1rem
+      //   small  h-10 = 40px  → half = 20px = 1.25rem
+      //   medium h-14 = 56px  → half = 28px = 1.75rem
+      //   large  h-24 = 96px  → half = 48px = 3rem
+      //   xlarge h-34 = 136px → half = 68px = 4.25rem
+      //
+      // Round press-morph target = MD3 square corner for that size tier.
+      // Square rest radius = same MD3 corner (no morph).
 
-      // square: xsmall / small → 12dp corner (rounded-md = 12px)
-      { shape: "square", size: "xsmall", className: "[--ib-radius:0.75rem]" },
-      { shape: "square", size: "small", className: "[--ib-radius:0.75rem]" },
-      // square: medium → 16dp corner (rounded-lg token = 16px)
-      { shape: "square", size: "medium", className: "[--ib-radius:1rem]" },
-      // square: large / xlarge → 28dp corner (rounded-xl token = 28px)
-      { shape: "square", size: "large", className: "[--ib-radius:1.75rem]" },
-      { shape: "square", size: "xlarge", className: "[--ib-radius:1.75rem]" },
+      // ── round: rest radius (half height) ──────────────────────────────────
+      { shape: "round", size: "xsmall", className: "[--ib-radius:1rem]" },
+      { shape: "round", size: "small", className: "[--ib-radius:1.25rem]" },
+      { shape: "round", size: "medium", className: "[--ib-radius:1.75rem]" },
+      { shape: "round", size: "large", className: "[--ib-radius:3rem]" },
+      { shape: "round", size: "xlarge", className: "[--ib-radius:4.25rem]" },
 
-      // round press-morph: shrink to the square value for that size on press
+      // ── round: press-morph target (square corner for that size) ───────────
       { shape: "round", size: "xsmall", className: "[--ib-radius-press:0.75rem]" },
       { shape: "round", size: "small", className: "[--ib-radius-press:0.75rem]" },
       { shape: "round", size: "medium", className: "[--ib-radius-press:1rem]" },
       { shape: "round", size: "large", className: "[--ib-radius-press:1.75rem]" },
       { shape: "round", size: "xlarge", className: "[--ib-radius-press:1.75rem]" },
+
+      // ── square: rest radius (MD3 shape scale) ─────────────────────────────
+      // xsmall / small → 12px (0.75rem), medium → 16px (1rem), large / xlarge → 28px (1.75rem)
+      { shape: "square", size: "xsmall", className: "[--ib-radius:0.75rem]" },
+      { shape: "square", size: "small", className: "[--ib-radius:0.75rem]" },
+      { shape: "square", size: "medium", className: "[--ib-radius:1rem]" },
+      { shape: "square", size: "large", className: "[--ib-radius:1.75rem]" },
+      { shape: "square", size: "xlarge", className: "[--ib-radius:1.75rem]" },
 
       // ══════════════════════════════════════════════════════════════════════
       // VARIANT × COLOR — CSS role variable assignments

--- a/packages/react/src/components/IconButton/IconButtonHeadless.tsx
+++ b/packages/react/src/components/IconButton/IconButtonHeadless.tsx
@@ -1,72 +1,85 @@
+"use client";
+
 import { forwardRef, useRef } from "react";
-import { useButton } from "react-aria";
-import type { AriaButtonProps } from "react-aria";
+import { useButton, useHover, useFocusRing } from "react-aria";
 import { mergeProps, filterDOMProps } from "@react-aria/utils";
+import type { AriaButtonProps } from "react-aria";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 
 /**
  * Headless IconButton Component (Layer 2)
  *
  * Unstyled icon button primitive using React Aria for accessibility.
- * Provides behavior only - bring your own styles.
+ * Provides behavior AND emits MD3-compliant data-* interaction attributes
+ * so the styled Layer 3 can drive all visual states through CSS alone.
+ *
+ * Emitted data attributes (via getInteractionDataAttributes):
+ * - `data-hovered`       — pointer is over the button
+ * - `data-focus-visible` — keyboard/programmatic focus is visible
+ * - `data-pressed`       — button is being pressed
+ * - `data-selected`      — toggle button is in the ON state
+ * - `data-disabled`      — button is non-interactive
+ *
+ * Content flags (set explicitly):
+ * - `data-toggle`        — button is a toggle (selected prop is defined)
  *
  * Features:
  * - Full keyboard navigation (Enter, Space)
- * - Screen reader support
+ * - Screen reader support (aria-pressed for toggle buttons)
  * - Touch/pointer event handling
  * - Focus management
+ * - Hover detection (useHover — pointer-only, not keyboard)
  * - Disabled state handling
- * - Toggle button support (aria-pressed)
  *
  * @example
  * ```tsx
- * // Use for custom styling
- * <IconButtonHeadless className="custom-icon-button-class" aria-label="Delete">
+ * // Advanced custom styling
+ * <IconButtonHeadless
+ *   aria-label="Delete"
+ *   className="group/icon-button my-custom-classes"
+ *   isSelected={false}
+ *   isToggle={false}
+ *   isDisabled={false}
+ * >
  *   <IconDelete />
  * </IconButtonHeadless>
  * ```
  */
 export interface IconButtonHeadlessProps extends AriaButtonProps {
-  /**
-   * Additional CSS classes
-   */
+  /** Additional CSS classes */
   className?: string;
 
-  /**
-   * Icon content (React node)
-   */
+  /** Icon content */
   children: React.ReactNode;
 
-  /**
-   * Tab index for keyboard navigation
-   * @default 0
-   */
+  /** Tab index for keyboard navigation @default 0 */
   tabIndex?: number;
 
-  /**
-   * Mouse down handler (for ripple effect)
-   */
+  /** Mouse down handler (for ripple effect) */
   onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 
-  /**
-   * Button type attribute
-   * @default 'button'
-   */
+  /** Button type attribute @default 'button' */
   type?: "button" | "submit" | "reset";
 
   /**
-   * Toggle state (for toggle buttons)
-   * Sets aria-pressed attribute
+   * Toggle selected state.
+   * When defined, sets aria-pressed and emits data-selected / data-toggle.
    */
-  selected?: boolean;
+  isSelected?: boolean;
 
   /**
-   * REQUIRED: Accessible label for screen readers
+   * Whether this button behaves as a toggle (i.e. selected prop was passed).
+   * Drives `data-toggle` attribute; determines whether aria-pressed is set.
    */
+  isToggle?: boolean;
+
+  /** Whether the button is disabled */
+  isDisabled?: boolean;
+
+  /** REQUIRED: Accessible label for screen readers */
   "aria-label": string;
 
-  /**
-   * HTML title attribute for tooltip
-   */
+  /** HTML title attribute for tooltip */
   title?: string;
 }
 
@@ -78,56 +91,61 @@ export const IconButtonHeadless = forwardRef<HTMLButtonElement, IconButtonHeadle
       tabIndex = 0,
       onMouseDown,
       type,
-      selected,
+      isSelected,
+      isToggle = false,
+      isDisabled = false,
       "aria-label": ariaLabel,
       title,
       ...props
     },
     forwardedRef
   ) => {
-    // Internal ref for React Aria
     const internalRef = useRef<HTMLButtonElement>(null);
-
-    // Merge internal ref with forwarded ref
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLButtonElement>;
 
-    // React Aria hook - handles all accessibility
-    const { buttonProps } = useButton(
+    // React Aria hooks — behavior layer
+    const { buttonProps, isPressed } = useButton(
       {
         ...props,
-        // Ensure element type is 'button' for proper semantics
         elementType: "button",
-        // Pass aria-label
         "aria-label": ariaLabel,
+        isDisabled,
       },
       ref
     );
 
-    // Filter out React Aria-specific props that shouldn't be passed to the DOM element
+    const { isHovered, hoverProps } = useHover({ isDisabled });
+    const { isFocusVisible, focusProps } = useFocusRing();
 
+    // Filter non-DOM props before spreading
     const domProps = filterDOMProps(props);
 
-    // Merge React Aria props with custom props and filtered DOM props
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const mergedProps: React.ButtonHTMLAttributes<HTMLButtonElement> = mergeProps(
-      buttonProps,
-      domProps,
-      {
-        tabIndex,
-        className,
-        onMouseDown,
-        type: type ?? "button",
-        // Add aria-pressed for toggle buttons (only if selected is defined)
-        ...(selected !== undefined && { "aria-pressed": selected }),
-        // Add title if provided
-        ...(title && { title }),
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ) as any;
+    const mergedProps = mergeProps(buttonProps, hoverProps, focusProps, domProps, {
+      tabIndex,
+      className,
+      onMouseDown,
+      type: type ?? "button",
+      ...(title && { title }),
+      // aria-pressed only when acting as a toggle button
+      ...(isToggle && { "aria-pressed": isSelected ?? false }),
+    }) as React.ButtonHTMLAttributes<HTMLButtonElement>;
 
     return (
-      // eslint-disable-next-line react/button-has-type
-      <button {...mergedProps} ref={ref} type={type ?? "button"}>
+      <button
+        {...mergedProps}
+        ref={ref}
+        type={type === "submit" ? "submit" : type === "reset" ? "reset" : "button"}
+        // Interaction state attributes — consumed by group-data-[x]/icon-button selectors
+        {...getInteractionDataAttributes({
+          isHovered,
+          isFocusVisible,
+          isPressed,
+          ...(isToggle ? { isSelected: isSelected ?? false } : {}),
+          isDisabled,
+        })}
+        // Content flag: present when acting as a toggle, absent otherwise
+        data-toggle={isToggle ? "" : undefined}
+      >
         {children}
       </button>
     );

--- a/packages/react/src/components/IconButton/index.ts
+++ b/packages/react/src/components/IconButton/index.ts
@@ -1,11 +1,22 @@
 export { IconButton } from "./IconButton";
 export { IconButtonHeadless } from "./IconButtonHeadless";
-export { iconButtonVariants } from "./IconButton.variants";
+export {
+  iconButtonRootVariants,
+  iconButtonStateLayerVariants,
+  iconButtonIconVariants,
+} from "./IconButton.variants";
 export type {
   IconButtonProps,
   IconButtonVariant,
   IconButtonColor,
   IconButtonSize,
+  IconButtonWidth,
+  IconButtonShape,
 } from "./IconButton.types";
-export type { IconButtonVariants } from "./IconButton.variants";
+export type {
+  IconButtonVariants,
+  IconButtonRootVariants,
+  IconButtonStateLayerVariants,
+  IconButtonIconVariants,
+} from "./IconButton.variants";
 export type { IconButtonHeadlessProps } from "./IconButtonHeadless";


### PR DESCRIPTION
## Summary

- Refactor `IconButton` to the M3 Expressive 5-tier sizing system with `width` and `shape` props
- Migrate to Variants-vs-States architecture (React Aria `data-*` attributes + slot CVA)
- Add press shape-morph for round buttons with per-size half-height radius (fixes sharp-corner flash)
- Add `selectedIcon` prop for toggle buttons

**Breaking changes:**
- `size` values renamed: `small`→`xsmall`, `medium`→`small`, `large`→`medium`; new `large` (96dp) and `xlarge` (136dp) added

## Test plan

- [x] `pnpm lint && pnpm typecheck`
- [x] IconButton test suite (78 tests passing)
- [ ] Storybook visual check for all sizes, shapes, variants, and press morph