### PR TITLE
refactor(badge): MD3 expressive variants/states and icon-corner anchoring

### DIFF
--- a/.changeset/badge-md3-expressive-refactor.md
+++ b/.changeset/badge-md3-expressive-refactor.md
@@ -1,0 +1,16 @@
+---
+"@tinybigui/react": minor
+---
+
+**Badge: align with MD3 spec and variants/states architecture (breaking)**
+
+Removes the non-spec `color` prop (and `BadgeColor` type) from `Badge`, `BadgeContent`, and `DrawerItemBadgeConfig`. The MD3 badge specification defines only the error color role (`bg-error` / `text-on-error`), which is now hardcoded in the CVA base.
+
+**Migration:** Remove any `color` prop usage from `<Badge>` and `<DrawerItem badge={{ color: … }}>`.
+
+**Styling changes:**
+
+- Migrates from CVA variant keys for `size`, `color`, `invisible`, and `reducedMotion` to the variants-vs-states architecture used by Button and Switch.
+- Dot vs count is now a content flag (`data-dot`) set directly on the element; visibility is a runtime flag (`data-invisible`).
+- Show/hide animation uses MD3 Expressive spatial token pair (`duration-expressive-fast-spatial` + `ease-expressive-fast-spatial`) instead of mixed scale+opacity transitions.
+- Reduced-motion guard applied at the component level (conditional class, not a CVA variant).

--- a/.changeset/badge-md3-icon-anchor-placement.md
+++ b/.changeset/badge-md3-icon-anchor-placement.md
@@ -1,0 +1,27 @@
+---
+"@tinybigui/react": patch
+---
+
+fix(badge): anchor indicator to icon corner per MD3 spec
+
+## What changed
+
+The Badge indicator now straddles the wrapped element's top-right corner instead of floating fully outside it.
+
+**Before:** `absolute -top-1 -right-1` pushed the badge 4dp outside the host's top-right edge. When wrapping a padded `IconButton`, the badge landed on the button border rather than on the icon itself.
+
+**After:** `absolute top-0 right-0 -translate-y-1/2 translate-x-1/2` places the badge center on the host's top-right corner (half-in, half-out), matching the MD3 spec diagram. This is host-size-agnostic — the badge sits correctly on a 24dp bare icon, a nav chip, or any other wrapped element.
+
+> Tailwind v4 note: `translate-*` and `scale-*` map to independent native CSS `translate:` / `scale:` properties, so the static corner translate does not interfere with the existing `scale-0`/`scale-100` show/hide animation.
+
+## Drawer trailing badge
+
+`DrawerItem`'s config-based badge (`badge={{ count: N }}`) no longer uses `<Badge><span/>` (which would apply the absolute translate to a 0-size anchor). It now renders a direct `<span role="status">` using the new `badgeStaticVariants` — same visual appearance (colors, sizing, dot/invisible flags) but inline (no absolute positioning).
+
+## New export
+
+`badgeStaticVariants` and `BadgeStaticVariants` are now exported from `@tinybigui/react` for consumers who need an inline badge pill in custom layouts.
+
+## Migration
+
+No API changes. If you relied on the `absolute -top-1 -right-1` offset for a custom layout workaround, update your wrapping to match the new `top-0 right-0 -translate-y-1/2 translate-x-1/2` placement.

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof Badge> = {
     docs: {
       description: {
         component:
-          "MD3 Badge — a small status indicator overlaid on icons and navigation items. Supports dot (small) and count (large) variants. https://m3.material.io/components/badges/overview",
+          "MD3 Badge — a small status indicator overlaid on icons and navigation items. Uses the MD3 error color role (bg-error / text-on-error). Supports dot (small 6dp) and count (large 16dp) forms. https://m3.material.io/components/badges/overview",
       },
     },
   },
@@ -36,11 +36,6 @@ const meta: Meta<typeof Badge> = {
     max: {
       control: "number",
       description: "Maximum count before overflow truncation (e.g. '999+').",
-    },
-    color: {
-      control: "select",
-      options: ["error", "primary"],
-      description: "Badge color role mapped to MD3 design tokens.",
     },
     invisible: {
       control: "boolean",
@@ -59,7 +54,6 @@ type Story = StoryObj<typeof Badge>;
 export const Default: Story = {
   args: {
     count: 3,
-    color: "error",
   },
   render: (args) => (
     <Badge {...args}>
@@ -72,7 +66,7 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          "Default Badge wrapping an IconButton with error color and count=3. All controls in the panel are wired for interactive exploration.",
+          "Default Badge wrapping an IconButton with count=3. All controls in the panel are wired for interactive exploration.",
       },
     },
   },
@@ -90,7 +84,7 @@ export const DotBadge: Story = {
     docs: {
       description: {
         story:
-          "Dot badge — no count provided, so a small dot indicator is rendered. Use to signal new unread activity without a specific count.",
+          "Dot badge — no count provided, so a 6dp dot indicator is rendered. Use to signal new unread activity without a specific count.",
       },
     },
   },
@@ -108,7 +102,7 @@ export const CountBadge: Story = {
     docs: {
       description: {
         story:
-          "Large count badge showing 5. The badge adopts the pill shape whenever a count is provided.",
+          "Large count badge (16dp height) showing 5. The badge adopts the pill shape whenever a count is provided.",
       },
     },
   },
@@ -185,41 +179,6 @@ export const CustomMax: Story = {
   },
 };
 
-export const PrimaryColor: Story = {
-  render: () => (
-    <Badge count={4} color="primary">
-      <IconButton aria-label="Notifications">
-        <IconBell />
-      </IconButton>
-    </Badge>
-  ),
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Badge with color='primary', using the MD3 primary color role instead of the default error role.",
-      },
-    },
-  },
-};
-
-export const ErrorColor: Story = {
-  render: () => (
-    <Badge count={4} color="error">
-      <IconButton aria-label="Notifications">
-        <IconBell />
-      </IconButton>
-    </Badge>
-  ),
-  parameters: {
-    docs: {
-      description: {
-        story: "Badge with color='error' (the default). Maps to the MD3 error design token.",
-      },
-    },
-  },
-};
-
 const InvisibleBadgeDemo = (): React.ReactElement => {
   const [invisible, setInvisible] = React.useState(false);
   return (
@@ -246,7 +205,7 @@ export const InvisibleBadge: Story = {
     docs: {
       description: {
         story:
-          "invisible=true hides the badge with a scale-out / opacity transition. Click the toggle button to animate the hide and show and observe the reduced-motion-aware transition.",
+          "invisible=true hides the badge with a scale-out transition (MD3 Expressive fast-spatial spring). Click the toggle button to animate show and hide, observing the reduced-motion-aware behaviour.",
       },
     },
   },
@@ -272,7 +231,7 @@ export const ZeroCount: Story = {
 
 export const WrappingIconButton: Story = {
   render: () => (
-    <Badge count={3} color="error">
+    <Badge count={3}>
       <IconButton aria-label="Messages" variant="filled">
         <IconMail />
       </IconButton>
@@ -349,22 +308,13 @@ export const AllVariants: Story = {
         </Badge>
         <span className="text-on-surface text-xs">Overflow</span>
       </div>
-
-      <div className="flex flex-col items-center gap-3">
-        <Badge count={4} color="primary">
-          <IconButton aria-label="Primary color badge demo">
-            <IconBell />
-          </IconButton>
-        </Badge>
-        <span className="text-on-surface text-xs">Primary</span>
-      </div>
     </div>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "Side-by-side showcase of all Badge variants: dot, single-digit, multi-digit, overflow ('999+'), and primary color.",
+          "Side-by-side showcase of all Badge forms: dot (6dp), single-digit, multi-digit, and overflow ('999+'). All use the MD3 error color role.",
       },
     },
   },
@@ -374,7 +324,6 @@ export const Playground: Story = {
   args: {
     count: 3,
     max: 999,
-    color: "error",
     invisible: false,
   },
   render: (args) => (
@@ -388,7 +337,7 @@ export const Playground: Story = {
     docs: {
       description: {
         story:
-          "Fully interactive playground — use the controls panel to adjust count, max, color, invisible, and aria-label and see all combinations live.",
+          "Fully interactive playground — use the controls panel to adjust count, max, invisible, and aria-label and see all combinations live.",
       },
     },
   },

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -15,6 +15,22 @@ const IconMail = (): React.ReactElement => (
   </svg>
 );
 
+/**
+ * A 24dp icon host — wraps the SVG in a span so the badge wrapper has a
+ * fixed-size element to straddle. Using a bare icon (not a full IconButton)
+ * matches the MD3 spec diagram where the badge center sits on the top-right
+ * corner of the icon shape itself.
+ */
+const IconHost = ({
+  children,
+  className = "text-on-surface-variant",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}): React.ReactElement => (
+  <span className={`inline-flex h-6 w-6 items-center justify-center ${className}`}>{children}</span>
+);
+
 const meta: Meta<typeof Badge> = {
   title: "Components/Badge",
   component: Badge,
@@ -23,7 +39,7 @@ const meta: Meta<typeof Badge> = {
     docs: {
       description: {
         component:
-          "MD3 Badge — a small status indicator overlaid on icons and navigation items. Uses the MD3 error color role (bg-error / text-on-error). Supports dot (small 6dp) and count (large 16dp) forms. https://m3.material.io/components/badges/overview",
+          "MD3 Badge — a small status indicator overlaid on icons and navigation items. The badge center straddles the wrapped element's top-right corner (`top-0 right-0 -translate-y-1/2 translate-x-1/2`), matching the MD3 spec. Uses the MD3 error color role (bg-error / text-on-error). Supports dot (small 6dp) and count (large 16dp) forms. https://m3.material.io/components/badges/overview",
       },
     },
   },
@@ -57,16 +73,16 @@ export const Default: Story = {
   },
   render: (args) => (
     <Badge {...args}>
-      <IconButton aria-label="Notifications">
+      <IconHost>
         <IconBell />
-      </IconButton>
+      </IconHost>
     </Badge>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "Default Badge wrapping an IconButton with count=3. All controls in the panel are wired for interactive exploration.",
+          "Default Badge wrapping a 24dp icon host with count=3. The badge center sits on the icon's top-right corner (MD3 spec). All controls in the panel are wired for interactive exploration.",
       },
     },
   },
@@ -75,16 +91,16 @@ export const Default: Story = {
 export const DotBadge: Story = {
   render: () => (
     <Badge>
-      <IconButton aria-label="Notifications">
+      <IconHost>
         <IconBell />
-      </IconButton>
+      </IconHost>
     </Badge>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "Dot badge — no count provided, so a 6dp dot indicator is rendered. Use to signal new unread activity without a specific count.",
+          "Dot badge — no count provided, so a 6dp dot indicator is rendered. The dot center sits on the icon's top-right corner. Use to signal new unread activity without a specific count.",
       },
     },
   },
@@ -93,16 +109,16 @@ export const DotBadge: Story = {
 export const CountBadge: Story = {
   render: () => (
     <Badge count={5}>
-      <IconButton aria-label="Messages">
+      <IconHost>
         <IconMail />
-      </IconButton>
+      </IconHost>
     </Badge>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "Large count badge (16dp height) showing 5. The badge adopts the pill shape whenever a count is provided.",
+          "Large count badge (16dp height) showing 5. The pill center straddles the icon's top-right corner, matching the MD3 spec diagram.",
       },
     },
   },
@@ -111,9 +127,9 @@ export const CountBadge: Story = {
 export const SingleDigit: Story = {
   render: () => (
     <Badge count={7}>
-      <IconButton aria-label="Alerts">
+      <IconHost>
         <IconBell />
-      </IconButton>
+      </IconHost>
     </Badge>
   ),
   parameters: {
@@ -128,9 +144,9 @@ export const SingleDigit: Story = {
 export const MultiDigit: Story = {
   render: () => (
     <Badge count={42}>
-      <IconButton aria-label="Notifications">
+      <IconHost>
         <IconBell />
-      </IconButton>
+      </IconHost>
     </Badge>
   ),
   parameters: {
@@ -146,9 +162,9 @@ export const MultiDigit: Story = {
 export const Overflow: Story = {
   render: () => (
     <Badge count={1000} max={999}>
-      <IconButton aria-label="Notifications">
+      <IconHost>
         <IconBell />
-      </IconButton>
+      </IconHost>
     </Badge>
   ),
   parameters: {
@@ -164,9 +180,9 @@ export const Overflow: Story = {
 export const CustomMax: Story = {
   render: () => (
     <Badge count={50} max={9}>
-      <IconButton aria-label="Messages">
+      <IconHost>
         <IconMail />
-      </IconButton>
+      </IconHost>
     </Badge>
   ),
   parameters: {
@@ -184,9 +200,9 @@ const InvisibleBadgeDemo = (): React.ReactElement => {
   return (
     <div className="flex flex-col items-center gap-6">
       <Badge count={3} invisible={invisible}>
-        <IconButton aria-label="Notifications">
+        <IconHost>
           <IconBell />
-        </IconButton>
+        </IconHost>
       </Badge>
       <button
         type="button"
@@ -205,7 +221,7 @@ export const InvisibleBadge: Story = {
     docs: {
       description: {
         story:
-          "invisible=true hides the badge with a scale-out transition (MD3 Expressive fast-spatial spring). Click the toggle button to animate show and hide, observing the reduced-motion-aware behaviour.",
+          "invisible=true hides the badge with a scale-out transition (MD3 Expressive fast-spatial spring). The badge scales to zero from its corner-anchored position. Click the toggle button to animate show and hide, observing the reduced-motion-aware behaviour.",
       },
     },
   },
@@ -214,9 +230,9 @@ export const InvisibleBadge: Story = {
 export const ZeroCount: Story = {
   render: () => (
     <Badge count={0}>
-      <IconButton aria-label="Notifications">
+      <IconHost>
         <IconBell />
-      </IconButton>
+      </IconHost>
     </Badge>
   ),
   parameters: {
@@ -241,7 +257,7 @@ export const WrappingIconButton: Story = {
     docs: {
       description: {
         story:
-          "Badge composing an existing IconButton with variant='filled' — demonstrates transparent wrapping of any component variant.",
+          "Badge composing a full IconButton (variant='filled'). The badge center straddles the button's top-right corner — the larger host pushes the badge further out from the icon. For spec-precise icon-corner placement, wrap a bare icon host as shown in the Default story.",
       },
     },
   },
@@ -264,7 +280,7 @@ export const WrappingNavigationItem: Story = {
     docs: {
       description: {
         story:
-          "Badge composing a navigation item mockup with count=3. Mirrors MD3 bottom navigation badge usage where the badge overlays a nav pill chip.",
+          "Badge composing a navigation item mockup with count=3. The badge straddles the top-right corner of the nav pill chip. Mirrors MD3 bottom navigation badge usage.",
       },
     },
   },
@@ -275,36 +291,36 @@ export const AllVariants: Story = {
     <div className="flex flex-row items-end gap-8">
       <div className="flex flex-col items-center gap-3">
         <Badge>
-          <IconButton aria-label="Dot badge demo">
+          <IconHost>
             <IconBell />
-          </IconButton>
+          </IconHost>
         </Badge>
         <span className="text-on-surface text-xs">Dot</span>
       </div>
 
       <div className="flex flex-col items-center gap-3">
         <Badge count={7}>
-          <IconButton aria-label="Single-digit badge demo">
+          <IconHost>
             <IconBell />
-          </IconButton>
+          </IconHost>
         </Badge>
         <span className="text-on-surface text-xs">Single digit</span>
       </div>
 
       <div className="flex flex-col items-center gap-3">
         <Badge count={42}>
-          <IconButton aria-label="Multi-digit badge demo">
+          <IconHost>
             <IconBell />
-          </IconButton>
+          </IconHost>
         </Badge>
         <span className="text-on-surface text-xs">Multi-digit</span>
       </div>
 
       <div className="flex flex-col items-center gap-3">
         <Badge count={1000} max={999}>
-          <IconButton aria-label="Overflow badge demo">
+          <IconHost>
             <IconBell />
-          </IconButton>
+          </IconHost>
         </Badge>
         <span className="text-on-surface text-xs">Overflow</span>
       </div>
@@ -314,7 +330,7 @@ export const AllVariants: Story = {
     docs: {
       description: {
         story:
-          "Side-by-side showcase of all Badge forms: dot (6dp), single-digit, multi-digit, and overflow ('999+'). All use the MD3 error color role.",
+          "Side-by-side showcase of all Badge forms: dot (6dp), single-digit, multi-digit, and overflow ('999+'). All use the MD3 error color role and corner-overlap placement anchored to a 24dp icon host.",
       },
     },
   },
@@ -328,9 +344,9 @@ export const Playground: Story = {
   },
   render: (args) => (
     <Badge {...args}>
-      <IconButton aria-label="Playground notifications">
+      <IconHost>
         <IconBell />
-      </IconButton>
+      </IconHost>
     </Badge>
   ),
   parameters: {

--- a/packages/react/src/components/Badge/Badge.test.tsx
+++ b/packages/react/src/components/Badge/Badge.test.tsx
@@ -115,14 +115,23 @@ describe("Badge", () => {
     expect(wrapper).toHaveClass("relative");
   });
 
-  test("renders BadgeContent absolutely positioned", () => {
+  test("renders BadgeContent with MD3 corner-overlap placement classes", () => {
     render(
       <Badge count={3}>
         <button type="button">Host</button>
       </Badge>
     );
     const badge = screen.getByRole("status");
-    expect(badge).toHaveClass("absolute", "-top-1", "-right-1");
+    // MD3 spec: badge center straddles the wrapped element's top-right corner.
+    // top-0 right-0 positions the badge's top-right at the host's top-right,
+    // then -translate-y-1/2 translate-x-1/2 moves the center onto that corner.
+    expect(badge).toHaveClass(
+      "absolute",
+      "top-0",
+      "right-0",
+      "-translate-y-1/2",
+      "translate-x-1/2"
+    );
   });
 
   test("with invisible={true} sets data-invisible on the badge indicator", () => {

--- a/packages/react/src/components/Badge/Badge.test.tsx
+++ b/packages/react/src/components/Badge/Badge.test.tsx
@@ -30,16 +30,16 @@ describe("BadgeContent", () => {
     expect(badge).toHaveTextContent("99+");
   });
 
-  test('with color="error" applies bg-error class', () => {
-    render(<BadgeContent color="error" />);
+  test("applies bg-error class (MD3 error color role)", () => {
+    render(<BadgeContent count={3} />);
     const badge = screen.getByRole("status");
     expect(badge).toHaveClass("bg-error");
   });
 
-  test('with color="primary" applies bg-primary class', () => {
-    render(<BadgeContent color="primary" />);
+  test("applies text-on-error class (MD3 error color role)", () => {
+    render(<BadgeContent count={3} />);
     const badge = screen.getByRole("status");
-    expect(badge).toHaveClass("bg-primary");
+    expect(badge).toHaveClass("text-on-error");
   });
 
   test('derives aria-label from count ("3 notifications")', () => {
@@ -58,6 +58,48 @@ describe("BadgeContent", () => {
     render(<BadgeContent count={5} aria-label="5 unread messages" />);
     const badge = screen.getByRole("status");
     expect(badge).toHaveAttribute("aria-label", "5 unread messages");
+  });
+
+  describe("content flags", () => {
+    test("sets data-dot when no count is provided (dot badge)", () => {
+      render(<BadgeContent />);
+      const badge = screen.getByRole("status");
+      expect(badge).toHaveAttribute("data-dot", "");
+    });
+
+    test("does NOT set data-dot when count is provided", () => {
+      render(<BadgeContent count={3} />);
+      const badge = screen.getByRole("status");
+      expect(badge).not.toHaveAttribute("data-dot");
+    });
+  });
+
+  describe("visibility flag", () => {
+    test("does NOT set data-invisible when visible (default)", () => {
+      render(<BadgeContent count={3} />);
+      const badge = screen.getByRole("status");
+      expect(badge).not.toHaveAttribute("data-invisible");
+    });
+
+    test("sets data-invisible when invisible={true}", () => {
+      render(<BadgeContent count={3} invisible />);
+      const badge = screen.getByRole("status");
+      expect(badge).toHaveAttribute("data-invisible", "");
+    });
+
+    test("applies scale-0 class via data-[invisible] (invisible=true)", () => {
+      render(<BadgeContent count={3} invisible />);
+      const badge = screen.getByRole("status");
+      // CVA base adds scale-100; data-[invisible]:scale-0 overrides via cascade.
+      // We check the data attribute which drives the Tailwind selector.
+      expect(badge).toHaveAttribute("data-invisible", "");
+    });
+
+    test("applies scale-100 class when visible", () => {
+      render(<BadgeContent count={5} />);
+      const badge = screen.getByRole("status");
+      expect(badge).toHaveClass("scale-100");
+    });
   });
 });
 
@@ -83,34 +125,45 @@ describe("Badge", () => {
     expect(badge).toHaveClass("absolute", "-top-1", "-right-1");
   });
 
-  test("with invisible={true} applies scale-0 opacity-0 classes", () => {
+  test("with invisible={true} sets data-invisible on the badge indicator", () => {
     render(
       <Badge count={3} invisible>
         <button type="button">Host</button>
       </Badge>
     );
     const badge = screen.getByRole("status");
-    expect(badge).toHaveClass("scale-0", "opacity-0");
+    expect(badge).toHaveAttribute("data-invisible", "");
   });
 
-  test("with count={0} is invisible (not shown)", () => {
+  test("with count={0} is invisible (data-invisible present)", () => {
     render(
       <Badge count={0}>
         <button type="button">Host</button>
       </Badge>
     );
     const badge = screen.getByRole("status");
-    expect(badge).toHaveClass("scale-0", "opacity-0");
+    expect(badge).toHaveAttribute("data-invisible", "");
   });
 
-  test("with count={5} is visible by default", () => {
+  test("with count={5} is visible (data-invisible absent)", () => {
     render(
       <Badge count={5}>
         <button type="button">Host</button>
       </Badge>
     );
     const badge = screen.getByRole("status");
-    expect(badge).toHaveClass("scale-100", "opacity-100");
+    expect(badge).not.toHaveAttribute("data-invisible");
+  });
+
+  test("dot badge (no count) sets data-dot and no data-invisible", () => {
+    render(
+      <Badge>
+        <button type="button">Host</button>
+      </Badge>
+    );
+    const badge = screen.getByRole("status");
+    expect(badge).toHaveAttribute("data-dot", "");
+    expect(badge).not.toHaveAttribute("data-invisible");
   });
 
   test("forwardRef: ref correctly attached to the root wrapper element", () => {

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -13,8 +13,8 @@ import type { BadgeProps } from "./Badge.types";
  * (dot or count indicator). Automatically hides the badge when
  * `count` is `0` or `invisible` is `true`.
  *
- * Respects `prefers-reduced-motion` — transitions are omitted when
- * the user has requested reduced motion.
+ * Respects `prefers-reduced-motion` — the scale transition is omitted
+ * when the user has requested reduced motion.
  *
  * @example
  * ```tsx
@@ -35,18 +35,7 @@ import type { BadgeProps } from "./Badge.types";
  * ```
  */
 export const Badge = forwardRef<HTMLDivElement, BadgeProps>(
-  (
-    {
-      count,
-      max = 999,
-      color = "error",
-      invisible = false,
-      "aria-label": ariaLabel,
-      className,
-      children,
-    },
-    ref
-  ) => {
+  ({ count, max = 999, invisible = false, "aria-label": ariaLabel, className, children }, ref) => {
     const isReduced = useReducedMotion();
     const shouldShow = !invisible && (count === undefined || count > 0);
 
@@ -56,7 +45,6 @@ export const Badge = forwardRef<HTMLDivElement, BadgeProps>(
         <BadgeContent
           count={count}
           max={max}
-          color={color}
           invisible={!shouldShow}
           aria-label={ariaLabel}
           reducedMotion={isReduced}

--- a/packages/react/src/components/Badge/Badge.types.ts
+++ b/packages/react/src/components/Badge/Badge.types.ts
@@ -1,11 +1,6 @@
 import type React from "react";
 
 /**
- * Badge color roles (Material Design 3)
- */
-export type BadgeColor = "error" | "primary";
-
-/**
  * Props for the BadgeContent indicator element.
  *
  * Renders either a small dot (no count) or a count pill (with count).
@@ -23,13 +18,7 @@ export interface BadgeContentProps {
   max?: number;
 
   /**
-   * Badge color role mapped to MD3 design tokens.
-   * @default 'error'
-   */
-  color?: BadgeColor;
-
-  /**
-   * Whether the badge is invisible (scale-0 / opacity-0).
+   * Whether the badge is invisible (scale-0).
    * @default false
    */
   invisible?: boolean;
@@ -101,11 +90,6 @@ export interface BadgeHeadlessProps {
  * <Badge count={1200} max={99}>
  *   <IconButton icon={<MailIcon />} aria-label="Messages" />
  * </Badge>
- *
- * // Primary color
- * <Badge count={5} color="primary">
- *   <IconButton icon={<BellIcon />} aria-label="Alerts" />
- * </Badge>
  * ```
  */
 export interface BadgeProps {
@@ -119,12 +103,6 @@ export interface BadgeProps {
    * @default 999
    */
   max?: number;
-
-  /**
-   * Badge color role mapped to MD3 design tokens.
-   * @default 'error'
-   */
-  color?: BadgeColor;
 
   /**
    * When `true`, hides the badge indicator.

--- a/packages/react/src/components/Badge/Badge.variants.ts
+++ b/packages/react/src/components/Badge/Badge.variants.ts
@@ -1,46 +1,72 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 Badge Content Variants (CVA)
+ * Material Design 3 Badge Variants
  *
- * Manages the visual appearance of the badge indicator element:
- * - `size`: small (6dp dot) or large (16dp min-width pill)
- * - `color`: MD3 color role — error (default) or primary
- * - `invisible`: scale/opacity toggle for show/hide animation
- * - `reducedMotion`: strips transition when `prefers-reduced-motion` is active
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no state/content variants, no compoundVariants).
+ * - Dot vs count distinction is a content flag — set as `data-dot` on the element.
+ * - Visibility is a runtime flag — set as `data-invisible` on the element.
+ * - Motion class is applied conditionally in the component (not in CVA) so reduced-motion
+ *   can be guarded at the JS level without a variant key.
+ *
+ * Slot responsibilities:
+ *   badgeVariants — the sole <span> indicator; owns shape, color, size, content/visibility flags
+ *
+ * MD3 Spec (m3.material.io/components/badges/specs):
+ *   Small (dot): 6dp circle — no text, no padding. `data-[dot]` overrides to size-1.5
+ *   Large (number): height 16dp, min-width 16dp, padding 4dp horizontal, shape corner-full
+ *   Container: error (bg-error / text-on-error) — only role defined in spec
+ *   Typography: label-small (11sp / 1.6 line-height) — applied as base; overridden to zero for dot
+ *   Position: absolute, top-right corner of host element (-4dp on each axis)
+ *
+ * State-layer opacities: badge is non-interactive — no hover/focus/pressed layers
+ * Disabled: badge is hidden via invisible prop (host element owns disabled state)
  */
-export const badgeVariants = cva(
-  ["absolute -top-1 -right-1 rounded-full flex items-center justify-center"],
-  {
-    variants: {
-      size: {
-        small: "size-1.5",
-        large: "min-w-4 h-4 px-1 text-label-small",
-      },
-      color: {
-        error: "bg-error text-on-error",
-        primary: "bg-primary text-on-primary",
-      },
-      invisible: {
-        true: "scale-0 opacity-0",
-        false: "scale-100 opacity-100",
-      },
-      reducedMotion: {
-        true: "",
-        false:
-          "transition-[transform,opacity] duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
-      },
-    },
-    defaultVariants: {
-      size: "large",
-      color: "error",
-      invisible: false,
-      reducedMotion: false,
-    },
-  }
-);
+
+// ─── BADGE INDICATOR ─────────────────────────────────────────────────────────
 
 /**
- * Extract variant prop types from CVA
+ * Single indicator element — dot or count pill.
+ *
+ * Content flags (set explicitly by BadgeContent, never by this CVA):
+ *   `data-dot`       → element has no count; renders as 6dp dot
+ *   `data-invisible` → element is hidden (scale-0); runtime show/hide control
+ *
+ * The dot overrides clear out the large-badge sizing applied in the base
+ * using self-targeting `data-[dot]:` selectors placed after the base classes
+ * so they win by cascade order at equal specificity.
+ *
+ * Visibility uses scale only (not scale + opacity) per the MD3 Expressive
+ * scale-in/out pattern for small components. The transition-transform class
+ * is applied conditionally by the component (outside CVA) to allow a
+ * component-level reduced-motion guard.
  */
+export const badgeVariants = cva([
+  // ── Layout / shape ──────────────────────────────────────────────────────────
+  "absolute -top-1 -right-1",
+  "flex items-center justify-center",
+  "rounded-full",
+  // ── Large (count) sizing — base defaults ────────────────────────────────────
+  // Height 16dp, min-width 16dp, horizontal padding 4dp
+  "h-4 min-w-4 px-1",
+  // ── Color — error role (only MD3-spec role for badges) ──────────────────────
+  "bg-error text-on-error",
+  // ── Typography — label-small, tight leading, tabular numbers ────────────────
+  "text-label-small leading-none tabular-nums",
+  // ── Visibility (runtime flag) ────────────────────────────────────────────────
+  // Base: fully visible
+  "scale-100",
+  // data-invisible: scale to zero (visually hidden; aria-label still readable by SR)
+  "data-[invisible]:scale-0",
+  // ── Dot content flag overrides (placed last — cascade wins over base sizing) ─
+  // Clear out the count-pill sizing, set 6dp circle
+  "data-[dot]:size-1.5",
+  "data-[dot]:min-w-0",
+  "data-[dot]:p-0",
+  "data-[dot]:text-[0]", // suppress any stray text rendering on dot
+]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
 export type BadgeVariants = VariantProps<typeof badgeVariants>;

--- a/packages/react/src/components/Badge/Badge.variants.ts
+++ b/packages/react/src/components/Badge/Badge.variants.ts
@@ -11,31 +11,67 @@ import { cva, type VariantProps } from "class-variance-authority";
  *   can be guarded at the JS level without a variant key.
  *
  * Slot responsibilities:
- *   badgeVariants — the sole <span> indicator; owns shape, color, size, content/visibility flags
+ *   badgeVariants       — anchored indicator (<span> over a wrapped icon); owns placement + appearance
+ *   badgeStaticVariants — trailing pill (inline, no absolute placement); shares appearance only
  *
  * MD3 Spec (m3.material.io/components/badges/specs):
  *   Small (dot): 6dp circle — no text, no padding. `data-[dot]` overrides to size-1.5
  *   Large (number): height 16dp, min-width 16dp, padding 4dp horizontal, shape corner-full
  *   Container: error (bg-error / text-on-error) — only role defined in spec
  *   Typography: label-small (11sp / 1.6 line-height) — applied as base; overridden to zero for dot
- *   Position: absolute, top-right corner of host element (-4dp on each axis)
+ *   Position: badge center sits on the host element's top-right corner (straddling).
+ *             Achieved via `top-0 right-0 -translate-y-1/2 translate-x-1/2` — host-size-agnostic.
+ *             Mirrors the NavigationBar icon-wrapper badge approach.
+ *             In Tailwind v4, `translate-*` and `scale-*` map to the independent native CSS
+ *             `translate:` / `scale:` properties, so the static corner translate does NOT
+ *             interfere with the scale-0/scale-100 show/hide animation.
  *
  * State-layer opacities: badge is non-interactive — no hover/focus/pressed layers
  * Disabled: badge is hidden via invisible prop (host element owns disabled state)
  */
 
-// ─── BADGE INDICATOR ─────────────────────────────────────────────────────────
+// ─── SHARED APPEARANCE ────────────────────────────────────────────────────────
+//
+// Common classes between the anchored (badgeVariants) and the static trailing
+// (badgeStaticVariants) forms. Separated so both stay DRY without creating a
+// third CVA that callers would have to compose manually.
+
+const badgeAppearance = [
+  // ── Shape ─────────────────────────────────────────────────────────────────────
+  "flex items-center justify-center",
+  "rounded-full",
+  // ── Large (count) sizing — base defaults ──────────────────────────────────────
+  // Height 16dp, min-width 16dp, horizontal padding 4dp
+  "h-4 min-w-4 px-1",
+  // ── Color — error role (only MD3-spec role for badges) ────────────────────────
+  "bg-error text-on-error",
+  // ── Typography — label-small, tight leading, tabular numbers ──────────────────
+  "text-label-small leading-none tabular-nums",
+  // ── Visibility (runtime flag) ──────────────────────────────────────────────────
+  // Base: fully visible
+  "scale-100",
+  // data-invisible: scale to zero (visually hidden; aria-label still readable by SR)
+  "data-[invisible]:scale-0",
+  // ── Dot content flag overrides (placed last — cascade wins over base sizing) ───
+  // Clear out the count-pill sizing, set 6dp circle
+  "data-[dot]:size-1.5",
+  "data-[dot]:min-w-0",
+  "data-[dot]:p-0",
+  "data-[dot]:text-[0]", // suppress any stray text rendering on dot
+] as const;
+
+// ─── BADGE INDICATOR (ANCHORED) ───────────────────────────────────────────────
 
 /**
- * Single indicator element — dot or count pill.
+ * Anchored indicator element — badge center straddles the wrapped host's
+ * top-right corner via `top-0 right-0 -translate-y-1/2 translate-x-1/2`.
+ *
+ * Use this variant (via `BadgeContent`) when the badge wraps an icon element
+ * (e.g. a 24dp icon span, an IconButton) and needs to overlay its corner.
  *
  * Content flags (set explicitly by BadgeContent, never by this CVA):
  *   `data-dot`       → element has no count; renders as 6dp dot
  *   `data-invisible` → element is hidden (scale-0); runtime show/hide control
- *
- * The dot overrides clear out the large-badge sizing applied in the base
- * using self-targeting `data-[dot]:` selectors placed after the base classes
- * so they win by cascade order at equal specificity.
  *
  * Visibility uses scale only (not scale + opacity) per the MD3 Expressive
  * scale-in/out pattern for small components. The transition-transform class
@@ -43,30 +79,29 @@ import { cva, type VariantProps } from "class-variance-authority";
  * component-level reduced-motion guard.
  */
 export const badgeVariants = cva([
-  // ── Layout / shape ──────────────────────────────────────────────────────────
-  "absolute -top-1 -right-1",
-  "flex items-center justify-center",
-  "rounded-full",
-  // ── Large (count) sizing — base defaults ────────────────────────────────────
-  // Height 16dp, min-width 16dp, horizontal padding 4dp
-  "h-4 min-w-4 px-1",
-  // ── Color — error role (only MD3-spec role for badges) ──────────────────────
-  "bg-error text-on-error",
-  // ── Typography — label-small, tight leading, tabular numbers ────────────────
-  "text-label-small leading-none tabular-nums",
-  // ── Visibility (runtime flag) ────────────────────────────────────────────────
-  // Base: fully visible
-  "scale-100",
-  // data-invisible: scale to zero (visually hidden; aria-label still readable by SR)
-  "data-[invisible]:scale-0",
-  // ── Dot content flag overrides (placed last — cascade wins over base sizing) ─
-  // Clear out the count-pill sizing, set 6dp circle
-  "data-[dot]:size-1.5",
-  "data-[dot]:min-w-0",
-  "data-[dot]:p-0",
-  "data-[dot]:text-[0]", // suppress any stray text rendering on dot
+  // ── Anchored placement — badge center on host's top-right corner ──────────────
+  // top-0 right-0 places the badge's own top-right at the host's top-right,
+  // then the 1/2-element translate moves the badge center onto that corner.
+  // Host-size-agnostic: works for any wrapped element (icon, avatar, nav chip).
+  "absolute top-0 right-0 -translate-y-1/2 translate-x-1/2",
+  ...badgeAppearance,
 ]);
+
+// ─── BADGE INDICATOR (STATIC / TRAILING) ─────────────────────────────────────
+
+/**
+ * Inline (non-anchored) indicator for trailing slots such as the Drawer item.
+ *
+ * No absolute positioning or translate — the pill sits inline in a flex row.
+ * Shares all appearance classes with `badgeVariants` so the visual output
+ * (colors, sizing, dot/invisible flags) remains identical.
+ *
+ * Use in `DrawerItem`'s trailing badge slot where the badge is not overlaid
+ * on an icon but rendered as a count chip at the trailing edge of the row.
+ */
+export const badgeStaticVariants = cva(["inline-flex", ...badgeAppearance]);
 
 // ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
 
 export type BadgeVariants = VariantProps<typeof badgeVariants>;
+export type BadgeStaticVariants = VariantProps<typeof badgeStaticVariants>;

--- a/packages/react/src/components/Badge/BadgeContent.tsx
+++ b/packages/react/src/components/Badge/BadgeContent.tsx
@@ -33,7 +33,17 @@ const getAriaLabel = (count: number | undefined, override: string | undefined): 
  * Badge Content Indicator
  *
  * Renders the badge's visual element — either a small dot (no count)
- * or a count pill. Applies CVA variants for size, color, and visibility.
+ * or a count pill. Applies the `badgeVariants` base classes and sets
+ * content/visibility data flags directly on the element.
+ *
+ * Content flags (structural — not interaction state):
+ *   `data-dot`       → element is a dot badge (no count)
+ *   `data-invisible` → element is hidden (scale-0)
+ *
+ * Motion:
+ *   `transition-transform duration-expressive-fast-spatial ease-expressive-fast-spatial`
+ *   is applied when `reducedMotion` is false (component-level guard, per
+ *   md3-motion.mdc: JS-driven animations must guard at the component level).
  *
  * Uses `role="status"` so screen readers announce changes to the count.
  */
@@ -42,7 +52,6 @@ export const BadgeContent = forwardRef<HTMLSpanElement, BadgeContentProps>(
     {
       count,
       max = 999,
-      color = "error",
       invisible = false,
       "aria-label": ariaLabelOverride,
       reducedMotion = false,
@@ -50,7 +59,7 @@ export const BadgeContent = forwardRef<HTMLSpanElement, BadgeContentProps>(
     },
     ref
   ) => {
-    const size = count === undefined ? "small" : "large";
+    const isDot = count === undefined;
     const displayValue = getDisplayValue(count, max);
     const ariaLabel = getAriaLabel(count, ariaLabelOverride);
 
@@ -59,7 +68,20 @@ export const BadgeContent = forwardRef<HTMLSpanElement, BadgeContentProps>(
         ref={ref}
         role="status"
         aria-label={ariaLabel}
-        className={cn(badgeVariants({ size, color, invisible, reducedMotion }), className)}
+        // ── Content flag: dot vs count ──────────────────────────────────────
+        data-dot={isDot ? "" : undefined}
+        // ── Visibility runtime flag ─────────────────────────────────────────
+        data-invisible={invisible ? "" : undefined}
+        className={cn(
+          badgeVariants(),
+          // MD3 Expressive spatial motion for show/hide scale animation.
+          // Spatial pairing: scale transform → expressive-fast-spatial token.
+          // Guarded at the component level; do NOT use CSS-only reduced-motion
+          // because this is a JS-conditional class, not a persistent transition.
+          !reducedMotion &&
+            "duration-expressive-fast-spatial ease-expressive-fast-spatial transition-transform",
+          className
+        )}
       >
         {displayValue}
       </span>

--- a/packages/react/src/components/Badge/index.ts
+++ b/packages/react/src/components/Badge/index.ts
@@ -8,7 +8,12 @@ export { BadgeHeadless } from "./BadgeHeadless";
 export { BadgeContent } from "./BadgeContent";
 
 // CVA Variants
-export { badgeVariants, type BadgeVariants } from "./Badge.variants";
+export {
+  badgeVariants,
+  badgeStaticVariants,
+  type BadgeVariants,
+  type BadgeStaticVariants,
+} from "./Badge.variants";
 
 // Types
 export type { BadgeProps, BadgeHeadlessProps, BadgeContentProps } from "./Badge.types";

--- a/packages/react/src/components/Badge/index.ts
+++ b/packages/react/src/components/Badge/index.ts
@@ -11,4 +11,4 @@ export { BadgeContent } from "./BadgeContent";
 export { badgeVariants, type BadgeVariants } from "./Badge.variants";
 
 // Types
-export type { BadgeProps, BadgeHeadlessProps, BadgeContentProps, BadgeColor } from "./Badge.types";
+export type { BadgeProps, BadgeHeadlessProps, BadgeContentProps } from "./Badge.types";

--- a/packages/react/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react/src/components/Drawer/Drawer.stories.tsx
@@ -408,7 +408,7 @@ export const MultipleSections: Story = {
 // ─── Badge config items ──────────────────────────────────────────────────────
 
 export const WithBadgeConfig: Story = {
-  name: "Standard — Badge config (count + color)",
+  name: "Standard — Badge config (count)",
   render: () => (
     <div className="bg-surface relative h-screen">
       <Drawer variant="standard" open aria-label="App navigation">
@@ -417,7 +417,7 @@ export const WithBadgeConfig: Story = {
         </div>
         <DrawerItem icon={<InboxIcon />} label="Inbox" isActive badge={{ count: 24 }} />
         <DrawerItem icon={<StarredIcon />} label="Starred" />
-        <DrawerItem icon={<DraftsIcon />} label="Drafts" badge={{ count: 3, color: "primary" }} />
+        <DrawerItem icon={<DraftsIcon />} label="Drafts" badge={{ count: 3 }} />
         <DrawerSection header="More" showDivider>
           <DrawerItem icon={<SettingsIcon />} label="Settings" />
           <DrawerItem icon={<HelpIcon />} label="Help & feedback" />
@@ -572,40 +572,6 @@ export const WithBadgeItems: Story = {
         <DrawerSection header="More" showDivider>
           <DrawerItem icon={<SettingsIcon />} label="Settings" />
           <DrawerItem icon={<HelpIcon />} label="Help & feedback" />
-        </DrawerSection>
-      </Drawer>
-    </div>
-  ),
-};
-
-// ─── BadgePrimaryColor ────────────────────────────────────────────────────────
-
-export const BadgePrimaryColor: Story = {
-  name: "Standard — Badge with primary color",
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "DrawerItem with `badge={{ color: 'primary', count: 2 }}` demonstrating the primary color role for badge indicators — useful for app-level notifications or priority-flagged destinations.",
-      },
-    },
-  },
-  render: () => (
-    <div className="bg-surface relative h-screen">
-      <Drawer variant="standard" open aria-label="App navigation">
-        <div className="px-4 pt-6 pb-4">
-          <span className="text-headline-small text-on-surface">Mail</span>
-        </div>
-        <DrawerItem
-          icon={<InboxIcon />}
-          label="Inbox"
-          isActive
-          badge={{ color: "primary", count: 2 }}
-        />
-        <DrawerItem icon={<StarredIcon />} label="Starred" />
-        <DrawerItem icon={<DraftsIcon />} label="Drafts" />
-        <DrawerSection header="More" showDivider>
-          <DrawerItem icon={<SettingsIcon />} label="Settings" />
         </DrawerSection>
       </Drawer>
     </div>

--- a/packages/react/src/components/Drawer/Drawer.test.tsx
+++ b/packages/react/src/components/Drawer/Drawer.test.tsx
@@ -540,10 +540,10 @@ describe("DrawerItem — Badge support", () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  test("renders Badge with primary color when badge config specifies primary", () => {
-    render(<DrawerItem label="Inbox" badge={{ count: 1, color: "primary" }} />);
+  test("renders Badge with error color role (MD3 spec) when badge config is provided", () => {
+    render(<DrawerItem label="Inbox" badge={{ count: 1 }} />);
     const badge = screen.getByRole("status");
-    expect(badge.className).toContain("bg-primary");
+    expect(badge).toHaveClass("bg-error");
   });
 });
 

--- a/packages/react/src/components/Drawer/Drawer.types.ts
+++ b/packages/react/src/components/Drawer/Drawer.types.ts
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import type { AriaButtonProps, AriaDialogProps, AriaLinkOptions } from "react-aria";
-import type { BadgeColor } from "../Badge/Badge.types";
 
 /**
  * Structural variant of the Navigation Drawer.
@@ -21,8 +20,6 @@ export type DrawerVariant = "standard" | "modal";
 export interface DrawerItemBadgeConfig {
   /** Numeric count to display. Omit for a dot indicator. */
   count?: number;
-  /** Badge color role. @default 'error' */
-  color?: BadgeColor;
 }
 
 /**
@@ -158,8 +155,8 @@ export interface DrawerItemProps extends AriaButtonProps, Pick<AriaLinkOptions, 
    * // ReactNode badge (backward compatible)
    * <DrawerItem label="Inbox" badge={<span>3</span>} />
    *
-   * // Config badge (renders Badge component)
-   * <DrawerItem label="Inbox" badge={{ count: 3, color: 'primary' }} />
+   * // Config badge (renders Badge component using MD3 error color role)
+   * <DrawerItem label="Inbox" badge={{ count: 3 }} />
    * ```
    */
   badge?: ReactNode | DrawerItemBadgeConfig;

--- a/packages/react/src/components/Drawer/DrawerItem.tsx
+++ b/packages/react/src/components/Drawer/DrawerItem.tsx
@@ -3,7 +3,7 @@
 import type React from "react";
 import { forwardRef, isValidElement, useContext } from "react";
 import { HeadlessDrawerItem, DrawerIconOnlyContext } from "./DrawerHeadless";
-import { Badge } from "../Badge";
+import { badgeStaticVariants } from "../Badge/Badge.variants";
 import { drawerItemVariants } from "./Drawer.variants";
 import { cn } from "../../utils/cn";
 import { useRipple } from "../../hooks/useRipple";
@@ -15,6 +15,26 @@ import type { DrawerItemProps, DrawerItemBadgeConfig } from "./Drawer.types";
  */
 function isBadgeConfig(badge: unknown): badge is DrawerItemBadgeConfig {
   return typeof badge === "object" && badge !== null && !isValidElement(badge) && "count" in badge;
+}
+
+/**
+ * Derives the visible text for the trailing badge pill.
+ * - No `count` → empty string (dot)
+ * - `count` ≤ `max` → count as string
+ * - `count` > `max` → `"${max}+"`
+ */
+function getBadgeDisplayValue(count: number | undefined, max: number): string {
+  if (count === undefined) return "";
+  return count > max ? `${max}+` : count.toString();
+}
+
+/**
+ * Derives the accessible label for the trailing badge pill.
+ * - No `count` → `"New"`
+ * - With `count` → `"${count} notifications"`
+ */
+function getBadgeAriaLabel(count: number | undefined): string {
+  return count === undefined ? "New" : `${count} notifications`;
 }
 
 /**
@@ -81,11 +101,24 @@ export const DrawerItem = forwardRef<HTMLElement, DrawerItemProps>(
       if (!badge) return null;
 
       if (isBadgeConfig(badge)) {
+        // Drawer trailing badge: rendered as an inline static pill (not anchored/overlaid).
+        // Uses badgeStaticVariants so colors, sizing, and dot/invisible flags are identical
+        // to the anchored BadgeContent, but without the absolute translate positioning.
+        const max = 999;
+        const isDot = badge.count === undefined;
+        const displayValue = getBadgeDisplayValue(badge.count, max);
+        const ariaLabel = getBadgeAriaLabel(badge.count);
+
         return (
           <span className="relative z-10 ml-auto flex shrink-0 items-center pr-2">
-            <Badge {...(badge.count !== undefined ? { count: badge.count } : {})}>
-              <span />
-            </Badge>
+            <span
+              role="status"
+              aria-label={ariaLabel}
+              data-dot={isDot ? "" : undefined}
+              className={cn(badgeStaticVariants())}
+            >
+              {displayValue}
+            </span>
           </span>
         );
       }

--- a/packages/react/src/components/Drawer/DrawerItem.tsx
+++ b/packages/react/src/components/Drawer/DrawerItem.tsx
@@ -14,12 +14,7 @@ import type { DrawerItemProps, DrawerItemBadgeConfig } from "./Drawer.types";
  * Distinguishes config objects from React elements / primitives.
  */
 function isBadgeConfig(badge: unknown): badge is DrawerItemBadgeConfig {
-  return (
-    typeof badge === "object" &&
-    badge !== null &&
-    !isValidElement(badge) &&
-    ("count" in badge || "color" in badge)
-  );
+  return typeof badge === "object" && badge !== null && !isValidElement(badge) && "count" in badge;
 }
 
 /**
@@ -36,7 +31,7 @@ function isBadgeConfig(badge: unknown): badge is DrawerItemBadgeConfig {
  * - Ripple effect on interaction
  * - Hover/focus/pressed state layers (MD3 spec: 8% / 12%)
  * - Optional leading icon (24dp slot)
- * - Optional trailing badge — `ReactNode` or `{ count, color }` config
+ * - Optional trailing badge — `ReactNode` or `{ count }` config
  * - Icon-only mode: label hidden, `title` tooltip via `DrawerIconOnlyContext`
  * - Disabled state: `opacity-38`, non-interactive
  *
@@ -45,8 +40,8 @@ function isBadgeConfig(badge: unknown): badge is DrawerItemBadgeConfig {
  * // Active item with icon
  * <DrawerItem icon={<HomeIcon />} label="Home" isActive onPress={() => navigate('/')} />
  *
- * // Item with Badge config
- * <DrawerItem label="Inbox" badge={{ count: 5, color: 'primary' }} />
+ * // Item with Badge config (uses MD3 error color role)
+ * <DrawerItem label="Inbox" badge={{ count: 5 }} />
  *
  * // Disabled
  * <DrawerItem label="Disabled Feature" isDisabled />
@@ -88,10 +83,7 @@ export const DrawerItem = forwardRef<HTMLElement, DrawerItemProps>(
       if (isBadgeConfig(badge)) {
         return (
           <span className="relative z-10 ml-auto flex shrink-0 items-center pr-2">
-            <Badge
-              {...(badge.count !== undefined ? { count: badge.count } : {})}
-              {...(badge.color !== undefined ? { color: badge.color } : {})}
-            >
+            <Badge {...(badge.count !== undefined ? { count: badge.count } : {})}>
               <span />
             </Badge>
           </span>

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -233,13 +233,7 @@ export type {
   ListItemVariants,
 } from "./List";
 export { Badge, BadgeHeadless, BadgeContent, badgeVariants } from "./Badge";
-export type {
-  BadgeProps,
-  BadgeHeadlessProps,
-  BadgeContentProps,
-  BadgeColor,
-  BadgeVariants,
-} from "./Badge";
+export type { BadgeProps, BadgeHeadlessProps, BadgeContentProps, BadgeVariants } from "./Badge";
 
 export {
   FABMenu,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -331,7 +331,6 @@ export type {
   BadgeProps,
   BadgeHeadlessProps,
   BadgeContentProps,
-  BadgeColor,
   BadgeVariants,
 } from "./components/Badge";
 


### PR DESCRIPTION
## Summary

- Refactors `Badge` to the variants-vs-states architecture used by Button, Switch, and IconButton
- Removes non-spec `color` prop from `Badge`, `BadgeContent`, and `DrawerItemBadgeConfig` (MD3 badge uses error color only)
- Anchors badge indicator to the wrapped element's top-right corner per MD3 spec (`top-0 right-0 -translate-y-1/2 translate-x-1/2`)
- Adds `badgeStaticVariants` export for inline badge pills (used by `DrawerItem` trailing badge)
- Updates `DrawerItem` config-based badge to render inline static pill instead of absolute-positioned anchor
- Expands Badge test coverage; fixes Storybook composition examples

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (1976 tests passing)
- [ ] Verify Badge stories in Storybook (corner anchoring on icon, IconButton, nav chip)
- [ ] Verify DrawerItem trailing badge in Storybook