### PR TITLE
feat(chip): md3 expressive refactor — slot-based architecture and token corrections

### DIFF
--- a/.changeset/chip-md3-expressive-refactor.md
+++ b/.changeset/chip-md3-expressive-refactor.md
@@ -1,0 +1,71 @@
+---
+"@tinybigui/react": minor
+---
+
+**chip: MD3 Expressive refactor — slot-based architecture, token corrections, new elevated support**
+
+### Architecture
+
+The Chip component has been rewritten to follow the same slot-based "Variants vs States"
+architecture used by `Button` and `Switch`:
+
+- All interaction/selection states are now driven by `data-*` attributes set via
+  `getInteractionDataAttributes` and consumed by each slot via `group-data-[x]/chip`
+  Tailwind selectors — no state values in CVA variants.
+- `useHover`, `useFocusRing`, and `isPressed` (via press lifecycle callbacks) are now
+  tracked in `Chip.tsx` and threaded to `ChipHeadless` via `bodyPassthrough` and
+  `removePassthrough`.
+- Dedicated focus ring slot (`chipFocusRingVariants`) rendered outside `overflow-hidden`
+  so it extends 3px beyond the chip boundary and is never clipped.
+- Remove button gets its own `group/chip-remove` scope with an independent circular
+  state layer (`chipRemoveStateLayerVariants`).
+- Spring motion tokens throughout: `ease-spring-standard-fast-effects` for
+  color/opacity/shadow; `ease-spring-standard-fast-spatial` for the filter checkmark
+  width animation.
+
+### MD3 Token Corrections
+
+Per-type color tokens now match the MD3 Expressive spec exactly:
+
+| Type                  | Container             | Border            | Label                    | Leading icon             |
+| --------------------- | --------------------- | ----------------- | ------------------------ | ------------------------ |
+| `assist`              | transparent           | `outline`         | `on-surface`             | **`primary`**            |
+| `filter` (unselected) | transparent           | `outline`         | `on-surface-variant`     | `on-surface-variant`     |
+| `filter` (selected)   | `secondary-container` | none              | `on-secondary-container` | `on-secondary-container` |
+| `input`               | transparent           | `outline-variant` | `on-surface-variant`     | `on-surface-variant`     |
+| `suggestion`          | transparent           | `outline`         | `on-surface-variant`     | `on-surface-variant`     |
+
+### New Features
+
+- **Elevated surface for all chip types** — `surface="elevated"` now works on `filter`
+  and `input` chips in addition to `assist` and `suggestion`.
+
+### Breaking Changes (pre-1.0 minor)
+
+- **`surface` default changed from `"tonal"` to `"flat"`**. If you relied on the
+  default, add `surface="elevated"` explicitly if you want the elevated style, or
+  omit `surface` / use `surface="flat"` for the MD3 default transparent outlined style.
+- **`surface="tonal"` is deprecated.** It maps to `"flat"` internally and emits a
+  `console.warn` in non-production environments. Migrate: replace `surface="tonal"` with
+  `surface="flat"` (or simply omit `surface`).
+
+### New Exports
+
+```ts
+// Slot variant functions
+(chipStateLayerVariants,
+  chipFocusRingVariants,
+  chipLeadingIconVariants,
+  chipTrailingIconVariants,
+  chipCheckmarkVariants,
+  chipCheckmarkIconVariants,
+  chipLabelVariants,
+  chipRemoveButtonVariants,
+  chipRemoveStateLayerVariants);
+
+// Variant prop types
+(ChipStateLayerVariants, ChipLeadingIconVariants);
+
+// Passthrough prop types (for advanced headless usage)
+(ChipBodyPassthroughProps, ChipRemovePassthroughProps);
+```

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -63,7 +63,7 @@ const meta: Meta<typeof Chip> = {
     docs: {
       description: {
         component: `
-**Material Design 3 Chip** — a compact, interactive element used for actions, filters, inputs, and suggestions.
+**Material Design 3 Chip (MD3 Expressive)** — a compact, interactive element used for actions, filters, inputs, and suggestions.
 
 MD3 defines four distinct chip types, each with its own interaction model:
 
@@ -74,11 +74,20 @@ MD3 defines four distinct chip types, each with its own interaction model:
 | \`input\` | Represents a user-entered value; removable | two buttons (body + remove) |
 | \`suggestion\` | Offers a contextual suggestion | \`button\` |
 
-**Surfaces** — Assist and Suggestion chips support \`tonal\` (default) and \`elevated\`.
+**Surfaces:**
+- \`flat\` (default) — transparent container with MD3 outline border. This is the MD3 spec default. All four chip types support it.
+- \`elevated\` — \`surface-container-low\` fill + \`shadow-elevation-1\`. Hovers to \`shadow-elevation-2\`. All four chip types support it.
+- \`tonal\` — **@deprecated.** Maps to \`flat\` and logs a \`console.warn\` in development. Use \`flat\` instead.
+
+**MD3 Expressive per-type icon colors:**
+- Assist leading icon → \`primary\`
+- Filter/Input/Suggestion → \`on-surface-variant\`; filter selected → \`on-secondary-container\`
+
+**Motion:** Spring-based tokens (\`ease-spring-standard-fast-effects\`, \`ease-spring-standard-fast-spatial\`) — no hardcoded durations.
 
 **Keyboard:** Tab to focus · Enter/Space to press/toggle · Backspace on input chip removes it.
 
-[MD3 Chips spec →](https://m3.material.io/components/chips/overview)
+[MD3 Chips spec →](https://m3.material.io/components/chips/specs)
         `.trim(),
       },
     },
@@ -92,8 +101,9 @@ MD3 defines four distinct chip types, each with its own interaction model:
     },
     surface: {
       control: "select",
-      options: ["tonal", "elevated"],
-      description: "Surface style (Assist and Suggestion chips only)",
+      options: ["flat", "elevated", "tonal"],
+      description:
+        "Surface style. `flat` (default): transparent + outline. `elevated`: fill + shadow. `tonal`: deprecated alias for `flat`.",
     },
     selected: {
       control: "boolean",
@@ -121,7 +131,7 @@ export const Default: Story = {
   args: {
     type: "assist",
     label: "Set alarm",
-    surface: "tonal",
+    surface: "flat",
     isDisabled: false,
   },
   parameters: {
@@ -135,7 +145,7 @@ export const Default: Story = {
 };
 
 // ---------------------------------------------------------------------------
-// Assist Chip — tonal surface
+// Assist Chip — flat surface (MD3 default)
 // ---------------------------------------------------------------------------
 
 export const AssistChip: Story = {
@@ -149,14 +159,14 @@ export const AssistChip: Story = {
     docs: {
       description: {
         story:
-          "Assist chips trigger contextual actions related to the current content. The tonal surface uses `secondary-container` fill. **Keyboard:** Tab · Enter/Space to activate.",
+          "Assist chips trigger contextual actions. The **flat** surface (MD3 default) uses a transparent container + `border-outline`. The leading icon color is `primary` per MD3 spec. **Keyboard:** Tab · Enter/Space to activate.",
       },
     },
   },
 };
 
 // ---------------------------------------------------------------------------
-// Assist Chip Elevated
+// Assist Chip — Elevated
 // ---------------------------------------------------------------------------
 
 export const AssistChipElevated: Story = {
@@ -175,14 +185,14 @@ export const AssistChipElevated: Story = {
     docs: {
       description: {
         story:
-          "Elevated assist chips use `surface-container-low` with `shadow-elevation-1` to lift the chip off the surface. Prefer the tonal variant on white/light backgrounds.",
+          "Elevated assist chips use `surface-container-low` fill + `shadow-elevation-1` base, lifting to `shadow-elevation-2` on hover. Prefer the flat variant on white/light backgrounds.",
       },
     },
   },
 };
 
 // ---------------------------------------------------------------------------
-// Filter Chip — uncontrolled (aria-pressed visible in a11y panel)
+// Filter Chip — flat (uncontrolled)
 // ---------------------------------------------------------------------------
 
 export const FilterChip: Story = {
@@ -197,7 +207,29 @@ export const FilterChip: Story = {
     docs: {
       description: {
         story:
-          "Uncontrolled filter chips manage their own selection state. Open the **Accessibility** panel to confirm `aria-pressed` toggles on click. **Keyboard:** Tab · Enter/Space to toggle.",
+          "Uncontrolled filter chips manage their own selection state. Selected state: `bg-secondary-container` fill, `text-on-secondary-container`. Open the **Accessibility** panel to confirm `aria-pressed` toggles on click. **Keyboard:** Tab · Enter/Space to toggle.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Filter Chip — Elevated
+// ---------------------------------------------------------------------------
+
+export const FilterChipElevated: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-3">
+      <Chip type="filter" surface="elevated" label="Vegetarian" defaultSelected />
+      <Chip type="filter" surface="elevated" label="Vegan" />
+      <Chip type="filter" surface="elevated" label="Gluten-free" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Elevated filter chips: unselected state uses `surface-container-low` fill + shadow-elevation-1. Selected state overrides to `bg-secondary-container` — the elevation is preserved. All four chip types support the elevated surface.",
       },
     },
   },
@@ -230,14 +262,14 @@ export const FilterChipControlled: Story = {
     docs: {
       description: {
         story:
-          "Controlled filter chip — the parent manages selection via `selected` + `onSelectionChange`. The label updates to reflect state, demonstrating that the component re-renders correctly.",
+          "Controlled filter chip — the parent manages selection via `selected` + `onSelectionChange`. The label updates to reflect state.",
       },
     },
   },
 };
 
 // ---------------------------------------------------------------------------
-// Filter Chip With Checkmark animation
+// Filter Chip — Checkmark spring animation
 // ---------------------------------------------------------------------------
 
 const FilterChipWithCheckmarkDemo = (): React.ReactElement => {
@@ -258,14 +290,14 @@ export const FilterChipWithCheckmark: Story = {
     docs: {
       description: {
         story:
-          "Demonstrates the MD3 checkmark slide-in animation on filter chip selection. The checkmark uses `transition-[width,opacity]` with the `ease-emphasized-decelerate` easing token.",
+          "Demonstrates the MD3 checkmark spring animation on filter chip selection. Width uses `ease-spring-standard-fast-spatial` (spatial token); opacity uses `ease-spring-standard-fast-effects` (effects token) — MD3 motion pairing rules enforced.",
       },
     },
   },
 };
 
 // ---------------------------------------------------------------------------
-// Input Chip — remove button
+// Input Chip — flat + remove button
 // ---------------------------------------------------------------------------
 
 const InputChipDemo = (): React.ReactElement => {
@@ -291,7 +323,43 @@ export const InputChip: Story = {
     docs: {
       description: {
         story:
-          "Input chips represent user-entered values (e.g. tags). Click the × button to remove a chip with a fade-out animation. **Keyboard:** Tab to the × button · Enter/Space to remove.",
+          "Input chips represent user-entered values (e.g. tags). Uses `border-outline-variant` per MD3 spec. Click the × button to remove a chip with a fade-out animation. **Keyboard:** Tab to the × button · Enter/Space to remove.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Input Chip — Elevated
+// ---------------------------------------------------------------------------
+
+const InputChipElevatedDemo = (): React.ReactElement => {
+  const [chips, setChips] = useState(["React", "TypeScript"]);
+  const remove = (label: string): void => {
+    setChips((prev) => prev.filter((c) => c !== label));
+  };
+  return (
+    <ChipSet>
+      {chips.map((label) => (
+        <Chip
+          key={label}
+          type="input"
+          surface="elevated"
+          label={label}
+          onRemove={() => remove(label)}
+        />
+      ))}
+    </ChipSet>
+  );
+};
+
+export const InputChipElevated: Story = {
+  render: () => <InputChipElevatedDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Elevated input chips. The elevated surface is now available for input chips — useful for placing chips on textured or colored backgrounds.",
       },
     },
   },
@@ -329,14 +397,14 @@ export const InputChipKeyboardRemoval: Story = {
     docs: {
       description: {
         story:
-          "Demonstrates keyboard removal of input chips. Tab to reach the × remove button on each chip, then press Enter or Space. The chip fades out with an `animate-md-fade-out` animation before being unmounted.",
+          "Demonstrates keyboard removal of input chips. Tab to reach the × remove button on each chip, then press Enter or Space. The chip fades out with `animate-md-fade-out` before unmounting.",
       },
     },
   },
 };
 
 // ---------------------------------------------------------------------------
-// Suggestion Chip — tonal
+// Suggestion Chip — flat
 // ---------------------------------------------------------------------------
 
 export const SuggestionChip: Story = {
@@ -351,14 +419,14 @@ export const SuggestionChip: Story = {
     docs: {
       description: {
         story:
-          "Suggestion chips offer smart replies or contextual actions. They behave identically to assist chips but are semantically distinct per MD3. **Keyboard:** Tab · Enter/Space to activate.",
+          "Suggestion chips offer smart replies or contextual actions. They are semantically distinct from assist chips but share the same interaction model. Label/icon color: `on-surface-variant` per MD3 spec. **Keyboard:** Tab · Enter/Space to activate.",
       },
     },
   },
 };
 
 // ---------------------------------------------------------------------------
-// Suggestion Chip Elevated
+// Suggestion Chip — Elevated
 // ---------------------------------------------------------------------------
 
 export const SuggestionChipElevated: Story = {
@@ -373,14 +441,14 @@ export const SuggestionChipElevated: Story = {
     docs: {
       description: {
         story:
-          "Elevated suggestion chips lift off the surface using `shadow-elevation-1`. Useful when placed on colored or patterned backgrounds where the tonal fill would blend in.",
+          "Elevated suggestion chips. Useful when placed on colored or patterned backgrounds where a flat outlined chip would blend in.",
       },
     },
   },
 };
 
 // ---------------------------------------------------------------------------
-// All Types — side by side in a ChipSet
+// All Types — side by side
 // ---------------------------------------------------------------------------
 
 export const AllTypes: Story = {
@@ -396,7 +464,30 @@ export const AllTypes: Story = {
     docs: {
       description: {
         story:
-          "All four MD3 chip types displayed side by side. Notice the different visual treatments: tonal fills for assist/suggestion, fixed tonal for filter/input, and the remove button on the input chip.",
+          "All four MD3 chip types in their default flat surface. Notice the different visual treatments: assist uses `border-outline` + label `on-surface`; filter/suggestion use `border-outline` + label `on-surface-variant`; input uses `border-outline-variant`.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// All Types — Elevated
+// ---------------------------------------------------------------------------
+
+export const AllTypesElevated: Story = {
+  render: () => (
+    <ChipSet>
+      <Chip type="assist" surface="elevated" label="Assist" />
+      <Chip type="filter" surface="elevated" label="Filter" />
+      <Chip type="input" surface="elevated" label="Input" onRemove={noop} />
+      <Chip type="suggestion" surface="elevated" label="Suggestion" />
+    </ChipSet>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All four chip types with the `elevated` surface — a new addition in this release. Each type gains `surface-container-low` fill + `shadow-elevation-1`, hovering to `shadow-elevation-2`.",
       },
     },
   },
@@ -419,7 +510,72 @@ export const WithLeadingIcon: Story = {
     docs: {
       description: {
         story:
-          "Chips with 18×18dp inline SVG leading icons. Icons are wrapped in a `size-4.5` span and marked `aria-hidden` — the chip label provides the accessible name. All icon colors inherit `currentColor`.",
+          "Chips with 18×18dp inline SVG leading icons. Icon colors follow MD3 spec: assist → `primary`; filter/input/suggestion → `on-surface-variant` (selected filter → `on-secondary-container`). All icon colors inherit `currentColor`.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// States — hover / focus / disabled (simulated)
+// ---------------------------------------------------------------------------
+
+export const States: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="text-on-surface-variant mb-2 text-xs font-medium tracking-wide uppercase">
+          Enabled (default)
+        </p>
+        <ChipSet>
+          <Chip type="assist" label="Assist" />
+          <Chip type="filter" label="Filter" />
+          <Chip type="filter" label="Filter selected" selected />
+          <Chip type="input" label="Input" onRemove={noop} />
+          <Chip type="suggestion" label="Suggestion" />
+        </ChipSet>
+      </div>
+      <div>
+        <p className="text-on-surface-variant mb-2 text-xs font-medium tracking-wide uppercase">
+          Disabled
+        </p>
+        <ChipSet>
+          <Chip type="assist" label="Assist" isDisabled />
+          <Chip type="filter" label="Filter" isDisabled />
+          <Chip type="filter" label="Filter selected" selected isDisabled />
+          <Chip type="input" label="Input" isDisabled onRemove={noop} />
+          <Chip type="suggestion" label="Suggestion" isDisabled />
+        </ChipSet>
+      </div>
+      <div>
+        <p className="text-on-surface-variant mb-2 text-xs font-medium tracking-wide uppercase">
+          Elevated surface — all types
+        </p>
+        <ChipSet>
+          <Chip type="assist" surface="elevated" label="Assist" />
+          <Chip type="filter" surface="elevated" label="Filter" />
+          <Chip type="filter" surface="elevated" label="Filter selected" selected />
+          <Chip type="input" surface="elevated" label="Input" onRemove={noop} />
+          <Chip type="suggestion" surface="elevated" label="Suggestion" />
+        </ChipSet>
+      </div>
+      <div>
+        <p className="text-on-surface-variant mb-2 text-xs font-medium tracking-wide uppercase">
+          Elevated + disabled
+        </p>
+        <ChipSet>
+          <Chip type="assist" surface="elevated" label="Assist" isDisabled />
+          <Chip type="filter" surface="elevated" label="Filter" isDisabled />
+          <Chip type="input" surface="elevated" label="Input" isDisabled onRemove={noop} />
+        </ChipSet>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "State overview: enabled (default), disabled, elevated surface, and elevated + disabled. Hover/focus/pressed states use MD3 state layers at 8%/10%/10% opacity driven by `data-*` attributes via `group-data-[x]/chip` selectors — no CSS `:hover` pseudo-classes.",
       },
     },
   },
@@ -442,14 +598,47 @@ export const DisabledState: Story = {
     docs: {
       description: {
         story:
-          "All four chip types in the disabled state. Disabled chips receive `opacity-38` and `pointer-events-none`. React Aria ensures `aria-disabled` is set and keyboard interaction is blocked.",
+          "All four chip types in the disabled state. `data-[disabled]:text-on-surface/38`, `data-[disabled]:border-on-surface/12`, transparent bg. React Aria ensures `aria-disabled` is set and keyboard interaction is blocked.",
       },
     },
   },
 };
 
 // ---------------------------------------------------------------------------
-// ChipSet Layout — flex-wrap with constrained container
+// Deprecated surface="tonal" note
+// ---------------------------------------------------------------------------
+
+export const DeprecatedTonalSurface: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="bg-warning-container text-on-warning-container border-outline rounded-md border px-4 py-3 text-sm">
+        <strong>⚠ Deprecated:</strong> <code>surface=&quot;tonal&quot;</code> is an alias for{" "}
+        <code>surface=&quot;flat&quot;</code> and will log a <code>console.warn</code> in
+        development. Migrate to <code>surface=&quot;flat&quot;</code>.
+      </div>
+      <ChipSet>
+        {/* @ts-expect-error intentionally demonstrating the deprecated value */}
+        <Chip type="assist" surface="tonal" label="Tonal (deprecated)" />
+        <Chip type="assist" surface="flat" label="Flat (use this)" />
+      </ChipSet>
+      <p className="text-on-surface-variant text-xs">
+        Both chips render identically. Open the browser console to see the deprecation warning for
+        the tonal chip.
+      </p>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the deprecated `surface="tonal"` alias. It maps to `flat` internally and emits a `console.warn` in development. **Migrate: replace `surface="tonal"` with `surface="flat"`** — or simply omit `surface` since `flat` is the default.',
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// ChipSet Layout — flex-wrap
 // ---------------------------------------------------------------------------
 
 export const ChipSetLayout: Story = {
@@ -472,7 +661,7 @@ export const ChipSetLayout: Story = {
     docs: {
       description: {
         story:
-          "A `ChipSet` inside a `max-w-xs` container demonstrating `flex-wrap` behavior. Chips flow into multiple rows as needed. The 8dp gap (`gap-2`) is applied consistently between all chips.",
+          "A `ChipSet` inside a `max-w-xs` container demonstrating `flex-wrap` behavior. Chips flow into multiple rows as needed. The 8dp gap (`gap-2`) is applied consistently.",
       },
     },
   },
@@ -529,7 +718,7 @@ export const FilterGroup: Story = {
     docs: {
       description: {
         story:
-          "Realistic multi-select filter UI with five category filter chips. Selection state is managed externally with `useState` and a `Set`. Multiple chips can be active simultaneously. **Keyboard:** Tab between chips · Enter/Space to toggle each.",
+          "Realistic multi-select filter UI with five category filter chips. Selection state is managed externally with `useState` and a `Set`. **Keyboard:** Tab between chips · Enter/Space to toggle each.",
       },
     },
   },
@@ -573,7 +762,7 @@ export const InputChipList: Story = {
     docs: {
       description: {
         story:
-          "Realistic tag-input UI starting with five input chips. Clicking the × on any chip removes it individually with a fade-out animation. Each chip's remove button is independently keyboard-focusable. **Keyboard:** Tab to × · Enter/Space to remove.",
+          "Realistic tag-input UI starting with five input chips. Clicking × on any chip removes it with a fade-out animation. Each chip's remove button has its own `group/chip-remove` state layer for independent hover/focus/pressed states. **Keyboard:** Tab to × · Enter/Space to remove.",
       },
     },
   },
@@ -587,7 +776,7 @@ export const Playground: Story = {
   args: {
     type: "assist",
     label: "Chip label",
-    surface: "tonal",
+    surface: "flat",
     selected: false,
     isDisabled: false,
   },
@@ -595,7 +784,7 @@ export const Playground: Story = {
     docs: {
       description: {
         story:
-          "Full interactive playground. Use the Controls panel to explore every combination of `type`, `surface`, `selected`, `isDisabled`, and `label`. Note: `selected` only affects filter chips; `surface` only affects assist and suggestion chips.",
+          "Full interactive playground. Use the Controls panel to explore every combination of `type`, `surface`, `selected`, `isDisabled`, and `label`. Note: `selected` only affects filter chips; `surface` affects all chip types.",
       },
     },
   },

--- a/packages/react/src/components/Chip/Chip.test.tsx
+++ b/packages/react/src/components/Chip/Chip.test.tsx
@@ -52,8 +52,6 @@ describe("ChipHeadless — Assist", () => {
 
   test("6. isDisabled disables the button (native disabled or aria-disabled)", () => {
     render(<ChipHeadless type="assist" label="Set alarm" isDisabled />);
-    // React Aria's useButton sets the native `disabled` attribute on <button> elements.
-    // This is the correct WCAG pattern — disabled buttons should not be focusable.
     const button = screen.getByRole("button", { name: "Set alarm" });
     expect(button).toBeDisabled();
   });
@@ -219,109 +217,302 @@ describe("ChipHeadless — General", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Chip (Styled) — base classes
+// Chip (Styled) — base shape and layout classes
 // ---------------------------------------------------------------------------
 
-describe("Chip — base classes", () => {
-  test("26. applies rounded-sm, h-8, text-label-large", () => {
+describe("Chip — base shape and layout classes", () => {
+  test("26. applies h-8, rounded-sm, text-label-large", () => {
     render(<Chip type="assist" label="Help" />);
     const chip = screen.getByRole("button", { name: "Help" });
-    expect(chip).toHaveClass("rounded-sm");
     expect(chip).toHaveClass("h-8");
+    expect(chip).toHaveClass("rounded-sm");
     expect(chip).toHaveClass("text-label-large");
   });
 
-  test("27. applies bg-surface-container-low for filter chip (unselected)", () => {
-    render(<Chip type="filter" label="Veg" />);
-    const chip = screen.getByRole("button", { name: "Veg" });
-    expect(chip).toHaveClass("bg-surface-container-low");
+  test("27. applies group/chip class on root", () => {
+    render(<Chip type="assist" label="Help" />);
+    const chip = screen.getByRole("button", { name: "Help" });
+    expect(chip).toHaveClass("group/chip");
   });
 
-  test("28. applies bg-secondary-container for filter chip (selected)", () => {
-    render(<Chip type="filter" label="Veg" selected />);
-    const chip = screen.getByRole("button", { name: "Veg" });
-    expect(chip).toHaveClass("bg-secondary-container");
-  });
-
-  test("29. applies border border-outline for filter chip (unselected)", () => {
-    render(<Chip type="filter" label="Veg" />);
-    const chip = screen.getByRole("button", { name: "Veg" });
-    expect(chip).toHaveClass("border");
-    expect(chip).toHaveClass("border-outline");
-  });
-
-  test("30. applies border-0 for filter chip (selected)", () => {
-    render(<Chip type="filter" label="Veg" selected />);
-    const chip = screen.getByRole("button", { name: "Veg" });
-    expect(chip).toHaveClass("border-0");
+  test("28. base padding px-4 with no icons", () => {
+    render(<Chip type="assist" label="Help" />);
+    const chip = screen.getByRole("button", { name: "Help" });
+    expect(chip).toHaveClass("px-4");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Chip — Assist chip surface
+// Chip — MD3 per-type flat surface color tokens
 // ---------------------------------------------------------------------------
 
-describe("Chip — Assist chip surface", () => {
-  test("31. tonal: applies bg-surface-container-low and border border-outline", () => {
-    render(<Chip type="assist" label="Help" surface="tonal" />);
+describe("Chip — MD3 per-type color tokens (flat surface)", () => {
+  test("29. assist: transparent bg + border-outline + text-on-surface", () => {
+    render(<Chip type="assist" label="Help" />);
     const chip = screen.getByRole("button", { name: "Help" });
-    expect(chip).toHaveClass("bg-surface-container-low");
-    expect(chip).toHaveClass("border");
+    expect(chip).toHaveClass("bg-transparent");
     expect(chip).toHaveClass("border-outline");
+    expect(chip).toHaveClass("text-on-surface");
   });
 
-  test("32. elevated: applies shadow-elevation-1 and hover:shadow-elevation-2", () => {
-    render(<Chip type="assist" label="Help" surface="elevated" />);
+  test("30. filter (unselected): transparent + border-outline + text-on-surface-variant", () => {
+    render(<Chip type="filter" label="Veg" />);
+    const chip = screen.getByRole("button", { name: "Veg" });
+    expect(chip).toHaveClass("bg-transparent");
+    expect(chip).toHaveClass("border-outline");
+    expect(chip).toHaveClass("text-on-surface-variant");
+  });
+
+  test("31. filter (selected): bg-secondary-container via group-data selector", () => {
+    render(<Chip type="filter" label="Veg" selected />);
+    // The group-data selector is a CSS class string — verify it is in the class list
+    const chip = screen.getByRole("button", { name: "Veg" });
+    // CSS classes for the selected state are group-data selectors applied as Tailwind classes
+    expect(chip.className).toContain("group-data-[selected]/chip:bg-secondary-container");
+  });
+
+  test("32. input: transparent + border-outline-variant + text-on-surface-variant", () => {
+    const { container } = render(<Chip type="input" label="React" onRemove={vi.fn()} />);
+    const chipRoot = container.firstChild as HTMLElement;
+    expect(chipRoot).toHaveClass("bg-transparent");
+    expect(chipRoot).toHaveClass("border-outline-variant");
+    expect(chipRoot).toHaveClass("text-on-surface-variant");
+  });
+
+  test("33. suggestion: transparent + border-outline + text-on-surface-variant", () => {
+    render(<Chip type="suggestion" label="See photos" />);
+    const chip = screen.getByRole("button", { name: "See photos" });
+    expect(chip).toHaveClass("bg-transparent");
+    expect(chip).toHaveClass("border-outline");
+    expect(chip).toHaveClass("text-on-surface-variant");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chip — Elevated surface
+// ---------------------------------------------------------------------------
+
+describe("Chip — Elevated surface", () => {
+  test("34. elevated assist: bg-surface-container-low, border-0, shadow-elevation-1", () => {
+    render(<Chip type="assist" surface="elevated" label="Help" />);
     const chip = screen.getByRole("button", { name: "Help" });
+    expect(chip).toHaveClass("bg-surface-container-low");
     expect(chip).toHaveClass("shadow-elevation-1");
-    expect(chip).toHaveClass("hover:shadow-elevation-2");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Chip — disabled state
-// ---------------------------------------------------------------------------
-
-describe("Chip — disabled state", () => {
-  test("33. applies text-on-surface/38 and border-on-surface/12 when disabled", () => {
-    render(<Chip type="assist" label="Help" surface="tonal" isDisabled />);
-    const chip = screen.getByRole("button", { name: "Help" });
-    expect(chip).toHaveClass("text-on-surface/38");
-    expect(chip).toHaveClass("border-on-surface/12");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Chip — filter checkmark animation
-// ---------------------------------------------------------------------------
-
-describe("Chip — filter checkmark", () => {
-  test("34. checkmark container is present in DOM for filter chips", () => {
-    const { container } = render(<Chip type="filter" label="Veg" />);
-    // The checkmark span is a sibling of the label inside the chip
-    const spans = container.querySelectorAll("span");
-    // At least one span manages the checkmark width/opacity transition
-    expect(spans.length).toBeGreaterThan(0);
   });
 
-  test("35. when selected: checkmark container has w-4.5 and opacity-100", () => {
-    const { container } = render(<Chip type="filter" label="Veg" selected />);
-    const checkmarkContainer = container.querySelector(".w-4\\.5.opacity-100");
-    expect(checkmarkContainer).toBeInTheDocument();
-  });
-
-  test("36. when unselected: checkmark container has w-0 and opacity-0", () => {
-    const { container } = render(<Chip type="filter" label="Veg" />);
-    const checkmarkContainer = container.querySelector(".w-0.opacity-0");
-    expect(checkmarkContainer).toBeInTheDocument();
-  });
-
-  test("37a. filter chip always has transition-[background-color,color] duration-short4 ease-standard", () => {
-    render(<Chip type="filter" label="Veg" />);
+  test("35. elevated filter: bg-surface-container-low + shadow-elevation-1", () => {
+    render(<Chip type="filter" surface="elevated" label="Veg" />);
     const chip = screen.getByRole("button", { name: "Veg" });
-    expect(chip).toHaveClass("transition-[background-color,color]");
-    expect(chip).toHaveClass("duration-short4");
-    expect(chip).toHaveClass("ease-standard");
+    expect(chip).toHaveClass("bg-surface-container-low");
+    expect(chip).toHaveClass("shadow-elevation-1");
+  });
+
+  test("36. elevated input: bg-surface-container-low + shadow-elevation-1", () => {
+    const { container } = render(
+      <Chip type="input" surface="elevated" label="React" onRemove={vi.fn()} />
+    );
+    const chipRoot = container.firstChild as HTMLElement;
+    expect(chipRoot).toHaveClass("bg-surface-container-low");
+    expect(chipRoot).toHaveClass("shadow-elevation-1");
+  });
+
+  test("37. elevated suggestion: bg-surface-container-low + shadow-elevation-1", () => {
+    render(<Chip type="suggestion" surface="elevated" label="See photos" />);
+    const chip = screen.getByRole("button", { name: "See photos" });
+    expect(chip).toHaveClass("bg-surface-container-low");
+    expect(chip).toHaveClass("shadow-elevation-1");
+  });
+
+  test("38. elevated chip has data-[hovered]:shadow-elevation-2 class", () => {
+    render(<Chip type="assist" surface="elevated" label="Help" />);
+    const chip = screen.getByRole("button", { name: "Help" });
+    expect(chip.className).toContain("data-[hovered]:shadow-elevation-2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chip — Disabled state
+// ---------------------------------------------------------------------------
+
+describe("Chip — Disabled state", () => {
+  test("39. disabled chip has data-[disabled] self-targeting classes", () => {
+    render(<Chip type="assist" label="Help" isDisabled />);
+    const chip = screen.getByRole("button", { name: "Help" });
+    expect(chip.className).toContain("data-[disabled]:text-on-surface/38");
+    expect(chip.className).toContain("data-[disabled]:border-on-surface/12");
+  });
+
+  test("40. disabled chip has data-disabled attribute set", () => {
+    render(<Chip type="assist" label="Help" isDisabled />);
+    const chip = screen.getByRole("button", { name: "Help" });
+    expect(chip).toHaveAttribute("data-disabled", "");
+  });
+
+  test("41. disabled filter chip (selected) has data-[selected]:data-[disabled] class", () => {
+    render(<Chip type="filter" label="Veg" selected isDisabled />);
+    const chip = screen.getByRole("button", { name: "Veg" });
+    expect(chip.className).toContain("data-[selected]:data-[disabled]:bg-on-surface/12");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chip — State layer slot
+// ---------------------------------------------------------------------------
+
+describe("Chip — State layer slot", () => {
+  test("42. state layer span is present in non-input chips", () => {
+    const { container } = render(<Chip type="assist" label="Help" />);
+    // State layer is an absolute span with group-data opacity classes
+    const stateLayer = container.querySelector('span[aria-hidden="true"].absolute');
+    expect(stateLayer).toBeInTheDocument();
+  });
+
+  test("43. state layer has group-data-[hovered] opacity class for correct type", () => {
+    const { container } = render(<Chip type="assist" label="Help" />);
+    const spans = Array.from(container.querySelectorAll('span[aria-hidden="true"]'));
+    const stateLayer = spans.find((s) =>
+      s.className.includes("group-data-[hovered]/chip:opacity-8")
+    );
+    expect(stateLayer).toBeInTheDocument();
+  });
+
+  test("44. state layer is hidden when disabled (group-data-[disabled]/chip:hidden)", () => {
+    const { container } = render(<Chip type="assist" label="Help" />);
+    const spans = Array.from(container.querySelectorAll('span[aria-hidden="true"]'));
+    const stateLayer = spans.find((s) => s.className.includes("group-data-[disabled]/chip:hidden"));
+    expect(stateLayer).toBeInTheDocument();
+  });
+
+  test("45. assist chip state layer color is bg-on-surface", () => {
+    const { container } = render(<Chip type="assist" label="Help" />);
+    const spans = Array.from(container.querySelectorAll('span[aria-hidden="true"]'));
+    const stateLayer = spans.find((s) => s.className.includes("bg-on-surface"));
+    expect(stateLayer).toBeInTheDocument();
+  });
+
+  test("46. filter chip state layer has group-data-[selected] secondary-container color", () => {
+    const { container } = render(<Chip type="filter" label="Veg" />);
+    const spans = Array.from(container.querySelectorAll('span[aria-hidden="true"]'));
+    const stateLayer = spans.find((s) =>
+      s.className.includes("group-data-[selected]/chip:bg-on-secondary-container")
+    );
+    expect(stateLayer).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chip — Focus ring slot
+// ---------------------------------------------------------------------------
+
+describe("Chip — Focus ring slot", () => {
+  test("47. focus ring span is present", () => {
+    const { container } = render(<Chip type="assist" label="Help" />);
+    const spans = Array.from(container.querySelectorAll('span[aria-hidden="true"]'));
+    const focusRing = spans.find((s) => s.className.includes("outline-secondary"));
+    expect(focusRing).toBeInTheDocument();
+  });
+
+  test("48. focus ring has inset-[-3px] for extension outside chip boundary", () => {
+    const { container } = render(<Chip type="assist" label="Help" />);
+    const spans = Array.from(container.querySelectorAll('span[aria-hidden="true"]'));
+    const focusRing = spans.find((s) => s.className.includes("inset-[-3px]"));
+    expect(focusRing).toBeInTheDocument();
+  });
+
+  test("49. focus ring has group-data-[focus-visible]/chip:opacity-100", () => {
+    const { container } = render(<Chip type="assist" label="Help" />);
+    const spans = Array.from(container.querySelectorAll('span[aria-hidden="true"]'));
+    const focusRing = spans.find((s) =>
+      s.className.includes("group-data-[focus-visible]/chip:opacity-100")
+    );
+    expect(focusRing).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chip — Leading icon colors
+// ---------------------------------------------------------------------------
+
+describe("Chip — Leading icon colors", () => {
+  const icon = <span data-testid="icon">★</span>;
+
+  test("50. assist leading icon has text-primary class", () => {
+    const { container } = render(<Chip type="assist" label="Help" leadingIcon={icon} />);
+    const iconWrapper = container.querySelector(".text-primary");
+    expect(iconWrapper).toBeInTheDocument();
+  });
+
+  test("51. filter leading icon has text-on-surface-variant class", () => {
+    const { container } = render(<Chip type="filter" label="Veg" leadingIcon={icon} />);
+    const iconWrapper = container.querySelector(".text-on-surface-variant");
+    expect(iconWrapper).toBeInTheDocument();
+  });
+
+  test("52. input leading icon has text-on-surface-variant class", () => {
+    const { container } = render(
+      <Chip type="input" label="React" leadingIcon={icon} onRemove={vi.fn()} />
+    );
+    const iconWrapper = container.querySelector(".text-on-surface-variant");
+    expect(iconWrapper).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chip — Filter checkmark animation
+// ---------------------------------------------------------------------------
+
+describe("Chip — Filter checkmark", () => {
+  test("53. checkmark container is present for filter chips", () => {
+    const { container } = render(<Chip type="filter" label="Veg" />);
+    const checkmarkContainer = container.querySelector(
+      'span[aria-hidden="true"].inline-flex.overflow-hidden'
+    );
+    expect(checkmarkContainer).toBeInTheDocument();
+  });
+
+  test("54. checkmark container has group-data-[selected]/chip:w-[18px] class", () => {
+    const { container } = render(<Chip type="filter" label="Veg" />);
+    const spans = Array.from(container.querySelectorAll('span[aria-hidden="true"]'));
+    const checkmark = spans.find((s) =>
+      s.className.includes("group-data-[selected]/chip:w-[18px]")
+    );
+    expect(checkmark).toBeInTheDocument();
+  });
+
+  test("55. checkmark icon has spatial spring motion class", () => {
+    const { container } = render(<Chip type="filter" label="Veg" />);
+    const spans = Array.from(container.querySelectorAll("span"));
+    const checkmarkContainer = spans.find((s) =>
+      s.className.includes("duration-spring-standard-fast-spatial")
+    );
+    expect(checkmarkContainer).toBeInTheDocument();
+  });
+
+  test("56. checkmark icon opacity class uses spring-standard-fast-effects", () => {
+    const { container } = render(<Chip type="filter" label="Veg" />);
+    const spans = Array.from(container.querySelectorAll("span"));
+    const iconWrapper = spans.find((s) =>
+      s.className.includes("group-data-[selected]/chip:opacity-100")
+    );
+    expect(iconWrapper).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chip — data-* interaction attributes on root
+// ---------------------------------------------------------------------------
+
+describe("Chip — data-* interaction attributes", () => {
+  test("57. non-disabled chip does NOT have data-disabled attribute", () => {
+    render(<Chip type="assist" label="Help" />);
+    const chip = screen.getByRole("button", { name: "Help" });
+    expect(chip).not.toHaveAttribute("data-disabled");
+  });
+
+  test("58. disabled chip has data-disabled='' attribute", () => {
+    render(<Chip type="assist" label="Help" isDisabled />);
+    const chip = screen.getByRole("button", { name: "Help" });
+    expect(chip).toHaveAttribute("data-disabled", "");
   });
 });
 
@@ -330,7 +521,7 @@ describe("Chip — filter checkmark", () => {
 // ---------------------------------------------------------------------------
 
 describe("Chip — Input removal animation", () => {
-  test("37. clicking remove button adds animate-md-fade-out to chip root", async () => {
+  test("59. clicking remove button adds animate-md-fade-out to chip root", async () => {
     const user = userEvent.setup();
     const onRemove = vi.fn();
     const { container } = render(<Chip type="input" label="React" onRemove={onRemove} />);
@@ -341,33 +532,31 @@ describe("Chip — Input removal animation", () => {
     expect(chipRoot).toHaveClass("animate-md-fade-out");
   });
 
-  test("38. onRemove is NOT called immediately — only after animationend", async () => {
+  test("60. onRemove is NOT called immediately — only after animationend", async () => {
     const user = userEvent.setup();
     const onRemove = vi.fn();
     const { container } = render(<Chip type="input" label="React" onRemove={onRemove} />);
     const chipRoot = container.firstChild as HTMLElement;
 
     await user.click(screen.getByRole("button", { name: "Remove React" }));
-    // onRemove should NOT have been called yet
     expect(onRemove).not.toHaveBeenCalled();
 
-    // Simulate the CSS animation completing
     fireEvent.animationEnd(chipRoot);
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Chip — ripple
+// Chip — Ripple
 // ---------------------------------------------------------------------------
 
-describe("Chip — ripple", () => {
-  test("39. ripple container is present for interactive chips", () => {
+describe("Chip — Ripple", () => {
+  test("61. ripple container is present for interactive chips", () => {
     const { container } = render(<Chip type="assist" label="Help" />);
     expect(container.querySelector("[data-ripple-container]")).toBeInTheDocument();
   });
 
-  test("40. ripple container is clipped to rounded-sm via rounded-[inherit]", () => {
+  test("62. ripple container has rounded-[inherit] for correct clipping", () => {
     const { container } = render(<Chip type="assist" label="Help" />);
     const rippleContainer = container.querySelector("[data-ripple-container]");
     expect(rippleContainer).toHaveClass("rounded-[inherit]");
@@ -375,28 +564,90 @@ describe("Chip — ripple", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Chip — padding
+// Chip — Motion tokens (no legacy hardcoded durations)
 // ---------------------------------------------------------------------------
 
-describe("Chip — padding", () => {
-  test("41. no icon: applies px-4", () => {
+describe("Chip — Motion tokens", () => {
+  test("63. root chip has spring-standard-fast-effects transition", () => {
     render(<Chip type="assist" label="Help" />);
     const chip = screen.getByRole("button", { name: "Help" });
-    expect(chip).toHaveClass("px-4");
+    expect(chip).toHaveClass("duration-spring-standard-fast-effects");
+    expect(chip).toHaveClass("ease-spring-standard-fast-effects");
   });
 
-  test("42. with leadingIcon: applies pl-3 pr-4", () => {
-    render(<Chip type="assist" label="Help" leadingIcon={<span>★</span>} />);
-    const chip = screen.getByRole("button", { name: "Help" });
-    expect(chip).toHaveClass("pl-3");
-    expect(chip).toHaveClass("pr-4");
+  test("64. filter chip does NOT have legacy duration-short4 class", () => {
+    render(<Chip type="filter" label="Veg" />);
+    const chip = screen.getByRole("button", { name: "Veg" });
+    expect(chip).not.toHaveClass("duration-short4");
+    expect(chip).not.toHaveClass("ease-standard");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chip — Deprecated surface="tonal"
+// ---------------------------------------------------------------------------
+
+describe("Chip — Deprecated surface tonal", () => {
+  test("65. surface=tonal logs a console.warn in development", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    render(<Chip type="assist" label="Help" surface="tonal" />);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('surface="tonal" is deprecated'));
+    warnSpy.mockRestore();
   });
 
-  test("43. input chip: applies pl-3 pr-3", () => {
+  test("66. surface=tonal renders the same as surface=flat (transparent bg)", () => {
+    const { container: flatContainer } = render(
+      <Chip type="assist" label="Help A" surface="flat" />
+    );
+    const flatChip = flatContainer.querySelector("button")!;
+
+    // Suppress the expected deprecation warning
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { container: tonalContainer } = render(
+      <Chip type="assist" label="Help B" surface="tonal" />
+    );
+    warnSpy.mockRestore();
+
+    const tonalChip = tonalContainer.querySelector("button")!;
+    // Both should have transparent bg and border-outline (flat surface tokens)
+    expect(flatChip).toHaveClass("bg-transparent");
+    expect(tonalChip).toHaveClass("bg-transparent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chip — Axe accessibility — styled component
+// ---------------------------------------------------------------------------
+
+describe("Chip — Axe accessibility (styled)", () => {
+  test("67. axe check — assist chip, no violations", async () => {
+    const { container } = render(<Chip type="assist" label="Set alarm" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("68. axe check — filter chip (selected), no violations", async () => {
+    const { container } = render(<Chip type="filter" label="Vegetarian" selected />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("69. axe check — input chip, no violations", async () => {
     const { container } = render(<Chip type="input" label="React" onRemove={vi.fn()} />);
-    const chipRoot = container.firstChild as HTMLElement;
-    expect(chipRoot).toHaveClass("pl-3");
-    expect(chipRoot).toHaveClass("pr-3");
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("70. axe check — elevated suggestion chip, no violations", async () => {
+    const { container } = render(<Chip type="suggestion" surface="elevated" label="See photos" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("71. axe check — disabled filter chip, no violations", async () => {
+    const { container } = render(<Chip type="filter" label="Veg" isDisabled />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });
 

--- a/packages/react/src/components/Chip/Chip.tsx
+++ b/packages/react/src/components/Chip/Chip.tsx
@@ -2,9 +2,22 @@
 
 import { forwardRef, useState, useCallback } from "react";
 import type React from "react";
+import { useHover, useFocusRing, mergeProps } from "react-aria";
 import { ChipHeadless } from "./ChipHeadless";
-import { chipVariants } from "./Chip.variants";
+import {
+  chipVariants,
+  chipStateLayerVariants,
+  chipFocusRingVariants,
+  chipLeadingIconVariants,
+  chipTrailingIconVariants,
+  chipCheckmarkVariants,
+  chipCheckmarkIconVariants,
+  chipLabelVariants,
+  chipRemoveButtonVariants,
+  chipRemoveStateLayerVariants,
+} from "./Chip.variants";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
 import type { ChipProps } from "./Chip.types";
 
@@ -45,21 +58,6 @@ const CheckIcon = (): React.ReactElement => (
 );
 
 // ---------------------------------------------------------------------------
-// State layer — shared across all chip types
-// ---------------------------------------------------------------------------
-
-const StateLayer = (): React.ReactElement => (
-  <span
-    aria-hidden="true"
-    className={cn(
-      "bg-on-surface pointer-events-none absolute inset-0 rounded-sm opacity-0",
-      "duration-spring-standard-fast-effects ease-spring-standard-fast-effects transition-opacity",
-      "group-focus-within:opacity-12 group-hover:opacity-8 group-active:opacity-12"
-    )}
-  />
-);
-
-// ---------------------------------------------------------------------------
 // Public Chip component (Layer 3: Styled)
 // ---------------------------------------------------------------------------
 
@@ -68,18 +66,33 @@ const StateLayer = (): React.ReactElement => (
  *
  * Unified styled chip covering all four MD3 chip types.
  * Built on `ChipHeadless` for world-class accessibility via React Aria.
- * Uses CVA for type-safe variant management.
  *
- * | Type         | Surface       | Selection | Remove |
- * |--------------|---------------|-----------|--------|
- * | `assist`     | tonal/elevated | —         | —      |
- * | `filter`     | fixed tonal   | ✅         | —      |
- * | `input`      | fixed tonal   | —         | ✅     |
- * | `suggestion` | tonal/elevated | —         | —      |
+ * Implements the Variants-vs-States architecture: all interaction/selection
+ * states are expressed as `data-*` attributes on the root and consumed by each
+ * slot via `group-data-[x]/chip` Tailwind selectors — no state variants in CVA.
+ *
+ * Features:
+ * - ✅ 4 MD3 chip types: assist, filter, input, suggestion
+ * - ✅ 2 surfaces: flat (transparent + outline), elevated (shadow + fill)
+ * - ✅ MD3-correct per-type icon colors (assist leading = primary, etc.)
+ * - ✅ Filter chip checkmark with spring animation
+ * - ✅ Input chip removal with animate-md-fade-out
+ * - ✅ Proper MD3 state layer (hover 8%, focus 10%, pressed 10%)
+ * - ✅ Spring motion tokens (no hardcoded durations)
+ * - ✅ Dedicated focus ring slot (outside overflow-hidden)
+ * - ✅ Full keyboard accessibility (via React Aria)
+ * - ✅ Deprecated `surface="tonal"` — warns and maps to `flat`
+ *
+ * MD3 Specifications:
+ * - Height: 32dp (h-8), corner-small 8dp (rounded-sm)
+ * - Padding: 16dp base; 8dp leading side when icon present
+ * - Icon size: 18px × 18px
+ * - State layers: 8% hover, 10% focus/pressed
+ * - Elevation: level-1 base → level-2 hover (elevated surface)
  *
  * @example
  * ```tsx
- * // Assist chip
+ * // Assist chip (default flat surface)
  * <Chip type="assist" label="Set alarm" onPress={handlePress} />
  *
  * // Elevated assist chip
@@ -100,7 +113,7 @@ export const Chip = forwardRef<HTMLButtonElement, ChipProps>(
     {
       type,
       label,
-      surface = "tonal",
+      surface: surfaceProp = "flat",
       selected,
       defaultSelected,
       onSelectionChange,
@@ -113,9 +126,21 @@ export const Chip = forwardRef<HTMLButtonElement, ChipProps>(
     },
     ref
   ) => {
+    // Resolve deprecated surface="tonal" → "flat" with dev warning
+    const surface = ((): "flat" | "elevated" => {
+      if (surfaceProp === "tonal") {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(
+            '[Chip] surface="tonal" is deprecated. Use surface="flat" instead. ' +
+              '"tonal" will be removed in a future minor version.'
+          );
+        }
+        return "flat";
+      }
+      return surfaceProp;
+    })();
+
     // ── Filter chip selected state management ────────────────────────────────
-    // We mirror the toggle state here so the checkmark can react to it.
-    // The headless layer is always driven as controlled from this component.
     const [localSelected, setLocalSelected] = useState(defaultSelected ?? false);
     const isControlled = selected !== undefined;
     const effectiveSelected = type === "filter" ? (isControlled ? selected : localSelected) : false;
@@ -130,11 +155,24 @@ export const Chip = forwardRef<HTMLButtonElement, ChipProps>(
       [isControlled, onSelectionChange]
     );
 
+    // ── Interaction state tracking (body / main chip) ─────────────────────────
+    const [isPressed, setIsPressed] = useState(false);
+    const handlePressStart = useCallback(() => setIsPressed(true), []);
+    const handlePressEnd = useCallback(() => setIsPressed(false), []);
+
+    const { isHovered, hoverProps } = useHover({ isDisabled });
+    const { isFocusVisible, focusProps } = useFocusRing();
+
+    // ── Interaction state tracking (remove button — input chip only) ──────────
+    const [isRemovePressed, setIsRemovePressed] = useState(false);
+    const { isHovered: isRemoveHovered, hoverProps: removeHoverProps } = useHover({ isDisabled });
+    const { isFocusVisible: isRemoveFocusVisible, focusProps: removeFocusProps } = useFocusRing();
+
     // ── Ripple ───────────────────────────────────────────────────────────────
     const { onMouseDown: handleRipple, ripples } = useRipple({ disabled: isDisabled });
 
     // ── Derived flags ────────────────────────────────────────────────────────
-    const hasLeadingIcon = Boolean(leadingIcon);
+    const hasLeadingIcon = Boolean(leadingIcon) || type === "filter";
 
     // ── Input chip: removal animation ────────────────────────────────────────
     const [isRemoving, setIsRemoving] = useState(false);
@@ -149,64 +187,103 @@ export const Chip = forwardRef<HTMLButtonElement, ChipProps>(
       }
     }, [isRemoving, onRemove]);
 
-    // ── Shared chip variant classes ──────────────────────────────────────────
-    const chipClass = (): string =>
-      cn(
-        chipVariants({
-          chipType: type,
-          surface: type === "assist" || type === "suggestion" ? surface : undefined,
-          selected: type === "filter" ? effectiveSelected : undefined,
-          isDisabled,
-          hasLeadingIcon,
-          hasRemoveButton: false,
-        }),
-        className
-      );
+    // ── Body interaction data attributes ─────────────────────────────────────
+    const bodyDataAttrs = getInteractionDataAttributes({
+      isHovered,
+      isFocusVisible,
+      isPressed,
+      ...(type === "filter" && { isSelected: effectiveSelected }),
+      isDisabled,
+    });
+
+    // ── Root classes (shared base) ────────────────────────────────────────────
+    const rootClass = cn(chipVariants({ chipType: type, surface }), "group/chip", className);
 
     // ── Input chip ───────────────────────────────────────────────────────────
-    // Renders a wrapper <span> as the chip root to:
-    //  1. Apply chip styles and the removal animation class
-    //  2. Host the ripple container (triggered from onMouseDown on the span)
+    // Renders a wrapper <span> as the chip root so we can:
+    //  1. Apply chip styles + removal animation class
+    //  2. Carry the group/chip scope so all slot selectors work
     //  3. Listen for animationend before calling the real onRemove callback
     // The inner <ChipHeadless className="contents"> uses CSS display:contents
     // so the two buttons become direct flex children of the wrapper span.
     if (type === "input") {
+      const removeDataAttrs = getInteractionDataAttributes({
+        isHovered: isRemoveHovered,
+        isFocusVisible: isRemoveFocusVisible,
+        isPressed: isRemovePressed,
+        isDisabled,
+      });
+
       return (
         <span
           className={cn(
-            chipVariants({
-              chipType: "input",
-              isDisabled,
-              hasLeadingIcon,
-              hasRemoveButton: true,
-            }),
+            chipVariants({ chipType: "input", surface }),
+            "group/chip",
             isRemoving && "animate-md-fade-out",
             className
           )}
+          // Spread the body interaction attrs onto the root wrapper so
+          // group-data-[x]/chip slot selectors work for the chip body area.
+          // (The remove button has its own group/chip-remove scope.)
+          {...bodyDataAttrs}
+          data-with-leading={hasLeadingIcon ? "" : undefined}
+          data-with-trailing=""
           onAnimationEnd={handleAnimationEnd}
         >
+          {/* Ripple */}
           {ripples}
-          <StateLayer />
+
+          {/* State layer */}
+          <span className={cn(chipStateLayerVariants({ chipType: "input" }))} aria-hidden="true" />
+
+          {/* Focus ring — outside overflow-hidden */}
+          <span className={cn(chipFocusRingVariants())} aria-hidden="true" />
+
           <ChipHeadless
             type="input"
             label={label}
             isDisabled={isDisabled}
             onRemove={handleRemove}
             onMouseDown={handleRipple}
-            removeIcon={<CloseIcon />}
-            removeButtonClassName="relative z-10 inline-flex size-4.5 shrink-0 items-center text-on-surface-variant"
+            removeButtonClassName={cn(chipRemoveButtonVariants())}
+            removeIcon={
+              <>
+                {/* Remove button state layer */}
+                <span
+                  className={cn(chipRemoveStateLayerVariants())}
+                  aria-hidden="true"
+                  {...{ "data-remove-state-layer": "" }}
+                />
+                <CloseIcon />
+              </>
+            }
             ref={ref}
             className="contents"
+            bodyPassthrough={{
+              onPressStart: handlePressStart,
+              onPressEnd: handlePressEnd,
+            }}
+            removePassthrough={{
+              dataAttributes: removeDataAttrs,
+              eventHandlers: mergeProps(removeHoverProps, removeFocusProps) as Record<
+                string,
+                unknown
+              >,
+              onPressStart: () => setIsRemovePressed(true),
+              onPressEnd: () => setIsRemovePressed(false),
+            }}
           >
+            {/* Leading icon */}
             {leadingIcon && (
               <span
                 aria-hidden="true"
-                className="relative z-10 inline-flex size-4.5 shrink-0 items-center"
+                className={cn(chipLeadingIconVariants({ chipType: "input" }))}
               >
                 {leadingIcon}
               </span>
             )}
-            <span className="relative z-10">{label}</span>
+            {/* Label */}
+            <span className={cn(chipLabelVariants())}>{label}</span>
           </ChipHeadless>
         </span>
       );
@@ -225,42 +302,45 @@ export const Chip = forwardRef<HTMLButtonElement, ChipProps>(
         {...(type !== "filter" && onPress !== undefined && { onPress })}
         isDisabled={isDisabled}
         onMouseDown={handleRipple}
-        className={chipClass()}
+        className={cn(rootClass)}
+        bodyPassthrough={{
+          dataAttributes: bodyDataAttrs,
+          onPressStart: handlePressStart,
+          onPressEnd: handlePressEnd,
+          eventHandlers: mergeProps(hoverProps, focusProps) as Record<string, unknown>,
+        }}
       >
+        {/* Ripple */}
         {ripples}
-        <StateLayer />
 
-        {/* Filter chip checkmark — slides in/out on selection change */}
+        {/* State layer */}
+        <span className={cn(chipStateLayerVariants({ chipType: type }))} aria-hidden="true" />
+
+        {/* Focus ring — absolute sibling, outside overflow-hidden */}
+        <span className={cn(chipFocusRingVariants())} aria-hidden="true" />
+
+        {/* Filter chip checkmark — width spring */}
         {type === "filter" && (
-          <span
-            className={cn(
-              "duration-short4 ease-emphasized-decelerate inline-flex overflow-hidden transition-[width,opacity]",
-              effectiveSelected ? "w-4.5 opacity-100" : "w-0 opacity-0"
-            )}
-          >
-            <CheckIcon />
+          <span className={cn(chipCheckmarkVariants())} aria-hidden="true">
+            <span className={cn(chipCheckmarkIconVariants())}>
+              <CheckIcon />
+            </span>
           </span>
         )}
 
         {/* Leading icon */}
         {leadingIcon && (
-          <span
-            aria-hidden="true"
-            className="relative z-10 inline-flex size-4.5 shrink-0 items-center"
-          >
+          <span aria-hidden="true" className={cn(chipLeadingIconVariants({ chipType: type }))}>
             {leadingIcon}
           </span>
         )}
 
         {/* Label */}
-        <span className="relative z-10">{label}</span>
+        <span className={cn(chipLabelVariants())}>{label}</span>
 
         {/* Trailing icon (Assist / Suggestion only) */}
         {trailingIcon && (
-          <span
-            aria-hidden="true"
-            className="relative z-10 inline-flex size-4.5 shrink-0 items-center"
-          >
+          <span aria-hidden="true" className={cn(chipTrailingIconVariants())}>
             {trailingIcon}
           </span>
         )}

--- a/packages/react/src/components/Chip/Chip.types.ts
+++ b/packages/react/src/components/Chip/Chip.types.ts
@@ -4,22 +4,23 @@ import type { PressEvent } from "react-aria";
 /**
  * The four MD3 chip types, each with distinct interaction semantics.
  *
- * - `assist` – triggers an action (e.g. "Set alarm")
- * - `filter` – toggles a filter on/off (`aria-pressed`)
- * - `input` – represents a value the user entered; can be removed
+ * - `assist`     – triggers an action (e.g. "Set alarm")
+ * - `filter`     – toggles a filter on/off (`aria-pressed`)
+ * - `input`      – represents a value the user entered; can be removed
  * - `suggestion` – offers a contextual suggestion (acts like assist)
  */
 export type ChipType = "assist" | "filter" | "input" | "suggestion";
 
 /**
- * Surface style for Assist and Suggestion chips.
+ * Surface style for chips.
  *
- * - `tonal` – uses secondary-container fill (default)
- * - `elevated` – uses surface-container-low fill with elevation shadow
+ * - `flat`     – transparent container with outline border (MD3 default)
+ * - `elevated` – `surface-container-low` fill with elevation shadow; all four chip types support this
+ * - `tonal`    – @deprecated Use `flat` instead. Will be removed in a future minor version.
  *
- * @default 'tonal'
+ * @default 'flat'
  */
-export type ChipSurface = "tonal" | "elevated";
+export type ChipSurface = "flat" | "elevated" | "tonal";
 
 /**
  * Material Design 3 Chip Component Props
@@ -54,8 +55,13 @@ export interface ChipProps {
   label: string;
 
   /**
-   * Surface style (Assist and Suggestion chips only).
-   * @default 'tonal'
+   * Surface style applied to the chip.
+   *
+   * - `flat` (default) — transparent container with outline border per MD3 spec.
+   * - `elevated` — `surface-container-low` fill + elevation shadow; works with all chip types.
+   * - `tonal` — @deprecated alias for `flat`; logs a console.warn in development.
+   *
+   * @default 'flat'
    */
   surface?: ChipSurface;
 
@@ -86,6 +92,11 @@ export interface ChipProps {
 
   /**
    * Icon rendered before the label.
+   * Color follows the MD3 spec per chip type:
+   * - assist → `text-primary`
+   * - filter (unselected) → `text-on-surface-variant`; (selected) → `text-on-secondary-container`
+   * - input → `text-on-surface-variant`
+   * - suggestion → `text-on-surface-variant`
    */
   leadingIcon?: React.ReactNode;
 
@@ -104,6 +115,61 @@ export interface ChipProps {
    * Additional CSS classes (Tailwind).
    */
   className?: string;
+}
+
+/**
+ * Props passed through to the chip body element (button) in ChipHeadless.
+ * Allows the styled layer to inject data-* interaction attributes and
+ * merged hover/focus event handlers.
+ */
+export interface ChipBodyPassthroughProps {
+  /**
+   * Merged hover/focus/press event handlers from the styled layer.
+   * Spread onto the body <button>.
+   */
+  eventHandlers?: Record<string, unknown>;
+
+  /**
+   * data-* interaction attributes emitted by getInteractionDataAttributes.
+   * Spread onto the body <button>.
+   */
+  dataAttributes?: Record<string, string | undefined>;
+
+  /**
+   * onPressStart forwarded into useButton/useToggleButton for isPressed tracking.
+   */
+  onPressStart?: () => void;
+
+  /**
+   * onPressEnd forwarded into useButton/useToggleButton for isPressed tracking.
+   */
+  onPressEnd?: () => void;
+}
+
+/**
+ * Props passed through to the remove button element in InputChipImpl.
+ */
+export interface ChipRemovePassthroughProps {
+  /**
+   * data-* interaction attributes for the remove button.
+   */
+  dataAttributes?: Record<string, string | undefined>;
+
+  /**
+   * Merged hover/focus event handlers from useHover + useFocusRing.
+   * Spread onto the remove <button> alongside React Aria's buttonProps.
+   */
+  eventHandlers?: Record<string, unknown>;
+
+  /**
+   * onPressStart for remove button isPressed tracking.
+   */
+  onPressStart?: () => void;
+
+  /**
+   * onPressEnd for remove button isPressed tracking.
+   */
+  onPressEnd?: () => void;
 }
 
 /**
@@ -163,7 +229,7 @@ export interface ChipHeadlessProps {
   isDisabled?: boolean;
 
   /**
-   * Additional CSS classes (Tailwind).
+   * Additional CSS classes applied to the chip body button.
    */
   className?: string;
 
@@ -174,7 +240,7 @@ export interface ChipHeadlessProps {
 
   /**
    * Icon rendered inside the remove button (Input chips only).
-   * Typically an ×/close SVG.
+   * Typically an ×/close SVG wrapped in a fragment with a state layer span.
    */
   removeIcon?: React.ReactNode;
 
@@ -188,6 +254,18 @@ export interface ChipHeadlessProps {
    * Used by the styled layer to trigger the ripple effect.
    */
   onMouseDown?: React.MouseEventHandler<HTMLButtonElement>;
+
+  /**
+   * Interaction data attributes + merged handlers from the styled layer.
+   * Spread onto the body <button> to enable group-data-[x]/chip slot selectors.
+   */
+  bodyPassthrough?: ChipBodyPassthroughProps;
+
+  /**
+   * Interaction data attributes + handlers for the remove button (Input chips only).
+   * Spread onto the remove <button>.
+   */
+  removePassthrough?: ChipRemovePassthroughProps;
 }
 
 /**

--- a/packages/react/src/components/Chip/Chip.variants.ts
+++ b/packages/react/src/components/Chip/Chip.variants.ts
@@ -1,148 +1,405 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 Chip Variants (CVA)
+ * Material Design 3 Chip Variants (Slot-based "Variants vs States" architecture)
  *
- * Covers all four chip types (assist, filter, input, suggestion) with
- * surface, selection, disabled, and padding variants.
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (chipType × surface).
+ * - All interaction/selection states are driven by data-* attributes on the root
+ *   via group-data-[x]/chip Tailwind selectors in each slot's base classes.
+ * - Content flags (data-with-leading, data-with-trailing) are set explicitly by
+ *   the component and consumed by the root slot for padding adjustments.
  *
- * Padding resolution (via tailwind-merge in `cn()`):
- *   base `px-4`  →  hasLeadingIcon overrides with `pl-3 pr-4`
- *                →  hasRemoveButton overrides with `pl-3 pr-3`
- * Both can be combined and the last-applied wins through tailwind-merge.
+ * Slot responsibilities:
+ *   chipVariants             — root button/span; shape, color, elevation, padding
+ *   chipStateLayerVariants   — hover/focus/press opacity overlay (absolute inset)
+ *   chipFocusRingVariants    — keyboard focus outline, outside overflow-hidden
+ *   chipLeadingIconVariants  — leading icon wrapper; color per type + selected/disabled
+ *   chipTrailingIconVariants — trailing icon wrapper; assist/suggestion only
+ *   chipCheckmarkVariants    — filter chip checkmark container (width spring)
+ *   chipLabelVariants        — label text slot
+ *   chipRemoveButtonVariants — input chip remove button wrapper
+ *   chipRemoveStateLayerVariants — state layer inside remove button circle
+ *
+ * MD3 Spec (Expressive):
+ *   Shape:   corner-small (8dp) → rounded-sm
+ *   Height:  32dp → h-8
+ *   Padding: 16dp base; 8dp leading side with icon
+ *   Gap:     8dp → gap-2
+ *   Icon:    18px × 18px
+ *   State-layer opacities: hover 8% | focus 10% | pressed 10%
+ *   Disabled: container transparent, border 12% opacity, content 38% opacity
+ *
+ * Per-type color tokens (MD3 strict):
+ *   assist:     bg=transparent border=outline      label=on-surface     leadingIcon=primary   stateLayer=on-surface
+ *   filter:     bg=transparent border=outline      label=on-surface-variant                   stateLayer=on-surface-variant
+ *   filter sel: bg=secondary-container border=none label=on-secondary-container               stateLayer=on-secondary-container
+ *   input:      bg=transparent border=outline-variant label=on-surface-variant                stateLayer=on-surface-variant
+ *   suggestion: bg=transparent border=outline      label=on-surface-variant                   stateLayer=on-surface-variant
+ *
+ * Elevation per state (elevated surface):
+ *   base=1 → hover=2 → focus/pressed=1 (doubled pressed selector wins over hover)
+ */
+
+// ─── ROOT ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Root chip element.
+ *
+ * IMPORTANT — overflow is intentionally NOT on the root.
+ * Clipping is delegated to the state-layer and ripple containers via
+ * `overflow-hidden rounded-[inherit]` so the focus ring span (inset-[-3px])
+ * can extend outside the chip boundary and remain fully visible.
+ *
+ * Padding is driven by content flags:
+ *   base px-4 (16dp)
+ *   data-[with-leading]: pl-2 pr-4  (8dp leading, 16dp trailing)
+ *   data-[with-trailing]: pl-4 pr-2
+ *   data-[with-leading][with-trailing]: pl-2 pr-2
+ * These are self-targeting data-[x]: selectors (no group scope needed).
  */
 export const chipVariants = cva(
   [
-    // Base layout — always applied
-    "relative inline-flex items-center overflow-hidden rounded-sm h-8",
-    "text-label-large cursor-pointer gap-1 group px-4",
-    // Focus ring
-    "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
+    // Layout + shape
+    "relative inline-flex items-center justify-center",
+    "h-8 rounded-sm cursor-pointer select-none",
+    "text-label-large gap-2",
+    // Base padding (no icons)
+    "px-4",
+    // Content-flag padding overrides (self-targeting)
+    "data-[with-leading]:pl-2 data-[with-leading]:pr-4",
+    "data-[with-trailing]:pr-2",
+    // Effects transition (color/bg/shadow/border)
+    "transition-[background-color,border-color,box-shadow,color]",
+    "duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Disabled self-targeting
+    "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+    "data-[disabled]:text-on-surface/38 data-[disabled]:border-on-surface/12",
+    "data-[disabled]:bg-transparent data-[disabled]:shadow-none",
   ],
   {
     variants: {
       /**
-       * MD3 chip type — determines interaction model and default styling.
+       * MD3 chip type — determines base color tokens.
        */
       chipType: {
-        assist: "",
-        // Filter and Input chips have a fixed tonal surface style.
-        // The transition is on the base class so deselection also animates
-        // (adding it only in the selected compound variant would mean the
-        // transition property disappears at the same moment the color reverts,
-        // causing an instant jump back to the unselected color).
-        filter:
-          "bg-surface-container-low text-on-surface border border-outline transition-[background-color,color] duration-short4 ease-standard",
-        input: "bg-surface-container-low text-on-surface border border-outline",
-        suggestion: "",
+        /**
+         * Assist — transparent + outline border; label on-surface; leading icon primary.
+         * State layer color: on-surface.
+         */
+        assist: ["bg-transparent border border-outline text-on-surface"],
+
+        /**
+         * Filter — transparent + outline border; label on-surface-variant.
+         * Selected state via group-data selectors (no CVA variant key).
+         * State layer color: on-surface-variant → on-secondary-container when selected.
+         */
+        filter: [
+          "bg-transparent border border-outline text-on-surface-variant",
+          // Selected: secondary-container fill, no border, on-secondary-container label
+          "group-data-[selected]/chip:bg-secondary-container",
+          "group-data-[selected]/chip:border-0",
+          "group-data-[selected]/chip:text-on-secondary-container",
+          // Disabled + selected overrides (self-targeting, doubled to win over singly-chained selected)
+          "data-[selected]:data-[disabled]:bg-on-surface/12",
+          "data-[selected]:data-[disabled]:border-0",
+        ],
+
+        /**
+         * Input — transparent + outline-variant border; label/icons on-surface-variant.
+         * State layer color: on-surface-variant.
+         */
+        input: ["bg-transparent border border-outline-variant text-on-surface-variant"],
+
+        /**
+         * Suggestion — transparent + outline border; label on-surface-variant.
+         * State layer color: on-surface-variant.
+         */
+        suggestion: ["bg-transparent border border-outline text-on-surface-variant"],
       },
 
       /**
-       * Surface style for Assist and Suggestion chips only.
-       * Applied via compound variants so it has no effect on Filter/Input.
+       * Surface style — elevated adds shadow and surface-container-low background.
+       * All four chip types support elevated.
+       * Note: "flat" and the deprecated "tonal" both resolve to the same base style
+       * (transparent + border from chipType). The elevated compound variant overrides.
        */
       surface: {
-        tonal: "",
+        flat: "",
         elevated: "",
-      },
-
-      /**
-       * Selected state — only meaningful for Filter chips.
-       * Applied via compound variant.
-       */
-      selected: {
-        true: "",
-        false: "",
-      },
-
-      /**
-       * MD3 disabled state: content 38% opacity, border 12% opacity, no background.
-       * Kept here only for `pointer-events-none`; color/bg overrides live in the
-       * disabled compound variants at the bottom so they win over surface compounds.
-       */
-      isDisabled: {
-        true: "pointer-events-none",
-        false: "",
-      },
-
-      /**
-       * Adjusts leading padding when a leading icon is present.
-       * Overrides the base `px-4` → `pl-3 pr-4`.
-       */
-      hasLeadingIcon: {
-        true: "pl-3 pr-4",
-        false: "",
-      },
-
-      /**
-       * Adjusts trailing padding for Input chips with a remove button.
-       * Takes precedence over hasLeadingIcon via tailwind-merge: `pl-3 pr-3`.
-       */
-      hasRemoveButton: {
-        true: "pl-3 pr-3",
-        false: "",
+        /** @deprecated Use `flat` instead. */
+        tonal: "",
       },
     },
 
     compoundVariants: [
-      // ── Assist chip surfaces ───────────────────────────────────────────────
+      // ── Elevated surface (all chip types) ─────────────────────────────────
+      // Shared elevated base: surface-container-low fill, no border, level-1 elevation
       {
-        chipType: "assist",
-        surface: "tonal",
-        className: "bg-surface-container-low text-on-surface border border-outline",
-      },
-      {
-        chipType: "assist",
         surface: "elevated",
+        chipType: "assist",
         className: [
-          "bg-surface-container-low text-on-surface shadow-elevation-1",
-          "hover:shadow-elevation-2 transition-shadow duration-short2 ease-standard",
+          "bg-surface-container-low border-0 shadow-elevation-1",
+          "data-[hovered]:shadow-elevation-2",
+          "data-[focus-visible]:shadow-elevation-1",
+          "data-[pressed]:data-[pressed]:shadow-elevation-1",
         ],
       },
-
-      // ── Suggestion chip surfaces ───────────────────────────────────────────
       {
-        chipType: "suggestion",
-        surface: "tonal",
-        className: "bg-surface-container-low text-on-surface border border-outline",
-      },
-      {
-        chipType: "suggestion",
         surface: "elevated",
-        className: [
-          "bg-surface-container-low text-on-surface shadow-elevation-1",
-          "hover:shadow-elevation-2 transition-shadow duration-short2 ease-standard",
-        ],
-      },
-
-      // ── Filter chip selected state ─────────────────────────────────────────
-      {
         chipType: "filter",
-        selected: true,
-        className: "bg-secondary-container text-on-secondary-container border-0",
+        className: [
+          "bg-surface-container-low border-0 shadow-elevation-1",
+          "data-[hovered]:shadow-elevation-2",
+          "data-[focus-visible]:shadow-elevation-1",
+          "data-[pressed]:data-[pressed]:shadow-elevation-1",
+          // Selected overrides bg; elevation stays
+          "group-data-[selected]/chip:bg-secondary-container",
+        ],
       },
-
-      // ── Disabled overrides — placed last so they always win ────────────────
-      // These must follow all surface/selection compound variants to ensure
-      // tailwind-merge keeps the disabled classes over any surface classes.
       {
-        isDisabled: true,
-        className: "text-on-surface/38 border-on-surface/12 bg-transparent",
+        surface: "elevated",
+        chipType: "input",
+        className: [
+          "bg-surface-container-low border-0 shadow-elevation-1",
+          "data-[hovered]:shadow-elevation-2",
+          "data-[focus-visible]:shadow-elevation-1",
+          "data-[pressed]:data-[pressed]:shadow-elevation-1",
+        ],
+      },
+      {
+        surface: "elevated",
+        chipType: "suggestion",
+        className: [
+          "bg-surface-container-low border-0 shadow-elevation-1",
+          "data-[hovered]:shadow-elevation-2",
+          "data-[focus-visible]:shadow-elevation-1",
+          "data-[pressed]:data-[pressed]:shadow-elevation-1",
+        ],
+      },
+      // Deprecated tonal maps to flat (same as no override)
+      {
+        surface: "tonal",
+        chipType: "assist",
+        className: "",
+      },
+      {
+        surface: "tonal",
+        chipType: "filter",
+        className: "",
+      },
+      {
+        surface: "tonal",
+        chipType: "input",
+        className: "",
+      },
+      {
+        surface: "tonal",
+        chipType: "suggestion",
+        className: "",
       },
     ],
 
     defaultVariants: {
       chipType: "assist",
-      surface: "tonal",
-      selected: false,
-      isDisabled: false,
-      hasLeadingIcon: false,
-      hasRemoveButton: false,
+      surface: "flat",
     },
   }
 );
 
+// ─── STATE LAYER ─────────────────────────────────────────────────────────────
+
 /**
- * Extract variant prop types from CVA
+ * State layer — absolute inset overlay that transitions opacity on interaction.
+ *
+ * overflow-hidden clips the ripple + state layer to the chip shape without
+ * affecting the focus ring (which is a sibling outside, not a child inside).
+ *
+ * Color follows MD3 per type:
+ *   assist    → bg-on-surface
+ *   filter    → bg-on-surface-variant; selected → bg-on-secondary-container
+ *   input     → bg-on-surface-variant
+ *   suggestion → bg-on-surface-variant
+ *
+ * Opacities: 0 rest → 8% hover → 10% focus → 10% pressed (doubled wins)
  */
+export const chipStateLayerVariants = cva(
+  [
+    "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+    "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Hover: 8%
+    "group-data-[hovered]/chip:opacity-8",
+    // Focus: 10%
+    "group-data-[focus-visible]/chip:opacity-10",
+    // Pressed: 10%, doubled selector wins over hover
+    "group-data-[pressed]/chip:group-data-[pressed]/chip:opacity-10",
+    // No state layer when disabled
+    "group-data-[disabled]/chip:hidden",
+  ],
+  {
+    variants: {
+      chipType: {
+        assist: "bg-on-surface",
+        filter: [
+          "bg-on-surface-variant",
+          // Selected: switch to on-secondary-container color
+          "group-data-[selected]/chip:bg-on-secondary-container",
+        ],
+        input: "bg-on-surface-variant",
+        suggestion: "bg-on-surface-variant",
+      },
+    },
+    defaultVariants: { chipType: "assist" },
+  }
+);
+
+// ─── FOCUS RING ────────────────────────────────────────────────────────────────
+
+/**
+ * Focus ring overlay.
+ *
+ * Rendered as an absolute `<span>` with `inset-[-3px]` so it extends 3px
+ * outside the chip boundary. This requires that `overflow-hidden` is NOT
+ * on the root — overflow clipping is moved to the state layer instead.
+ *
+ * Always present in the DOM (opacity-0 at rest) for smooth CSS transitions.
+ */
+export const chipFocusRingVariants = cva([
+  "pointer-events-none absolute inset-[-3px] rounded-sm",
+  "outline outline-2 outline-offset-0 outline-secondary",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/chip:opacity-100",
+]);
+
+// ─── LEADING ICON ─────────────────────────────────────────────────────────────
+
+/**
+ * Leading icon wrapper.
+ *
+ * MD3 per-type icon color:
+ *   assist    → primary (unselected/selected)
+ *   filter    → on-surface-variant; selected → on-secondary-container
+ *   input     → on-surface-variant
+ *   suggestion → on-surface-variant
+ *
+ * Disabled: on-surface/38 for all types.
+ * `invisible` (not `hidden`) to keep layout stable if icon is conditionally rendered.
+ */
+export const chipLeadingIconVariants = cva(
+  [
+    "relative z-10 inline-flex shrink-0 items-center justify-center size-[18px]",
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    "group-data-[disabled]/chip:text-on-surface/38",
+  ],
+  {
+    variants: {
+      chipType: {
+        assist: "text-primary",
+        filter: [
+          "text-on-surface-variant",
+          "group-data-[selected]/chip:text-on-secondary-container",
+        ],
+        input: "text-on-surface-variant",
+        suggestion: "text-on-surface-variant",
+      },
+    },
+    defaultVariants: { chipType: "assist" },
+  }
+);
+
+// ─── TRAILING ICON ────────────────────────────────────────────────────────────
+
+/**
+ * Trailing icon wrapper (Assist and Suggestion chips only).
+ * Always on-surface-variant per MD3 spec.
+ */
+export const chipTrailingIconVariants = cva([
+  "relative z-10 inline-flex shrink-0 items-center justify-center size-[18px]",
+  "text-on-surface-variant",
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "group-data-[disabled]/chip:text-on-surface/38",
+]);
+
+// ─── CHECKMARK (FILTER) ───────────────────────────────────────────────────────
+
+/**
+ * Filter chip checkmark container.
+ *
+ * Animated width (spatial spring) + opacity (effects spring) on selection change.
+ * Width transition is intentionally spatial since it moves adjacent content.
+ * The inner SVG uses effects transition for opacity so color/opacity don't overshoot.
+ */
+export const chipCheckmarkVariants = cva([
+  "inline-flex overflow-hidden shrink-0",
+  // Spatial spring for width (moves adjacent text — this is a spatial animation)
+  "transition-[width] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+  // Collapsed state
+  "w-0",
+  // Expanded state when selected
+  "group-data-[selected]/chip:w-[18px]",
+]);
+
+/**
+ * Inner checkmark icon wrapper — opacity only (effects token, no overshoot).
+ */
+export const chipCheckmarkIconVariants = cva([
+  "inline-flex items-center justify-center size-[18px] shrink-0",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[selected]/chip:opacity-100",
+  // Color: on-secondary-container when selected; inherits on-surface-variant at rest (invisible)
+  "text-on-secondary-container",
+  "group-data-[disabled]/chip:text-on-surface/38",
+]);
+
+// ─── LABEL ────────────────────────────────────────────────────────────────────
+
+/**
+ * Label text wrapper.
+ * Typography and color are inherited from the root chipVariants classes.
+ * z-10 keeps it above the state layer and ripple overlays.
+ */
+export const chipLabelVariants = cva(["relative z-10 inline-flex items-center"]);
+
+// ─── REMOVE BUTTON (INPUT) ───────────────────────────────────────────────────
+
+/**
+ * Remove button wrapper for input chips.
+ *
+ * MD3: 18dp circular interactive area with its own state layer.
+ * Uses `group/chip-remove` as a separate group scope so its own state
+ * layer doesn't interfere with the main chip's `group/chip` selectors.
+ *
+ * The remove button is a separate focusable element (Tab stop) inside
+ * the chip wrapper — it must NOT inherit the chip's press/hover state.
+ */
+export const chipRemoveButtonVariants = cva([
+  "relative z-10 inline-flex size-[18px] shrink-0 items-center justify-center",
+  "rounded-full cursor-pointer",
+  "text-on-surface-variant",
+  "group/chip-remove",
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "data-[disabled]:text-on-surface/38 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+]);
+
+/**
+ * State layer for the remove button's circular hit area.
+ * Uses `group-data-[x]/chip-remove` to scope to the remove button only.
+ */
+export const chipRemoveStateLayerVariants = cva([
+  // Slightly larger circle (32dp touch target centered on 18dp icon)
+  "absolute inset-[-7px] rounded-full pointer-events-none opacity-0",
+  "bg-on-surface-variant",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "group-data-[hovered]/chip-remove:opacity-8",
+  "group-data-[focus-visible]/chip-remove:opacity-10",
+  "group-data-[pressed]/chip-remove:group-data-[pressed]/chip-remove:opacity-10",
+  "group-data-[disabled]/chip-remove:hidden",
+]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
 export type ChipVariants = VariantProps<typeof chipVariants>;
+export type ChipStateLayerVariants = VariantProps<typeof chipStateLayerVariants>;
+export type ChipLeadingIconVariants = VariantProps<typeof chipLeadingIconVariants>;

--- a/packages/react/src/components/Chip/ChipHeadless.tsx
+++ b/packages/react/src/components/Chip/ChipHeadless.tsx
@@ -12,13 +12,56 @@ import type { ChipHeadlessProps } from "./Chip.types";
 // Each chip type has distinct React Aria hook requirements. Hooks cannot be
 // called conditionally, so we use separate forwardRef components per type and
 // select the correct one in the public ChipHeadless switcher below.
+//
+// The styled layer (Chip.tsx) injects interaction data attributes and event
+// handlers via `bodyPassthrough` (and `removePassthrough` for input chips).
+// These are spread onto the DOM element after React Aria's props so they do
+// not get stripped by the React Aria hooks' internal prop filtering.
 // ---------------------------------------------------------------------------
+
+/**
+ * Strip React Aria-specific props that must not reach the DOM.
+ * Returns only HTML-safe passthrough properties.
+ */
+function stripAriaProps(handlers: Record<string, unknown>): Record<string, unknown> {
+  const {
+    isDisabled: _isDisabled,
+    onPress: _onPress,
+    onPressStart: _onPressStart,
+    onPressEnd: _onPressEnd,
+    onPressChange: _onPressChange,
+    onPressUp: _onPressUp,
+    ...html
+  } = handlers;
+  return html;
+}
+
+/**
+ * Build press lifecycle callbacks for useButton/useToggleButton.
+ * Uses conditional spreading to satisfy exactOptionalPropertyTypes: true —
+ * React Aria's onPressStart/onPressEnd must be a function, not undefined.
+ */
+function buildPressCallbacks(
+  onPressStart?: () => void,
+  onPressEnd?: () => void
+): {
+  onPressStart?: () => void;
+  onPressEnd?: () => void;
+} {
+  return {
+    ...(onPressStart !== undefined && { onPressStart }),
+    ...(onPressEnd !== undefined && { onPressEnd }),
+  };
+}
 
 /**
  * Assist chip implementation — uses `useButton` (Enter/Space → onPress).
  */
 const AssistChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
-  ({ label, onPress, isDisabled, className, onMouseDown, children }, forwardedRef) => {
+  (
+    { label, onPress, isDisabled, className, onMouseDown, children, bodyPassthrough },
+    forwardedRef
+  ) => {
     const internalRef = useRef<HTMLButtonElement>(null);
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLButtonElement>;
 
@@ -26,11 +69,19 @@ const AssistChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
       {
         ...(onPress !== undefined && { onPress }),
         ...(isDisabled !== undefined && { isDisabled }),
+        ...buildPressCallbacks(bodyPassthrough?.onPressStart, bodyPassthrough?.onPressEnd),
       },
       ref
     );
 
-    const mergedProps = mergeProps(buttonProps, { onMouseDown });
+    const htmlPassthrough = stripAriaProps(bodyPassthrough?.eventHandlers ?? {});
+
+    const mergedProps = mergeProps(
+      buttonProps,
+      { onMouseDown },
+      bodyPassthrough?.dataAttributes ?? {},
+      htmlPassthrough
+    );
 
     return (
       <button {...mergedProps} type="button" ref={ref} className={className}>
@@ -56,6 +107,7 @@ const FilterChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
       className,
       onMouseDown,
       children,
+      bodyPassthrough,
     },
     forwardedRef
   ) => {
@@ -67,12 +119,20 @@ const FilterChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
       ...(defaultSelected !== undefined && { defaultSelected }),
       ...(onSelectionChange !== undefined && { onChange: onSelectionChange }),
       ...(isDisabled !== undefined && { isDisabled }),
+      ...buildPressCallbacks(bodyPassthrough?.onPressStart, bodyPassthrough?.onPressEnd),
     };
 
     const state = useToggleState(toggleProps);
     const { buttonProps } = useToggleButton(toggleProps, state, ref);
 
-    const mergedProps = mergeProps(buttonProps, { onMouseDown });
+    const htmlPassthrough = stripAriaProps(bodyPassthrough?.eventHandlers ?? {});
+
+    const mergedProps = mergeProps(
+      buttonProps,
+      { onMouseDown },
+      bodyPassthrough?.dataAttributes ?? {},
+      htmlPassthrough
+    );
 
     return (
       <button {...mergedProps} type="button" ref={ref} className={className}>
@@ -102,6 +162,8 @@ const InputChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
       removeIcon,
       removeButtonClassName,
       children,
+      bodyPassthrough,
+      removePassthrough,
     },
     forwardedRef
   ) => {
@@ -113,6 +175,7 @@ const InputChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
       {
         "aria-label": label,
         ...(isDisabled !== undefined && { isDisabled }),
+        ...buildPressCallbacks(bodyPassthrough?.onPressStart, bodyPassthrough?.onPressEnd),
       },
       ref
     );
@@ -122,6 +185,7 @@ const InputChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
         "aria-label": `Remove ${label}`,
         onPress: () => onRemove?.(),
         ...(isDisabled !== undefined && { isDisabled }),
+        ...buildPressCallbacks(removePassthrough?.onPressStart, removePassthrough?.onPressEnd),
       },
       removeRef
     );
@@ -133,7 +197,21 @@ const InputChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
       }
     };
 
-    const mergedChipProps = mergeProps(chipButtonProps, { onKeyDown: handleKeyDown, onMouseDown });
+    const htmlBodyPassthrough = stripAriaProps(bodyPassthrough?.eventHandlers ?? {});
+    const htmlRemovePassthrough = stripAriaProps(removePassthrough?.eventHandlers ?? {});
+
+    const mergedChipProps = mergeProps(
+      chipButtonProps,
+      { onKeyDown: handleKeyDown, onMouseDown },
+      bodyPassthrough?.dataAttributes ?? {},
+      htmlBodyPassthrough
+    );
+
+    const mergedRemoveProps = mergeProps(
+      removeButtonProps,
+      removePassthrough?.dataAttributes ?? {},
+      htmlRemovePassthrough
+    );
 
     return (
       <span className={className}>
@@ -141,7 +219,7 @@ const InputChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
           {children ?? label}
         </button>
         <button
-          {...removeButtonProps}
+          {...mergedRemoveProps}
           type="button"
           ref={removeRef}
           className={removeButtonClassName}
@@ -158,7 +236,10 @@ InputChipImpl.displayName = "InputChipImpl";
  * Suggestion chip implementation — uses `useButton` (identical to Assist).
  */
 const SuggestionChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
-  ({ label, onPress, isDisabled, className, onMouseDown, children }, forwardedRef) => {
+  (
+    { label, onPress, isDisabled, className, onMouseDown, children, bodyPassthrough },
+    forwardedRef
+  ) => {
     const internalRef = useRef<HTMLButtonElement>(null);
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLButtonElement>;
 
@@ -166,11 +247,19 @@ const SuggestionChipImpl = forwardRef<HTMLButtonElement, ChipHeadlessProps>(
       {
         ...(onPress !== undefined && { onPress }),
         ...(isDisabled !== undefined && { isDisabled }),
+        ...buildPressCallbacks(bodyPassthrough?.onPressStart, bodyPassthrough?.onPressEnd),
       },
       ref
     );
 
-    const mergedProps = mergeProps(buttonProps, { onMouseDown });
+    const htmlPassthrough = stripAriaProps(bodyPassthrough?.eventHandlers ?? {});
+
+    const mergedProps = mergeProps(
+      buttonProps,
+      { onMouseDown },
+      bodyPassthrough?.dataAttributes ?? {},
+      htmlPassthrough
+    );
 
     return (
       <button {...mergedProps} type="button" ref={ref} className={className}>
@@ -190,6 +279,10 @@ SuggestionChipImpl.displayName = "SuggestionChipImpl";
  *
  * Unstyled chip primitive covering all four MD3 chip types. Delegates to the
  * correct React Aria hook per `type` — bring your own styles.
+ *
+ * The styled layer (Chip.tsx) passes `bodyPassthrough` to inject data-* interaction
+ * attributes and merged hover/focus handlers onto the body button, enabling the
+ * group-data-[x]/chip slot selectors defined in Chip.variants.ts.
  *
  * | type         | Hook                                    | Key behaviour                    |
  * |------------- |-----------------------------------------|----------------------------------|

--- a/packages/react/src/components/Chip/index.ts
+++ b/packages/react/src/components/Chip/index.ts
@@ -1,12 +1,35 @@
 export { ChipHeadless } from "./ChipHeadless";
 export { Chip } from "./Chip";
 export { ChipSet } from "./ChipSet";
-export { chipVariants } from "./Chip.variants";
-export type { ChipVariants } from "./Chip.variants";
+
+// Slot variant functions
+export {
+  chipVariants,
+  chipStateLayerVariants,
+  chipFocusRingVariants,
+  chipLeadingIconVariants,
+  chipTrailingIconVariants,
+  chipCheckmarkVariants,
+  chipCheckmarkIconVariants,
+  chipLabelVariants,
+  chipRemoveButtonVariants,
+  chipRemoveStateLayerVariants,
+} from "./Chip.variants";
+
+// Variant prop types
+export type {
+  ChipVariants,
+  ChipStateLayerVariants,
+  ChipLeadingIconVariants,
+} from "./Chip.variants";
+
+// Component prop types
 export type {
   ChipType,
   ChipSurface,
   ChipProps,
   ChipHeadlessProps,
+  ChipBodyPassthroughProps,
+  ChipRemovePassthroughProps,
   ChipSetProps,
 } from "./Chip.types";


### PR DESCRIPTION
## Summary

- Rewrites Chip to the slot-based "Variants vs States" architecture matching Button/Switch: interaction states via `data-*` attributes + `group-data-[x]/chip` slot selectors, dedicated `chipStateLayerVariants`, `chipFocusRingVariants`, `chipLeadingIconVariants`, etc.
- Corrects all MD3 color tokens per spec (flat chip = transparent + outline border, per-type icon colors: assist leading → `primary`, others → `on-surface-variant`).
- Adds `surface="elevated"` support for all four chip types (was only assist + suggestion before).
- Deprecates `surface="tonal"` with a `console.warn`; maps to `flat` internally.
- Spring motion tokens throughout — removes legacy `duration-short4`/`ease-standard`/`ease-emphasized-decelerate`.
- 71 tests, all passing. Lint + typecheck clean.

## Breaking Changes (pre-1.0 minor)

- `surface` default: `"tonal"` → `"flat"`
- `surface="tonal"`: deprecated, console.warn in non-production, maps to `flat`

## Test Plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 2003 tests passing (32 test files)
- [ ] Visual check in Storybook: all chip types, flat/elevated surfaces, state layers, filter checkmark spring, input removal, disabled states