### PR TITLE
refactor(fab): M3 Expressive — slot architecture, size scale, solid colors

### DIFF
--- a/.changeset/fab-md3-expressive.md
+++ b/.changeset/fab-md3-expressive.md
@@ -1,0 +1,30 @@
+---
+"@tinybigui/react": minor
+---
+
+refactor(fab): M3 Expressive refactor — slot architecture, new size scale, solid colors
+
+**Breaking changes (pre-1.0 minor bump):**
+
+- Default `size` changed from `"medium"` to `"fab"`. Update `size="medium"` if you relied on the 56dp size — it now renders the 80dp M3 Expressive Medium FAB.
+- `size="medium"` now renders a **80dp** container (M3 Expressive Medium FAB), not 56dp.
+- Default `color` changed from `"primary"` to `"primary-container"`. The old `color="primary"` is now a **solid** color style (`bg-primary / text-on-primary`).
+- `color="secondary"` and `color="tertiary"` are now **solid** styles (bg-secondary / bg-tertiary).
+
+**New features:**
+
+- `size="fab"` (56dp) — new canonical default size.
+- `size="medium"` (80dp) — M3 Expressive Medium FAB with 20dp corners and 28dp icon.
+- `color="primary-container"` / `"secondary-container"` / `"tertiary-container"` — container color styles (previous default behaviour).
+- `color="primary"` / `"secondary"` / `"tertiary"` — new solid color styles (M3 Expressive).
+- Dedicated focus-ring slot (`inset-[-3px]`, keyboard-only, never clipped).
+- Dedicated state-layer slot with correct opacities: hover 8% / focus 10% / pressed 10%.
+- State-layer color matches icon/on-color per MD3 spec.
+- Elevation 3 base → 4 hover → 3 focus/pressed per MD3 spec.
+- `useHover` + `useFocusRing` + `isPressed` via React Aria — full `group-data-[x]/fab` attribute system.
+- MD3 motion tokens (`duration-spring-standard-fast-effects`, `ease-spring-standard-fast-effects`) replace hardcoded `duration-200`.
+
+**Deprecated (functional, with dev warning):**
+
+- `size="small"` — use `size="fab"` instead.
+- `color="surface"` — use `color="primary-container"` instead.

--- a/packages/react/src/components/FAB/FAB.stories.tsx
+++ b/packages/react/src/components/FAB/FAB.stories.tsx
@@ -1,31 +1,34 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { FAB } from "./FAB";
 import React from "react";
+import { FAB } from "./FAB";
 
-// Sample icons for stories (24×24px for small/medium/extended, 36×36px for large)
+// ── Sample icons ──────────────────────────────────────────────────────────────
+
 const IconAdd = ({ size = 24 }: { size?: number }): React.ReactElement => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
     <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
   </svg>
 );
 
-const IconEdit = (): React.ReactElement => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+const IconEdit = ({ size = 24 }: { size?: number }): React.ReactElement => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
     <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
   </svg>
 );
 
-const IconCamera = (): React.ReactElement => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+const IconCamera = ({ size = 24 }: { size?: number }): React.ReactElement => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
     <path d="M12 15.2c-2.07 0-3.75-1.68-3.75-3.75S9.93 7.7 12 7.7s3.75 1.68 3.75 3.75-1.68 3.75-3.75 3.75zm7.13-8.45H17.5l-1.69-2.25h-5.62l-1.69 2.25H5.87c-.61 0-1.1.49-1.1 1.1v11.5c0 .61.49 1.1 1.1 1.1h13.25c.61 0 1.1-.49 1.1-1.1V7.85c.01-.61-.48-1.1-1.09-1.1z" />
   </svg>
 );
 
-const IconShare = (): React.ReactElement => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+const IconShare = ({ size = 24 }: { size?: number }): React.ReactElement => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
     <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
   </svg>
 );
+
+// ── Meta ──────────────────────────────────────────────────────────────────────
 
 const meta: Meta<typeof FAB> = {
   title: "Components/FAB",
@@ -34,8 +37,23 @@ const meta: Meta<typeof FAB> = {
     layout: "centered",
     docs: {
       description: {
-        component:
-          "Material Design 3 Floating Action Button - High-emphasis button for primary screen action. Supports 4 sizes: small (40px), medium (56px), large (96px), and extended (with text).",
+        component: `
+**Material Design 3 Floating Action Button — M3 Expressive**
+
+High-emphasis button for the primary screen action. The FAB is always the most prominent interactive element on the screen.
+
+**M3 Expressive size scale:**
+- \`fab\` (56dp) — Default. Standard FAB.
+- \`medium\` (80dp) — Medium FAB. New in M3 Expressive.
+- \`large\` (96dp) — Large FAB.
+- \`extended\` (56dp height) — Extended FAB with icon + text.
+- \`small\` (40dp) — @deprecated. Use \`fab\` instead.
+
+**Color styles:**
+- Container: \`primary-container\` (default), \`secondary-container\`, \`tertiary-container\`
+- Solid (M3 Expressive): \`primary\`, \`secondary\`, \`tertiary\`
+- \`surface\` — @deprecated. Use \`primary-container\`.
+        `.trim(),
       },
     },
   },
@@ -43,21 +61,30 @@ const meta: Meta<typeof FAB> = {
   argTypes: {
     size: {
       control: "select",
-      options: ["small", "medium", "large", "extended"],
+      options: ["fab", "medium", "large", "extended", "small"],
       description: "FAB size variant",
     },
     color: {
       control: "select",
-      options: ["primary", "secondary", "tertiary", "surface"],
-      description: "Color scheme for the FAB",
+      options: [
+        "primary-container",
+        "secondary-container",
+        "tertiary-container",
+        "primary",
+        "secondary",
+        "tertiary",
+        "surface",
+      ],
+      description: "Color style for the FAB",
     },
     icon: {
       control: false,
-      description: "Icon content (required). Recommended size: 24x24px (36x36px for large)",
+      description:
+        "Icon content (required). Sizes: 24dp (fab/extended/small), 28dp (medium), 36dp (large)",
     },
     "aria-label": {
       control: "text",
-      description: "Mandatory accessible label for the FAB (required for all sizes)",
+      description: "Mandatory accessible label (required for all FAB sizes)",
     },
     isDisabled: {
       control: "boolean",
@@ -65,11 +92,11 @@ const meta: Meta<typeof FAB> = {
     },
     loading: {
       control: "boolean",
-      description: "Show loading spinner",
+      description: "Show loading spinner and disable interaction",
     },
     disableRipple: {
       control: "boolean",
-      description: "Disable ripple effect",
+      description: "Disable the MD3 ripple effect",
     },
   },
 };
@@ -77,118 +104,262 @@ const meta: Meta<typeof FAB> = {
 export default meta;
 type Story = StoryObj<typeof FAB>;
 
-// Default Story
+// ── Default ───────────────────────────────────────────────────────────────────
+
 export const Default: Story = {
   args: {
     "aria-label": "Create new item",
     icon: <IconAdd />,
-    size: "medium",
-    color: "primary",
+    size: "fab",
+    color: "primary-container",
   },
 };
 
-// Sizes
-export const Small: Story = {
+// ── Sizes ─────────────────────────────────────────────────────────────────────
+
+export const Fab: Story = {
+  name: "FAB (56dp) — Default",
   args: {
-    "aria-label": "Add photo",
-    icon: <IconCamera />,
-    size: "small",
+    "aria-label": "Create new item",
+    icon: <IconAdd />,
+    size: "fab",
+  },
+  parameters: {
+    docs: {
+      description: { story: "Standard FAB — 56dp, 16dp corner radius. Default size." },
+    },
   },
 };
 
 export const Medium: Story = {
+  name: "Medium FAB (80dp) — M3 Expressive",
   args: {
     "aria-label": "Create new item",
-    icon: <IconAdd />,
+    icon: <IconAdd size={28} />,
     size: "medium",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Medium FAB — 80dp, 20dp corner radius, 28dp icon. New in M3 Expressive. Recommended for most primary-action use cases on compact/medium screens.",
+      },
+    },
   },
 };
 
 export const Large: Story = {
+  name: "Large FAB (96dp)",
   args: {
     "aria-label": "Compose",
     icon: <IconAdd size={36} />,
     size: "large",
   },
+  parameters: {
+    docs: {
+      description: { story: "Large FAB — 96dp, 28dp corner radius, 36dp icon." },
+    },
+  },
 };
 
 export const Extended: Story = {
+  name: "Extended FAB",
   args: {
-    "aria-label": "Create new item",
+    "aria-label": "Create new document",
     icon: <IconAdd />,
     size: "extended",
     children: "Create",
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Extended FAB — 56dp height, variable width. Icon + text label side by side.",
+      },
+    },
+  },
 };
 
-// All Sizes Showcase
 export const AllSizes: Story = {
+  name: "All Sizes",
   render: () => (
     <div className="flex items-end gap-6">
-      <FAB aria-label="Small FAB" icon={<IconAdd />} size="small" />
-      <FAB aria-label="Medium FAB" icon={<IconAdd />} size="medium" />
-      <FAB aria-label="Large FAB" icon={<IconAdd size={36} />} size="large" />
-      <FAB aria-label="Extended FAB" icon={<IconAdd />} size="extended">
-        Create
-      </FAB>
+      <div className="flex flex-col items-center gap-2">
+        <FAB aria-label="FAB" icon={<IconAdd />} size="fab" />
+        <span className="text-label-small text-on-surface-variant">fab (56dp)</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <FAB aria-label="Medium FAB" icon={<IconAdd size={28} />} size="medium" />
+        <span className="text-label-small text-on-surface-variant">medium (80dp)</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <FAB aria-label="Large FAB" icon={<IconAdd size={36} />} size="large" />
+        <span className="text-label-small text-on-surface-variant">large (96dp)</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <FAB aria-label="Extended FAB" icon={<IconAdd />} size="extended">
+          Create
+        </FAB>
+        <span className="text-label-small text-on-surface-variant">extended</span>
+      </div>
     </div>
   ),
+  parameters: {
+    docs: {
+      description: { story: "All recommended M3 Expressive FAB sizes." },
+    },
+  },
 };
 
-// Colors
-export const Colors: Story = {
+// ── Colors ────────────────────────────────────────────────────────────────────
+
+export const ContainerColors: Story = {
+  name: "Container Colors (default set)",
   render: () => (
     <div className="flex flex-col gap-6">
-      <div className="flex gap-4">
+      <p className="text-body-small text-on-surface-variant">Container color styles (default)</p>
+      <div className="flex items-center gap-4">
+        <FAB aria-label="Primary container" icon={<IconAdd />} color="primary-container" />
+        <FAB aria-label="Secondary container" icon={<IconEdit />} color="secondary-container" />
+        <FAB aria-label="Tertiary container" icon={<IconCamera />} color="tertiary-container" />
+      </div>
+      <div className="flex items-center gap-4">
+        <FAB
+          aria-label="Primary container extended"
+          icon={<IconAdd />}
+          size="extended"
+          color="primary-container"
+        >
+          Primary
+        </FAB>
+        <FAB
+          aria-label="Secondary container extended"
+          icon={<IconEdit />}
+          size="extended"
+          color="secondary-container"
+        >
+          Secondary
+        </FAB>
+        <FAB
+          aria-label="Tertiary container extended"
+          icon={<IconCamera />}
+          size="extended"
+          color="tertiary-container"
+        >
+          Tertiary
+        </FAB>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Container color styles. `primary-container` is the default and recommended color for most FABs.",
+      },
+    },
+  },
+};
+
+export const SolidColors: Story = {
+  name: "Solid Colors (M3 Expressive)",
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <p className="text-body-small text-on-surface-variant">
+        Solid color styles — new in M3 Expressive
+      </p>
+      <div className="flex items-center gap-4">
         <FAB aria-label="Primary" icon={<IconAdd />} color="primary" />
         <FAB aria-label="Secondary" icon={<IconEdit />} color="secondary" />
         <FAB aria-label="Tertiary" icon={<IconCamera />} color="tertiary" />
-        <FAB aria-label="Surface" icon={<IconShare />} color="surface" />
       </div>
-      <div className="flex gap-4">
-        <FAB aria-label="Primary" icon={<IconAdd />} color="primary" size="extended">
+      <div className="flex items-center gap-4">
+        <FAB aria-label="Primary extended" icon={<IconAdd />} size="extended" color="primary">
           Primary
         </FAB>
-        <FAB aria-label="Secondary" icon={<IconEdit />} color="secondary" size="extended">
+        <FAB aria-label="Secondary extended" icon={<IconEdit />} size="extended" color="secondary">
           Secondary
         </FAB>
-        <FAB aria-label="Tertiary" icon={<IconCamera />} color="tertiary" size="extended">
+        <FAB aria-label="Tertiary extended" icon={<IconCamera />} size="extended" color="tertiary">
           Tertiary
-        </FAB>
-        <FAB aria-label="Surface" icon={<IconShare />} color="surface" size="extended">
-          Surface
         </FAB>
       </div>
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Solid color styles introduced in M3 Expressive. Use when the container style doesn't provide enough contrast or emphasis.",
+      },
+    },
+  },
 };
 
-// Extended FAB Variants
-export const ExtendedVariants: Story = {
+// ── States ────────────────────────────────────────────────────────────────────
+
+export const States: Story = {
   render: () => (
-    <div className="flex flex-col gap-4">
-      <FAB aria-label="Create new document" icon={<IconAdd />} size="extended">
-        Create
-      </FAB>
-      <FAB aria-label="Edit document" icon={<IconEdit />} size="extended">
-        Edit
-      </FAB>
-      <FAB aria-label="Add photo" icon={<IconCamera />} size="extended">
-        Add Photo
-      </FAB>
-      <FAB aria-label="Share content" icon={<IconShare />} size="extended">
-        Share
-      </FAB>
+    <div className="flex flex-col gap-8">
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">Enabled (default)</p>
+        <FAB aria-label="Add" icon={<IconAdd />} />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">
+          Hovered (8% state layer, elevation 4)
+        </p>
+        <p className="text-body-small text-on-surface-variant mb-3">
+          Hover over the FAB to see the state layer and elevated shadow.
+        </p>
+        <FAB aria-label="Add" icon={<IconAdd />} />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">
+          Focused (10% state layer, keyboard-only focus ring)
+        </p>
+        <p className="text-body-small text-on-surface-variant mb-3">
+          Tab to the FAB to see the focus ring.
+        </p>
+        <FAB aria-label="Add" icon={<IconAdd />} />
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">Disabled</p>
+        <div className="flex gap-4">
+          <FAB aria-label="Add" icon={<IconAdd />} isDisabled />
+          <FAB aria-label="Edit" icon={<IconEdit />} color="secondary-container" isDisabled />
+          <FAB aria-label="Create" icon={<IconAdd />} size="extended" isDisabled>
+            Create
+          </FAB>
+        </div>
+      </div>
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-3">Loading</p>
+        <div className="flex gap-4">
+          <FAB aria-label="Creating" icon={<IconAdd />} loading />
+          <FAB aria-label="Editing" icon={<IconEdit />} color="secondary-container" loading />
+          <FAB aria-label="Creating" icon={<IconAdd />} size="extended" loading>
+            Creating...
+          </FAB>
+        </div>
+      </div>
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "FAB interaction states per MD3 spec. Hover adds elevation-4 and 8% state layer. Focus (keyboard) shows a secondary outline ring at 10% state layer. Disabled uses 12%/38% opacity. Loading disables and shows a spinner.",
+      },
+    },
+  },
 };
 
-// States
 export const Disabled: Story = {
   render: () => (
-    <div className="flex gap-4">
+    <div className="flex flex-wrap gap-4">
       <FAB aria-label="Add" icon={<IconAdd />} isDisabled />
-      <FAB aria-label="Edit" icon={<IconEdit />} color="secondary" isDisabled />
+      <FAB aria-label="Edit" icon={<IconEdit />} color="secondary-container" isDisabled />
+      <FAB aria-label="Camera" icon={<IconCamera />} color="primary" isDisabled />
       <FAB aria-label="Create" icon={<IconAdd />} size="extended" isDisabled>
         Create
       </FAB>
@@ -198,9 +369,9 @@ export const Disabled: Story = {
 
 export const Loading: Story = {
   render: () => (
-    <div className="flex gap-4">
+    <div className="flex flex-wrap gap-4">
       <FAB aria-label="Creating" icon={<IconAdd />} loading />
-      <FAB aria-label="Editing" icon={<IconEdit />} color="secondary" loading />
+      <FAB aria-label="Editing" icon={<IconEdit />} color="secondary-container" loading />
       <FAB aria-label="Creating" icon={<IconAdd />} size="extended" loading>
         Creating...
       </FAB>
@@ -208,24 +379,49 @@ export const Loading: Story = {
   ),
 };
 
-// Positioning Examples
+// ── Extended FAB variants ─────────────────────────────────────────────────────
+
+export const ExtendedVariants: Story = {
+  name: "Extended FAB — Variants",
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <FAB aria-label="Create new document" icon={<IconAdd />} size="extended">
+        Create
+      </FAB>
+      <FAB
+        aria-label="Edit document"
+        icon={<IconEdit />}
+        size="extended"
+        color="secondary-container"
+      >
+        Edit
+      </FAB>
+      <FAB aria-label="Add photo" icon={<IconCamera />} size="extended" color="tertiary-container">
+        Add Photo
+      </FAB>
+      <FAB aria-label="Share content" icon={<IconShare />} size="extended" color="primary">
+        Share
+      </FAB>
+    </div>
+  ),
+};
+
+// ── Positioning ───────────────────────────────────────────────────────────────
+
 export const PositioningExamples: Story = {
   render: () => (
     <div className="border-outline bg-surface-container relative h-96 w-full rounded-lg border p-4">
       <div className="h-full overflow-auto">
-        <h3 className="mb-4 text-lg font-medium">Scroll Content Here</h3>
-        <p className="mb-4">
-          This demonstrates how FABs are typically positioned. In a real application, the FAB would
-          be fixed to the viewport, not the container.
+        <h3 className="text-title-medium mb-4">Scroll Content</h3>
+        <p className="text-body-medium mb-4">
+          In a real app, use `className="fixed bottom-4 right-4"` to pin the FAB to the viewport.
         </p>
         {Array.from({ length: 20 }).map((_, i) => (
-          <p key={i} className="mb-2">
+          <p key={i} className="text-body-small text-on-surface-variant mb-2">
             Content line {i + 1}
           </p>
         ))}
       </div>
-
-      {/* Bottom-right (most common) */}
       <FAB aria-label="Create new" icon={<IconAdd />} className="absolute right-4 bottom-4" />
     </div>
   ),
@@ -233,58 +429,14 @@ export const PositioningExamples: Story = {
     docs: {
       description: {
         story:
-          "FABs are typically positioned fixed in the bottom-right corner. Use className to position the FAB as needed (e.g., `fixed bottom-4 right-4`).",
+          'FABs are typically fixed to the bottom-right corner of the viewport. Use `className` for positioning (e.g. `className="fixed bottom-4 right-4"`).',
       },
     },
   },
 };
 
-// Real-World Examples
-export const EmailCompose: Story = {
-  render: () => (
-    <div className="flex flex-col gap-4">
-      <div className="border-outline bg-surface rounded-lg border p-6">
-        <h3 className="mb-4 text-lg font-bold">Inbox</h3>
-        <p className="text-on-surface-variant">Your emails will appear here...</p>
-      </div>
-      <FAB aria-label="Compose new email" icon={<IconEdit />} size="extended">
-        Compose
-      </FAB>
-    </div>
-  ),
-  parameters: {
-    docs: {
-      description: {
-        story: "Example: Email app with compose action",
-      },
-    },
-  },
-};
+// ── Interactive ───────────────────────────────────────────────────────────────
 
-export const PhotoGallery: Story = {
-  render: () => (
-    <div className="flex flex-col gap-4">
-      <div className="border-outline bg-surface rounded-lg border p-6">
-        <h3 className="mb-4 text-lg font-bold">Photo Gallery</h3>
-        <div className="grid grid-cols-3 gap-2">
-          {Array.from({ length: 9 }).map((_, i) => (
-            <div key={i} className="bg-surface-variant aspect-square rounded" />
-          ))}
-        </div>
-      </div>
-      <FAB aria-label="Add photo" icon={<IconCamera />} />
-    </div>
-  ),
-  parameters: {
-    docs: {
-      description: {
-        story: "Example: Photo gallery with add photo action",
-      },
-    },
-  },
-};
-
-// Interactive Example
 const InteractiveExample = (): React.ReactElement => {
   const [items, setItems] = React.useState<string[]>([]);
   const [loading, setLoading] = React.useState(false);
@@ -292,21 +444,23 @@ const InteractiveExample = (): React.ReactElement => {
   const handleAdd = (): void => {
     setLoading(true);
     setTimeout(() => {
-      setItems([...items, `Item ${items.length + 1}`]);
+      setItems((prev) => [...prev, `Item ${prev.length + 1}`]);
       setLoading(false);
     }, 1000);
   };
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="border-outline bg-surface rounded-lg border p-6">
-        <h3 className="mb-4 text-lg font-bold">My Items</h3>
+    <div className="flex w-72 flex-col gap-4">
+      <div className="border-outline bg-surface min-h-32 rounded-lg border p-6">
+        <h3 className="text-title-medium mb-4">My Items</h3>
         {items.length === 0 ? (
-          <p className="text-on-surface-variant">No items yet. Click the FAB to add one!</p>
+          <p className="text-body-medium text-on-surface-variant">No items yet. Click the FAB!</p>
         ) : (
-          <ul className="list-inside list-disc">
+          <ul className="list-inside list-disc space-y-1">
             {items.map((item, i) => (
-              <li key={i}>{item}</li>
+              <li key={i} className="text-body-medium">
+                {item}
+              </li>
             ))}
           </ul>
         )}
@@ -329,19 +483,56 @@ export const Interactive: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Interactive example with loading state when adding items",
+        story: "Interactive example with loading state when adding items.",
       },
     },
   },
 };
 
-// Playground
+// ── Deprecated (baseline) ─────────────────────────────────────────────────────
+
+export const DeprecatedSmall: Story = {
+  name: "⚠️ Deprecated — Small FAB (40dp)",
+  args: {
+    "aria-label": "Add photo",
+    icon: <IconCamera />,
+    size: "small",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**Deprecated.** `size='small'` (40dp) is no longer recommended in M3 Expressive. Use `size='fab'` (56dp) instead. Kept for backward compatibility.",
+      },
+    },
+  },
+};
+
+export const DeprecatedSurface: Story = {
+  name: "⚠️ Deprecated — Surface Color",
+  args: {
+    "aria-label": "Share content",
+    icon: <IconShare />,
+    color: "surface",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**Deprecated.** `color='surface'` is no longer recommended in M3 Expressive. Use `color='primary-container'` instead. Kept for backward compatibility.",
+      },
+    },
+  },
+};
+
+// ── Playground ────────────────────────────────────────────────────────────────
+
 export const Playground: Story = {
   args: {
     "aria-label": "Create new item",
     icon: <IconAdd />,
-    size: "medium",
-    color: "primary",
+    size: "fab",
+    color: "primary-container",
     isDisabled: false,
     loading: false,
     disableRipple: false,
@@ -349,7 +540,7 @@ export const Playground: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Play around with all the FAB props to see how they work together.",
+        story: "Explore all FAB props with the controls below.",
       },
     },
   },

--- a/packages/react/src/components/FAB/FAB.test.tsx
+++ b/packages/react/src/components/FAB/FAB.test.tsx
@@ -8,12 +8,13 @@ import { FAB } from "./FAB";
 import React from "react";
 import { isKeyboardAccessible, hasAccessibleLabel } from "../../../test/helpers";
 
-// Mock icons for testing
 const IconAdd = (): React.ReactElement => <svg data-testid="icon-add" />;
 const IconEdit = (): React.ReactElement => <svg data-testid="icon-edit" />;
 const IconCamera = (): React.ReactElement => <svg data-testid="icon-camera" />;
 
 describe("FAB", () => {
+  // ── Rendering ───────────────────────────────────────────────────────────────
+
   describe("Rendering", () => {
     test("renders FAB with icon content", () => {
       render(<FAB aria-label="Create new item" icon={<IconAdd />} />);
@@ -26,22 +27,30 @@ describe("FAB", () => {
       expect(screen.getByLabelText("Add photo")).toBeInTheDocument();
     });
 
-    test("renders medium size by default", () => {
+    // ── Default size is 'fab' (56dp) ──────────────────────────────────────────
+
+    test("renders fab size by default (56dp)", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} />);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("h-14", "w-14"); // 56px
+      expect(button).toHaveClass("h-14", "w-14"); // 56dp
     });
 
-    test("renders small size", () => {
+    test("renders small size (40dp)", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} size="small" />);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("h-10", "w-10"); // 40px
+      expect(button).toHaveClass("h-10", "w-10"); // 40dp
     });
 
-    test("renders large size", () => {
+    test("renders medium size (80dp, M3 Expressive)", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} size="medium" />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("h-20", "w-20"); // 80dp
+    });
+
+    test("renders large size (96dp)", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} size="large" />);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("h-24", "w-24"); // 96px
+      expect(button).toHaveClass("h-24", "w-24"); // 96dp
     });
 
     test("renders extended size with text", () => {
@@ -51,60 +60,113 @@ describe("FAB", () => {
         </FAB>
       );
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("h-14"); // 56px height
+      expect(button).toHaveClass("h-14"); // 56dp height
       expect(screen.getByText("Create")).toBeInTheDocument();
     });
 
-    test("renders with primary color by default", () => {
+    // ── Default color is 'primary-container' ──────────────────────────────────
+
+    test("renders with primary-container color by default", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} />);
       const button = screen.getByRole("button");
       expect(button).toHaveClass("bg-primary-container", "text-on-primary-container");
     });
 
-    test("renders with secondary color", () => {
-      render(<FAB aria-label="Add" icon={<IconAdd />} color="secondary" />);
+    // ── Container color styles ────────────────────────────────────────────────
+
+    test("renders with secondary-container color", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} color="secondary-container" />);
       const button = screen.getByRole("button");
       expect(button).toHaveClass("bg-secondary-container", "text-on-secondary-container");
     });
 
-    test("renders with tertiary color", () => {
-      render(<FAB aria-label="Add" icon={<IconAdd />} color="tertiary" />);
+    test("renders with tertiary-container color", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} color="tertiary-container" />);
       const button = screen.getByRole("button");
       expect(button).toHaveClass("bg-tertiary-container", "text-on-tertiary-container");
     });
 
-    test("renders with surface color", () => {
-      render(<FAB aria-label="Add" icon={<IconAdd />} color="surface" />);
+    // ── Solid color styles (M3 Expressive) ───────────────────────────────────
+
+    test("renders with solid primary color", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} color="primary" />);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-surface", "text-primary");
+      expect(button).toHaveClass("bg-primary", "text-on-primary");
     });
 
-    test("has elevation shadow by default", () => {
+    test("renders with solid secondary color", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} color="secondary" />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-secondary", "text-on-secondary");
+    });
+
+    test("renders with solid tertiary color", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} color="tertiary" />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-tertiary", "text-on-tertiary");
+    });
+
+    // ── Deprecated surface color ──────────────────────────────────────────────
+
+    test("renders with deprecated surface color (surface-container-high)", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} color="surface" />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-surface-container-high", "text-primary");
+    });
+
+    // ── Corner radii ──────────────────────────────────────────────────────────
+
+    test("fab size has 16dp corner radius (rounded-2xl)", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("rounded-2xl");
+      expect(button).not.toHaveClass("rounded-full");
+    });
+
+    test("medium size has 20dp corner radius (rounded-[20px])", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} size="medium" />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("rounded-[20px]");
+    });
+
+    test("small size has 12dp corner radius (rounded-xl)", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} size="small" />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("rounded-xl");
+    });
+
+    // ── Elevation ─────────────────────────────────────────────────────────────
+
+    test("has elevation-3 shadow by default", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} />);
       const button = screen.getByRole("button");
       expect(button).toHaveClass("shadow-elevation-3");
     });
 
-    test("has proper border radius (not fully rounded)", () => {
+    // ── Slots presence ────────────────────────────────────────────────────────
+
+    test("renders state-layer slot", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} />);
       const button = screen.getByRole("button");
-      // Medium FAB uses 16px (rounded-2xl), not rounded-full
-      expect(button).toHaveClass("rounded-2xl");
-      expect(button).not.toHaveClass("rounded-full");
+      // State layer is an aria-hidden span inside the button
+      const stateLayer = button.querySelector('span[aria-hidden="true"]');
+      expect(stateLayer).toBeInTheDocument();
     });
+
+    // ── className passthrough ─────────────────────────────────────────────────
 
     test("merges custom className", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} className="custom-class" />);
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("custom-class");
+      expect(screen.getByRole("button")).toHaveClass("custom-class");
     });
 
     test("applies title attribute", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} title="Add new item" />);
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("title", "Add new item");
+      expect(screen.getByRole("button")).toHaveAttribute("title", "Add new item");
     });
   });
+
+  // ── Extended FAB ────────────────────────────────────────────────────────────
 
   describe("Extended FAB", () => {
     test("renders icon and text together", () => {
@@ -124,19 +186,17 @@ describe("FAB", () => {
         </FAB>
       );
       const button = screen.getByRole("button");
-      // Extended FAB should not have fixed width classes like w-14
-      expect(button).not.toHaveClass("w-14", "w-10", "w-24");
+      expect(button).not.toHaveClass("w-14", "w-10", "w-24", "w-20");
     });
 
-    test("applies correct padding for extended variant", () => {
+    test("applies asymmetric padding for extended variant", () => {
       render(
         <FAB aria-label="Create new" icon={<IconAdd />} size="extended">
           Create
         </FAB>
       );
       const button = screen.getByRole("button");
-      // Extended FAB has asymmetric padding
-      expect(button).toHaveClass("pl-4", "pr-5"); // 16px leading, 20px trailing
+      expect(button).toHaveClass("pl-4", "pr-5");
     });
 
     test("renders extended FAB with longer text", () => {
@@ -147,27 +207,47 @@ describe("FAB", () => {
       );
       expect(screen.getByText("Create New Document")).toBeInTheDocument();
     });
+
+    test("does not render text for non-extended sizes", () => {
+      render(
+        <FAB aria-label="Add" icon={<IconAdd />} size="fab">
+          Hidden Text
+        </FAB>
+      );
+      expect(screen.queryByText("Hidden Text")).not.toBeInTheDocument();
+    });
   });
 
+  // ── States ──────────────────────────────────────────────────────────────────
+
   describe("States", () => {
-    test("handles disabled state", () => {
+    test("handles disabled state — button is disabled", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} isDisabled />);
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    test("handles disabled state — data-disabled attribute is set", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} isDisabled />);
+      expect(screen.getByRole("button")).toHaveAttribute("data-disabled");
+    });
+
+    test("handles disabled state — data-[disabled] classes applied", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} isDisabled />);
       const button = screen.getByRole("button");
-      expect(button).toBeDisabled();
-      // Check for disabled styling classes
-      expect(button).toHaveClass("pointer-events-none", "cursor-not-allowed");
-      // Shadow should be none
-      expect(button.className).toContain("shadow-none");
+      // Disabled styling uses data-[disabled]: Tailwind conditional classes
+      expect(button).toHaveClass(
+        "data-[disabled]:pointer-events-none",
+        "data-[disabled]:cursor-not-allowed"
+      );
     });
 
-    test("renders loading state", () => {
+    test("renders loading state — spinner is visible", () => {
       render(<FAB aria-label="Creating" icon={<IconAdd />} loading />);
-      const button = screen.getByRole("button");
       expect(screen.getByRole("progressbar")).toBeInTheDocument();
-      expect(button).toBeDisabled();
+      expect(screen.getByRole("button")).toBeDisabled();
     });
 
-    test("hides icon when loading", () => {
+    test("hides icon when loading (invisible not hidden)", () => {
       render(<FAB aria-label="Creating" icon={<IconAdd />} loading />);
       const icon = screen.getByTestId("icon-add");
       expect(icon.parentElement).toHaveClass("invisible");
@@ -175,17 +255,17 @@ describe("FAB", () => {
 
     test("shows spinner when loading", () => {
       render(<FAB aria-label="Creating" icon={<IconAdd />} loading />);
-      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+      expect(screen.getByRole("progressbar", { name: "Loading" })).toBeInTheDocument();
     });
   });
+
+  // ── Interactions ─────────────────────────────────────────────────────────────
 
   describe("Interactions", () => {
     test("calls onPress when clicked", async () => {
       const user = userEvent.setup();
       const onPress = vi.fn();
-
       render(<FAB aria-label="Add" icon={<IconAdd />} onPress={onPress} />);
-
       await user.click(screen.getByRole("button"));
       expect(onPress).toHaveBeenCalledTimes(1);
     });
@@ -193,72 +273,70 @@ describe("FAB", () => {
     test("does not call onPress when disabled", async () => {
       const user = userEvent.setup();
       const onPress = vi.fn();
-
       render(<FAB aria-label="Add" icon={<IconAdd />} onPress={onPress} isDisabled />);
-
       await user.click(screen.getByRole("button"));
       expect(onPress).not.toHaveBeenCalled();
     });
 
-    test("handles keyboard interaction with Enter key", async () => {
+    test("handles Enter key", async () => {
       const user = userEvent.setup();
       const onPress = vi.fn();
-
       render(<FAB aria-label="Add" icon={<IconAdd />} onPress={onPress} />);
-
-      const button = screen.getByRole("button");
-      button.focus();
+      screen.getByRole("button").focus();
       await user.keyboard("{Enter}");
       expect(onPress).toHaveBeenCalledTimes(1);
     });
 
-    test("handles keyboard interaction with Space key", async () => {
+    test("handles Space key", async () => {
       const user = userEvent.setup();
       const onPress = vi.fn();
-
       render(<FAB aria-label="Add" icon={<IconAdd />} onPress={onPress} />);
-
-      const button = screen.getByRole("button");
-      button.focus();
+      screen.getByRole("button").focus();
       await user.keyboard(" ");
       expect(onPress).toHaveBeenCalledTimes(1);
     });
 
     test("is keyboard accessible", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} />);
-      const button = screen.getByRole("button");
-      expect(isKeyboardAccessible(button)).toBe(true);
+      expect(isKeyboardAccessible(screen.getByRole("button"))).toBe(true);
     });
 
-    test("shows focus indicator when focused", () => {
+    test("shows focus when focused", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} />);
       const button = screen.getByRole("button");
       button.focus();
       expect(button).toHaveFocus();
     });
+
+    test("handles rapid clicks", async () => {
+      const user = userEvent.setup();
+      const onPress = vi.fn();
+      render(<FAB aria-label="Add" icon={<IconAdd />} onPress={onPress} />);
+      await user.tripleClick(screen.getByRole("button"));
+      expect(onPress).toHaveBeenCalledTimes(3);
+    });
   });
+
+  // ── Accessibility ────────────────────────────────────────────────────────────
 
   describe("Accessibility", () => {
     test("has accessible label", () => {
       render(<FAB aria-label="Add new item" icon={<IconAdd />} />);
-      const button = screen.getByRole("button");
-      expect(hasAccessibleLabel(button)).toBe(true);
+      expect(hasAccessibleLabel(screen.getByRole("button"))).toBe(true);
     });
 
-    test("requires aria-label (enforced by types)", () => {
+    test("aria-label is applied to the button", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} />);
-      const button = screen.getByRole("button");
-      expect(button).toHaveAccessibleName("Add");
+      expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Add");
     });
 
-    test("extended FAB still requires aria-label even with text", () => {
+    test("extended FAB still requires aria-label even with visible text", () => {
       render(
         <FAB aria-label="Create new item" icon={<IconAdd />} size="extended">
           Create
         </FAB>
       );
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("aria-label", "Create new item");
+      expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Create new item");
     });
 
     test("has proper button role", () => {
@@ -266,21 +344,14 @@ describe("FAB", () => {
       expect(screen.getByRole("button")).toBeInTheDocument();
     });
 
-    test("includes icon in accessibility tree", () => {
-      render(<FAB aria-label="Add new item" icon={<IconAdd />} />);
-      expect(screen.getByTestId("icon-add")).toBeInTheDocument();
-    });
-
-    test("disabled FAB has aria-disabled", () => {
+    test("disabled FAB has disabled attribute", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} isDisabled />);
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("disabled");
+      expect(screen.getByRole("button")).toHaveAttribute("disabled");
     });
 
     test("loading FAB is disabled", () => {
       render(<FAB aria-label="Creating" icon={<IconAdd />} loading />);
-      const button = screen.getByRole("button");
-      expect(button).toBeDisabled();
+      expect(screen.getByRole("button")).toBeDisabled();
     });
 
     test("loading spinner has accessible label", () => {
@@ -289,101 +360,102 @@ describe("FAB", () => {
     });
   });
 
-  describe("Ripple Effect", () => {
-    test("shows ripple effect by default", () => {
-      render(<FAB aria-label="Add" icon={<IconAdd />} />);
-      const button = screen.getByRole("button");
-      // Ripple container should be present (initially empty)
-      const ripples = button.querySelectorAll(".animate-ripple");
-      expect(ripples.length).toBeGreaterThanOrEqual(0);
-    });
-
-    test("disables ripple when disableRipple is true", () => {
-      render(<FAB aria-label="Add" icon={<IconAdd />} disableRipple />);
-      const button = screen.getByRole("button");
-      const ripples = button.querySelectorAll(".animate-ripple");
-      expect(ripples.length).toBe(0);
-    });
-
-    test("does not show ripple when disabled", () => {
-      render(<FAB aria-label="Add" icon={<IconAdd />} isDisabled />);
-      const button = screen.getByRole("button");
-      const ripples = button.querySelectorAll(".animate-ripple");
-      expect(ripples.length).toBe(0);
-    });
-  });
+  // ── Button type ──────────────────────────────────────────────────────────────
 
   describe("Button Types", () => {
     test("defaults to button type", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} />);
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("type", "button");
+      expect(screen.getByRole("button")).toHaveAttribute("type", "button");
     });
 
     test("supports submit type", () => {
       render(<FAB aria-label="Submit" icon={<IconEdit />} type="submit" />);
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("type", "submit");
+      expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
     });
 
     test("supports reset type", () => {
       render(<FAB aria-label="Reset" icon={<IconEdit />} type="reset" />);
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("type", "reset");
+      expect(screen.getByRole("button")).toHaveAttribute("type", "reset");
     });
   });
 
-  describe("Positioning", () => {
-    test("is not fixed by default in tests", () => {
+  // ── Ripple ───────────────────────────────────────────────────────────────────
+
+  describe("Ripple Effect", () => {
+    test("ripple container exists by default", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} />);
       const button = screen.getByRole("button");
-      // In test environment, we don't apply fixed positioning automatically
-      // This is tested in Storybook/browser environment
-      expect(button).toBeInTheDocument();
+      const ripples = button.querySelectorAll(".animate-ripple");
+      expect(ripples.length).toBeGreaterThanOrEqual(0);
     });
 
-    test("accepts custom className for positioning", () => {
-      render(<FAB aria-label="Add" icon={<IconAdd />} className="fixed right-4 bottom-4" />);
-      const button = screen.getByRole("button");
-      expect(button).toHaveClass("fixed", "bottom-4", "right-4");
+    test("no ripple when disableRipple is true", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} disableRipple />);
+      const ripples = screen.getByRole("button").querySelectorAll(".animate-ripple");
+      expect(ripples.length).toBe(0);
+    });
+
+    test("no ripple when disabled", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} isDisabled />);
+      const ripples = screen.getByRole("button").querySelectorAll(".animate-ripple");
+      expect(ripples.length).toBe(0);
     });
   });
 
-  describe("Size Variations", () => {
-    test("renders all size variations", () => {
-      const sizes = ["small", "medium", "large"] as const;
+  // ── Positioning ───────────────────────────────────────────────────────────────
 
+  describe("Positioning", () => {
+    test("accepts custom className for positioning", () => {
+      render(<FAB aria-label="Add" icon={<IconAdd />} className="fixed right-4 bottom-4" />);
+      expect(screen.getByRole("button")).toHaveClass("fixed", "bottom-4", "right-4");
+    });
+  });
+
+  // ── All sizes + colors render ─────────────────────────────────────────────────
+
+  describe("Size Variations", () => {
+    test("renders all size variations without error", () => {
+      const sizes = ["fab", "medium", "large", "small"] as const;
       sizes.forEach((size) => {
-        const { container } = render(
+        const { unmount } = render(
           <FAB aria-label={`${size} FAB`} icon={<IconAdd />} size={size} />
         );
-        expect(container.querySelector("button")).toBeInTheDocument();
+        expect(screen.getByRole("button")).toBeInTheDocument();
+        unmount();
       });
     });
 
-    test("small FAB has minimum touch target", () => {
+    test("small FAB has minimum touch target margin", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} size="small" />);
-      const button = screen.getByRole("button");
-      // Small FAB is 40x40px with 4px margin = 48x48px touch target
-      expect(button).toHaveClass("h-10", "w-10"); // 40px
+      expect(screen.getByRole("button")).toHaveClass("m-1"); // 4dp margin → 48dp touch target
     });
   });
 
   describe("Color Variations", () => {
-    test("renders all color variations", () => {
-      const colors = ["primary", "secondary", "tertiary", "surface"] as const;
-
+    test("renders all color variations without error", () => {
+      const colors = [
+        "primary-container",
+        "secondary-container",
+        "tertiary-container",
+        "primary",
+        "secondary",
+        "tertiary",
+        "surface",
+      ] as const;
       colors.forEach((color) => {
-        const { container } = render(
+        const { unmount } = render(
           <FAB aria-label={`${color} FAB`} icon={<IconAdd />} color={color} />
         );
-        expect(container.querySelector("button")).toBeInTheDocument();
+        expect(screen.getByRole("button")).toBeInTheDocument();
+        unmount();
       });
     });
   });
 
+  // ── Edge cases ────────────────────────────────────────────────────────────────
+
   describe("Edge Cases", () => {
-    test("handles missing icon gracefully in extended FAB", () => {
+    test("handles null icon gracefully", () => {
       render(
         <FAB aria-label="Create" icon={null} size="extended">
           Create
@@ -398,18 +470,9 @@ describe("FAB", () => {
       render(<FAB aria-label="Add" icon={<IconAdd />} ref={ref} />);
       expect(ref.current).toBeInstanceOf(HTMLButtonElement);
     });
-
-    test("handles rapid clicks", async () => {
-      const user = userEvent.setup();
-      const onPress = vi.fn();
-
-      render(<FAB aria-label="Add" icon={<IconAdd />} onPress={onPress} />);
-
-      const button = screen.getByRole("button");
-      await user.tripleClick(button);
-      expect(onPress).toHaveBeenCalledTimes(3);
-    });
   });
+
+  // ── Development warnings ──────────────────────────────────────────────────────
 
   describe("Development Warnings", () => {
     const originalEnv = process.env.NODE_ENV;
@@ -420,52 +483,90 @@ describe("FAB", () => {
       consoleWarn.mockClear();
     });
 
-    test("warns when icon is missing in development", () => {
+    test("warns when icon is missing", () => {
       process.env.NODE_ENV = "development";
-
       render(<FAB aria-label="Empty" icon={null} />);
-
       expect(consoleWarn).toHaveBeenCalledWith(
-        "[FAB] FAB must have an icon. Please provide the icon prop."
+        "[FAB] FAB must have an icon. Please provide the `icon` prop."
       );
     });
 
-    test("warns when extended FAB has no text in development", () => {
+    test("warns when extended FAB has no children", () => {
       process.env.NODE_ENV = "development";
-
       render(<FAB aria-label="Create" icon={<IconAdd />} size="extended" />);
-
       expect(consoleWarn).toHaveBeenCalledWith(
-        "[FAB] Extended FAB requires text label as children."
+        "[FAB] Extended FAB requires a text label as `children`."
+      );
+    });
+
+    test("warns when non-extended FAB has children", () => {
+      process.env.NODE_ENV = "development";
+      render(
+        <FAB aria-label="Add" icon={<IconAdd />} size="fab">
+          Hidden
+        </FAB>
+      );
+      expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining("size='extended'"));
+    });
+
+    test("warns when deprecated size='small' is used", () => {
+      process.env.NODE_ENV = "development";
+      render(<FAB aria-label="Add" icon={<IconAdd />} size="small" />);
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "[FAB] `size='small'` is deprecated in M3 Expressive. Use `size='fab'` (56dp) instead."
+      );
+    });
+
+    test("warns when deprecated color='surface' is used", () => {
+      process.env.NODE_ENV = "development";
+      render(<FAB aria-label="Add" icon={<IconAdd />} color="surface" />);
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "[FAB] `color='surface'` is deprecated in M3 Expressive. Use `color='primary-container'` instead."
       );
     });
   });
 
+  // ── Axe accessibility ──────────────────────────────────────────────────────────
+
   describe("Axe Accessibility", () => {
-    test("has no accessibility violations", async () => {
+    test("has no accessibility violations — default fab", async () => {
       const { container } = render(<FAB aria-label="Add new item" icon={<IconAdd />} />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
 
-    test("has no accessibility violations when disabled", async () => {
+    test("has no accessibility violations — medium size", async () => {
+      const { container } = render(
+        <FAB aria-label="Add new item" icon={<IconAdd />} size="medium" />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations — disabled", async () => {
       const { container } = render(<FAB aria-label="Add" icon={<IconAdd />} isDisabled />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
 
-    test("has no accessibility violations in loading state", async () => {
+    test("has no accessibility violations — loading", async () => {
       const { container } = render(<FAB aria-label="Creating" icon={<IconAdd />} loading />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
 
-    test("has no accessibility violations for extended FAB", async () => {
+    test("has no accessibility violations — extended FAB", async () => {
       const { container } = render(
         <FAB aria-label="Create new item" icon={<IconAdd />} size="extended">
           Create
         </FAB>
       );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no accessibility violations — solid primary color", async () => {
+      const { container } = render(<FAB aria-label="Add" icon={<IconAdd />} color="primary" />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });

--- a/packages/react/src/components/FAB/FAB.tsx
+++ b/packages/react/src/components/FAB/FAB.tsx
@@ -1,25 +1,37 @@
 "use client";
 
-import { forwardRef } from "react";
+import { forwardRef, useRef, useState, useCallback } from "react";
 import type React from "react";
+import { useHover, useFocusRing, mergeProps } from "react-aria";
 import { FABHeadless } from "./FABHeadless";
-import { fabVariants, type FABVariants } from "./FAB.variants";
+import {
+  fabVariants,
+  fabStateLayerVariants,
+  fabFocusRingVariants,
+  fabIconVariants,
+  fabLabelVariants,
+  type FABVariants,
+} from "./FAB.variants";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
 import type { FABProps } from "./FAB.types";
-import { mergeProps } from "@react-aria/utils";
 
 /**
- * Loading spinner component
+ * Loading spinner — matches Button's Spinner for consistency.
  */
 const Spinner = (): React.ReactElement => (
   <svg
     role="progressbar"
     aria-label="Loading"
-    className="h-6 w-6 animate-spin"
+    className="relative z-10 animate-spin"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
+    // Spinner matches the icon slot width/height via inherited size from parent span
+    width="1em"
+    height="1em"
+    style={{ fontSize: "inherit" }}
   >
     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
     <path
@@ -31,123 +43,171 @@ const Spinner = (): React.ReactElement => (
 );
 
 /**
- * Material Design 3 FAB (Floating Action Button) Component
+ * Material Design 3 FAB (Floating Action Button) — M3 Expressive
  *
- * High-emphasis button for primary screen action.
- * Supports 4 sizes: small, medium, large, extended
- * Implementation uses Tailwind CSS classes mapped to MD3 tokens.
+ * High-emphasis button for the primary screen action.
+ * Implements the Variants-vs-States architecture: all interaction states are
+ * expressed as data-* attributes on the root and consumed by each slot via
+ * group-data-[x]/fab Tailwind selectors — no state variants in CVA.
+ *
+ * Features:
+ * - ✅ MD3 Expressive size scale: fab (56dp), medium (80dp), large (96dp), extended, small (dep)
+ * - ✅ Container + solid color styles (primary-container, primary, secondary*, tertiary*)
+ * - ✅ Elevation 3 base → 4 hover → 3 focus/pressed per MD3 spec
+ * - ✅ State-layer color = icon/on-color per MD3 spec
+ * - ✅ Correct state-layer opacities: hover 8% / focus 10% / pressed 10%
+ * - ✅ Dedicated focus ring slot (inset-[-3px], keyboard-only)
+ * - ✅ Loading state with spinner
+ * - ✅ Ripple effect (Material Design)
+ * - ✅ Full keyboard accessibility via React Aria
+ *
+ * @example
+ * ```tsx
+ * // Default FAB (56dp, primary-container)
+ * <FAB aria-label="Create" icon={<IconAdd />} />
+ *
+ * // Medium FAB (80dp, M3 Expressive)
+ * <FAB aria-label="Create" icon={<IconAdd />} size="medium" />
+ *
+ * // Solid primary color (M3 Expressive)
+ * <FAB aria-label="Add" icon={<IconAdd />} color="primary" />
+ *
+ * // Extended FAB with text
+ * <FAB aria-label="Create document" icon={<IconAdd />} size="extended">
+ *   Create
+ * </FAB>
+ * ```
  */
-export const FAB = forwardRef<HTMLButtonElement, FABProps & Omit<FABVariants, "isDisabled">>(
+export const FAB = forwardRef<HTMLButtonElement, FABProps & Omit<FABVariants, never>>(
   (
     {
-      // Variant props (CVA)
-      size = "medium",
-      color = "primary",
-      // FAB specific props
+      // Variant props
+      size = "fab",
+      color = "primary-container",
+
+      // Content
       icon,
       children,
-      "aria-label": ariaLabel,
+
+      // State
       loading = false,
       disableRipple = false,
+      isDisabled = false,
+
+      // Styling
       className,
-      // React Aria props
-      isDisabled: propIsDisabled = false,
-      onPress,
-      onMouseDown,
+
+      // Accessibility
+      "aria-label": ariaLabel,
       title,
+
+      // Passthrough — forwarded to FABHeadless
+      tabIndex = 0,
+      type = "button",
+
+      // Passed through to FABHeadless → useButton
       ...props
     },
     ref
   ) => {
-    // Development warnings
+    const fabRef = useRef<HTMLButtonElement>(null);
+    const resolvedRef = (ref ?? fabRef) as React.RefObject<HTMLButtonElement>;
+
+    const isFABDisabled = isDisabled || loading;
+
+    // ── Interaction state tracking ──────────────────────────────────────────
+    const [isPressed, setIsPressed] = useState(false);
+    const handlePressStart = useCallback(() => setIsPressed(true), []);
+    const handlePressEnd = useCallback(() => setIsPressed(false), []);
+
+    const { isHovered, hoverProps } = useHover({ isDisabled: isFABDisabled });
+    const { isFocusVisible, focusProps } = useFocusRing();
+
+    // Ripple effect
+    const { onMouseDown: handleRipple, ripples } = useRipple({
+      disabled: isFABDisabled || disableRipple,
+    });
+
+    // ── Development warnings ─────────────────────────────────────────────────
     if (process.env.NODE_ENV === "development") {
       if (!icon) {
-        console.warn("[FAB] FAB must have an icon. Please provide the icon prop.");
+        console.warn("[FAB] FAB must have an icon. Please provide the `icon` prop.");
       }
-
       if (size === "extended" && !children) {
-        console.warn("[FAB] Extended FAB requires text label as children.");
+        console.warn("[FAB] Extended FAB requires a text label as `children`.");
       }
-
       if (size !== "extended" && children) {
         console.warn(
-          "[FAB] Children (text) is only used for extended FAB. For icon-only FAB, use icon prop only."
+          "[FAB] `children` (text label) is only rendered for `size='extended'`. For icon-only FABs, use the `icon` prop only."
+        );
+      }
+      // Deprecation warnings
+      if (size === "small") {
+        console.warn(
+          "[FAB] `size='small'` is deprecated in M3 Expressive. Use `size='fab'` (56dp) instead."
+        );
+      }
+      if (color === "surface") {
+        console.warn(
+          "[FAB] `color='surface'` is deprecated in M3 Expressive. Use `color='primary-container'` instead."
         );
       }
     }
 
-    // Combine disabled states
-    const isDisabled = propIsDisabled || loading;
-
-    // Ripple effect
-    const { onMouseDown: handleRipple, ripples } = useRipple({
-      disabled: isDisabled || disableRipple,
-    });
-
-    // Merge user's onMouseDown with ripple handler
-    const mergedOnMouseDown = (e: React.MouseEvent<HTMLButtonElement>): void => {
-      onMouseDown?.(e);
-      handleRipple(e);
-    };
-
-    const mergedPropsValue = mergeProps(props, {
-      ...(onPress && { onPress }),
-      onMouseDown: mergedOnMouseDown,
-      isDisabled,
-    });
-
     return (
       <FABHeadless
-        ref={ref}
+        {...mergeProps(
+          hoverProps,
+          focusProps,
+          { onPressStart: handlePressStart, onPressEnd: handlePressEnd },
+          props
+        )}
+        ref={resolvedRef}
+        type={type}
+        isDisabled={isFABDisabled}
+        tabIndex={tabIndex}
+        onMouseDown={handleRipple}
+        aria-label={ariaLabel}
+        {...(title !== undefined && { title })}
+        // ── Interaction data attributes ─────────────────────────────────────
+        {...getInteractionDataAttributes({
+          isHovered,
+          isFocusVisible,
+          isPressed,
+          isDisabled: isFABDisabled,
+        })}
+        // ── Content flags ───────────────────────────────────────────────────
+        data-with-icon={icon ? "" : undefined}
+        data-loading={loading ? "" : undefined}
         className={cn(
-          // Base classes
-          "relative inline-flex items-center justify-center",
-          "overflow-hidden transition-all duration-200",
-          "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
-          "shrink-0",
-
-          // State layers (hover, focus, active)
-          "before:absolute before:inset-0 before:rounded-[inherit] before:transition-opacity before:duration-200",
-          "before:bg-current before:opacity-0",
-          "hover:before:opacity-8",
-          "focus-visible:before:opacity-12",
-          "active:before:opacity-12",
-
-          // Elevation
-          "shadow-elevation-3 hover:shadow-elevation-4",
-
-          // CVA variants
-          fabVariants({ size, color, isDisabled }),
-
-          // User custom classes
+          fabVariants({ size, color }),
+          // group/fab: enables group-data-[x]/fab child selectors in all slots
+          "group/fab",
           className
         )}
-        aria-label={ariaLabel}
-        {...(title && { title })}
-        {...mergedPropsValue}
       >
         {/* Ripple effect */}
         {ripples}
 
-        {/* Icon (hidden when loading) */}
-        {icon && (
-          <span className={cn("relative z-10 inline-flex shrink-0", loading && "invisible")}>
-            {icon}
-          </span>
-        )}
+        {/* State layer — absolute overlay; transitions opacity on interaction */}
+        <span className={cn(fabStateLayerVariants({ color }))} aria-hidden="true" />
 
-        {/* Loading spinner (shown when loading, overlays icon position) */}
+        {/* Focus ring — absolute, extends 3px outside boundary; keyboard-only */}
+        <span className={cn(fabFocusRingVariants())} aria-hidden="true" />
+
+        {/* Icon — invisible (not hidden) when loading so layout stays stable */}
+        {icon && <span className={cn(fabIconVariants({ size, hidden: loading }))}>{icon}</span>}
+
+        {/* Loading spinner — overlays icon position */}
         {loading && (
-          <span className="relative z-10">
+          <span className={cn(fabIconVariants({ size }))}>
             <Spinner />
           </span>
         )}
 
-        {/* Text label (extended FAB only) */}
+        {/* Text label — extended FAB only */}
         {size === "extended" && children && (
-          <span className="relative z-10 inline-flex items-center text-sm font-medium tracking-[0.1px]">
-            {children}
-          </span>
+          <span className={cn(fabLabelVariants())}>{children}</span>
         )}
       </FABHeadless>
     );

--- a/packages/react/src/components/FAB/FAB.types.ts
+++ b/packages/react/src/components/FAB/FAB.types.ts
@@ -2,112 +2,163 @@ import type { AriaButtonProps } from "react-aria";
 import type React from "react";
 
 /**
- * FAB size types
+ * FAB size types — MD3 Expressive scale.
+ *
+ * | Value      | Height | Icon  | Corner | Notes                        |
+ * |------------|--------|-------|--------|------------------------------|
+ * | `fab`      | 56dp   | 24dp  | 16dp   | Default. Regular FAB.        |
+ * | `medium`   | 80dp   | 28dp  | 20dp   | Medium FAB (M3 Expressive).  |
+ * | `large`    | 96dp   | 36dp  | 28dp   | Large FAB.                   |
+ * | `extended` | 56dp   | 24dp  | 16dp   | Extended FAB with text label.|
+ * | `small`    | 40dp   | 24dp  | 12dp   | @deprecated — Use `fab`.     |
+ *
+ * @default 'fab'
  */
-export type FABSize = "small" | "medium" | "large" | "extended";
+export type FABSize = "fab" | "medium" | "large" | "extended" | "small";
 
 /**
- * FAB color scheme
+ * FAB color styles — MD3 Expressive color roles.
+ *
+ * **Container styles (default set):**
+ * - `primary-container` — bg-primary-container / text-on-primary-container (default)
+ * - `secondary-container` — bg-secondary-container / text-on-secondary-container
+ * - `tertiary-container` — bg-tertiary-container / text-on-tertiary-container
+ *
+ * **Solid styles (M3 Expressive):**
+ * - `primary` — bg-primary / text-on-primary
+ * - `secondary` — bg-secondary / text-on-secondary
+ * - `tertiary` — bg-tertiary / text-on-tertiary
+ *
+ * **Deprecated:**
+ * - `surface` — @deprecated Use `primary-container`. Maps to surface-container-high.
+ *
+ * @default 'primary-container'
  */
-export type FABColor = "primary" | "secondary" | "tertiary" | "surface";
+export type FABColor =
+  | "primary-container"
+  | "secondary-container"
+  | "tertiary-container"
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "surface";
 
 /**
  * Material Design 3 FAB (Floating Action Button) Component Props
  *
- * High-emphasis button for primary screen action.
- * Supports 4 sizes: small (40px), medium (56px), large (96px), extended (variable width with text)
- *
- * ⚠️ IMPORTANT:
- * - Only ONE FAB per screen
- * - aria-label is REQUIRED (even for extended FAB with text)
- * - Use for primary constructive actions only (create, add, compose)
- * - NOT for destructive (delete), navigation (back), or secondary actions
+ * High-emphasis button for the primary screen action.
+ * Implements the MD3 Expressive FAB spec with a slot-based architecture
+ * matching Button and Switch for consistent interaction state handling.
  *
  * @example
  * ```tsx
- * // Standard FAB (medium)
- * <FAB aria-label="Create new item" icon={<IconAdd />} />
+ * // Default FAB (56dp)
+ * <FAB aria-label="Create" icon={<IconAdd />} />
  *
- * // Small FAB
- * <FAB aria-label="Add photo" icon={<IconCamera />} size="small" />
+ * // Medium FAB (80dp, M3 Expressive)
+ * <FAB aria-label="Create" icon={<IconAdd />} size="medium" />
  *
- * // Large FAB
+ * // Large FAB (96dp)
  * <FAB aria-label="Compose" icon={<IconEdit />} size="large" />
  *
- * // Extended FAB (with text)
- * <FAB aria-label="Create new document" icon={<IconAdd />} size="extended">
+ * // Extended FAB (with text label)
+ * <FAB aria-label="Create document" icon={<IconAdd />} size="extended">
  *   Create
  * </FAB>
  *
+ * // Solid primary color (M3 Expressive)
+ * <FAB aria-label="Add" icon={<IconAdd />} color="primary" />
+ *
  * // Loading state
  * <FAB aria-label="Creating" icon={<IconAdd />} loading />
- *
- * // Secondary color
- * <FAB aria-label="Edit" icon={<IconEdit />} color="secondary" />
  * ```
  */
 export interface FABProps extends AriaButtonProps {
   /**
-   * FAB size variant
-   * - small: 40×40px (24px icon)
-   * - medium: 56×56px (24px icon) - default
-   * - large: 96×96px (36px icon)
-   * - extended: Variable width with text (24px icon)
-   * @default 'medium'
+   * FAB size variant.
+   *
+   * - `fab` (56dp) — Default. Standard FAB.
+   * - `medium` (80dp) — Medium FAB. M3 Expressive. Previously 56dp; now remapped.
+   * - `large` (96dp) — Large FAB.
+   * - `extended` (56dp height) — Extended FAB with icon and text label.
+   * - `small` (40dp) — @deprecated. Use `fab` instead.
+   *
+   * @default 'fab'
    */
   size?: FABSize;
 
   /**
-   * Color scheme
-   * @default 'primary'
+   * Color style for the FAB.
+   *
+   * - `primary-container` — Default. bg-primary-container / text-on-primary-container.
+   * - `secondary-container` — bg-secondary-container / text-on-secondary-container.
+   * - `tertiary-container` — bg-tertiary-container / text-on-tertiary-container.
+   * - `primary` — Solid. bg-primary / text-on-primary (M3 Expressive).
+   * - `secondary` — Solid. bg-secondary / text-on-secondary (M3 Expressive).
+   * - `tertiary` — Solid. bg-tertiary / text-on-tertiary (M3 Expressive).
+   * - `surface` — @deprecated. Use `primary-container`.
+   *
+   * @default 'primary-container'
    */
   color?: FABColor;
 
   /**
    * Icon content (required).
-   * Recommended sizes:
-   * - small/medium/extended: 24x24px
-   * - large: 36x36px
+   * Recommended icon sizes per variant:
+   * - `fab` / `extended` / `small`: 24×24px
+   * - `medium`: 28×28px
+   * - `large`: 36×36px
    */
   icon: React.ReactNode;
 
   /**
-   * Text label (required for extended FAB, ignored for other sizes)
+   * Text label — only rendered for `size="extended"`.
    */
   children?: React.ReactNode;
 
   /**
-   * Mandatory accessible label for the FAB.
-   * This is crucial for screen readers as FAB is icon-based.
-   * Even extended FAB with text requires aria-label.
+   * Mandatory accessible label for all FAB sizes.
+   * Required even for extended FABs that have visible text.
    */
   "aria-label": string;
 
   /**
-   * Loading state - shows spinner, disables interaction
+   * Shows a loading spinner and disables interaction.
    * @default false
    */
   loading?: boolean;
 
   /**
-   * Disable ripple effect
+   * Disables the MD3 ripple press-feedback animation.
    * @default false
    */
   disableRipple?: boolean;
 
   /**
-   * Additional CSS classes (Tailwind)
-   * Can be used for positioning (e.g., "fixed bottom-4 right-4")
+   * Additional Tailwind classes — commonly used for positioning
+   * (e.g. `className="fixed bottom-4 right-4"`).
    */
   className?: string;
 
   /**
-   * HTML title attribute for tooltip
+   * HTML title attribute for tooltip.
    */
   title?: string;
 
   /**
-   * Mouse down handler (for ripple effect and custom handling)
+   * Mouse down handler (merged with the internal ripple handler).
    */
   onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+
+  /**
+   * Tab index for keyboard navigation.
+   * @default 0
+   */
+  tabIndex?: number | undefined;
+
+  /**
+   * Button type attribute.
+   * @default 'button'
+   */
+  type?: "button" | "submit" | "reset";
 }

--- a/packages/react/src/components/FAB/FAB.variants.ts
+++ b/packages/react/src/components/FAB/FAB.variants.ts
@@ -1,199 +1,330 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 FAB Variants (CVA)
+ * Material Design 3 FAB Variants — Slot-based architecture
  *
- * Type-safe variant management for FAB component.
- * Uses Tailwind CSS classes mapped to MD3 design tokens.
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no disabled/loading state variants).
+ * - All interaction states are driven by data-* attributes on the root via
+ *   group-data-[x]/fab Tailwind selectors in each slot's base classes.
+ * - Content flags (data-with-icon, data-loading) are set explicitly by the component.
+ * - Self-targeting data-[x]: selectors handle root-level disabled styling.
  *
- * Key differences from Button/IconButton:
- * - NOT fully rounded (uses specific corner radius: 12px/16px/28px)
- * - Always has elevation (shadow-elevation-3)
- * - Larger sizes (40px/56px/96px)
- * - Extended variant with variable width
+ * Slot responsibilities:
+ *   fabVariants           — root <button>; shape per size, color per variant,
+ *                           elevation (base 3 → hover 4 → focus/pressed 3),
+ *                           self data-[disabled] styling, group/fab scope.
+ *   fabStateLayerVariants — absolute inset overlay, opacity 0/8%/10%/10%,
+ *                           color = icon/on-color per MD3 spec.
+ *   fabFocusRingVariants  — keyboard focus outline ring (inset-[-3px]).
+ *                           MUST NOT sit inside overflow-hidden.
+ *   fabIconVariants       — icon wrapper; size per FAB size variant.
+ *   fabLabelVariants      — extended FAB text label slot.
+ *
+ * MD3 Expressive size scale:
+ *   fab      → 56dp  container, 16dp corner, 24dp icon  (default)
+ *   medium   → 80dp  container, 20dp corner, 28dp icon  (M3 Expressive)
+ *   large    → 96dp  container, 28dp corner, 36dp icon
+ *   extended → 56dp  height,    16dp corner, 24dp icon  (+ text label)
+ *   small    → 40dp  container, 12dp corner, 24dp icon  (@deprecated)
+ *
+ * MD3 Expressive color roles:
+ *   primary-container   → bg-primary-container   / text-on-primary-container   (default)
+ *   secondary-container → bg-secondary-container / text-on-secondary-container
+ *   tertiary-container  → bg-tertiary-container  / text-on-tertiary-container
+ *   primary             → bg-primary             / text-on-primary             (solid, M3 Expressive)
+ *   secondary           → bg-secondary           / text-on-secondary           (solid, M3 Expressive)
+ *   tertiary            → bg-tertiary            / text-on-tertiary            (solid, M3 Expressive)
+ *   surface             → bg-surface-container-high / text-primary             (@deprecated)
+ *
+ * Elevation per state (MD3 spec):
+ *   base    → elevation-3
+ *   hovered → elevation-4  (shadow-elevation-4)
+ *   focused → elevation-3  (doubled selector wins over hover)
+ *   pressed → elevation-3  (doubled selector wins over hover)
+ *   disabled → no shadow
+ *
+ * State-layer opacities (MD3):
+ *   hover  → 8%   (opacity-8)
+ *   focus  → 10%  (opacity-10)
+ *   pressed→ 10%  (opacity-10, doubled selector wins over hover's 8%)
+ *
+ * Important — overflow-hidden is NOT on the root button.
+ * The focus ring span has `inset-[-3px]` to extend outside the button boundary,
+ * which requires the root to not clip overflow. Overflow clipping is delegated
+ * to the state layer and ripple container (overflow-hidden + rounded-[inherit]).
  */
+
+// ─── FAB ROOT / CONTAINER ─────────────────────────────────────────────────────
+
 export const fabVariants = cva(
   [
-    // Base classes (always applied)
-    "relative inline-flex items-center justify-center cursor-pointer",
-    "overflow-hidden",
-    "transition-all duration-200",
-    "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
-    "shrink-0", // Prevent shrinking in flex containers
-
-    // State layers (hover, focus, active)
-    "before:absolute before:inset-0 before:rounded-[inherit] before:transition-opacity before:duration-200",
-    "before:bg-current before:opacity-0",
-    "hover:before:opacity-8",
-    "focus-visible:before:opacity-12",
-    "active:before:opacity-12",
-
-    // Elevation (floating appearance)
-    "shadow-elevation-3", // Default elevation
-    "hover:shadow-elevation-4", // Hover elevation
+    // Layout — NO overflow-hidden here (focus ring must extend outside)
+    "relative inline-flex items-center justify-center cursor-pointer select-none",
+    "shrink-0",
+    // Effects transition: color / bg / shadow — standard spring, no overshoot
+    "transition-[color,background-color,box-shadow]",
+    "duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Disabled — self-targeting data-[x]: selectors (not group-data — these target the root itself)
+    "data-[disabled]:bg-on-surface/12 data-[disabled]:text-on-surface/38",
+    "data-[disabled]:shadow-none data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
   ],
   {
     variants: {
       /**
-       * FAB size (controls dimensions and icon size)
+       * FAB size — controls container dimensions, corner radius, and icon slot size.
        */
       size: {
-        small: [
-          "h-10 w-10", // 40×40px
-          "p-2", // 8px padding for 24px icon
-          "rounded-xl", // 12px corner radius (not fully rounded!)
-          "m-1", // 4px margin for 48×48px touch target
+        /**
+         * fab (default) — 56×56dp, 16dp corner radius.
+         * MD3 standard FAB.
+         */
+        fab: [
+          "h-14 w-14", // 56dp
+          "rounded-2xl", // 16dp corner
         ],
+
+        /**
+         * medium — 80×80dp, 20dp corner radius.
+         * M3 Expressive Medium FAB. Previously this value mapped to 56dp;
+         * it is now remapped to the Expressive 80dp Medium FAB.
+         */
         medium: [
-          "h-14 w-14", // 56×56px
-          "p-4", // 16px padding for 24px icon
-          "rounded-2xl", // 16px corner radius
+          "h-20 w-20", // 80dp
+          "rounded-[20px]", // 20dp corner (large-increased shape token)
         ],
+
+        /**
+         * large — 96×96dp, 28dp corner radius.
+         */
         large: [
-          "h-24 w-24", // 96×96px
-          "p-[30px]", // 30px padding for 36px icon
-          "rounded-[28px]", // 28px corner radius (custom value)
+          "h-24 w-24", // 96dp
+          "rounded-[28px]", // 28dp corner
         ],
+
+        /**
+         * extended — 56dp height, variable width, 16dp corner.
+         * Icon + text label side by side.
+         * Padding: 16dp leading (icon side), 20dp trailing (text side).
+         * Gap: 12dp between icon and label (MD3 spec).
+         */
         extended: [
-          "h-14", // 56px height (same as medium)
-          "rounded-2xl", // 16px corner radius
-          "pl-4 pr-5", // Asymmetric padding: 16px leading, 20px trailing
-          "gap-2", // 8px gap between icon and text
+          "h-14", // 56dp height
+          "rounded-2xl", // 16dp corner
+          "pl-4 pr-5", // 16dp leading, 20dp trailing
+          "gap-3", // 12dp gap between icon and label
+        ],
+
+        /**
+         * @deprecated Use `fab` (56dp) instead.
+         * small — 40×40dp, 12dp corner radius. No longer recommended in M3 Expressive.
+         * Kept functional for backward compatibility.
+         */
+        small: [
+          "h-10 w-10", // 40dp
+          "rounded-xl", // 12dp corner
+          "m-1", // 4dp margin for 48×48dp minimum touch target
         ],
       },
 
       /**
-       * Color scheme (MD3 color roles)
+       * FAB color — controls container + on-color.
+       * State-layer color in fabStateLayerVariants must match icon/on-color.
        */
       color: {
-        primary: "",
-        secondary: "",
-        tertiary: "",
-        surface: "",
-      },
-
-      /**
-       * Disabled state
-       */
-      isDisabled: {
-        true: "pointer-events-none cursor-not-allowed !bg-on-surface/12 !text-on-surface/38 !shadow-none",
-        false: "",
+        "primary-container": [
+          "bg-primary-container text-on-primary-container",
+          // Elevation base=3, hover=4 (state driven), disabled handled by root data-[disabled]
+          "shadow-elevation-3",
+          "group-data-[hovered]/fab:shadow-elevation-4",
+          // Focus / pressed: return to elevation-3
+          // Doubled attribute selector gives higher specificity than single hover selector
+          "group-data-[focus-visible]/fab:shadow-elevation-3",
+          "group-data-[pressed]/fab:group-data-[pressed]/fab:shadow-elevation-3",
+        ],
+        "secondary-container": [
+          "bg-secondary-container text-on-secondary-container",
+          "shadow-elevation-3",
+          "group-data-[hovered]/fab:shadow-elevation-4",
+          "group-data-[focus-visible]/fab:shadow-elevation-3",
+          "group-data-[pressed]/fab:group-data-[pressed]/fab:shadow-elevation-3",
+        ],
+        "tertiary-container": [
+          "bg-tertiary-container text-on-tertiary-container",
+          "shadow-elevation-3",
+          "group-data-[hovered]/fab:shadow-elevation-4",
+          "group-data-[focus-visible]/fab:shadow-elevation-3",
+          "group-data-[pressed]/fab:group-data-[pressed]/fab:shadow-elevation-3",
+        ],
+        primary: [
+          "bg-primary text-on-primary",
+          "shadow-elevation-3",
+          "group-data-[hovered]/fab:shadow-elevation-4",
+          "group-data-[focus-visible]/fab:shadow-elevation-3",
+          "group-data-[pressed]/fab:group-data-[pressed]/fab:shadow-elevation-3",
+        ],
+        secondary: [
+          "bg-secondary text-on-secondary",
+          "shadow-elevation-3",
+          "group-data-[hovered]/fab:shadow-elevation-4",
+          "group-data-[focus-visible]/fab:shadow-elevation-3",
+          "group-data-[pressed]/fab:group-data-[pressed]/fab:shadow-elevation-3",
+        ],
+        tertiary: [
+          "bg-tertiary text-on-tertiary",
+          "shadow-elevation-3",
+          "group-data-[hovered]/fab:shadow-elevation-4",
+          "group-data-[focus-visible]/fab:shadow-elevation-3",
+          "group-data-[pressed]/fab:group-data-[pressed]/fab:shadow-elevation-3",
+        ],
+        /** @deprecated Use `primary-container` instead. */
+        surface: [
+          "bg-surface-container-high text-primary",
+          "shadow-elevation-3",
+          "group-data-[hovered]/fab:shadow-elevation-4",
+          "group-data-[focus-visible]/fab:shadow-elevation-3",
+          "group-data-[pressed]/fab:group-data-[pressed]/fab:shadow-elevation-3",
+        ],
       },
     },
 
-    /**
-     * Compound variants - combinations of size + color
-     */
-    compoundVariants: [
-      // ====================
-      // PRIMARY COLOR
-      // ====================
-      {
-        color: "primary",
-        size: "small",
-        className: "bg-primary-container text-on-primary-container",
-      },
-      {
-        color: "primary",
-        size: "medium",
-        className: "bg-primary-container text-on-primary-container",
-      },
-      {
-        color: "primary",
-        size: "large",
-        className: "bg-primary-container text-on-primary-container",
-      },
-      {
-        color: "primary",
-        size: "extended",
-        className: "bg-primary-container text-on-primary-container",
-      },
-
-      // ====================
-      // SECONDARY COLOR
-      // ====================
-      {
-        color: "secondary",
-        size: "small",
-        className: "bg-secondary-container text-on-secondary-container",
-      },
-      {
-        color: "secondary",
-        size: "medium",
-        className: "bg-secondary-container text-on-secondary-container",
-      },
-      {
-        color: "secondary",
-        size: "large",
-        className: "bg-secondary-container text-on-secondary-container",
-      },
-      {
-        color: "secondary",
-        size: "extended",
-        className: "bg-secondary-container text-on-secondary-container",
-      },
-
-      // ====================
-      // TERTIARY COLOR
-      // ====================
-      {
-        color: "tertiary",
-        size: "small",
-        className: "bg-tertiary-container text-on-tertiary-container",
-      },
-      {
-        color: "tertiary",
-        size: "medium",
-        className: "bg-tertiary-container text-on-tertiary-container",
-      },
-      {
-        color: "tertiary",
-        size: "large",
-        className: "bg-tertiary-container text-on-tertiary-container",
-      },
-      {
-        color: "tertiary",
-        size: "extended",
-        className: "bg-tertiary-container text-on-tertiary-container",
-      },
-
-      // ====================
-      // SURFACE COLOR
-      // ====================
-      {
-        color: "surface",
-        size: "small",
-        className: "bg-surface text-primary",
-      },
-      {
-        color: "surface",
-        size: "medium",
-        className: "bg-surface text-primary",
-      },
-      {
-        color: "surface",
-        size: "large",
-        className: "bg-surface text-primary",
-      },
-      {
-        color: "surface",
-        size: "extended",
-        className: "bg-surface text-primary",
-      },
-    ],
-
-    /**
-     * Default variants
-     */
     defaultVariants: {
-      size: "medium",
-      color: "primary",
-      isDisabled: false,
+      size: "fab",
+      color: "primary-container",
     },
   }
 );
 
+// ─── STATE LAYER ─────────────────────────────────────────────────────────────
+
 /**
- * Extract variant prop types from CVA
+ * State layer — absolute inset overlay that transitions opacity on interaction.
+ *
+ * Per MD3 spec, the state-layer color must equal the icon/on-color:
+ *   primary-container   → bg-on-primary-container
+ *   secondary-container → bg-on-secondary-container
+ *   tertiary-container  → bg-on-tertiary-container
+ *   primary (solid)     → bg-on-primary
+ *   secondary (solid)   → bg-on-secondary
+ *   tertiary (solid)    → bg-on-tertiary
+ *   surface (deprecated)→ bg-primary
+ *
+ * Opacity:
+ *   0 at rest · 8% hover · 10% focus · 10% pressed · hidden when disabled
+ *
+ * overflow-hidden is placed HERE (not on root) so the state layer clips to
+ * the FAB shape while the focus ring span can extend outside.
  */
+export const fabStateLayerVariants = cva(
+  [
+    "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+    // Effects transition — opacity must not overshoot
+    "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Hover: 8%
+    "group-data-[hovered]/fab:opacity-8",
+    // Focus: 10%
+    "group-data-[focus-visible]/fab:opacity-10",
+    // Pressed: 10% — doubled selector wins over hover's 8%
+    "group-data-[pressed]/fab:group-data-[pressed]/fab:opacity-10",
+    // No state layer when disabled
+    "group-data-[disabled]/fab:hidden",
+  ],
+  {
+    variants: {
+      color: {
+        "primary-container": "bg-on-primary-container",
+        "secondary-container": "bg-on-secondary-container",
+        "tertiary-container": "bg-on-tertiary-container",
+        primary: "bg-on-primary",
+        secondary: "bg-on-secondary",
+        tertiary: "bg-on-tertiary",
+        /** @deprecated */
+        surface: "bg-primary",
+      },
+    },
+    defaultVariants: { color: "primary-container" },
+  }
+);
+
+// ─── FOCUS RING ───────────────────────────────────────────────────────────────
+
+/**
+ * Focus ring overlay.
+ *
+ * Rendered as an absolute `<span>` with `inset-[-3px]` so it extends 3px
+ * outside the button boundary. This REQUIRES that `overflow-hidden` is NOT
+ * on the root `<button>` element — overflow clipping is moved to the ripple
+ * container and state layer instead.
+ *
+ * Always present in the DOM (opacity-0 at rest), transitions to opacity-100
+ * on keyboard/programmatic focus — avoids layout shifts.
+ */
+export const fabFocusRingVariants = cva([
+  "pointer-events-none absolute inset-[-3px] rounded-[inherit]",
+  "outline outline-2 outline-offset-0 outline-secondary",
+  // Effects transition — opacity change must not overshoot
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/fab:opacity-100",
+]);
+
+// ─── ICON ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Icon wrapper slot.
+ *
+ * MD3 icon sizes per FAB size:
+ *   fab / extended / small  → 24×24px (size-6)
+ *   medium                  → 28×28px (size-7)
+ *   large                   → 36×36px (size-9)
+ *
+ * `invisible` (not `hidden`) when loading — keeps the layout stable so the
+ * spinner can occupy the same space without reflowing.
+ * Color is inherited from the parent button's text color.
+ */
+export const fabIconVariants = cva(
+  [
+    "relative z-10 inline-flex shrink-0 items-center justify-center",
+    // Color transition uses effects token (no spatial overshoot on color)
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  ],
+  {
+    variants: {
+      size: {
+        fab: "size-6", // 24dp
+        medium: "size-7", // 28dp
+        large: "size-9", // 36dp
+        extended: "size-6", // 24dp
+        small: "size-6", // 24dp
+      },
+      hidden: {
+        true: "invisible",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      size: "fab",
+      hidden: false,
+    },
+  }
+);
+
+// ─── LABEL (Extended FAB only) ────────────────────────────────────────────────
+
+/**
+ * Text label wrapper for extended FAB.
+ * Typography: Label Large (MD3 spec for FAB labels).
+ * z-10 keeps it above the state layer and ripple overlays.
+ */
+export const fabLabelVariants = cva([
+  "relative z-10 inline-flex items-center",
+  "text-label-large tracking-[0.1px]",
+]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
 export type FABVariants = VariantProps<typeof fabVariants>;
+export type FABStateLayerVariants = VariantProps<typeof fabStateLayerVariants>;
+export type FABFocusRingVariants = VariantProps<typeof fabFocusRingVariants>;
+export type FABIconVariants = VariantProps<typeof fabIconVariants>;
+export type FABLabelVariants = VariantProps<typeof fabLabelVariants>;

--- a/packages/react/src/components/FAB/FABHeadless.tsx
+++ b/packages/react/src/components/FAB/FABHeadless.tsx
@@ -1,13 +1,13 @@
 import { forwardRef, useRef } from "react";
 import { useButton } from "react-aria";
 import type { AriaButtonProps } from "react-aria";
-import { mergeProps, filterDOMProps } from "@react-aria/utils";
+import { mergeProps } from "@react-aria/utils";
 
 /**
  * Headless FAB Component (Layer 2)
  *
  * Unstyled FAB primitive using React Aria for accessibility.
- * Provides behavior only - bring your own styles.
+ * Provides behavior only — bring your own styles.
  *
  * Features:
  * - Full keyboard navigation (Enter, Space)
@@ -15,51 +15,41 @@ import { mergeProps, filterDOMProps } from "@react-aria/utils";
  * - Touch/pointer event handling
  * - Focus management
  * - Disabled state handling
+ * - Press lifecycle callbacks (onPressStart/onPressEnd) for pressed state tracking
  *
  * @example
  * ```tsx
- * // Use for custom styling
- * <FABHeadless className="custom-fab-class" aria-label="Add">
+ * <FABHeadless aria-label="Add" className="custom-fab">
  *   <IconAdd />
  * </FABHeadless>
  * ```
  */
 export interface FABHeadlessProps extends AriaButtonProps {
-  /**
-   * Additional CSS classes
-   */
+  /** Additional CSS classes */
   className?: string;
 
-  /**
-   * FAB content (icon and optional text)
-   */
+  /** FAB content (icon and optional text) */
   children: React.ReactNode;
 
   /**
-   * Tab index for keyboard navigation
+   * Tab index for keyboard navigation.
    * @default 0
    */
   tabIndex?: number;
 
-  /**
-   * Mouse down handler (for ripple effect)
-   */
+  /** Mouse down handler (for ripple effect) */
   onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 
   /**
-   * Button type attribute
+   * Button type attribute.
    * @default 'button'
    */
   type?: "button" | "submit" | "reset";
 
-  /**
-   * REQUIRED: Accessible label for screen readers
-   */
+  /** REQUIRED: Accessible label for screen readers */
   "aria-label": string;
 
-  /**
-   * HTML title attribute for tooltip
-   */
+  /** HTML title attribute for tooltip */
   title?: string;
 }
 
@@ -73,42 +63,49 @@ export const FABHeadless = forwardRef<HTMLButtonElement, FABHeadlessProps>(
       type,
       "aria-label": ariaLabel,
       title,
-      ...props
+      ...restProps
     },
     forwardedRef
   ) => {
-    // Internal ref for React Aria
     const internalRef = useRef<HTMLButtonElement>(null);
-
-    // Merge internal ref with forwarded ref
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLButtonElement>;
 
-    // React Aria hook - handles all accessibility
+    // React Aria hook — handles all accessibility
     const { buttonProps } = useButton(
       {
-        ...props,
+        ...restProps,
         elementType: "button",
       },
       ref
     );
 
-    // Filter out React Aria-specific props that shouldn't be passed to the DOM element
-    const domProps = filterDOMProps(props);
+    // Strip React Aria-specific event props that must not reach the DOM,
+    // then pass the remainder (data-*, interaction callbacks, etc.) through.
+    const {
+      isDisabled: _isDisabled,
+      onPress: _onPress,
+      onPressStart: _onPressStart,
+      onPressEnd: _onPressEnd,
+      onPressChange: _onPressChange,
+      onPressUp: _onPressUp,
+      ...htmlAttrs
+    } = restProps;
 
-    // Merge React Aria props with custom props and filtered DOM props
-    const mergedProps = mergeProps(buttonProps, domProps, {
-      tabIndex,
-      className,
-      onMouseDown,
-      type: type ?? "button",
-      "aria-label": ariaLabel, // Add aria-label
-      // Add title if provided
-      ...(title && { title }),
-    }) as React.ButtonHTMLAttributes<HTMLButtonElement>;
+    const mergedProps = mergeProps(
+      buttonProps,
+      {
+        tabIndex,
+        className,
+        onMouseDown,
+        "aria-label": ariaLabel,
+        ...(title !== undefined && { title }),
+      },
+      htmlAttrs
+    ) as React.ButtonHTMLAttributes<HTMLButtonElement>;
 
     return (
-      // eslint-disable-next-line react/button-has-type
-      <button {...mergedProps} ref={ref}>
+      // eslint-disable-next-line react/button-has-type -- type is dynamically passed from props
+      <button {...mergedProps} ref={ref} type={type ?? "button"}>
         {children}
       </button>
     );

--- a/packages/react/src/components/FAB/index.ts
+++ b/packages/react/src/components/FAB/index.ts
@@ -1,6 +1,18 @@
 export { FAB } from "./FAB";
 export { FABHeadless } from "./FABHeadless";
-export { fabVariants } from "./FAB.variants";
+export {
+  fabVariants,
+  fabStateLayerVariants,
+  fabFocusRingVariants,
+  fabIconVariants,
+  fabLabelVariants,
+} from "./FAB.variants";
 export type { FABProps, FABSize, FABColor } from "./FAB.types";
-export type { FABVariants } from "./FAB.variants";
+export type {
+  FABVariants,
+  FABStateLayerVariants,
+  FABFocusRingVariants,
+  FABIconVariants,
+  FABLabelVariants,
+} from "./FAB.variants";
 export type { FABHeadlessProps } from "./FABHeadless";


### PR DESCRIPTION
## Summary

- Refactors FAB to slot-based "Variants vs States" architecture (mirrors Button/Switch)
- New MD3 Expressive size scale: `fab` (56dp default), `medium` (80dp), `large` (96dp), `extended`
- New solid color styles (`primary`, `secondary`, `tertiary`) alongside container styles
- Breaking API changes documented in changeset (default size/color, medium remapped to 80dp)

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` — all green (1961 tests)
- [x] Storybook visual check: all sizes, container + solid colors, states, deprecated section
- [x] Changeset added for minor bump (`@tinybigui/react`)