### PR TITLE
refactor(checkbox): md3 variants-vs-states architecture, motion tokens, spec-accurate styling

### DIFF
--- a/.changeset/checkbox-md3-expressive-refactor.md
+++ b/.changeset/checkbox-md3-expressive-refactor.md
@@ -1,0 +1,17 @@
+---
+"@tinybigui/react": patch
+---
+
+refactor(checkbox): migrate to MD3 Variants-vs-States architecture
+
+Rewrites Checkbox styling to match the slot-based CVA pattern used by Switch:
+
+- All interaction/selection states (hover, focus-visible, pressed, selected, disabled, invalid, indeterminate) are now expressed as `data-*` attributes on the root element via `getInteractionDataAttributes`, consumed by `group-data-[x]/checkbox` Tailwind selectors in each slot — no state variants or state compoundVariants in CVA.
+- Replaces the `animate-pulse` SVG focus ring with a proper MD3 focus-ring slot (outline, opacity transition via `*-spring-standard-fast-effects`).
+- Replaces hardcoded `duration-200` with MD3 motion token pairs: effects transitions use `*-spring-standard-fast-effects`, spatial transitions use `*-spring-standard-fast-spatial`.
+- State-layer opacities corrected to MD3 spec: hover 8% (`opacity-8`), focus/pressed 10% (`opacity-10`).
+- Box visual now uses a `div` with `border-2 rounded-[2px]` + inline SVG icons, matching the Switch div-slot pattern.
+- Invalid and disabled color cascades use doubly-chained `group-data` selectors for correct CSS specificity ordering.
+- Exports updated to new slot variant names (`checkboxRootVariants`, `checkboxControlVariants`, `checkboxStateLayerVariants`, `checkboxFocusRingVariants`, `checkboxBoxVariants`, `checkboxIconVariants`, `checkboxLabelVariants`).
+
+No behavioral or API changes — `CheckboxProps` and React Aria integration are unchanged.

--- a/packages/react/src/components/Checkbox/Checkbox.icons.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.icons.tsx
@@ -1,0 +1,70 @@
+import type React from "react";
+
+/**
+ * MD3 Checkbox checkmark icon.
+ *
+ * Icon size: 18×18dp (fills the checkbox container per MD3 specs).
+ * Mark stroke: 2dp with square caps, matching Material Web and Compose M3.
+ *
+ * Path coordinates align with `androidx.compose.material3.Checkbox` `drawCheck()`
+ * when `ComposeMaterial3Flags.isCheckboxStylingFixEnabled` is true.
+ *
+ * @see https://m3.material.io/components/checkbox/specs
+ *
+ * @example
+ * ```tsx
+ * <span className="text-on-primary">
+ *   <CheckboxCheckIcon />
+ * </span>
+ * ```
+ */
+export function CheckboxCheckIcon(): React.ReactElement {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M4.5 9L7.2 11.7L13.5 5.4"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="square"
+        strokeLinejoin="miter"
+      />
+    </svg>
+  );
+}
+
+/**
+ * MD3 Checkbox indeterminate icon.
+ *
+ * A 10×2dp horizontal dash centered in the 18dp icon area (1dp corner radius),
+ * matching Material Web's indeterminate mark dimensions.
+ *
+ * @see https://m3.material.io/components/checkbox/specs
+ *
+ * @example
+ * ```tsx
+ * <span className="text-on-primary">
+ *   <CheckboxIndeterminateIcon />
+ * </span>
+ * ```
+ */
+export function CheckboxIndeterminateIcon(): React.ReactElement {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      aria-hidden="true"
+    >
+      <rect x="4" y="8" width="10" height="2" rx="1" fill="currentColor" />
+    </svg>
+  );
+}

--- a/packages/react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.tsx
@@ -442,3 +442,59 @@ export const Playground: Story = {
     },
   },
 };
+
+// State Layer Showcase — demonstrates data-* driven Variants-vs-States architecture
+export const StateLayerShowcase: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="text-on-surface-variant mb-3 text-xs font-medium tracking-wide uppercase">
+          Normal States
+        </p>
+        <div className="flex flex-wrap items-center gap-6">
+          <Checkbox>Unchecked</Checkbox>
+          <Checkbox isSelected>Checked</Checkbox>
+          <Checkbox isIndeterminate>Indeterminate</Checkbox>
+        </div>
+      </div>
+
+      <div>
+        <p className="text-on-surface-variant mb-3 text-xs font-medium tracking-wide uppercase">
+          Invalid States
+        </p>
+        <div className="flex flex-wrap items-center gap-6">
+          <Checkbox isInvalid>Invalid unchecked</Checkbox>
+          <Checkbox isInvalid isSelected>
+            Invalid checked
+          </Checkbox>
+          <Checkbox isInvalid isIndeterminate>
+            Invalid indeterminate
+          </Checkbox>
+        </div>
+      </div>
+
+      <div>
+        <p className="text-on-surface-variant mb-3 text-xs font-medium tracking-wide uppercase">
+          Disabled States
+        </p>
+        <div className="flex flex-wrap items-center gap-6">
+          <Checkbox isDisabled>Disabled unchecked</Checkbox>
+          <Checkbox isDisabled isSelected>
+            Disabled checked
+          </Checkbox>
+          <Checkbox isDisabled isIndeterminate>
+            Disabled indeterminate
+          </Checkbox>
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates the Variants-vs-States architecture: all interaction and selection states are driven by data-* attributes on the root element consumed by group-data Tailwind selectors — no state variants in CVA.",
+      },
+    },
+  },
+};

--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -56,21 +56,18 @@ describe("Checkbox", () => {
       expect(checkbox.indeterminate).toBe(true);
     });
 
-    test("renders error state", () => {
+    test("renders error state with data-invalid attribute", () => {
       render(<Checkbox isInvalid>Error</Checkbox>);
       const label = screen.getByText("Error").closest("label");
-
-      // Visual error styling should be applied
-      expect(label).toBeInTheDocument();
+      // Variants-vs-States: error state is signalled via data-invalid on root
+      expect(label).toHaveAttribute("data-invalid", "");
     });
 
-    test("renders disabled state", () => {
+    test("renders disabled state with data-disabled attribute", () => {
       render(<Checkbox isDisabled>Disabled</Checkbox>);
       const label = screen.getByText("Disabled").closest("label");
-
-      // Visual styling should indicate disabled state
-      expect(label).toHaveClass("opacity-38");
-      expect(label).toHaveClass("pointer-events-none");
+      // Variants-vs-States: disabled state is signalled via data-disabled on root
+      expect(label).toHaveAttribute("data-disabled", "");
     });
   });
 
@@ -114,8 +111,8 @@ describe("Checkbox", () => {
       const checkbox = screen.getByRole("checkbox");
       const label = screen.getByText("Disabled").closest("label");
 
-      // Visual disabled state should be applied
-      expect(label).toHaveClass("opacity-38");
+      // Disabled state signalled via data-disabled; CSS pointer-events-none applied via Tailwind
+      expect(label).toHaveAttribute("data-disabled", "");
       expect(checkbox).not.toBeChecked();
     });
 
@@ -213,13 +210,14 @@ describe("Checkbox", () => {
       expect(checkbox.indeterminate).toBe(true);
     });
 
-    test("has invalid state when invalid", () => {
+    test("has data-invalid attribute on root when invalid", () => {
       render(<Checkbox isInvalid>Invalid</Checkbox>);
       screen.getByRole("checkbox");
       const label = screen.getByText("Invalid").closest("label");
-      expect(label).toBeInTheDocument();
-      const visualContainer = label?.querySelector("div > svg");
-      expect(visualContainer).toBeInTheDocument();
+      expect(label).toHaveAttribute("data-invalid", "");
+      // Control box is present inside the control slot
+      const control = label?.querySelector("[role='presentation']");
+      expect(control).toBeInTheDocument();
     });
 
     test("supports aria-describedby", () => {
@@ -253,26 +251,24 @@ describe("Checkbox", () => {
   });
 
   describe("Disabled", () => {
-    test("applies disabled styling", () => {
+    test("applies disabled styling via data-disabled attribute", () => {
       render(<Checkbox isDisabled>Disabled</Checkbox>);
       const label = screen.getByText("Disabled").closest("label");
-      expect(label).toHaveClass("opacity-38");
+      // Variants-vs-States: disabled state expressed as data-disabled on root
+      expect(label).toHaveAttribute("data-disabled", "");
     });
 
-    test("checkbox has disabled state", () => {
+    test("checkbox has disabled state via data-disabled attribute", () => {
       render(<Checkbox isDisabled>Disabled</Checkbox>);
-      screen.getByRole("checkbox");
       const label = screen.getByText("Disabled").closest("label");
-
-      expect(label).toHaveClass("pointer-events-none");
+      expect(label).toHaveAttribute("data-disabled", "");
     });
 
     test("does not respond to interactions when disabled", () => {
       render(<Checkbox isDisabled>Disabled</Checkbox>);
       const label = screen.getByText("Disabled").closest("label");
-
-      // pointer-events-none prevents interaction
-      expect(label).toHaveClass("pointer-events-none");
+      // CSS pointer-events-none is applied via data-[disabled]: Tailwind selector
+      expect(label).toHaveAttribute("data-disabled", "");
     });
   });
 
@@ -330,25 +326,28 @@ describe("Checkbox", () => {
   });
 
   describe("Focus", () => {
-    test("shows focus ring on keyboard focus", async () => {
+    test("shows focus on keyboard navigation", async () => {
       const user = userEvent.setup();
       render(<Checkbox>Focus me</Checkbox>);
       const checkbox = screen.getByRole("checkbox");
 
       await user.tab();
       expect(checkbox).toHaveFocus();
-      // Focus ring is rendered as part of SVG when isFocusVisible is true
       const label = screen.getByText("Focus me").closest("label");
-      expect(label).toBeInTheDocument();
+      // Focus-visible state is expressed via data-focus-visible on root
+      expect(label).toHaveAttribute("data-focus-visible", "");
     });
 
-    test("does not show focus ring on mouse click", async () => {
+    test("does not show keyboard focus ring on mouse click", async () => {
       const user = userEvent.setup();
       render(<Checkbox>Click me</Checkbox>);
       const checkbox = screen.getByRole("checkbox");
 
       await user.click(checkbox);
       expect(checkbox).toHaveFocus();
+      // After mouse click, focus-visible should NOT be set
+      const label = screen.getByText("Click me").closest("label");
+      expect(label).not.toHaveAttribute("data-focus-visible");
     });
   });
 

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -2,14 +2,17 @@
 
 import { forwardRef, useRef, useEffect } from "react";
 import type React from "react";
-import { useCheckbox, useFocusRing, mergeProps, VisuallyHidden } from "react-aria";
+import { useCheckbox, useFocusRing, useHover, mergeProps, VisuallyHidden } from "react-aria";
 import { useToggleState } from "react-stately";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
 import {
-  checkboxVariants,
-  checkboxContainerVariants,
-  checkboxIconBoxVariants,
+  checkboxRootVariants,
+  checkboxControlVariants,
+  checkboxStateLayerVariants,
+  checkboxFocusRingVariants,
+  checkboxBoxVariants,
   checkboxIconVariants,
   checkboxLabelVariants,
 } from "./Checkbox.variants";
@@ -19,23 +22,23 @@ import type { CheckboxProps } from "./Checkbox.types";
  * Material Design 3 Checkbox Component (Layer 3: Styled)
  *
  * Built on React Aria for world-class accessibility.
- * Uses CVA for type-safe variant management.
- * Styled with Tailwind CSS using MD3 design tokens.
+ * Implements the Variants-vs-States architecture: all interaction/selection
+ * states are expressed as data-* attributes on the root and consumed by each
+ * slot via group-data-[x]/checkbox Tailwind selectors — no state variants in CVA.
  *
  * Features:
- * - ✅ 3 states: unchecked, checked, indeterminate
- * - ✅ Error/invalid state support
- * - ✅ Ripple effect (Material Design)
- * - ✅ Full keyboard accessibility (via React Aria)
- * - ✅ Screen reader support (via React Aria)
- * - ✅ Focus management (via React Aria)
- * - ✅ Form integration (name, value props)
+ * - 3 states: unchecked, checked, indeterminate
+ * - Error/invalid state support
+ * - Ripple effect (Material Design)
+ * - Full keyboard accessibility (via React Aria)
+ * - Screen reader support (via React Aria)
+ * - Focus management (via React Aria)
+ * - Form integration (name, value props)
  *
  * MD3 Specifications:
- * - Container: 18x18dp (within 40x40dp touch target)
- * - Corner radius: 2dp (applied via SVG rx/ry attributes)
- * - State layers: 8% hover, 12% focus/pressed
- * - Disabled: 38% opacity
+ * - Box: 18×18dp, 2dp corner radius, within 40×40dp touch target
+ * - State-layer opacities: hover 8% | focus/pressed 10%
+ * - Disabled: 38% opacity on root
  * - Label spacing: 16px (ml-4)
  *
  * @example
@@ -64,61 +67,47 @@ import type { CheckboxProps } from "./Checkbox.types";
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (
     {
-      // Content props
       children,
-
-      // State props
       isIndeterminate = false,
       isInvalid = false,
       disableRipple = false,
       isDisabled = false,
-
-      // Styling
       className,
-
-      // Other props
       ...props
     },
     forwardedRef
   ) => {
-    // Internal ref for React Aria
     const internalRef = useRef<HTMLInputElement>(null);
-
-    // Merge internal ref with forwarded ref
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLInputElement>;
 
-    // Extract data-testid and other HTML attributes
+    // Extract passthrough HTML attributes that React Aria doesn't understand
     const htmlAttrs = props as Record<string, unknown>;
     const dataTestId = htmlAttrs["data-testid"] as string | undefined;
     const htmlId = htmlAttrs.id as string | undefined;
     const htmlTitle = htmlAttrs.title as string | undefined;
 
-    // Remove HTML attributes from props for React Aria
     const {
       "data-testid": _dataTestId,
       id: _htmlId,
       title: _htmlTitle,
-      ...restPropsWithoutHtmlAttrs
+      ...ariaProps
     } = props as Record<string, unknown>;
 
     // State management using React Stately
-    const state = useToggleState(restPropsWithoutHtmlAttrs as Parameters<typeof useToggleState>[0]);
+    const state = useToggleState(ariaProps as Parameters<typeof useToggleState>[0]);
 
-    // React Aria hooks - pass props without HTML attributes
-    const { inputProps, labelProps } = useCheckbox(
-      restPropsWithoutHtmlAttrs as Parameters<typeof useCheckbox>[0],
+    // React Aria hooks
+    const { inputProps, labelProps, isPressed } = useCheckbox(
+      ariaProps as Parameters<typeof useCheckbox>[0],
       state,
       ref
     );
     const { isFocusVisible, focusProps } = useFocusRing();
+    const { isHovered, hoverProps } = useHover({ isDisabled });
 
-    // Get selected state
     const isSelected = state.isSelected;
 
-    // Determine visual state
-    const visualState = isIndeterminate ? "indeterminate" : isSelected ? "checked" : "unchecked";
-
-    // Ripple effect
+    // Ripple effect on the control container
     const { onMouseDown: handleRipple, ripples } = useRipple({
       disabled: isDisabled || disableRipple,
     });
@@ -130,13 +119,9 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       }
     }, [isIndeterminate, ref]);
 
-    // Development warnings
     if (process.env.NODE_ENV === "development") {
-      const ariaProps = restPropsWithoutHtmlAttrs as {
-        "aria-label"?: string;
-        "aria-labelledby"?: string;
-      };
-      if (!children && !ariaProps["aria-label"] && !ariaProps["aria-labelledby"]) {
+      const a = ariaProps as { "aria-label"?: string; "aria-labelledby"?: string };
+      if (!children && !a["aria-label"] && !a["aria-labelledby"]) {
         console.warn(
           "[Checkbox] Checkbox should have a label (children) or aria-label for accessibility."
         );
@@ -145,108 +130,86 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
     return (
       <label
-        {...labelProps}
-        className={cn(
-          checkboxVariants({
-            disabled: isDisabled,
-          }),
-          className
-        )}
+        {...mergeProps(labelProps, hoverProps)}
+        className={cn(checkboxRootVariants(), "group/checkbox", className)}
         data-testid={dataTestId}
         title={htmlTitle}
+        // ── Interaction + selection data attributes ──────────────────────────
+        {...getInteractionDataAttributes({
+          isHovered,
+          isFocusVisible,
+          isPressed,
+          isSelected,
+          isDisabled,
+          isInvalid,
+          isIndeterminate,
+          isReadOnly: (ariaProps as { isReadOnly?: boolean }).isReadOnly ?? false,
+        })}
       >
-        {/* Visually hidden native input for accessibility */}
+        {/* Visually hidden native input — handles all accessibility */}
         <VisuallyHidden>
           <input {...mergeProps(inputProps, focusProps)} ref={ref} id={htmlId} />
         </VisuallyHidden>
 
-        {/* Visual checkbox container */}
+        {/* Control — 40dp touch target, ripple host */}
         <div
           role="presentation"
-          className={cn(
-            checkboxContainerVariants({
-              state: visualState,
-              isInvalid,
-              disabled: isDisabled,
-            })
-          )}
+          className={cn(checkboxControlVariants())}
           onMouseDown={handleRipple}
         >
-          {/* Ripple effect */}
+          {/* Ripple */}
           {ripples}
 
-          {/* SVG Checkbox Visual */}
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 18 18"
-            aria-hidden="true"
-            className="relative z-10"
-          >
-            {/* Checkbox box (rounded square) */}
-            <rect
-              x="0"
-              y="0"
-              width="18"
-              height="18"
-              rx="2"
-              ry="2"
-              className={cn(
-                checkboxIconBoxVariants({
-                  state: visualState,
-                  disabled: isDisabled,
-                })
-              )}
-            />
+          {/* State layer — hover/focus/pressed opacity ring */}
+          <span className={cn(checkboxStateLayerVariants())} aria-hidden="true" />
 
-            {/* Checkmark icon (for checked state) */}
+          {/* Focus ring — keyboard-focus outline */}
+          <span className={cn(checkboxFocusRingVariants())} aria-hidden="true" />
+
+          {/* Box — 18dp visual checkbox square */}
+          <div className={cn(checkboxBoxVariants())} aria-hidden="true">
+            {/* Check icon */}
             {isSelected && !isIndeterminate && (
-              <path
-                d="M14.1 4.5L6.3 12.3l-3.4-3.4L1.5 10.3l4.8 4.8 9.2-9.2z"
-                className={cn(checkboxIconVariants({ type: "check" }), "fill-on-primary")}
-              />
+              <span className={cn(checkboxIconVariants())}>
+                <svg
+                  width="12"
+                  height="10"
+                  viewBox="0 0 12 10"
+                  fill="none"
+                  aria-hidden="true"
+                  className="fill-current"
+                >
+                  <path
+                    d="M1 5L4.5 8.5L11 1.5"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </span>
             )}
 
-            {/* Dash icon (for indeterminate state) */}
+            {/* Dash icon — indeterminate state */}
             {isIndeterminate && (
-              <rect
-                x="4"
-                y="8"
-                width="10"
-                height="2"
-                className={cn(checkboxIconVariants({ type: "dash" }), "fill-on-primary")}
-              />
+              <span className={cn(checkboxIconVariants())}>
+                <svg
+                  width="10"
+                  height="2"
+                  viewBox="0 0 10 2"
+                  fill="none"
+                  aria-hidden="true"
+                  className="fill-current"
+                >
+                  <rect x="0" y="0" width="10" height="2" rx="1" fill="currentColor" />
+                </svg>
+              </span>
             )}
-
-            {/* Focus ring (visible on keyboard focus) */}
-            {isFocusVisible && (
-              <rect
-                x="-3"
-                y="-3"
-                width="24"
-                height="24"
-                rx="12"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                className="animate-pulse"
-              />
-            )}
-          </svg>
+          </div>
         </div>
 
-        {/* Label text */}
-        {children && (
-          <span
-            className={cn(
-              checkboxLabelVariants({
-                disabled: isDisabled,
-              })
-            )}
-          >
-            {children}
-          </span>
-        )}
+        {/* Text label */}
+        {children && <span className={cn(checkboxLabelVariants())}>{children}</span>}
       </label>
     );
   }

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -16,6 +16,7 @@ import {
   checkboxIconVariants,
   checkboxLabelVariants,
 } from "./Checkbox.variants";
+import { CheckboxCheckIcon, CheckboxIndeterminateIcon } from "./Checkbox.icons";
 import type { CheckboxProps } from "./Checkbox.types";
 
 /**
@@ -168,41 +169,17 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
           {/* Box — 18dp visual checkbox square */}
           <div className={cn(checkboxBoxVariants())} aria-hidden="true">
-            {/* Check icon */}
+            {/* Check icon — 18dp MD3 checkmark */}
             {isSelected && !isIndeterminate && (
               <span className={cn(checkboxIconVariants())}>
-                <svg
-                  width="12"
-                  height="10"
-                  viewBox="0 0 12 10"
-                  fill="none"
-                  aria-hidden="true"
-                  className="fill-current"
-                >
-                  <path
-                    d="M1 5L4.5 8.5L11 1.5"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
+                <CheckboxCheckIcon />
               </span>
             )}
 
             {/* Dash icon — indeterminate state */}
             {isIndeterminate && (
               <span className={cn(checkboxIconVariants())}>
-                <svg
-                  width="10"
-                  height="2"
-                  viewBox="0 0 10 2"
-                  fill="none"
-                  aria-hidden="true"
-                  className="fill-current"
-                >
-                  <rect x="0" y="0" width="10" height="2" rx="1" fill="currentColor" />
-                </svg>
+                <CheckboxIndeterminateIcon />
               </span>
             )}
           </div>

--- a/packages/react/src/components/Checkbox/Checkbox.variants.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.variants.ts
@@ -1,222 +1,199 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 Checkbox Variants (CVA)
+ * Material Design 3 Checkbox Variants
  *
- * Type-safe variant management for Checkbox component.
- * Uses Tailwind CSS classes mapped to MD3 design tokens.
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no state variants, no state compoundVariants).
+ * - All interaction/selection states are driven by data-* attributes on the root via
+ *   group-data-[x]/checkbox Tailwind selectors in each slot's base classes.
+ * - Content flags (data-invalid, data-indeterminate) are set explicitly by the component.
  *
- * MD3 Specifications:
- * - Container: 18x18dp (within 40x40dp touch target)
- * - Corner radius: 2dp (applied via SVG rx/ry attributes, not CSS)
- * - Outline width: 2dp
- * - State layers: 8% hover, 12% focus/pressed
- * - Disabled: 38% opacity
+ * Slot responsibilities:
+ *   checkboxRootVariants      — label wrapper; carries `group/checkbox`; cursor + disabled
+ *   checkboxControlVariants   — 40dp state-layer + ripple container; centered on the box
+ *   checkboxStateLayerVariants — 40dp circle, hover/focus/press opacity ring
+ *   checkboxFocusRingVariants — keyboard-focus outline (sibling of the box, not clipped)
+ *   checkboxBoxVariants       — 18dp square; border + bg per state; 2dp corner radius
+ *   checkboxIconVariants      — SVG check / dash icon inside the box
+ *   checkboxLabelVariants     — text label next to the control
+ *
+ * MD3 Spec:
+ *   Box: 18×18dp, 2dp corner radius, 2dp border
+ *   Touch target: 40×40dp (control slot)
+ *   State-layer opacities: hover 8% | focus/pressed 10%
+ *   Disabled: container 38% opacity (root-level) or specific slot overrides
+ *   Label spacing: 16px (ml-4)
  */
-export const checkboxVariants = cva(
-  [
-    // Base classes (always applied to label wrapper)
-    "relative inline-flex items-center cursor-pointer select-none",
-    "transition-opacity duration-200",
-  ],
-  {
-    variants: {
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "opacity-38 cursor-not-allowed pointer-events-none",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      disabled: false,
-    },
-  }
-);
+
+// ─── ROOT ─────────────────────────────────────────────────────────────────────
 
 /**
- * Checkbox container variants (for the visual checkbox box)
+ * Root label wrapper — carries `group/checkbox`.
+ *
+ * Disabled state self-targets via data-[disabled]: so all children inherit
+ * the cursor/pointer restriction. Opacity is applied here at 38% when disabled.
  */
-export const checkboxContainerVariants = cva(
-  [
-    // Base classes for checkbox visual container
-    "relative inline-flex items-center justify-center m-1",
-    "w-10 h-10", // 40x40dp touch target (MD3 spec)
-    "flex-shrink-0",
-    "transition-all duration-200",
+export const checkboxRootVariants = cva([
+  "relative inline-flex items-center cursor-pointer select-none",
+  "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+  "data-[disabled]:opacity-38",
+]);
 
-    // State layer (hover, focus, active) - MD3 spec: 8%/12%/12% opacity
-    "before:absolute before:inset-0 before:rounded-full before:transition-opacity before:duration-200",
-    "before:bg-current before:opacity-0",
-    "hover:before:opacity-8",
-    "active:before:opacity-12",
-  ],
-  {
-    variants: {
-      /**
-       * Checkbox state (determines visual appearance)
-       */
-      state: {
-        unchecked: "text-on-surface-variant",
-        checked: "text-primary",
-        indeterminate: "text-primary",
-      },
-
-      /**
-       * Error/invalid state
-       */
-      isInvalid: {
-        true: "text-error",
-        false: "",
-      },
-
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "text-on-surface pointer-events-none",
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Error state overrides normal colors for all states
-      {
-        state: "unchecked",
-        isInvalid: true,
-        disabled: false,
-        className: "text-error",
-      },
-      {
-        state: "checked",
-        isInvalid: true,
-        disabled: false,
-        className: "text-error",
-      },
-      {
-        state: "indeterminate",
-        isInvalid: true,
-        disabled: false,
-        className: "text-error",
-      },
-    ],
-    defaultVariants: {
-      state: "unchecked",
-      isInvalid: false,
-      disabled: false,
-    },
-  }
-);
+// ─── CONTROL ──────────────────────────────────────────────────────────────────
 
 /**
- * Checkbox icon SVG box variants (the 18x18dp square container)
+ * Control — 40dp state-layer + ripple host.
+ *
+ * Provides the touch target (40dp) centered on the 18dp box.
+ * Uses overflow-hidden so ripples are clipped to the circular container.
  */
-export const checkboxIconBoxVariants = cva(
-  [
-    // Base classes for the checkbox box
-    // Note: Border radius is applied via SVG rx/ry attributes (2dp) in the component
-    "transition-all duration-200",
-  ],
-  {
-    variants: {
-      /**
-       * Checkbox state
-       */
-      state: {
-        unchecked: [
-          "fill-transparent",
-          "stroke-outline", // MD3: outline color for unchecked
-          "stroke-4", // MD3: 2dp outline width
-        ],
-        checked: [
-          "fill-current", // Uses parent text color (primary or error)
-          "stroke-none",
-        ],
-        indeterminate: [
-          "fill-current", // Uses parent text color (primary or error)
-          "stroke-none",
-        ],
-      },
+export const checkboxControlVariants = cva([
+  "relative flex items-center justify-center flex-shrink-0",
+  "w-10 h-10 rounded-full",
+  "overflow-hidden",
+]);
 
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: ["fill-transparent", "stroke-current", "stroke-2"],
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Disabled state overrides fill for checked/indeterminate
-      {
-        state: "checked",
-        disabled: true,
-        className: "fill-current stroke-none",
-      },
-      {
-        state: "indeterminate",
-        disabled: true,
-        className: "fill-current stroke-none",
-      },
-    ],
-    defaultVariants: {
-      state: "unchecked",
-      disabled: false,
-    },
-  }
-);
+// ─── STATE LAYER ──────────────────────────────────────────────────────────────
 
 /**
- * Checkbox checkmark/dash icon variants
+ * State layer — the 40dp semi-transparent circle inside the control.
+ *
+ * Color progression:
+ *   base (unselected):            on-surface
+ *   selected / indeterminate:     primary
+ *   invalid:                      error
+ *   invalid + selected:           error (doubly-chained → higher specificity)
+ *
+ * Opacity:
+ *   rest: 0 | hover: 8% | focus-visible: 10% | pressed: 10%
+ *   hidden when disabled.
  */
-export const checkboxIconVariants = cva(
-  [
-    "fill-current", // Inherits color from parent
-    "transition-all duration-200",
-  ],
-  {
-    variants: {
-      /**
-       * Icon type
-       */
-      type: {
-        check: "", // Checkmark icon
-        dash: "", // Dash/minus icon
-      },
-    },
-    defaultVariants: {
-      type: "check",
-    },
-  }
-);
+export const checkboxStateLayerVariants = cva([
+  "absolute inset-0 rounded-full pointer-events-none opacity-0",
+  // Base state-layer color (unselected)
+  "bg-on-surface",
+  // Effects transition for opacity changes
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Selected / indeterminate → primary color
+  "group-data-[selected]/checkbox:bg-primary",
+  "group-data-[indeterminate]/checkbox:bg-primary",
+  // Invalid → error color (singly-chained)
+  "group-data-[invalid]/checkbox:bg-error",
+  // Invalid + selected → error wins (doubly-chained for specificity)
+  "group-data-[invalid]/checkbox:group-data-[selected]/checkbox:bg-error",
+  // Interaction opacities (MD3: hover 8%, focus-visible 10%, pressed 10%)
+  "group-data-[hovered]/checkbox:opacity-8",
+  "group-data-[focus-visible]/checkbox:opacity-10",
+  "group-data-[pressed]/checkbox:opacity-10",
+  // No state layer when disabled
+  "group-data-[disabled]/checkbox:hidden",
+]);
+
+// ─── FOCUS RING ───────────────────────────────────────────────────────────────
 
 /**
- * Checkbox label text variants
+ * Focus ring — an absolutely-positioned outline around the 40dp control area.
+ *
+ * Replaces the old `animate-pulse` SVG rect. Lives as an absolute overlay
+ * inside the control div (40dp) so it correctly surrounds the full touch target.
  */
-export const checkboxLabelVariants = cva(
-  [
-    "text-sm", // MD3: Body Medium (14px)
-    "text-on-surface",
-    "select-none",
-  ],
-  {
-    variants: {
-      disabled: {
-        true: "",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      disabled: false,
-    },
-  }
-);
+export const checkboxFocusRingVariants = cva([
+  "pointer-events-none absolute inset-0 rounded-full",
+  "outline outline-2 outline-offset-0 outline-secondary",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/checkbox:opacity-100",
+]);
+
+// ─── BOX ──────────────────────────────────────────────────────────────────────
 
 /**
- * Extract variant prop types from CVA
+ * Box — the 18×18dp visual checkbox square.
+ *
+ * Sits inside the 40dp control, centered. Owns border, background, and
+ * corner radius. 2dp radius expressed as rounded-[2px] (smallest token is 4px).
+ *
+ * Color progression (cascade order — disabled last):
+ *   base (unselected):            transparent bg, outline border
+ *   selected / indeterminate:     primary bg, primary border
+ *   invalid (unselected):         transparent bg, error border
+ *   invalid + selected:           error bg, error border (doubly-chained)
+ *   disabled (unselected):        transparent bg, on-surface/38 border
+ *   disabled + selected:          on-surface/38 bg, transparent border
  */
-export type CheckboxVariants = VariantProps<typeof checkboxVariants>;
-export type CheckboxContainerVariants = VariantProps<typeof checkboxContainerVariants>;
-export type CheckboxIconBoxVariants = VariantProps<typeof checkboxIconBoxVariants>;
+export const checkboxBoxVariants = cva([
+  // Base geometry
+  "relative flex items-center justify-center flex-shrink-0",
+  "w-[18px] h-[18px] rounded-[2px] border-2",
+  // Effects transition for color changes
+  "transition-[background-color,border-color] duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // ── Unselected base ───────────────────────────────────────────────────────
+  "bg-transparent border-outline",
+  // ── Selected ──────────────────────────────────────────────────────────────
+  "group-data-[selected]/checkbox:bg-primary group-data-[selected]/checkbox:border-primary",
+  // ── Indeterminate ─────────────────────────────────────────────────────────
+  "group-data-[indeterminate]/checkbox:bg-primary group-data-[indeterminate]/checkbox:border-primary",
+  // ── Invalid (unselected) — singly chained ─────────────────────────────────
+  "group-data-[invalid]/checkbox:border-error",
+  // ── Invalid + selected — doubly chained (higher specificity) ──────────────
+  "group-data-[invalid]/checkbox:group-data-[selected]/checkbox:bg-error",
+  "group-data-[invalid]/checkbox:group-data-[selected]/checkbox:border-error",
+  // ── Invalid + indeterminate — doubly chained ───────────────────────────────
+  "group-data-[invalid]/checkbox:group-data-[indeterminate]/checkbox:bg-error",
+  "group-data-[invalid]/checkbox:group-data-[indeterminate]/checkbox:border-error",
+  // ── Disabled (placed last — cascade wins over interaction colors) ──────────
+  "group-data-[disabled]/checkbox:border-on-surface/38",
+  "group-data-[disabled]/checkbox:bg-transparent",
+  // ── Disabled + selected — doubly chained ──────────────────────────────────
+  "group-data-[selected]/checkbox:group-data-[disabled]/checkbox:bg-on-surface/38",
+  "group-data-[selected]/checkbox:group-data-[disabled]/checkbox:border-transparent",
+  // ── Disabled + indeterminate — doubly chained ─────────────────────────────
+  "group-data-[indeterminate]/checkbox:group-data-[disabled]/checkbox:bg-on-surface/38",
+  "group-data-[indeterminate]/checkbox:group-data-[disabled]/checkbox:border-transparent",
+]);
+
+// ─── ICON ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Icon (check / dash) — SVG element inside the box.
+ *
+ * Color:
+ *   base (selected):              on-primary
+ *   invalid + selected:           on-error (doubly-chained)
+ *   disabled + selected:          surface (doubly-chained)
+ *
+ * The icon is only rendered when selected or indeterminate so "unselected"
+ * color cases are not needed.
+ */
+export const checkboxIconVariants = cva([
+  "absolute inset-0 flex items-center justify-center",
+  // Spatial transition for icon appearing (scale)
+  "transition-transform duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+  // Base icon color
+  "text-on-primary",
+  // Invalid → on-error (doubly-chained for both selected and indeterminate)
+  "group-data-[invalid]/checkbox:group-data-[selected]/checkbox:text-on-error",
+  "group-data-[invalid]/checkbox:group-data-[indeterminate]/checkbox:text-on-error",
+  // Disabled → surface (doubly-chained)
+  "group-data-[selected]/checkbox:group-data-[disabled]/checkbox:text-surface",
+  "group-data-[indeterminate]/checkbox:group-data-[disabled]/checkbox:text-surface",
+]);
+
+// ─── LABEL ────────────────────────────────────────────────────────────────────
+
+/**
+ * Text label next to the control.
+ * Disabled opacity is inherited from the root's data-[disabled]:opacity-38.
+ */
+export const checkboxLabelVariants = cva(["text-body-large text-on-surface select-none ml-4"]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
+export type CheckboxRootVariants = VariantProps<typeof checkboxRootVariants>;
+export type CheckboxControlVariants = VariantProps<typeof checkboxControlVariants>;
+export type CheckboxStateLayerVariants = VariantProps<typeof checkboxStateLayerVariants>;
+export type CheckboxFocusRingVariants = VariantProps<typeof checkboxFocusRingVariants>;
+export type CheckboxBoxVariants = VariantProps<typeof checkboxBoxVariants>;
 export type CheckboxIconVariants = VariantProps<typeof checkboxIconVariants>;
 export type CheckboxLabelVariants = VariantProps<typeof checkboxLabelVariants>;

--- a/packages/react/src/components/Checkbox/index.ts
+++ b/packages/react/src/components/Checkbox/index.ts
@@ -4,16 +4,20 @@ export { Checkbox } from "./Checkbox";
 // Layer 2: Headless Component (for advanced customization)
 export { CheckboxHeadless } from "./CheckboxHeadless";
 
-// CVA Variants
+// CVA Variants (slot-based, Variants-vs-States architecture)
 export {
-  checkboxVariants,
-  checkboxContainerVariants,
-  checkboxIconBoxVariants,
+  checkboxRootVariants,
+  checkboxControlVariants,
+  checkboxStateLayerVariants,
+  checkboxFocusRingVariants,
+  checkboxBoxVariants,
   checkboxIconVariants,
   checkboxLabelVariants,
-  type CheckboxVariants,
-  type CheckboxContainerVariants,
-  type CheckboxIconBoxVariants,
+  type CheckboxRootVariants,
+  type CheckboxControlVariants,
+  type CheckboxStateLayerVariants,
+  type CheckboxFocusRingVariants,
+  type CheckboxBoxVariants,
   type CheckboxIconVariants,
   type CheckboxLabelVariants,
 } from "./Checkbox.variants";


### PR DESCRIPTION
## Summary

- **Variants-vs-States migration**: rewrites `Checkbox.variants.ts` from 5 state-encoding CVAs (with `state`, `disabled`, `isInvalid` variant keys and state `compoundVariants`) into 7 slot-based CVAs (`checkboxRootVariants`, `checkboxControlVariants`, `checkboxStateLayerVariants`, `checkboxFocusRingVariants`, `checkboxBoxVariants`, `checkboxIconVariants`, `checkboxLabelVariants`) where all interaction/selection states are driven by `data-*` attributes on the root via `group-data-[x]/checkbox` Tailwind selectors.
- **MD3-spec state layers**: adds `useHover` + `getInteractionDataAttributes` to `Checkbox.tsx`; hover 8% (`opacity-8`), focus/pressed 10% (`opacity-10`); state-layer color transitions via `*-spring-standard-fast-effects`; no state layer when disabled.
- **Proper focus ring**: replaces the non-MD3 `animate-pulse` SVG rect with a dedicated `checkboxFocusRingVariants` slot (absolute outline, opacity transition via `*-spring-standard-fast-effects`, shown only on `data-focus-visible`).
- **MD3 motion tokens**: replaces hardcoded `duration-200` with `*-spring-standard-fast-effects` (colors/opacity) and `*-spring-standard-fast-spatial` (icon transforms).
- **Div-box slot**: box visual refactored from an SVG `<rect>` with `stroke` to a `div` with `border-2 rounded-[2px]` + inline SVG check/dash icons, matching the Switch div-slot pattern.
- **Updated exports**: `index.ts` re-exports the new slot variant names and `VariantProps` types.
- **Tests updated**: DOM-structure-dependent assertions replaced with `data-attribute` assertions (`data-disabled`, `data-invalid`, `data-focus-visible`); all behavioral and axe accessibility tests preserved.
- **New story**: `StateLayerShowcase` demonstrates all state combinations side-by-side.

## Test plan

- [ ] `pnpm lint` — passes (0 errors)
- [ ] `pnpm typecheck` — passes (0 errors)
- [ ] `pnpm test` — 1976 tests across 32 files all pass
- [ ] Visually inspect in Storybook: unchecked, checked, indeterminate, invalid, disabled states; hover/focus/press state layers; focus ring visible on keyboard Tab; no focus ring on mouse click
- [ ] Verify label positioning and 40dp touch target in all states