### PR TITLE
refactor(tabs): md3 expressive styling — variants-vs-states architecture

### DIFF
--- a/.changeset/tabs-md3-expressive-refactor.md
+++ b/.changeset/tabs-md3-expressive-refactor.md
@@ -1,0 +1,5 @@
+---
+"@tinybigui/react": patch
+---
+
+refactor(tabs): MD3 Expressive styling refactor — Variants-vs-States architecture, correct state-layer/indicator tokens, spring motion, content-width primary indicator

--- a/packages/react/src/components/Tabs/Tab.tsx
+++ b/packages/react/src/components/Tabs/Tab.tsx
@@ -2,19 +2,25 @@
 
 import { forwardRef, useRef, useCallback } from "react";
 import type React from "react";
-import { useTab, useFocusRing } from "react-aria";
+import { useTab, useFocusRing, useHover } from "react-aria";
 import { mergeProps } from "@react-aria/utils";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
 import { useHeadlessTabsContext } from "./TabsHeadless";
 import { useTabsContext } from "./Tabs";
-import { tabVariants, tabIconVariants, tabBadgeVariants } from "./Tabs.variants";
+import {
+  tabVariants,
+  tabStateLayerVariants,
+  tabIconVariants,
+  tabBadgeVariants,
+} from "./Tabs.variants";
 import type { TabProps, TabBadgeValue } from "./Tabs.types";
 
 type TabElement = HTMLButtonElement;
 
 /**
- * Resolves a badge value to a displayable string or null
+ * Resolves a badge value to a displayable string or null.
  */
 function resolveBadgeDisplay(badge: TabBadgeValue | undefined): string | null {
   if (badge === undefined || badge === false) return null;
@@ -29,25 +35,26 @@ function resolveBadgeDisplay(badge: TabBadgeValue | undefined): string | null {
 /**
  * Material Design 3 Tab Component (Layer 3: Styled)
  *
- * Renders a single tab item inside a TabList.
- * Supports three content modes: icon-only, label-only, icon + label (stacked).
+ * Architecture: Variants-vs-States
+ * - Design-time variants (primary/secondary, fixed/scrollable) live in CVA.
+ * - All interaction states are expressed as data-* attributes on the root button
+ *   via getInteractionDataAttributes, consumed by slots using group-data-[x]/tab.
+ * - Content flags (data-with-icon, data-with-label) describe structure, set explicitly.
  *
- * Features:
- * - ✅ Icon-only, label-only, icon + label (stacked) content modes
- * - ✅ Ripple effect (Material Design)
- * - ✅ MD3 state layers (hover 8%, pressed 12%)
- * - ✅ Badge support (numeric, dot, 999+)
- * - ✅ Disabled state (opacity-38, not focusable)
- * - ✅ Full keyboard accessibility (via React Aria)
- * - ✅ Primary/secondary variant colors
+ * Slots:
+ *   root button   — group/tab; typography, label color, disabled, content flags
+ *   state layer   — absolute inset hover/focus/pressed overlay
+ *   content span  — data-tab-content; measured by TabList for primary indicator width
+ *   icon wrapper  — 24dp icon + badge anchor
+ *   label span    — truncated text label
  *
  * MD3 Specifications:
- * - Minimum height: 48dp
- * - Minimum width: 90dp
- * - Typography: Title Small (14px, weight 500, tracking 0.1px)
- * - Icon: 24x24dp
- * - Active indicator: 3dp primary / 2dp secondary
- * - State layers: 8% hover, 12% pressed/focus
+ * - Minimum height: 48dp (label/icon-only), 64dp (icon+label stacked)
+ * - Typography: Title Small (text-title-small, weight 500, tracking 0.1px)
+ * - Icon: 24×24dp
+ * - Active indicator: 3dp primary / 2dp secondary — both bg-primary
+ * - State layers: hover 8%, focus/pressed 10%
+ * - Disabled: 38% opacity (not focusable)
  *
  * @example
  * ```tsx
@@ -79,18 +86,20 @@ export const Tab = forwardRef<TabElement, TabProps>(
     const ref = (forwardedRef ?? internalRef) as React.RefObject<TabElement>;
 
     // React Aria: provides tabProps (role, aria-selected, aria-controls, tabIndex, keyboard events).
-    // HTMLButtonElement is structurally compatible with FocusableElement (@react-aria/focus),
-    // which is not exported. Casting through HTMLElement satisfies the ref parameter type.
+    // isPressed is available from useTab's TabAria return type.
     const {
       tabProps,
       isSelected,
       isDisabled: ariaIsDisabled,
+      isPressed,
     } = useTab({ key: id, isDisabled }, state, ref as React.RefObject<HTMLElement>);
 
     // Focus ring for keyboard focus indicator
     const { isFocusVisible, focusProps } = useFocusRing();
 
+    // Hover state for state-layer
     const finalIsDisabled = isDisabled || ariaIsDisabled;
+    const { isHovered, hoverProps } = useHover({ isDisabled: finalIsDisabled });
 
     // Ripple effect
     const { onMouseDown: handleRipple, ripples } = useRipple({
@@ -100,7 +109,6 @@ export const Tab = forwardRef<TabElement, TabProps>(
     // Direct selection handler — ensures click works reliably across all environments.
     // React Aria's useTab uses shouldSelectOnPressUp which depends on pointerup events.
     // In some environments (jsdom), pointer capture can interfere with pointerup dispatch.
-    // Adding a direct onClick fallback ensures selection always works on user click.
     const handleClick = useCallback(() => {
       if (!finalIsDisabled) {
         state.setSelectedKey(id);
@@ -109,92 +117,97 @@ export const Tab = forwardRef<TabElement, TabProps>(
 
     // Direct focus handler — ensures focusedKey is always in sync with DOM focus.
     // React Aria uses focusedKey to determine keyboard delegate's starting position.
-    // Without this, focusedKey may be null after programmatic DOM focus, breaking Arrow navigation.
     const handleFocus = useCallback(() => {
       if (!finalIsDisabled) {
         state.selectionManager.setFocusedKey(id);
       }
     }, [state.selectionManager, id, finalIsDisabled]);
 
-    // Merge all event handlers — tabProps includes ARIA attrs and keyboard handlers from React Aria.
-    // Keyboard navigation (ArrowRight/ArrowLeft/Home/End) is handled at the TabList level,
-    // not here, so we don't add an onKeyDown. Events bubble naturally from Tab → TabList.
-    const mergedProps = mergeProps(tabProps, focusProps, {
+    const mergedProps = mergeProps(tabProps, focusProps, hoverProps, {
       onMouseDown: disableRipple ? undefined : handleRipple,
       onClick: handleClick,
       onFocus: handleFocus,
     });
 
-    // Badge display
     const badgeDisplay = resolveBadgeDisplay(badge);
     const isDotBadge = badgeDisplay === "dot";
     const hasIcon = Boolean(icon);
     const hasLabel = Boolean(label);
 
-    // Use button for native click handling. role="tab" from tabProps overrides default button role.
-    // tabIndex: use isSelected (not isFocused from React Aria) so the selected tab is always reachable
-    // via Tab key, regardless of whether React Aria has initialized its internal focusedKey.
     return (
       <button
         {...mergedProps}
         ref={ref}
         type="button"
-        // Ensure data-key is set so React Aria's keyboard delegate can find this element by key
         data-key={String(id)}
-        // Override React Aria's isFocused-based tabIndex with selection-based roving tabIndex
+        // Roving tabIndex based on selection, not focus state
         tabIndex={finalIsDisabled ? -1 : isSelected ? 0 : -1}
-        className={cn(
-          tabVariants({
-            variant,
-            selected: isSelected,
-            disabled: finalIsDisabled,
-            layout,
-          }),
-          isFocusVisible && "outline-primary outline-2 outline-offset-2",
-          hasLabel && hasIcon && "min-h-16",
-          className
-        )}
+        className={cn(tabVariants({ variant, layout }), className)}
+        // ── Interaction data attributes (from React Aria state) ──────────
+        {...getInteractionDataAttributes({
+          isHovered,
+          isFocusVisible,
+          isPressed,
+          isSelected,
+          isDisabled: finalIsDisabled,
+        })}
+        // ── Content flags (describe structure, NOT interaction state) ────
+        data-with-icon={hasIcon ? "" : undefined}
+        data-with-label={hasLabel ? "" : undefined}
         {...htmlProps}
       >
         {/* Ripple effect */}
         {!disableRipple && ripples}
 
-        {/* Icon with optional badge */}
-        {hasIcon && (
-          <span className={cn(tabIconVariants({ hasLabel }))}>
-            {icon}
-            {/* Badge on icon — aria-hidden to keep tab's accessible name clean */}
-            {badgeDisplay && (
-              <span
-                data-badge-type={isDotBadge ? "dot" : "count"}
-                aria-hidden="true"
-                className={cn(tabBadgeVariants({ type: isDotBadge ? "dot" : "count" }))}
-              >
-                {!isDotBadge && badgeDisplay}
-              </span>
-            )}
-          </span>
-        )}
+        {/* State layer — absolute inset, opacity driven by group-data-[x]/tab */}
+        <span className={cn(tabStateLayerVariants({ variant }))} aria-hidden="true" />
 
-        {/* Label */}
-        {hasLabel && (
-          <span className="relative z-10 truncate">
-            {label}
-            {/* Badge next to label — aria-hidden keeps accessible name clean */}
-            {!hasIcon && badgeDisplay && (
-              <span
-                data-badge-type={isDotBadge ? "dot" : "count"}
-                aria-hidden="true"
-                className={cn(
-                  "relative ml-1",
-                  tabBadgeVariants({ type: isDotBadge ? "dot" : "count" })
-                )}
-              >
-                {!isDotBadge && badgeDisplay}
-              </span>
-            )}
-          </span>
-        )}
+        {/*
+         * Content span — inline-flex, measured by TabList for primary indicator width.
+         * data-tab-content is the measurement anchor; TabList queries this element's
+         * bounding rect to center the primary indicator under the actual content.
+         */}
+        <span
+          data-tab-content
+          className="relative z-10 inline-flex flex-col items-center justify-center"
+        >
+          {/* Icon with optional badge */}
+          {hasIcon && (
+            <span className={cn(tabIconVariants({ hasLabel }))}>
+              {icon}
+              {/* Badge on icon — aria-hidden keeps tab's accessible name clean */}
+              {badgeDisplay && (
+                <span
+                  data-badge-type={isDotBadge ? "dot" : "count"}
+                  aria-hidden="true"
+                  className={cn(tabBadgeVariants({ type: isDotBadge ? "dot" : "count" }))}
+                >
+                  {!isDotBadge && badgeDisplay}
+                </span>
+              )}
+            </span>
+          )}
+
+          {/* Label */}
+          {hasLabel && (
+            <span className="truncate">
+              {label}
+              {/* Badge next to label when no icon — aria-hidden keeps accessible name clean */}
+              {!hasIcon && badgeDisplay && (
+                <span
+                  data-badge-type={isDotBadge ? "dot" : "count"}
+                  aria-hidden="true"
+                  className={cn(
+                    "relative ml-1",
+                    tabBadgeVariants({ type: isDotBadge ? "dot" : "count" })
+                  )}
+                >
+                  {!isDotBadge && badgeDisplay}
+                </span>
+              )}
+            </span>
+          )}
+        </span>
       </button>
     );
   }

--- a/packages/react/src/components/Tabs/TabList.tsx
+++ b/packages/react/src/components/Tabs/TabList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useRef, useLayoutEffect, useState, useCallback } from "react";
+import { forwardRef, useRef, useLayoutEffect, useState, useCallback, useEffect } from "react";
 import type React from "react";
 import { useTabList } from "react-aria";
 import { cn } from "../../utils/cn";
@@ -10,7 +10,7 @@ import { tabListVariants, tabIndicatorVariants } from "./Tabs.variants";
 import type { TabListProps } from "./Tabs.types";
 
 /**
- * Indicator position and width state for the animated sliding underline
+ * Indicator position and width state for the animated sliding underline.
  */
 interface IndicatorStyle {
   left: number;
@@ -24,15 +24,12 @@ interface IndicatorStyle {
  * Uses React Aria's useTabList for role="tablist", keyboard navigation,
  * and accessibility attributes.
  *
- * The active indicator slides to the selected tab using CSS transitions
- * with MD3 motion tokens (medium2 duration, emphasized easing).
+ * Active indicator behavior (MD3 spec):
+ * - Primary: indicator width = content (label/icon) width, centered under content.
+ *   Measured via the [data-tab-content] child span of the selected tab.
+ * - Secondary: indicator spans the full tab button width.
  *
- * MD3 Specifications:
- * - Container background: bg-surface
- * - Container height: 48dp
- * - Bottom border: 1dp, outline-variant color
- * - Fixed layout: tabs fill width equally
- * - Scrollable layout: overflow-x, no wrapping
+ * Motion: left and width are spatial properties → spring-standard-default-spatial.
  *
  * @example
  * ```tsx
@@ -59,8 +56,7 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
 
     // React Aria provides role="tablist", aria-label, and keyboard navigation.
-    // Conditionally spread ARIA props to satisfy exactOptionalPropertyTypes:
-    // passing undefined values explicitly would violate the strict optional type constraint.
+    // Conditionally spread ARIA props to satisfy exactOptionalPropertyTypes.
     const { tabListProps } = useTabList(
       {
         ...(ariaLabel !== undefined && { "aria-label": ariaLabel }),
@@ -76,7 +72,6 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
      * state.focusedKey. This is critical for test reliability: when a tab is focused
      * via element.focus() outside React's act() boundary, the setFocusedKey state
      * update is deferred and state.focusedKey may still be null when the keydown fires.
-     * Reading from the DOM directly avoids this race condition entirely.
      */
     const handleNavKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -89,11 +84,6 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
         const currentKey = focusedEl?.dataset?.key;
         if (!currentKey) return;
 
-        // Read the ordered tab keys and disabled state directly from the DOM.
-        // This is more reliable than state.collection.getKeys() because React Stately 3.x
-        // builds its collection through a virtual rendering context; when we compute
-        // <Item> elements programmatically inside Tabs.tsx, that context is never entered
-        // and state.collection remains empty. DOM attributes are always authoritative.
         const allTabEls = [...container.querySelectorAll<HTMLElement>("[data-key]")];
         const allKeys = allTabEls.map((el) => el.dataset.key!).filter(Boolean);
         const enabledKeys = allKeys.filter(
@@ -133,14 +123,8 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
       [state, ref]
     );
 
-    // Destructure onKeyDown so it can be used as a stable useCallback dependency.
     const { onKeyDown: tabListKeyDown } = tabListProps;
 
-    /**
-     * Combined keyboard handler: our DOM-based navigation runs first for arrow/home/end.
-     * If we call e.preventDefault() (signalling we handled it), React Aria's handler is
-     * skipped for that key. Other keys (Enter, Space, Tab) pass through to React Aria.
-     */
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
         handleNavKeyDown(e);
@@ -156,9 +140,13 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
     const [indicatorReady, setIndicatorReady] = useState(false);
 
     /**
-     * Recalculates indicator position/width from the selected tab's DOM rect.
-     * Uses the [aria-selected="true"] element as the target.
-     * Only calls setState if values changed to prevent infinite update loops.
+     * Recalculates indicator position and width from the selected tab's DOM.
+     *
+     * Primary variant: measures the [data-tab-content] inner span of the selected tab,
+     * which contains only the icon/label. The indicator is centered under this content
+     * (MD3 spec: indicator hugs content, not the full tab width).
+     *
+     * Secondary variant: measures the full selected tab button rect (full tab width).
      */
     const updateIndicator = useCallback(() => {
       const container = ref.current;
@@ -168,28 +156,56 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
       if (!selectedTab) return;
 
       const containerRect = container.getBoundingClientRect();
-      const tabRect = selectedTab.getBoundingClientRect();
 
-      const newLeft = tabRect.left - containerRect.left + container.scrollLeft;
-      const newWidth = tabRect.width;
+      if (variant === "primary") {
+        // Primary: measure the content span centered under icon/label
+        const contentEl = selectedTab.querySelector<HTMLElement>("[data-tab-content]");
+        if (!contentEl) return;
 
-      // Use functional update to avoid stale closure and prevent needless re-renders
-      setIndicatorStyle((prev) => {
-        if (prev.left === newLeft && prev.width === newWidth) return prev;
-        return { left: newLeft, width: newWidth };
-      });
+        const contentRect = contentEl.getBoundingClientRect();
+        const newLeft = contentRect.left - containerRect.left + container.scrollLeft;
+        const newWidth = contentRect.width;
+
+        setIndicatorStyle((prev) => {
+          if (prev.left === newLeft && prev.width === newWidth) return prev;
+          return { left: newLeft, width: newWidth };
+        });
+      } else {
+        // Secondary: indicator spans the full tab button width
+        const tabRect = selectedTab.getBoundingClientRect();
+        const newLeft = tabRect.left - containerRect.left + container.scrollLeft;
+        const newWidth = tabRect.width;
+
+        setIndicatorStyle((prev) => {
+          if (prev.left === newLeft && prev.width === newWidth) return prev;
+          return { left: newLeft, width: newWidth };
+        });
+      }
+
       setIndicatorReady(true);
-    }, [ref]);
+    }, [ref, variant]);
 
-    // Only re-run when the selected key changes (not every render)
+    // Re-measure when selection changes or variant changes
     useLayoutEffect(() => {
       updateIndicator();
     }, [state.selectedKey, updateIndicator]);
 
+    // Re-measure on container resize (e.g. window resize, flex layout reflow)
+    useEffect(() => {
+      const container = ref.current;
+      if (!container || typeof ResizeObserver === "undefined") return;
+
+      const observer = new ResizeObserver(() => {
+        updateIndicator();
+      });
+      observer.observe(container);
+
+      return () => {
+        observer.disconnect();
+      };
+    }, [ref, updateIndicator]);
+
     // ── Render ──────────────────────────────────────────────────────────────
-    // Merge handleKeyDown into tabListProps so jsx-a11y can't flag a "static" div with
-    // an explicit onKeyDown. The role="tablist" (from tabListProps) makes it interactive,
-    // but ESLint can't trace roles through spread operators — this avoids the false positive.
     const mergedTabListProps = { ...tabListProps, onKeyDown: handleKeyDown };
 
     return (
@@ -206,7 +222,6 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
             !indicatorReady && "opacity-0"
           )}
           style={{
-            // Dynamic left/width values from DOM measurements
             left: `${indicatorStyle.left}px`,
             width: `${indicatorStyle.width}px`,
           }}

--- a/packages/react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/react/src/components/Tabs/Tabs.test.tsx
@@ -375,18 +375,28 @@ describe("Tabs", () => {
   // ─── Variants ─────────────────────────────────────────────────────────────
 
   describe("Variants", () => {
-    test("primary variant: selected tab has text-primary class", () => {
+    test("primary variant: selected tab has data-selected attribute", () => {
       render(<BasicTabs defaultSelectedKey="photos" variant="primary" />);
-      expect(screen.getByRole("tab", { name: "Photos" })).toHaveClass("text-primary");
+      // Variants-vs-States: selection state is expressed as data-selected attribute,
+      // not a direct class. The group-data-[selected]/tab:text-primary CSS selector
+      // applies text-primary color when data-selected is present.
+      expect(screen.getByRole("tab", { name: "Photos" })).toHaveAttribute("data-selected");
     });
 
-    test("secondary variant: selected tab has text-on-surface class", () => {
+    test("primary variant: unselected tabs do not have data-selected attribute", () => {
+      render(<BasicTabs defaultSelectedKey="photos" variant="primary" />);
+      expect(screen.getByRole("tab", { name: "Music" })).not.toHaveAttribute("data-selected");
+    });
+
+    test("secondary variant: selected tab has data-selected attribute", () => {
       render(<BasicTabs defaultSelectedKey="photos" variant="secondary" />);
-      expect(screen.getByRole("tab", { name: "Photos" })).toHaveClass("text-on-surface");
+      // Variants-vs-States: group-data-[selected]/tab:text-on-surface applies on selection.
+      expect(screen.getByRole("tab", { name: "Photos" })).toHaveAttribute("data-selected");
     });
 
     test("unselected tab has text-on-surface-variant class for both variants", () => {
       const { rerender } = render(<BasicTabs defaultSelectedKey="photos" variant="primary" />);
+      // text-on-surface-variant is the base (inactive) color class applied directly
       expect(screen.getByRole("tab", { name: "Music" })).toHaveClass("text-on-surface-variant");
 
       rerender(
@@ -402,6 +412,20 @@ describe("Tabs", () => {
         </Tabs>
       );
       expect(screen.getByRole("tab", { name: "Music" })).toHaveClass("text-on-surface-variant");
+    });
+
+    test("tab renders a state layer slot (aria-hidden span)", () => {
+      render(<BasicTabs defaultSelectedKey="photos" variant="primary" />);
+      const tab = screen.getByRole("tab", { name: "Photos" });
+      // The state layer is the first child span with aria-hidden="true"
+      const stateLayer = tab.querySelector('span[aria-hidden="true"]');
+      expect(stateLayer).toBeInTheDocument();
+    });
+
+    test("tab renders data-tab-content span wrapping icon/label", () => {
+      render(<BasicTabs defaultSelectedKey="photos" variant="primary" />);
+      const tab = screen.getByRole("tab", { name: "Photos" });
+      expect(tab.querySelector("[data-tab-content]")).toBeInTheDocument();
     });
   });
 
@@ -488,7 +512,7 @@ describe("Tabs", () => {
       expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Videos" }));
     });
 
-    test("disabled tab has opacity-38 class", () => {
+    test("disabled tab has data-disabled attribute (drives opacity-38 via CSS)", () => {
       render(
         <Tabs aria-label="Test" defaultSelectedKey="photos">
           <TabList>
@@ -499,7 +523,9 @@ describe("Tabs", () => {
           <TabPanel id="music">Music</TabPanel>
         </Tabs>
       );
-      expect(screen.getByRole("tab", { name: "Music" })).toHaveClass("opacity-38");
+      // Variants-vs-States: disabled is expressed as data-disabled presence attribute.
+      // The data-[disabled]:opacity-38 Tailwind selector applies the 38% opacity.
+      expect(screen.getByRole("tab", { name: "Music" })).toHaveAttribute("data-disabled");
     });
   });
 
@@ -601,11 +627,12 @@ describe("Tabs", () => {
       expect(indicator).toHaveClass("bg-primary");
     });
 
-    test("secondary indicator has bg-on-surface-variant class", () => {
+    test("secondary indicator has bg-primary class (MD3: both variants use primary color)", () => {
       render(<BasicTabs defaultSelectedKey="photos" variant="secondary" />);
       const tablist = screen.getByRole("tablist");
       const indicator = tablist.querySelector("[data-tab-indicator]");
-      expect(indicator).toHaveClass("bg-on-surface-variant");
+      // MD3 spec: active indicator for secondary tabs uses --md-sys-color-primary (same as primary)
+      expect(indicator).toHaveClass("bg-primary");
     });
   });
 

--- a/packages/react/src/components/Tabs/Tabs.variants.ts
+++ b/packages/react/src/components/Tabs/Tabs.variants.ts
@@ -1,21 +1,48 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 TabList Variants (CVA)
+ * Material Design 3 Tabs Variants
  *
- * MD3 Specifications:
- * - Container background: bg-surface
- * - Container height: 48dp (fixed height tabs)
- * - Bottom border: outline-variant color, 1dp
- * - Fixed layout: tabs fill width equally
- * - Scrollable layout: tabs overflow horizontally, no wrapping
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no selected/disabled state variants).
+ * - All interaction/selection states are driven by data-* attributes on the root
+ *   via group-data-[x]/tab Tailwind selectors in each slot's base classes.
+ * - Content flags (data-with-icon, data-with-label) are set explicitly by Tab.
+ *
+ * Slot responsibilities:
+ *   tabListVariants         — container rail; bg-surface + bottom divider
+ *   tabVariants             — root button; group/tab; typography + label color; disabled
+ *   tabStateLayerVariants   — absolute inset overlay; hover/focus/pressed opacity ring
+ *   tabIndicatorVariants    — sliding underline; spatial spring motion
+ *   tabIconVariants         — 24dp icon wrapper + badge anchor
+ *   tabBadgeVariants        — numeric / dot badge
+ *   tabPanelVariants        — panel container
+ *
+ * MD3 Spec:
+ *   Container: bg-surface, border-b border-outline-variant
+ *   Height: 48dp label/icon-only | 64dp icon+label
+ *   Typography: Title Small (text-title-small, weight 500, tracking 0.1px)
+ *   Icon: 24dp
+ *   Inactive label/icon: text-on-surface-variant
+ *   Active label/icon: primary → text-primary | secondary → text-on-surface
+ *   Active indicator: primary 3dp bg-primary rounded-t-full | secondary 2dp bg-primary
+ *   State-layer opacities: hover 8% | focus 10% | pressed 10%
+ *   Disabled: content 38% opacity
+ *   Indicator motion: spatial spring (default tier)
+ */
+
+// ─── TAB LIST ─────────────────────────────────────────────────────────────────
+
+/**
+ * TabList container rail.
+ * Carries bg-surface and the bottom divider per MD3 spec.
+ * layout is the only design-time variant.
  */
 export const tabListVariants = cva(
   [
-    // Base classes
     "relative flex",
     "bg-surface",
-    // Bottom divider line (MD3 spec)
+    // MD3: 1dp bottom divider in outline-variant color
     "border-b border-outline-variant",
   ],
   {
@@ -31,65 +58,65 @@ export const tabListVariants = cva(
   }
 );
 
+// ─── TAB (ROOT) ───────────────────────────────────────────────────────────────
+
 /**
- * Material Design 3 Tab Item Variants (CVA)
+ * Root <button> element for each tab item.
+ * Carries `group/tab` and emits data-* interaction/content attributes.
  *
- * MD3 Specifications:
- * - Minimum height: 48dp
- * - Minimum width: 90dp (fixed), flexible (scrollable)
- * - Typography: Title Small (14px, weight 500, tracking 0.1px)
- * - State layers: 8% hover, 12% pressed/focus
- * - Disabled: 38% opacity
- * - Touch target: full tab area
+ * States are driven via group-data-[x]/tab selectors, NOT CVA variant props.
+ *   Inactive:  text-on-surface-variant (base)
+ *   Active:    text-primary (primary variant) | text-on-surface (secondary variant)
+ *   Disabled:  self-targeting data-[disabled]: selectors (38% opacity)
+ *   Icon+label height: data-[with-icon]:data-[with-label]:min-h-16
+ *
+ * Effects transition: color changes use spring-standard-fast-effects.
+ * Focus outline: visible via group-data-[focus-visible]/tab on root (above state layer).
  */
 export const tabVariants = cva(
   [
-    // Base layout
+    // Layout
     "relative flex flex-col items-center justify-center",
     "min-h-12 px-4",
     "cursor-pointer select-none",
+    // Clip state layer to tab boundary
     "overflow-hidden",
-    // Typography: MD3 Title Small
-    "text-sm font-medium tracking-[0.1px]",
-    // Transition
-    "transition-colors duration-200",
-    // Focus visible
+    // MD3 Title Small typography
+    "text-title-small font-medium tracking-[0.1px]",
+    // Effects transition for color changes (not spatial)
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Remove default button focus outline — handled via group-data-[focus-visible]/tab
     "focus-visible:outline-none",
-    // State layer via before pseudo-element
-    "before:absolute before:inset-0 before:transition-opacity before:duration-200",
-    "before:bg-current before:opacity-0",
-    "hover:before:opacity-8",
-    "active:before:opacity-12",
-    "focus-visible:before:opacity-12",
+    // Disabled — self-targeting data-[x]: selectors (not group)
+    "data-[disabled]:opacity-38 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+    // Icon+label stacked: 64dp height
+    "data-[with-icon]:data-[with-label]:min-h-16",
   ],
   {
     variants: {
       /**
-       * Tab variant (Primary or Secondary)
+       * Design-time variant: affects active label/icon color and state-layer color.
+       * primary: active → text-primary
+       * secondary: active → text-on-surface
        */
       variant: {
-        primary: "",
-        secondary: "",
+        primary: [
+          // Inactive: on-surface-variant (base)
+          "text-on-surface-variant",
+          // Active: text-primary
+          "group-data-[selected]/tab:text-primary",
+          // Disabled active: on-surface/38 inherits from opacity-38 on root
+        ],
+        secondary: [
+          // Inactive: on-surface-variant (base)
+          "text-on-surface-variant",
+          // Active: on-surface
+          "group-data-[selected]/tab:text-on-surface",
+        ],
       },
 
       /**
-       * Selected state
-       */
-      selected: {
-        true: "",
-        false: "",
-      },
-
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "opacity-38 cursor-not-allowed pointer-events-none",
-        false: "",
-      },
-
-      /**
-       * Layout determines min-width behavior
+       * Design-time variant: affects flex sizing in the tab row.
        */
       layout: {
         fixed: "flex-1",
@@ -97,70 +124,63 @@ export const tabVariants = cva(
       },
     },
 
-    compoundVariants: [
-      // Primary + selected
-      {
-        variant: "primary",
-        selected: true,
-        disabled: false,
-        className: "text-primary",
-      },
-      // Primary + unselected
-      {
-        variant: "primary",
-        selected: false,
-        disabled: false,
-        className: "text-on-surface-variant",
-      },
-      // Secondary + selected
-      {
-        variant: "secondary",
-        selected: true,
-        disabled: false,
-        className: "text-on-surface",
-      },
-      // Secondary + unselected
-      {
-        variant: "secondary",
-        selected: false,
-        disabled: false,
-        className: "text-on-surface-variant",
-      },
-    ],
+    // compoundVariants intentionally empty — state combinations are handled
+    // via group-data-[selected]/tab:group-data-[...]/tab: in state slot
+    compoundVariants: [],
 
     defaultVariants: {
       variant: "primary",
-      selected: false,
-      disabled: false,
       layout: "fixed",
     },
   }
 );
 
+// ─── STATE LAYER ─────────────────────────────────────────────────────────────
+
 /**
- * Active indicator variants (the sliding underline)
+ * State layer — absolute inset overlay transitioning opacity on interaction.
  *
- * MD3 Specifications:
- * - Primary: 3dp height, bg-primary, rounded-full corners
- * - Secondary: 2dp height, bg-on-surface-variant, no rounding
- * - Absolutely positioned at bottom of tab list
- * - Slides to selected tab using CSS transform
+ * Color:
+ *   primary inactive → bg-on-surface
+ *   primary active   → bg-primary (group-data-[selected]/tab:)
+ *   secondary        → bg-on-surface (always)
+ *
+ * Opacity:
+ *   0 at rest
+ *   8% hover  (group-data-[hovered]/tab:)
+ *   10% focus (group-data-[focus-visible]/tab:)
+ *   10% pressed — doubled selector wins over hover at same cascade position
+ *   hidden when disabled
+ *
+ * overflow-hidden on root clips this overlay to the tab shape.
  */
-export const tabIndicatorVariants = cva(
+export const tabStateLayerVariants = cva(
   [
-    // Base: absolutely positioned at bottom
-    "absolute bottom-0 left-0",
-    "pointer-events-none",
-    // Transition using MD3 motion tokens (medium2 duration, emphasized easing)
-    "transition-[left,width]",
-    "duration-medium2",
-    "ease-emphasized",
+    "absolute inset-0 pointer-events-none opacity-0",
+    // Effects transition for opacity — no spatial overshoot
+    "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Hover: 8%
+    "group-data-[hovered]/tab:opacity-8",
+    // Focus: 10%
+    "group-data-[focus-visible]/tab:opacity-10",
+    // Pressed: 10%, doubled selector beats hover at equal cascade position
+    "group-data-[pressed]/tab:group-data-[pressed]/tab:opacity-10",
+    // No state layer when disabled
+    "group-data-[disabled]/tab:hidden",
   ],
   {
     variants: {
       variant: {
-        primary: ["h-[3px]", "bg-primary", "rounded-t-sm"],
-        secondary: ["h-[2px]", "bg-on-surface-variant"],
+        primary: [
+          // Inactive state-layer color
+          "bg-on-surface",
+          // Active state-layer color (higher cascade position wins over base bg-on-surface)
+          "group-data-[selected]/tab:bg-primary",
+        ],
+        secondary: [
+          // Secondary: always on-surface
+          "bg-on-surface",
+        ],
       },
     },
     defaultVariants: {
@@ -169,59 +189,57 @@ export const tabIndicatorVariants = cva(
   }
 );
 
-/**
- * Tab panel variants
- *
- * MD3 Specifications:
- * - No specific container styling mandated
- * - Focus management: panel receives focus if no focusable children
- */
-export const tabPanelVariants = cva(
-  [
-    // Base panel styles
-    "outline-none",
-    "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
-  ],
-  {
-    variants: {},
-    defaultVariants: {},
-  }
-);
+// ─── ACTIVE INDICATOR ────────────────────────────────────────────────────────
 
 /**
- * Tab badge variants
+ * Active indicator — the sliding underline absolutely positioned at the bottom
+ * of the TabList container.
  *
- * Inline badge displayed in the upper-right area of the tab icon/label.
- * MD3 badge spec: small indicator for notification count or status.
+ * primary:   3dp height, bg-primary, rounded-t-full top corners
+ * secondary: 2dp height, bg-primary, no rounding
+ *
+ * Motion: left/width are spatial properties → spring-standard-default-spatial.
+ * Initial position and width are set inline by TabList via DOM measurement.
+ * Primary variant is measured to content width (label/icon inner span);
+ * secondary spans the full tab button width.
  */
-export const tabBadgeVariants = cva(
+export const tabIndicatorVariants = cva(
   [
-    // Base badge
-    "absolute",
-    "inline-flex items-center justify-center",
-    "bg-error text-on-error",
-    "font-medium leading-none",
+    "absolute bottom-0 left-0",
     "pointer-events-none",
+    // Spatial spring — indicator position/width are spatial (not effects)
+    "transition-[left,width]",
+    "duration-spring-standard-default-spatial",
+    "ease-spring-standard-default-spatial",
   ],
   {
     variants: {
-      type: {
-        dot: ["top-1 right-1", "w-1.5 h-1.5", "rounded-full"],
-        count: ["-top-1 -right-1", "min-w-[16px] h-4", "px-1", "rounded-full", "text-[11px]"],
+      variant: {
+        primary: ["h-[3px]", "bg-primary", "rounded-tl-sm rounded-tr-sm"],
+        secondary: ["h-[2px]", "bg-primary"],
       },
     },
     defaultVariants: {
-      type: "count",
+      variant: "primary",
     },
   }
 );
 
+// ─── ICON WRAPPER ─────────────────────────────────────────────────────────────
+
 /**
- * Tab icon wrapper variants
- * Positions icon relative to the badge
+ * Icon wrapper inside the tab content span.
+ * MD3 spec: 24dp icon size.
+ * hasLabel: adds bottom margin when stacked with a label.
  */
 export const tabIconVariants = cva(
-  ["relative", "inline-flex items-center justify-center", "w-6 h-6"],
+  [
+    "relative inline-flex items-center justify-center",
+    // MD3 tab icon size: 24dp
+    "size-6",
+    // Effects transition for color (inherited from parent, guard here too)
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  ],
   {
     variants: {
       hasLabel: {
@@ -235,10 +253,50 @@ export const tabIconVariants = cva(
   }
 );
 
-// Export variant prop types
+// ─── BADGE ────────────────────────────────────────────────────────────────────
+
+/**
+ * Badge — numeric count or dot indicator anchored to the icon wrapper.
+ * MD3 badge spec: bg-error text-on-error.
+ */
+export const tabBadgeVariants = cva(
+  [
+    "absolute",
+    "inline-flex items-center justify-center",
+    "bg-error text-on-error",
+    "font-medium leading-none",
+    "pointer-events-none",
+  ],
+  {
+    variants: {
+      type: {
+        dot: ["top-0 right-0", "w-1.5 h-1.5", "rounded-full"],
+        count: ["-top-1 -right-1", "min-w-[16px] h-4", "px-1", "rounded-full", "text-[11px]"],
+      },
+    },
+    defaultVariants: {
+      type: "count",
+    },
+  }
+);
+
+// ─── TAB PANEL ────────────────────────────────────────────────────────────────
+
+/**
+ * TabPanel container.
+ * MD3 does not specify panel container styling — focus management only.
+ */
+export const tabPanelVariants = cva([
+  "outline-none",
+  "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
 export type TabListVariants = VariantProps<typeof tabListVariants>;
 export type TabVariants = VariantProps<typeof tabVariants>;
+export type TabStateLayerVariants = VariantProps<typeof tabStateLayerVariants>;
 export type TabIndicatorVariants = VariantProps<typeof tabIndicatorVariants>;
-export type TabPanelVariants = VariantProps<typeof tabPanelVariants>;
-export type TabBadgeVariants = VariantProps<typeof tabBadgeVariants>;
 export type TabIconVariants = VariantProps<typeof tabIconVariants>;
+export type TabBadgeVariants = VariantProps<typeof tabBadgeVariants>;
+export type TabPanelVariants = VariantProps<typeof tabPanelVariants>;

--- a/packages/react/src/components/Tabs/index.ts
+++ b/packages/react/src/components/Tabs/index.ts
@@ -46,6 +46,7 @@ export type {
 export {
   tabListVariants,
   tabVariants,
+  tabStateLayerVariants,
   tabIndicatorVariants,
   tabPanelVariants,
   tabBadgeVariants,
@@ -55,6 +56,7 @@ export {
 export type {
   TabListVariants,
   TabVariants,
+  TabStateLayerVariants,
   TabIndicatorVariants,
   TabPanelVariants,
   TabBadgeVariants,


### PR DESCRIPTION
## Summary

- **Variants-vs-States architecture**: `Tabs.variants.ts` rewritten to remove `selected`/`disabled` CVA variants entirely. All interaction and selection states are now driven by `data-*` attributes on the root button (`group/tab`) and consumed by slot base classes via `group-data-[x]/tab:` selectors — identical to Button and Switch.
- **New `tabStateLayerVariants` slot**: replaces the forbidden `before:` pseudo-element approach. Absolute inset overlay with correct MD3 opacities — hover 8%, focus 10%, pressed 10% (was 12%). Color is variant-aware: primary inactive `bg-on-surface` → active `bg-primary`; secondary always `bg-on-surface`.
- **Correct indicator tokens**: both primary and secondary active indicators now use `bg-primary` (confirmed from `_md-comp-primary-tab.scss` / `_md-comp-secondary-tab.scss` — `active-indicator-color = --md-sys-color-primary` for both variants). Previously secondary was incorrectly using `bg-on-surface-variant`.
- **Correct indicator motion**: `transition-[left,width]` now uses `duration-spring-standard-default-spatial` + `ease-spring-standard-default-spatial`. `left`/`width` are spatial properties; using the legacy `ease-emphasized` + `duration-medium2` pair was wrong.
- **MD3-correct primary indicator width**: primary indicator now measures the `[data-tab-content]` inner span (icon/label), not the full tab button. Secondary still spans the full tab width.
- **ResizeObserver** added in `TabList.tsx` so the indicator position recalculates correctly on container layout reflow (e.g. window resize, flex changes).
- **`Tab.tsx`**: adds `useHover` + `isPressed` from `useTab`, emits `getInteractionDataAttributes`, sets content flags `data-with-icon`/`data-with-label`, wraps content in `data-tab-content` span.
- **Tests updated**: class assertions for `text-primary`/`text-on-surface` (now driven by CSS data selectors) replaced with `data-selected` attribute checks; `opacity-38` replaced with `data-disabled` attribute check; secondary indicator class updated to `bg-primary`.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 65/65 tests pass
- [x] `pnpm build` — clean ESM/CJS/DTS artifacts
- [ ] Visual review in Storybook (primary + secondary + scrollable + icon+label)