### PR TITLE
feat(bottomsheet): MD3 expressive handle refactor with variants-vs-states

### DIFF
--- a/.changeset/bottomsheet-md3-expressive.md
+++ b/.changeset/bottomsheet-md3-expressive.md
@@ -1,0 +1,14 @@
+---
+"@tinybigui/react": minor
+---
+
+feat(bottomsheet): refactor handle to Variants-vs-States architecture with MD3 state layer
+
+Refactors the BottomSheet drag handle to match the Button/Switch component pattern:
+
+- **Handle state layer**: new `bottomSheetHandleStateLayerVariants` slot — semi-transparent ring driven by `data-*` attributes. Opacities follow MD3 spec: hover 8%, focus/pressed 10%, dragged 16%.
+- **Handle focus ring**: new `bottomSheetHandleFocusRingVariants` slot — opacity-driven `outline-secondary` overlay replacing the previous raw `focus-visible:ring-*` utility classes. Avoids clipping by the container's `overflow-hidden`.
+- **Handle pill**: removed non-token `opacity-40`; `on-surface-variant` is already a low-emphasis color role and requires no opacity override per MD3 spec.
+- **React Aria wiring**: `useHover` and `useFocusRing` now drive `data-hovered` and `data-focus-visible` on the handle wrapper via `getInteractionDataAttributes`. The wrapper carries `group/handle` so all child slots consume state via `group-data-[x]/handle:` selectors.
+- **Presence-based encoding**: all `data-dragging` attributes (panel + handle) now use ternary encoding (`isDragging ? "" : undefined`) per component-variants architecture rule.
+- Exports two new variant functions (`bottomSheetHandleStateLayerVariants`, `bottomSheetHandleFocusRingVariants`) and their corresponding types.

--- a/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -140,7 +140,7 @@ export const StandardBottomSheet: Story = {
             <p className="text-title-medium text-on-surface">Midnight Drive</p>
             <p className="text-body-medium text-on-surface-variant">The Coastal Waves</p>
           </div>
-          <div className="bg-on-surface-variant h-1 w-full rounded-full opacity-40" />
+          <div className="bg-outline-variant h-px w-full" />
           <div className="flex items-center justify-center gap-4">
             <Button variant="text" aria-label="Previous track">
               ⏮

--- a/packages/react/src/components/BottomSheet/BottomSheet.test.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.test.tsx
@@ -701,7 +701,12 @@ describe("BottomSheet — styled layer", () => {
   // Test 40
   it("BottomSheetHandle pill has w-8 and h-1 classes", () => {
     render(<BottomSheet open aria-label="Test" />);
-    const pill = document.querySelector('span[aria-hidden="true"]');
+    // The handle wrapper contains three aria-hidden spans: state layer, focus ring, then pill.
+    // The pill is the last span and carries the w-8 / h-1 dimension classes.
+    const allSpans = document.querySelectorAll(
+      '[data-testid="bottom-sheet-handle"] span[aria-hidden="true"]'
+    );
+    const pill = allSpans[allSpans.length - 1];
     expect(pill).toHaveClass("w-8");
     expect(pill).toHaveClass("h-1");
   });
@@ -709,15 +714,22 @@ describe("BottomSheet — styled layer", () => {
   // Test 41
   it("BottomSheetHandle pill has bg-on-surface-variant class", () => {
     render(<BottomSheet open aria-label="Test" />);
-    const pill = document.querySelector('span[aria-hidden="true"]');
+    const allSpans = document.querySelectorAll(
+      '[data-testid="bottom-sheet-handle"] span[aria-hidden="true"]'
+    );
+    const pill = allSpans[allSpans.length - 1];
     expect(pill).toHaveClass("bg-on-surface-variant");
   });
 
-  // Test 42
-  it("BottomSheetHandle pill has opacity-40 class", () => {
+  // Test 42 — opacity-40 was removed in the MD3 refactor.
+  // on-surface-variant is already a low-emphasis color role; no opacity override is needed.
+  it("BottomSheetHandle pill does NOT have opacity-40 class (removed in MD3 refactor)", () => {
     render(<BottomSheet open aria-label="Test" />);
-    const pill = document.querySelector('span[aria-hidden="true"]');
-    expect(pill).toHaveClass("opacity-40");
+    const allSpans = document.querySelectorAll(
+      '[data-testid="bottom-sheet-handle"] span[aria-hidden="true"]'
+    );
+    const pill = allSpans[allSpans.length - 1];
+    expect(pill).not.toHaveClass("opacity-40");
   });
 
   // Test 43
@@ -856,18 +868,22 @@ describe("BottomSheet — accessibility", () => {
     expect(handle).toHaveAttribute("tabindex", "0");
   });
 
-  // Test 59
-  it("drag handle has focus-visible:ring-3 class", () => {
+  // Test 59 — raw focus-visible:ring-* replaced by the focus-ring overlay slot pattern.
+  it("drag handle wrapper does NOT have focus-visible:ring-3 class (replaced by overlay slot)", () => {
     render(<BottomSheet open aria-label="Test sheet" />);
     const handle = screen.getByTestId("bottom-sheet-handle");
-    expect(handle).toHaveClass("focus-visible:ring-3");
+    expect(handle).not.toHaveClass("focus-visible:ring-3");
   });
 
-  // Test 60
-  it("drag handle has focus-visible:ring-secondary class", () => {
+  // Test 60 — the focus ring overlay span carries outline-secondary instead.
+  it("drag handle has a focus-ring overlay slot with outline-secondary class", () => {
     render(<BottomSheet open aria-label="Test sheet" />);
-    const handle = screen.getByTestId("bottom-sheet-handle");
-    expect(handle).toHaveClass("focus-visible:ring-secondary");
+    // Focus ring is the second aria-hidden span inside the handle wrapper.
+    const allSpans = document.querySelectorAll(
+      '[data-testid="bottom-sheet-handle"] span[aria-hidden="true"]'
+    );
+    const focusRing = allSpans[1];
+    expect(focusRing).toHaveClass("outline-secondary");
   });
 
   // Test 61
@@ -937,8 +953,8 @@ describe("BottomSheet — panel snap height and drag style", () => {
     expect(panel).toHaveStyle({ height: "40%" });
   });
 
-  // Test 69
-  it("modal panel has data-dragging=true while handle is being dragged", () => {
+  // Test 69 — data-dragging uses presence-based ternary encoding (value is "", not "true")
+  it("modal panel has data-dragging attribute while handle is being dragged", () => {
     render(<BottomSheet open aria-label="Test" snapPoints={["50%"]} />);
     const handle = screen.getByTestId("bottom-sheet-handle");
     handle.setPointerCapture = vi.fn();
@@ -946,11 +962,12 @@ describe("BottomSheet — panel snap height and drag style", () => {
     act(() => {
       handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
     });
-    expect(screen.getByRole("dialog")).toHaveAttribute("data-dragging", "true");
+    // Ternary encoding: attribute is present with value "" (not "true")
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-dragging", "");
   });
 
-  // Test 70
-  it("standard panel has data-dragging=true while handle is being dragged", () => {
+  // Test 70 — presence-based ternary encoding on the standard variant panel
+  it("standard panel has data-dragging attribute while handle is being dragged", () => {
     render(<BottomSheet variant="standard" open aria-label="Test" snapPoints={["50%"]} />);
     const handle = screen.getByTestId("bottom-sheet-handle");
     handle.setPointerCapture = vi.fn();
@@ -958,7 +975,8 @@ describe("BottomSheet — panel snap height and drag style", () => {
       handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
     });
     const panel = document.querySelector("[data-animation-state]");
-    expect(panel).toHaveAttribute("data-dragging", "true");
+    // Ternary encoding: attribute is present with value "" (not "true")
+    expect(panel).toHaveAttribute("data-dragging", "");
   });
 
   // Test 71: Verify dragTranslateY in context becomes a finite number during drag.
@@ -987,9 +1005,9 @@ describe("BottomSheet — panel snap height and drag style", () => {
       handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientY: 200 }));
     });
 
-    // Wait for isDragging to propagate to the panel
+    // Wait for isDragging to propagate to the panel (ternary encoding: value is "")
     await waitFor(() => {
-      expect(screen.getByRole("dialog")).toHaveAttribute("data-dragging", "true");
+      expect(screen.getByRole("dialog")).toHaveAttribute("data-dragging", "");
     });
 
     // Dispatch pointermove — deltaY = 300 - 200 = 100 → dragTranslateY = 100
@@ -1020,9 +1038,97 @@ describe("BottomSheet — panel snap height and drag style", () => {
     act(() => {
       handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
     });
-    expect(screen.getByRole("dialog")).toHaveAttribute("data-dragging", "true");
+    // Ternary encoding: attribute is present with value ""
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-dragging", "");
     fireEvent.pointerUp(handle, { clientY: 200, pointerId: 1 });
     expect(screen.getByRole("dialog")).not.toHaveAttribute("data-dragging");
+  });
+});
+
+// ─── BottomSheet — handle slot structure (Variants-vs-States refactor) ───────
+
+describe("BottomSheet — handle slot structure", () => {
+  it("handle wrapper carries group/handle class", () => {
+    render(<BottomSheet open aria-label="Test sheet" />);
+    const handle = screen.getByTestId("bottom-sheet-handle");
+    expect(handle.className).toContain("group/handle");
+  });
+
+  it("handle wrapper has three aria-hidden child spans (state-layer, focus-ring, pill)", () => {
+    render(<BottomSheet open aria-label="Test sheet" />);
+    const spans = document.querySelectorAll(
+      '[data-testid="bottom-sheet-handle"] span[aria-hidden="true"]'
+    );
+    expect(spans).toHaveLength(3);
+  });
+
+  it("state-layer slot has bg-on-surface-variant and opacity-0 classes", () => {
+    render(<BottomSheet open aria-label="Test sheet" />);
+    const spans = document.querySelectorAll(
+      '[data-testid="bottom-sheet-handle"] span[aria-hidden="true"]'
+    );
+    const stateLayer = spans[0];
+    expect(stateLayer).toHaveClass("bg-on-surface-variant");
+    expect(stateLayer).toHaveClass("opacity-0");
+  });
+
+  it("state-layer slot has transition-opacity and spring-standard-fast-effects classes", () => {
+    render(<BottomSheet open aria-label="Test sheet" />);
+    const spans = document.querySelectorAll(
+      '[data-testid="bottom-sheet-handle"] span[aria-hidden="true"]'
+    );
+    const stateLayer = spans[0];
+    expect(stateLayer).toHaveClass("transition-opacity");
+    expect(stateLayer).toHaveClass("duration-spring-standard-fast-effects");
+    expect(stateLayer).toHaveClass("ease-spring-standard-fast-effects");
+  });
+
+  it("focus-ring slot has outline-secondary and opacity-0 classes", () => {
+    render(<BottomSheet open aria-label="Test sheet" />);
+    const spans = document.querySelectorAll(
+      '[data-testid="bottom-sheet-handle"] span[aria-hidden="true"]'
+    );
+    const focusRing = spans[1];
+    expect(focusRing).toHaveClass("outline-secondary");
+    expect(focusRing).toHaveClass("opacity-0");
+  });
+
+  it("focus-ring slot has transition-opacity class", () => {
+    render(<BottomSheet open aria-label="Test sheet" />);
+    const spans = document.querySelectorAll(
+      '[data-testid="bottom-sheet-handle"] span[aria-hidden="true"]'
+    );
+    const focusRing = spans[1];
+    expect(focusRing).toHaveClass("transition-opacity");
+  });
+
+  it("handle wrapper does NOT have raw focus-visible:ring-* classes (replaced by overlay slot)", () => {
+    render(<BottomSheet open aria-label="Test sheet" />);
+    const handle = screen.getByTestId("bottom-sheet-handle");
+    expect(handle).not.toHaveClass("focus-visible:ring-3");
+    expect(handle).not.toHaveClass("focus-visible:ring-secondary");
+    expect(handle).not.toHaveClass("focus-visible:ring-offset-2");
+  });
+
+  it("handle wrapper emits data-hovered attribute on hover", async () => {
+    const user = userEvent.setup();
+    render(<BottomSheet open aria-label="Test sheet" />);
+    const handle = screen.getByTestId("bottom-sheet-handle");
+    await user.hover(handle);
+    expect(handle).toHaveAttribute("data-hovered", "");
+    await user.unhover(handle);
+    expect(handle).not.toHaveAttribute("data-hovered");
+  });
+
+  it("handle wrapper emits data-dragging with empty string value (ternary encoding) during drag", () => {
+    render(<BottomSheet open aria-label="Test sheet" snapPoints={["50%"]} />);
+    const handle = screen.getByTestId("bottom-sheet-handle");
+    handle.setPointerCapture = vi.fn();
+    act(() => {
+      handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+    });
+    // Ternary encoding: presence-based, value is "" not "true"
+    expect(handle).toHaveAttribute("data-dragging", "");
   });
 });
 

--- a/packages/react/src/components/BottomSheet/BottomSheet.variants.ts
+++ b/packages/react/src/components/BottomSheet/BottomSheet.variants.ts
@@ -1,6 +1,34 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
-// ─── Animation variants ───────────────────────────────────────────────────────
+/**
+ * Material Design 3 Bottom Sheet Variants
+ *
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no state variants, no state compoundVariants).
+ * - The drag handle's interaction states are driven by data-* attributes on its wrapper
+ *   via group-data-[x]/handle Tailwind selectors in each slot's base classes.
+ * - Content flags (data-dragging) are set explicitly by the component, not via helper.
+ *
+ * Slot responsibilities:
+ *   bottomSheetVariants               — fixed container; surface, shape, elevation, snap spring
+ *   bottomSheetScrimVariants          — modal scrim overlay; opacity fade (screen-level token)
+ *   bottomSheetAnimationVariants      — enter/exit animation state machine classes
+ *   bottomSheetHandleWrapperVariants  — 48dp touch target; carries `group/handle`; data-* host
+ *   bottomSheetHandleStateLayerVariants — hover/focus/pressed/dragged opacity ring around pill
+ *   bottomSheetHandleFocusRingVariants  — keyboard focus outline overlay (opacity-driven)
+ *   bottomSheetHandlePillVariants     — 32×4dp pill decoration; pointer-events-none
+ *
+ * MD3 Spec:
+ *   Container surface: surface-container-low, elevation level-1
+ *   Shape: extra-large top corners (28dp), square bottom (attached to screen edge)
+ *   Width: full width up to 640dp; centered at max-width 640dp on wider viewports
+ *   Top margin: 72dp default, 56dp when viewport > 640dp
+ *   Drag handle: 32dp × 4dp, on-surface-variant, centered, 22dp top/bottom padding → 48dp target
+ *   Scrim: bg-scrim, 32% opacity
+ *   State-layer opacities: hover 8% | focus 10% | pressed 10% | dragged 16%
+ */
+
+// ─── ANIMATION VARIANTS ───────────────────────────────────────────────────────
 
 /**
  * CVA animation state variants for the Bottom Sheet panel.
@@ -8,7 +36,7 @@ import { cva, type VariantProps } from "class-variance-authority";
  * Motion decision rationale:
  * - Bottom sheet is a standard-size component → `default` speed tier
  * - Slides in/out of screen → composite `animate-md-*` utilities (not manual spring tokens)
- * - Scrim opacity is an effects property → `duration-short4 ease-standard` (legacy screen-level token)
+ * - Scrim opacity is an effects property → `duration-short4 ease-standard` (legacy screen-level)
  * - Snap spring is a spatial on-screen transition → `ease-spring-standard-default-spatial` +
  *   `duration-spring-standard-default-spatial` (applied in bottomSheetVariants base)
  * - Standard personality (not expressive) — sheets are utility UI, not moments of delight
@@ -17,7 +45,6 @@ export const bottomSheetAnimationVariants = cva("", {
   variants: {
     animationState: {
       // entering: initial mount frame — sheet starts below viewport (translateY(100%))
-      // The CSS is handled inside animate-md-slide-in-bottom keyframes
       entering: ["opacity-0"],
       // visible: entry animation active — animate-md-slide-in-bottom runs once
       visible: ["animate-md-slide-in-bottom"],
@@ -34,30 +61,29 @@ export const bottomSheetAnimationVariants = cva("", {
 
 export type BottomSheetAnimationVariants = VariantProps<typeof bottomSheetAnimationVariants>;
 
-// ─── Sheet container ──────────────────────────────────────────────────────────
+// ─── CONTAINER ────────────────────────────────────────────────────────────────
 
 /**
- * CVA variants for the Bottom Sheet container panel.
+ * Root container — the bottom sheet panel.
  *
  * MD3 tokens applied:
  * - Surface: bg-surface-container-low
  * - Elevation: shadow-elevation-1
- * - Shape: rounded-t-xl (top-left + top-right 28dp, bottom 0)
- * - Width: full width up to 640dp; centered at max-width 640dp on wider viewports
- *   (`mx-auto + max-w-[640px]` — at 752dp viewport this naturally produces the MD3-spec 56dp side margins)
- * - Height: constrained by max-height (72dp top margin by default, 56dp on > 640dp viewport)
- *   The sheet is always anchored to `bottom-0`; "top margin" is expressed as max-height so
- *   the sheet cannot overlap the top portion of the screen.
- * - Drag resize: height animates via `transition-[height]`; the sheet grows/shrinks from the
- *   bottom edge, always staying anchored — matching the MD3 spec "resize to another height" behaviour.
+ * - Shape: extra-large top corners (28dp via rounded-t-xl), square bottom (attached to edge)
+ * - Width: full width up to 640dp (mx-auto + w-[640px] max-w-full)
+ * - Height: snap-point driven via inline style; constrained by max-height to enforce top margin
+ *   Default: 72dp top margin → max-h-[calc(100vh-72px)]
+ *   Wide (> 640dp): 56dp top margin → sm:max-h-[calc(100vh-56px)]
+ * - Snap spring: spatial on-screen transition → spring-standard default spatial pair
+ *   data-[dragging]:transition-none suppresses spring during active drag (1:1 pointer tracking)
+ *
+ * NOTE: overflow-hidden clips content during height transitions. The handle's state layer and
+ * focus-ring overlay are sized/positioned to fit within the wrapper, so they are not clipped.
  */
 export const bottomSheetVariants = cva(
   [
     // Position: fixed to bottom edge, full width
-    "fixed",
-    "bottom-0",
-    "left-0",
-    "right-0",
+    "fixed bottom-0 left-0 right-0",
 
     // Surface token
     "bg-surface-container-low",
@@ -65,49 +91,38 @@ export const bottomSheetVariants = cva(
     // Elevation level 1 per MD3 spec
     "shadow-elevation-1",
 
-    // Shape: extra-large top corners (28dp), bottom corners are 0 (attached to screen edge)
+    // Shape: extra-large top corners (28dp), square bottom (screen-attached)
+    // NOTE: measurement-derived value from MD3 spec; permitted exception per component-variants rule
     "rounded-t-xl",
 
     // Layout
-    "flex",
-    "flex-col",
+    "flex flex-col",
 
-    // Max width constraint (full width up to 640dp)
+    // Width constraint (full width up to 640dp)
     "mx-auto",
     // NOTE: measurement-derived value from MD3 spec; permitted exception
     "w-[640px] max-w-full",
 
-    // Clip content during height transitions (sheet shrinks/grows from bottom edge)
+    // Clip content during height transitions
     "overflow-hidden",
 
-    // Transition: height for snap spring (MD3 spec — sheet "resizes" between heights)
-    // Standard personality, default speed tier, spatial: no overshoot.
-    // During drag, data-[dragging=true]:transition-none suppresses this so the
-    // sheet height follows the pointer 1:1 without transition lag.
-    // After drag release, the spring transition animates height to the new snap position.
+    // Snap spring: spatial property (height), standard personality, default tier
     "transition-[height]",
     "duration-spring-standard-default-spatial",
     "ease-spring-standard-default-spatial",
-    "data-[dragging=true]:transition-none",
+    // Suppress spring while dragging so the sheet follows the pointer 1:1
+    "data-[dragging]:transition-none",
     "will-change-[height]",
 
-    // Responsive layout: when viewport > 640dp, apply wider top margin per MD3 spec.
-    // The sheet remains bottom-anchored at all sizes. Side centering is handled by
-    // mx-auto + max-w-[640px] — at 752dp viewport this naturally produces 56dp side
-    // margins on each side (exactly matching MD3 measurements).
-    // Top margin is expressed as max-height so the sheet cannot overlap the top edge:
-    // - Default: 72dp top margin (max-h-[calc(100vh-72px)])
-    // - Wide viewport (> 640dp): 56dp top margin (sm:max-h-[calc(100vh-56px)])
+    // Responsive layout: top margin expressed as max-height
     // NOTE: measurement-derived values from MD3 spec; permitted exception
     "max-h-[calc(100vh-72px)]",
     "sm:max-h-[calc(100vh-56px)]",
-    // Top corners rounded at wide layout (sheet floats away from screen edge)
-    "rounded-t-xl",
   ],
   {
     variants: {
       variant: {
-        // Modal: above scrim (z-50)
+        // Modal: rendered above the scrim (z-50)
         modal: "z-50",
         // Standard: sits above normal content but below overlays
         standard: "z-10",
@@ -121,84 +136,174 @@ export const bottomSheetVariants = cva(
 
 export type BottomSheetVariants = VariantProps<typeof bottomSheetVariants>;
 
-// ─── Scrim overlay ────────────────────────────────────────────────────────────
+// ─── SCRIM ────────────────────────────────────────────────────────────────────
 
 /**
- * CVA for the scrim overlay (modal variant only).
+ * Scrim overlay (modal variant only).
  *
  * MD3 tokens applied:
  * - bg-scrim: scrim surface role
  * - opacity-32: 32% opacity per MD3 spec
- * - Transition: opacity fade (scrim is an effects property — legacy screen-level tokens)
+ * - Transition: opacity fade (scrim is a screen-level effects property → legacy duration tokens)
  */
 export const bottomSheetScrimVariants = cva([
-  "fixed",
-  "inset-0",
-  "z-40",
-  "bg-scrim",
-  "opacity-32",
-  "transition-opacity",
-  "duration-short4",
-  "ease-standard",
+  "fixed inset-0 z-40",
+  "bg-scrim opacity-32",
+  // Screen-level effects transition (scrim enters/exits the screen, not an on-screen state change)
+  "transition-opacity duration-short4 ease-standard",
 ]);
 
 export type BottomSheetScrimVariants = VariantProps<typeof bottomSheetScrimVariants>;
 
-// ─── Drag handle ──────────────────────────────────────────────────────────────
+// ─── HANDLE WRAPPER ───────────────────────────────────────────────────────────
 
 /**
- * CVA for the drag handle wrapper (touch/click target area).
+ * Drag handle wrapper — 48dp touch target area + group scope host.
  *
- * MD3 spec: the top 48dp of the sheet is the interactive touch target area
- * when the drag handle is present. The wrapper provides this touch target.
+ * Carries `group/handle` so all handle child slots can consume data-* interaction
+ * states via `group-data-[x]/handle:` Tailwind selectors without any CVA variant props.
+ *
+ * MD3 spec: 22dp top + 4dp handle + 22dp bottom = 48dp interaction zone.
+ * NOTE: py-[22px] is a measurement-derived value from MD3 spec; permitted exception.
+ *
+ * `relative` provides positioning context for the state layer and focus ring overlays.
+ * `focus-visible:outline-none` suppresses the browser default — the focus ring overlay
+ * in `bottomSheetHandleFocusRingVariants` provides the MD3-spec visible indicator instead.
  */
 export const bottomSheetHandleWrapperVariants = cva([
-  // Center the handle pill horizontally
-  "flex",
-  "items-center",
-  "justify-center",
+  // Center the pill horizontally; provide positioning context for overlays
+  "relative flex items-center justify-center w-full",
 
-  // Top/bottom padding creates the 48dp touch target area
-  // 22dp top + 4dp handle + 22dp bottom ≈ 48dp interaction zone (per MD3 measurements)
+  // 48dp touch target (22dp top + 4dp pill + 22dp bottom)
   // NOTE: measurement-derived value from MD3 spec; permitted exception
   "py-[22px]",
 
-  // Full width so the touch target spans the sheet
-  "w-full",
-
-  // Focus ring styling for keyboard/switch navigation
-  // MD3 spec: focus indicator color = secondary, thickness = 3dp, offset = 2dp
+  // Suppress browser default focus outline — the focus-ring overlay slot handles it
   "focus-visible:outline-none",
-  "focus-visible:ring-3",
-  "focus-visible:ring-secondary",
-  "focus-visible:ring-offset-2",
-  "focus-visible:rounded-sm",
 
-  // Cursor affordance
+  // Cursor affordance for drag interaction
   "cursor-ns-resize",
 ]);
 
+export type BottomSheetHandleWrapperVariants = VariantProps<
+  typeof bottomSheetHandleWrapperVariants
+>;
+
+// ─── HANDLE STATE LAYER ───────────────────────────────────────────────────────
+
 /**
- * CVA for the drag handle pill visual element.
+ * Drag handle state layer — the semi-transparent interaction feedback ring.
  *
- * MD3 tokens applied:
- * - bg-on-surface-variant: handle color
- * - w-8: 32dp width per MD3 spec
- * - h-1: 4dp height per MD3 spec
- * - rounded-full: fully rounded pill shape
- * - opacity-40: per MD3 spec (token deprecated but value still in spec)
+ * Positioned to wrap the pill snugly (not the full 48dp target) to keep the
+ * visual feedback proportional to the pill. Sized as a wide pill shape that
+ * encapsulates the 32dp × 4dp handle with generous rounded ends.
+ *
+ * Color: on-surface-variant (matches the pill's own color role per MD3).
+ * Opacity progression:
+ *   0 at rest
+ *   8%  hover
+ *   10% focus-visible / pressed
+ *   16% dragged (MD3 "dragged" state = 16%)
+ *
+ * Disabled on the handle is not applicable (handle is always interactive when sheet is open).
  */
-export const bottomSheetHandlePillVariants = cva([
-  "bg-on-surface-variant",
-  "opacity-40",
+export const bottomSheetHandleStateLayerVariants = cva([
+  // Overlay positioned centrally — sits behind the pill
+  "absolute pointer-events-none",
+  // Pill-shaped to complement the handle's form
   "rounded-full",
+  // Sized wider than the pill to provide a visible state layer halo
+  // 48dp wide × 16dp tall — centred by the flex wrapper
+  "w-12 h-4",
 
-  // Dimensions: 32dp × 4dp per MD3 spec (measurement-derived; permitted exception)
-  "w-8", // 32dp = 2rem = w-8
-  "h-1", // 4dp = 0.25rem = h-1
+  // State-layer color (same role as the pill)
+  "bg-on-surface-variant",
 
-  // Pill itself is decorative; the wrapper handles interaction
-  "pointer-events-none",
+  // Effects transition — opacity must NOT overshoot
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+
+  // Opacity at rest
+  "opacity-0",
+
+  // Hover: 8%
+  "group-data-[hovered]/handle:opacity-8",
+  // Focus-visible: 10%
+  "group-data-[focus-visible]/handle:opacity-10",
+  // Pressed: 10% (doubled selector wins over hover at same cascade position)
+  "group-data-[pressed]/handle:group-data-[pressed]/handle:opacity-10",
+  // Dragging: 16% (MD3 dragged state — highest on-screen opacity)
+  // Doubled selector wins over hover + pressed
+  "group-data-[dragging]/handle:group-data-[dragging]/handle:opacity-16",
 ]);
 
-export type BottomSheetHandleVariants = VariantProps<typeof bottomSheetHandleWrapperVariants>;
+export type BottomSheetHandleStateLayerVariants = VariantProps<
+  typeof bottomSheetHandleStateLayerVariants
+>;
+
+// ─── HANDLE FOCUS RING ────────────────────────────────────────────────────────
+
+/**
+ * Drag handle focus ring overlay.
+ *
+ * Rendered as an absolutely-positioned element that is always in the DOM
+ * (opacity-0 at rest, opacity-100 on keyboard/programmatic focus). The
+ * opacity-driven approach avoids layout shifts and enables a smooth transition.
+ *
+ * Positioned to wrap the pill tightly — slightly larger than the state layer
+ * to remain legible. Uses `outline` rather than `border` to avoid layout impact.
+ *
+ * MD3 spec: focus indicator color = secondary, weight ≈ 2–3dp.
+ * We use `outline-2 outline-secondary` to meet the intent with token classes.
+ *
+ * This element MUST be outside the pill's z-stack but inside the wrapper so
+ * it is not clipped by the container's `overflow-hidden`.
+ */
+export const bottomSheetHandleFocusRingVariants = cva([
+  "absolute pointer-events-none",
+  "rounded-full",
+  // Sized to sit around the state layer halo
+  "w-14 h-5",
+
+  // MD3 focus indicator: secondary color, 2dp weight
+  "outline outline-2 outline-offset-0 outline-secondary",
+
+  // Effects transition — opacity change must NOT overshoot
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+
+  // Hidden at rest; shown on keyboard/programmatic focus
+  "opacity-0",
+  "group-data-[focus-visible]/handle:opacity-100",
+]);
+
+export type BottomSheetHandleFocusRingVariants = VariantProps<
+  typeof bottomSheetHandleFocusRingVariants
+>;
+
+// ─── HANDLE PILL ──────────────────────────────────────────────────────────────
+
+/**
+ * Drag handle pill — the visible 32×4dp decoration.
+ *
+ * MD3 tokens applied:
+ * - bg-on-surface-variant: handle color (muted, low-emphasis by role — no opacity override needed)
+ * - w-8 / h-1: 32dp × 4dp per MD3 spec (measurement-derived; permitted exception)
+ * - rounded-full: fully-rounded pill shape
+ *
+ * `pointer-events-none` — all interaction is handled by the wrapper.
+ * `relative z-10` — renders above the state layer overlay.
+ */
+export const bottomSheetHandlePillVariants = cva([
+  "relative z-10 pointer-events-none",
+  "bg-on-surface-variant",
+  "rounded-full",
+  // Dimensions: 32dp × 4dp per MD3 spec (measurement-derived; permitted exception)
+  "w-8", // 32dp = 2rem
+  "h-1", // 4dp  = 0.25rem
+]);
+
+export type BottomSheetHandlePillVariants = VariantProps<typeof bottomSheetHandlePillVariants>;
+
+// ─── LEGACY TYPE ALIAS ────────────────────────────────────────────────────────
+
+// Kept for backward-compat with existing exports; prefer the specific slot types above.
+export type BottomSheetHandleVariants = BottomSheetHandleWrapperVariants;

--- a/packages/react/src/components/BottomSheet/BottomSheetHandle.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheetHandle.tsx
@@ -1,29 +1,76 @@
 "use client";
 
 import type { ReactElement } from "react";
+import { useHover, useFocusRing, mergeProps } from "react-aria";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useBottomSheetContext } from "./BottomSheetHeadless";
 import {
   bottomSheetHandleWrapperVariants,
+  bottomSheetHandleStateLayerVariants,
+  bottomSheetHandleFocusRingVariants,
   bottomSheetHandlePillVariants,
 } from "./BottomSheet.variants";
 import type { BottomSheetHandleProps } from "./BottomSheet.types";
 
+/**
+ * `BottomSheetHandle` — the draggable handle at the top of the Bottom Sheet.
+ *
+ * Implements the Variants-vs-States architecture used across TinyBigUI:
+ * - Carries `group/handle` on its wrapper so child slots consume data-* selectors.
+ * - Emits `getInteractionDataAttributes` for hover/focus/pressed states from React Aria.
+ * - Emits `data-dragging` as a component-specific content flag (ternary encoding).
+ * - Renders three slots inside the wrapper (stacked via absolute positioning):
+ *   1. State layer — hover/focus/pressed/dragged opacity feedback (aria-hidden)
+ *   2. Focus ring overlay — keyboard focus indicator (aria-hidden)
+ *   3. Pill — the visible 32×4dp decoration (aria-hidden)
+ *
+ * Pointer and keyboard props are injected from `BottomSheetContext` (via `useBottomSheetDrag`).
+ * React Aria `useHover` and `useFocusRing` are merged on top — they do not conflict with the
+ * existing `onPointerDown`/`onPointerUp` drag handlers.
+ */
 function BottomSheetHandle({
   className,
   "aria-label": ariaLabelOverride,
 }: BottomSheetHandleProps): ReactElement {
   const { handleProps, isDragging } = useBottomSheetContext();
 
+  // React Aria hooks — provide hover and focus-ring interaction state booleans.
+  // usePress is intentionally omitted: the drag hook's onPointerDown/onPointerUp
+  // already manage pressed state semantics; using usePress alongside would conflict.
+  const { isHovered, hoverProps } = useHover({});
+  const { isFocusVisible, focusProps } = useFocusRing();
+
+  // isDragging acts as the "pressed" analogue for the handle (MD3 dragged = 16% opacity).
+  // We pass it as isPressed so the state layer reacts to drag at the standard pressed tier,
+  // then also set data-dragging for the 16% dragged-specific override.
+  const mergedHandleProps = mergeProps(handleProps, hoverProps, focusProps);
+
   return (
     <div
-      {...handleProps}
+      {...mergedHandleProps}
       {...(ariaLabelOverride !== undefined ? { "aria-label": ariaLabelOverride } : {})}
-      className={cn(bottomSheetHandleWrapperVariants(), className)}
+      className={cn(bottomSheetHandleWrapperVariants(), "group/handle", className)}
       data-testid="bottom-sheet-handle"
-      data-dragging={isDragging || undefined}
+      // Interaction states via shared helper (presence-based ternary encoding)
+      {...getInteractionDataAttributes({
+        isHovered,
+        isFocusVisible,
+        // Treat active drag as pressed — drives the state layer to 10% opacity
+        isPressed: isDragging,
+      })}
+      // data-dragging is a component-specific content flag (not an interaction state)
+      // driving the 16% dragged-tier opacity on the state layer
+      data-dragging={isDragging ? "" : undefined}
     >
-      <span className={bottomSheetHandlePillVariants()} aria-hidden="true" />
+      {/* State layer — absolute, behind pill, aria-hidden */}
+      <span className={cn(bottomSheetHandleStateLayerVariants())} aria-hidden="true" />
+
+      {/* Focus ring overlay — absolute, behind pill, aria-hidden */}
+      <span className={cn(bottomSheetHandleFocusRingVariants())} aria-hidden="true" />
+
+      {/* Pill decoration — relative z-10, sits above overlays, aria-hidden */}
+      <span className={cn(bottomSheetHandlePillVariants())} aria-hidden="true" />
     </div>
   );
 }

--- a/packages/react/src/components/BottomSheet/BottomSheetHeadless.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheetHeadless.tsx
@@ -126,7 +126,7 @@ const BottomSheetModalPanel = ({
       aria-modal="true"
       className={cn(className, getAnimationClassName?.(animationState))}
       data-animation-state={animationState}
-      data-dragging={isDragging || undefined}
+      data-dragging={isDragging ? "" : undefined}
       style={panelStyle}
       onTransitionEnd={onTransitionEnd}
     >
@@ -365,7 +365,7 @@ export const BottomSheetHeadless = forwardRef<HTMLDivElement, BottomSheetHeadles
             ref={ref}
             className={cn(className, getAnimationClassName?.(animationState))}
             data-animation-state={animationState}
-            data-dragging={isDragging || undefined}
+            data-dragging={isDragging ? "" : undefined}
             style={panelStyle}
             onTransitionEnd={handleTransitionEnd}
           >

--- a/packages/react/src/components/BottomSheet/index.ts
+++ b/packages/react/src/components/BottomSheet/index.ts
@@ -16,9 +16,11 @@ export { useBottomSheetDrag } from "./useBottomSheetDrag";
 export {
   bottomSheetVariants,
   bottomSheetScrimVariants,
-  bottomSheetHandleWrapperVariants,
-  bottomSheetHandlePillVariants,
   bottomSheetAnimationVariants,
+  bottomSheetHandleWrapperVariants,
+  bottomSheetHandleStateLayerVariants,
+  bottomSheetHandleFocusRingVariants,
+  bottomSheetHandlePillVariants,
 } from "./BottomSheet.variants";
 
 // Types
@@ -36,4 +38,8 @@ export type {
   BottomSheetVariants,
   BottomSheetScrimVariants,
   BottomSheetHandleVariants,
+  BottomSheetHandleWrapperVariants,
+  BottomSheetHandleStateLayerVariants,
+  BottomSheetHandleFocusRingVariants,
+  BottomSheetHandlePillVariants,
 } from "./BottomSheet.variants";


### PR DESCRIPTION
## Summary

- Refactors BottomSheet drag handle to Variants-vs-States architecture matching Button/Switch pattern
- Adds `bottomSheetHandleStateLayerVariants` and `bottomSheetHandleFocusRingVariants` slots with MD3 spec opacities
- Wires React Aria `useHover` and `useFocusRing` via `data-*` attributes and `group/handle` selectors
- Removes non-token opacity override on handle pill; uses presence-based `data-dragging` encoding

## Test plan

- [x] `pnpm test` — 2019 tests passing
- [x] BottomSheet unit tests cover handle state layer, focus ring, and interaction attributes
- [x] Changeset added for minor bump