### PR TITLE
refactor(divider)!: slot-based cva, css-var thickness, rtl-logical insets; remove subheader label

### DIFF
--- a/.changeset/divider-md3-expressive-refactor.md
+++ b/.changeset/divider-md3-expressive-refactor.md
@@ -1,0 +1,20 @@
+---
+"@tinybigui/react": minor
+"@tinybigui/tokens": minor
+---
+
+refactor(divider)!: slot-based CVA, CSS-var thickness, logical RTL insets; remove subheader label
+
+**BREAKING CHANGES:**
+
+- `label` prop removed from `Divider`. The subheader variant (text centered between two rules) was not part of the MD3 divider spec and has been removed.
+- Inset variants now use logical inline properties (`margin-inline-start` / `margin-inline-end`) instead of physical margins. This is a visual change only in RTL layouts.
+
+**What changed:**
+
+- Styling switched from `border-*` to a background-fill approach (`bg-outline-variant`) on a zero-border element. Matches the `@material/web` `MdDivider` implementation.
+- Thickness is now controlled by the `--md-divider-thickness` CSS custom property (default `1px`, MD3 1dp). Override per instance: `<Divider style={{ "--md-divider-thickness": "2px" }} />`.
+- `Divider.variants.ts` rewritten following the documented slot-CVA architecture used by Button and Switch (spec header comment, array-form base, explicit `defaultVariants`).
+- `DividerHeadless` simplified — `label` and `children` props removed from the interface.
+- All MD3 design token classes (no arbitrary values).
+- 22 tests cover orientation, insets, bg token, ref forwarding, and axe accessibility.

--- a/packages/react/src/components/Divider/Divider.stories.tsx
+++ b/packages/react/src/components/Divider/Divider.stories.tsx
@@ -11,10 +11,11 @@ const meta: Meta<typeof Divider> = {
       description: {
         component:
           "Material Design 3 Divider — a thin line that groups content in lists and containers. " +
-          "Supports horizontal and vertical orientations, four inset variants (none, start, end, both), " +
-          "and an optional subheader label that renders centered text between two rule lines. " +
+          "Supports horizontal and vertical orientations, and four inset variants " +
+          "(none, start, end, both) using RTL-aware logical inline properties. " +
+          "Thickness is controlled via the `--md-divider-thickness` CSS custom property (default 1px). " +
           'Built on React Aria `useSeparator` for WCAG-compliant `role="separator"` semantics. ' +
-          "[MD3 spec](https://m3.material.io/components/divider/overview)",
+          "[MD3 spec](https://m3.material.io/components/divider/specs)",
       },
     },
   },
@@ -29,13 +30,9 @@ const meta: Meta<typeof Divider> = {
     inset: {
       control: "select",
       options: ["none", "start", "end", "both"],
-      description: "Shifts the start and/or end of the rule by 16dp to align with list content.",
-      table: { defaultValue: { summary: "none" } },
-    },
-    label: {
-      control: "text",
       description:
-        "Subheader label text. When provided, renders centered text between two rule lines.",
+        "Shifts the start and/or end of the rule by 16dp (logical inline offset — RTL-aware).",
+      table: { defaultValue: { summary: "none" } },
     },
     className: {
       control: "text",
@@ -60,7 +57,7 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          "Full-bleed horizontal divider with no inset or label. Use the controls panel " +
+          "Full-bleed horizontal divider with no inset. Use the controls panel " +
           "to explore all prop combinations.",
       },
     },
@@ -102,8 +99,7 @@ export const Vertical: Story = {
       description: {
         story:
           "Vertical divider inside a `flex` row separating two text blocks. " +
-          "Give the divider an explicit height (e.g. `h-8`) so it fills the desired span " +
-          "within the flex container.",
+          "`self-stretch` automatically fills the flex container's block axis.",
       },
     },
   },
@@ -125,8 +121,8 @@ export const InsetStart: Story = {
     docs: {
       description: {
         story:
-          '`inset="start"` adds a 16dp leading margin. Typical use: list rows where an avatar ' +
-          "or icon occupies the leading edge and the divider should align with the text.",
+          '`inset="start"` adds a 16dp logical inline-start margin (RTL-aware). ' +
+          "Typical use: list rows where an avatar or icon occupies the leading edge.",
       },
     },
   },
@@ -144,8 +140,8 @@ export const InsetEnd: Story = {
     docs: {
       description: {
         story:
-          '`inset="end"` adds a 16dp trailing margin, visually associating the rule with content ' +
-          "that stops before the trailing edge.",
+          '`inset="end"` adds a 16dp logical inline-end margin (RTL-aware), ' +
+          "visually associating the rule with content that stops before the trailing edge.",
       },
     },
   },
@@ -163,8 +159,8 @@ export const InsetBoth: Story = {
     docs: {
       description: {
         story:
-          '`inset="both"` adds 16dp margins on both ends, centering the rule between the ' +
-          "container edges.",
+          '`inset="both"` adds 16dp margins on both inline edges, centering the rule ' +
+          "between the container edges.",
       },
     },
   },
@@ -188,54 +184,85 @@ export const AllInsetVariants: Story = {
   parameters: {
     docs: {
       description: {
-        story:
-          "All four inset variants stacked vertically with labels, so you can compare the " +
-          "visual offset side-by-side.",
+        story: "All four inset variants stacked vertically with labels for easy visual comparison.",
       },
     },
   },
 };
 
 // ---------------------------------------------------------------------------
-// Subheader (labeled) variant
+// Thickness (CSS custom property override)
 // ---------------------------------------------------------------------------
 
-export const WithSubheaderLabel: Story = {
+export const Thickness: Story = {
   render: () => (
-    <div className="bg-surface w-80 rounded-lg p-4">
-      <Divider label="Section Title" />
+    <div className="bg-surface w-80 space-y-4 rounded-lg p-4">
+      <div>
+        <p className="text-on-surface-variant text-label-small mb-1 tracking-wider uppercase">
+          1px (default)
+        </p>
+        <Divider />
+      </div>
+      <div>
+        <p className="text-on-surface-variant text-label-small mb-1 tracking-wider uppercase">
+          2px
+        </p>
+        <Divider style={{ "--md-divider-thickness": "2px" }} />
+      </div>
+      <div>
+        <p className="text-on-surface-variant text-label-small mb-1 tracking-wider uppercase">
+          4px
+        </p>
+        <Divider style={{ "--md-divider-thickness": "4px" }} />
+      </div>
     </div>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "When `label` is provided the component renders a subheader divider: the text is " +
-          "centered between two horizontal rule lines, styled with `text-on-surface-variant` " +
-          'and `text-label-large`. The wrapper uses `role="group"` with `aria-label` for ' +
-          "accessible semantics.",
+          "Thickness is driven by the `--md-divider-thickness` CSS custom property " +
+          "(MD3 default: 1dp). Override it via the `style` prop — no new React prop needed. " +
+          "This matches the `md-web` `MdDivider` API.",
       },
     },
   },
 };
 
-export const SubheaderVariants: Story = {
+// ---------------------------------------------------------------------------
+// RTL — logical insets adapt to writing direction
+// ---------------------------------------------------------------------------
+
+export const RTLInsets: Story = {
   render: () => (
-    <div className="bg-surface w-80 rounded-lg p-6">
-      <p className="text-on-surface text-body-medium mb-4">Starred messages</p>
-      <Divider label="Today" />
-      <p className="text-on-surface text-body-medium my-4">Recent messages</p>
-      <Divider label="Yesterday" />
-      <p className="text-on-surface text-body-medium my-4">Older messages</p>
-      <Divider label="Last week" />
+    <div className="flex gap-8">
+      <div className="bg-surface w-60 rounded-lg p-4" dir="ltr">
+        <p className="text-on-surface-variant text-label-small mb-2 tracking-wider uppercase">
+          LTR
+        </p>
+        <p className="text-on-surface text-body-small mb-2">
+          inset=&quot;start&quot; (leading margin left)
+        </p>
+        <Divider inset="start" />
+      </div>
+      <div className="bg-surface w-60 rounded-lg p-4" dir="rtl">
+        <p className="text-on-surface-variant text-label-small mb-2 tracking-wider uppercase">
+          RTL
+        </p>
+        <p className="text-on-surface text-body-small mb-2">
+          inset=&quot;start&quot; (leading margin right)
+        </p>
+        <Divider inset="start" />
+      </div>
     </div>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "Three subheader dividers used as date-group separators in a message list, " +
-          "demonstrating a real-world subheader pattern.",
+          'Logical `inset="start"` uses `margin-inline-start` under the hood. ' +
+          "In LTR the indent appears on the left; in RTL it flips to the right automatically — " +
+          "no extra code needed.",
       },
     },
   },
@@ -266,9 +293,7 @@ export const InLayoutContext: Story = {
   parameters: {
     docs: {
       description: {
-        story:
-          "Horizontal divider used as a card section separator between two address blocks, " +
-          "a typical use case in checkout or profile screens.",
+        story: "Horizontal divider used as a card section separator between two address blocks.",
       },
     },
   },
@@ -351,7 +376,7 @@ export const VerticalInToolbar: Story = {
     docs: {
       description: {
         story:
-          "Vertical dividers separating logical action groups inside a text-formatting toolbar. ",
+          "Vertical dividers separating logical action groups inside a text-formatting toolbar.",
       },
     },
   },
@@ -372,7 +397,6 @@ export const LightAndDarkTheme: Story = {
           <Divider orientation="vertical" />
           <p className="text-on-surface-variant text-body-small flex-1">Right</p>
         </div>
-        <Divider label="Section" />
       </div>
       <div className="dark bg-surface shadow-elevation-1 w-64 rounded-xl p-6">
         <p className="text-on-surface text-label-medium mb-3 font-medium">Dark theme</p>
@@ -382,7 +406,6 @@ export const LightAndDarkTheme: Story = {
           <Divider orientation="vertical" />
           <p className="text-on-surface-variant text-body-small flex-1">Right</p>
         </div>
-        <Divider label="Section" />
       </div>
     </div>
   ),
@@ -390,9 +413,8 @@ export const LightAndDarkTheme: Story = {
     docs: {
       description: {
         story:
-          "Side-by-side light and dark surface containers, each showing a horizontal divider, " +
-          "a vertical divider inside a flex row, and a labeled subheader divider. " +
-          "Demonstrates that all divider variants adapt correctly to the active theme.",
+          "Side-by-side light and dark surface containers, each showing a horizontal and a " +
+          "vertical divider. Demonstrates that all variants adapt correctly to the active theme.",
       },
     },
   },
@@ -406,13 +428,11 @@ export const Playground: Story = {
   args: {
     orientation: "horizontal",
     inset: "none",
-    label: "",
     className: "",
   },
   render: (args: {
     orientation?: "horizontal" | "vertical";
     inset?: "none" | "start" | "end" | "both";
-    label?: string;
     className?: string;
   }) => (
     <div
@@ -421,7 +441,6 @@ export const Playground: Story = {
       <Divider
         orientation={args.orientation}
         inset={args.inset}
-        label={args.label ?? undefined}
         className={
           args.orientation === "vertical" ? `h-12 ${args.className ?? ""}` : args.className
         }
@@ -432,9 +451,8 @@ export const Playground: Story = {
     docs: {
       description: {
         story:
-          "Fully controllable story — use the controls panel to combine all props and explore " +
-          "every Divider state. The container switches between a flex row (vertical) and a " +
-          "block layout (horizontal) automatically.",
+          "Fully controllable story — use the controls panel to combine all props. " +
+          "The container switches between a flex row (vertical) and a block layout (horizontal) automatically.",
       },
     },
   },

--- a/packages/react/src/components/Divider/Divider.test.tsx
+++ b/packages/react/src/components/Divider/Divider.test.tsx
@@ -28,66 +28,65 @@ describe("Divider", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Orientation classes
+  // Orientation classes (bg-fill approach, CSS-var thickness)
   // ---------------------------------------------------------------------------
 
   describe("Orientation classes", () => {
-    test("applies border-t for horizontal orientation", () => {
+    test("applies bg-outline-variant as the fill color", () => {
       render(<Divider />);
-      expect(screen.getByRole("separator")).toHaveClass("border-t");
+      expect(screen.getByRole("separator")).toHaveClass("bg-outline-variant");
     });
 
-    test("applies border-l for vertical orientation", () => {
+    test("applies horizontal size class for horizontal orientation", () => {
+      render(<Divider />);
+      const el = screen.getByRole("separator");
+      expect(el).toHaveClass("w-full");
+    });
+
+    test("applies vertical size class for vertical orientation", () => {
       render(<Divider orientation="vertical" />);
-      expect(screen.getByRole("separator")).toHaveClass("border-l");
+      const el = screen.getByRole("separator");
+      expect(el).toHaveClass("self-stretch");
+    });
+
+    test("does not apply border-t for horizontal orientation", () => {
+      render(<Divider />);
+      expect(screen.getByRole("separator")).not.toHaveClass("border-t");
+    });
+
+    test("does not apply border-l for vertical orientation", () => {
+      render(<Divider orientation="vertical" />);
+      expect(screen.getByRole("separator")).not.toHaveClass("border-l");
     });
   });
 
   // ---------------------------------------------------------------------------
-  // Inset classes
+  // Inset classes — logical inline properties (RTL-aware)
   // ---------------------------------------------------------------------------
 
   describe("Inset variants", () => {
-    test('applies ml-4 when inset="start"', () => {
+    test('applies ms-4 when inset="start"', () => {
       render(<Divider inset="start" />);
-      expect(screen.getByRole("separator")).toHaveClass("ml-4");
+      expect(screen.getByRole("separator")).toHaveClass("ms-4");
     });
 
-    test('applies mr-4 when inset="end"', () => {
+    test('applies me-4 when inset="end"', () => {
       render(<Divider inset="end" />);
-      expect(screen.getByRole("separator")).toHaveClass("mr-4");
+      expect(screen.getByRole("separator")).toHaveClass("me-4");
     });
 
-    test('applies both ml-4 and mr-4 when inset="both"', () => {
+    test('applies both ms-4 and me-4 when inset="both"', () => {
       render(<Divider inset="both" />);
       const separator = screen.getByRole("separator");
-      expect(separator).toHaveClass("ml-4");
-      expect(separator).toHaveClass("mr-4");
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Label / subheader variant
-  // ---------------------------------------------------------------------------
-
-  describe("Label / subheader variant", () => {
-    test("renders label text when label prop is provided", () => {
-      render(<Divider label="Section" />);
-      expect(screen.getByText("Section")).toBeInTheDocument();
+      expect(separator).toHaveClass("ms-4");
+      expect(separator).toHaveClass("me-4");
     });
 
-    test("label text element has text-on-surface-variant and text-label-large classes", () => {
-      render(<Divider label="Section" />);
-      const labelEl = screen.getByText("Section");
-      expect(labelEl).toHaveClass("text-on-surface-variant");
-      expect(labelEl).toHaveClass("text-label-large");
-    });
-
-    test("with label renders two separator elements plus label span", () => {
-      render(<Divider label="Section" />);
-      const separators = screen.getAllByRole("separator");
-      expect(separators).toHaveLength(2);
-      expect(screen.getByText("Section").tagName).toBe("SPAN");
+    test('applies no inset classes when inset="none"', () => {
+      render(<Divider inset="none" />);
+      const separator = screen.getByRole("separator");
+      expect(separator).not.toHaveClass("ms-4");
+      expect(separator).not.toHaveClass("me-4");
     });
   });
 
@@ -100,6 +99,11 @@ describe("Divider", () => {
       render(<Divider className="my-custom-class" />);
       expect(screen.getByRole("separator")).toHaveClass("my-custom-class");
     });
+
+    test("accepts and applies custom className to vertical divider", () => {
+      render(<Divider orientation="vertical" className="my-custom-class" />);
+      expect(screen.getByRole("separator")).toHaveClass("my-custom-class");
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -107,9 +111,15 @@ describe("Divider", () => {
   // ---------------------------------------------------------------------------
 
   describe("Ref forwarding", () => {
-    test("forwards ref correctly", () => {
+    test("forwards ref correctly for horizontal divider", () => {
       const ref = createRef<HTMLElement>();
       render(<Divider ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+
+    test("forwards ref correctly for vertical divider", () => {
+      const ref = createRef<HTMLElement>();
+      render(<Divider ref={ref} orientation="vertical" />);
       expect(ref.current).toBeInstanceOf(HTMLElement);
     });
   });
@@ -135,8 +145,8 @@ describe("Divider", () => {
       expect(results).toHaveNoViolations();
     });
 
-    test("axe: no violations for labeled divider", async () => {
-      const { container } = render(<Divider label="Section" />);
+    test("axe: no violations for inset divider", async () => {
+      const { container } = render(<Divider inset="start" />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
@@ -156,5 +166,10 @@ describe("DividerHeadless", () => {
   test("renders a div element for vertical orientation", () => {
     render(<DividerHeadless orientation="vertical" />);
     expect(screen.getByRole("separator").tagName).toBe("DIV");
+  });
+
+  test("accepts and applies custom className", () => {
+    render(<DividerHeadless className="test-class" />);
+    expect(screen.getByRole("separator")).toHaveClass("test-class");
   });
 });

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { forwardRef } from "react";
-import type { ForwardedRef } from "react";
 
 import { cn } from "../../utils/cn";
 import { DividerHeadless } from "./DividerHeadless";
@@ -12,60 +11,42 @@ import type { DividerProps } from "./Divider.types";
  * Divider — MD3 Styled Component (Layer 3)
  *
  * A thin rule that separates content in lists and containers.
- * Supports horizontal/vertical orientations, inset variants, and an
- * optional subheader label that renders the text centered between two rules.
+ * Supports horizontal/vertical orientations and four inset variants.
  *
  * Built on `DividerHeadless` (React Aria `useSeparator`) for accessible
  * ARIA semantics. Uses CVA variants mapped to MD3 design tokens.
+ *
+ * Thickness is controlled via the `--md-divider-thickness` CSS custom property
+ * (default `1px`, matching the MD3 1dp spec). Override with a `style` prop:
+ *
+ * ```tsx
+ * <Divider style={{ "--md-divider-thickness": "2px" }} />
+ * ```
  *
  * @example
  * ```tsx
  * // Full-bleed horizontal divider
  * <Divider />
  *
- * // Inset from the start (16dp)
+ * // Inset from inline-start (RTL-aware, 16dp)
  * <Divider inset="start" />
  *
  * // Vertical divider inside a flex row
  * <Divider orientation="vertical" />
  *
- * // Subheader divider
- * <Divider label="Section Title" />
+ * // Custom thickness
+ * <Divider style={{ "--md-divider-thickness": "2px" }} />
  * ```
  */
 export const Divider = forwardRef<HTMLElement, DividerProps>(
-  ({ orientation = "horizontal", inset = "none", label, className }, ref) => {
-    if (label) {
-      return (
-        <div
-          ref={ref as ForwardedRef<HTMLDivElement>}
-          role="group"
-          aria-label={label}
-          className={cn("flex items-center gap-4", className)}
-        >
-          <DividerHeadless
-            orientation="horizontal"
-            className={cn(dividerVariants({ orientation: "horizontal", inset: "none" }), "flex-1")}
-          />
-          <span className="text-on-surface-variant text-label-large whitespace-nowrap">
-            {label}
-          </span>
-          <DividerHeadless
-            orientation="horizontal"
-            className={cn(dividerVariants({ orientation: "horizontal", inset: "none" }), "flex-1")}
-          />
-        </div>
-      );
-    }
-
-    return (
-      <DividerHeadless
-        ref={ref}
-        orientation={orientation}
-        className={cn(dividerVariants({ orientation, inset }), className)}
-      />
-    );
-  }
+  ({ orientation = "horizontal", inset = "none", className, style }, ref) => (
+    <DividerHeadless
+      ref={ref}
+      orientation={orientation}
+      className={cn(dividerVariants({ orientation, inset }), className)}
+      {...(style !== undefined && { style })}
+    />
+  )
 );
 
 Divider.displayName = "Divider";

--- a/packages/react/src/components/Divider/Divider.types.ts
+++ b/packages/react/src/components/Divider/Divider.types.ts
@@ -7,32 +7,51 @@ import type React from "react";
 export type DividerOrientation = "horizontal" | "vertical";
 
 /**
- * Divider inset — controls which end(s) of the rule are inset by 16dp.
- * Per MD3 spec: insets create visual association with list content.
+ * Divider inset — controls which end(s) of the rule are offset by 16dp.
+ *
+ * Uses logical inline properties (inline-start / inline-end) so insets adapt
+ * correctly to RTL writing modes.
+ *
  * @default 'none'
  */
 export type DividerInset = "none" | "start" | "end" | "both";
 
 /**
+ * CSS custom properties supported by the Divider component.
+ * Extends `React.CSSProperties` to allow the `--md-divider-thickness` variable.
+ */
+export interface DividerCSSProperties extends React.CSSProperties {
+  /** Thickness of the divider rule. MD3 default: 1dp (1px). */
+  "--md-divider-thickness"?: string;
+}
+
+/**
  * Material Design 3 Divider Component Props
  *
  * A thin line that groups content in lists and containers.
- * Supports horizontal/vertical orientations, inset variants, and a
- * subheader label variant.
+ * Supports horizontal/vertical orientations and four inset variants.
+ *
+ * Thickness is controlled via the `--md-divider-thickness` CSS custom property
+ * (default `1px`, matching the MD3 1dp specification). Override it with a style
+ * prop or an arbitrary Tailwind property:
+ *
+ * ```tsx
+ * <Divider style={{ "--md-divider-thickness": "2px" }} />
+ * ```
  *
  * @example
  * ```tsx
  * // Full-bleed horizontal divider (default)
  * <Divider />
  *
- * // Inset divider (16dp from start)
+ * // Inset divider — logical 16dp from inline-start (RTL-aware)
  * <Divider inset="start" />
  *
- * // Vertical divider
+ * // Vertical divider inside a flex row
  * <Divider orientation="vertical" />
  *
- * // Subheader / labeled divider
- * <Divider label="Section Title" />
+ * // Custom thickness
+ * <Divider style={{ "--md-divider-thickness": "2px" }} />
  * ```
  */
 export interface DividerProps {
@@ -43,21 +62,21 @@ export interface DividerProps {
   orientation?: DividerOrientation;
 
   /**
-   * Inset — shifts the start and/or end of the rule by 16dp.
+   * Inset — shifts the start and/or end of the rule by 16dp (logical, RTL-aware).
    * @default 'none'
    */
   inset?: DividerInset;
 
   /**
-   * When provided, renders a subheader (labeled) divider with the text
-   * centered between two rule lines.
-   */
-  label?: string;
-
-  /**
    * Additional Tailwind CSS classes.
    */
   className?: string;
+
+  /**
+   * Inline styles. Supports the `--md-divider-thickness` CSS custom property
+   * to override the default 1dp thickness.
+   */
+  style?: DividerCSSProperties;
 }
 
 /**
@@ -70,7 +89,7 @@ export interface DividerProps {
  * ```tsx
  * <DividerHeadless
  *   orientation="horizontal"
- *   className="border-t border-outline-variant w-full"
+ *   className="w-full h-px bg-outline-variant"
  * />
  * ```
  */
@@ -87,14 +106,7 @@ export interface DividerHeadlessProps {
   className?: string;
 
   /**
-   * Subheader label text. Declared for interface completeness;
-   * rendering is handled by the styled `Divider` layer.
+   * Inline styles forwarded to the underlying element.
    */
-  label?: string;
-
-  /**
-   * Child content. Declared for interface extensibility;
-   * the headless primitive itself is a void/leaf element.
-   */
-  children?: React.ReactNode;
+  style?: DividerCSSProperties;
 }

--- a/packages/react/src/components/Divider/Divider.variants.ts
+++ b/packages/react/src/components/Divider/Divider.variants.ts
@@ -3,39 +3,68 @@ import { cva, type VariantProps } from "class-variance-authority";
 /**
  * Material Design 3 Divider Variants (CVA)
  *
- * Defines orientation and inset variants for the Divider component.
- * All classes use MD3 design token utilities — no arbitrary values.
+ * Architecture: Variants only — the Divider is a static, non-interactive element
+ * (no hover/focus/pressed states) so there is no state-layer machinery.
+ *
+ * Implementation strategy:
+ *   The border-* approach used previously required separate horizontal/vertical
+ *   logic and could not share a single thickness control. We now use a background
+ *   fill on a zero-border element, driven by a CSS custom property, which is the
+ *   same technique used by the official @material/web md-divider implementation.
+ *
+ * CSS variable:
+ *   --md-divider-thickness  (default: 1px, MD3 spec: 1dp)
+ *   Override via style or a Tailwind arbitrary property:
+ *     <Divider style={{ "--md-divider-thickness": "2px" }} />
  *
  * Orientation:
- *   horizontal — 1px top border, spans full width
- *   vertical   — 1px left border, spans full height (self-stretch in flex)
+ *   horizontal — full-width strip, height driven by --md-divider-thickness
+ *   vertical   — self-stretches to container height, width driven by var
  *
- * Inset (MD3 spec: 16dp offset):
- *   start — ml-4 (indented from the leading edge)
- *   end   — mr-4 (indented from the trailing edge)
- *   both  — ml-4 mr-4 (indented from both edges)
+ * Inset (MD3 spec: 16dp logical offset, RTL-aware):
+ *   start — ms-4  (inline-start, adapts to writing direction)
+ *   end   — me-4  (inline-end)
+ *   both  — ms-4 me-4
+ *
+ * MD3 Spec references:
+ *   Color:     outline-variant  (--md-sys-color-outline-variant)
+ *   Thickness: 1dp (no MD3 component token — exposed as a CSS var for parity with md-web)
+ *   Inset:     16dp (--md-comp-divider-leading-space / --md-comp-divider-trailing-space)
  */
 export const dividerVariants = cva(
-  // Base: always apply the MD3 outline-variant color to the border
-  "border-outline-variant",
+  [
+    // Zero border — color comes from background fill (matches md-web strategy)
+    "shrink-0 border-0",
+    // MD3 outline-variant color token
+    "bg-outline-variant",
+    // Default thickness — consumers override via the CSS custom property
+    "[--md-divider-thickness:1px]",
+  ],
   {
     variants: {
       /**
        * Controls the axis of the visual rule.
+       *
+       * horizontal — stretches to full inline width; block size is --md-divider-thickness
+       * vertical   — self-stretches to the block axis of the flex/grid parent;
+       *              inline size is --md-divider-thickness
        */
       orientation: {
-        horizontal: "border-t",
-        vertical: "border-l h-auto self-stretch",
+        horizontal: "w-full h-[var(--md-divider-thickness)]",
+        vertical: "self-stretch h-auto w-[var(--md-divider-thickness)]",
       },
 
       /**
-       * Inset — which end(s) are offset by 16dp per MD3 spec.
+       * Inset — logical inline offset per MD3 spec (16dp = 1rem = Tailwind spacing-4).
+       *
+       * Uses logical properties (ms-N / me-N) for correct behaviour under RTL
+       * writing modes (Arabic, Hebrew, etc.).
        */
       inset: {
         none: "",
-        start: "ml-4",
-        end: "mr-4",
-        both: "ml-4 mr-4",
+        start: "ms-4",
+        end: "me-4",
+        both: "ms-4 me-4",
       },
     },
 

--- a/packages/react/src/components/Divider/DividerHeadless.tsx
+++ b/packages/react/src/components/Divider/DividerHeadless.tsx
@@ -15,19 +15,18 @@ import type { DividerHeadlessProps } from "./Divider.types";
  * - Horizontal → renders `<hr>` (implicit ARIA separator role)
  * - Vertical   → renders `<div>` with explicit `role="separator"`
  *
- * Bring your own styles via the `className` prop.
+ * Bring your own styles via the `className` or `style` props.
  *
  * @example
  * ```tsx
- * // Used inside the styled Divider, or directly for custom styling:
  * <DividerHeadless
  *   orientation="horizontal"
- *   className="border-t border-outline-variant w-full"
+ *   className="w-full h-px bg-outline-variant"
  * />
  * ```
  */
 export const DividerHeadless = forwardRef<HTMLElement, DividerHeadlessProps>(
-  ({ orientation = "horizontal", className }, ref) => {
+  ({ orientation = "horizontal", className, style }, ref) => {
     const { separatorProps } = useSeparator({
       orientation,
       elementType: orientation === "vertical" ? "div" : "hr",
@@ -35,7 +34,12 @@ export const DividerHeadless = forwardRef<HTMLElement, DividerHeadlessProps>(
 
     if (orientation === "vertical") {
       return (
-        <div {...separatorProps} ref={ref as ForwardedRef<HTMLDivElement>} className={className} />
+        <div
+          {...separatorProps}
+          ref={ref as ForwardedRef<HTMLDivElement>}
+          className={className}
+          style={style}
+        />
       );
     }
 
@@ -45,6 +49,7 @@ export const DividerHeadless = forwardRef<HTMLElement, DividerHeadlessProps>(
         aria-orientation="horizontal"
         ref={ref as ForwardedRef<HTMLHRElement>}
         className={className}
+        style={style}
       />
     );
   }

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -762,7 +762,7 @@ describe("List — insetDivider", () => {
     expect(divider).toBeInTheDocument();
   });
 
-  test("52. Inset Divider has ml-4 class (16dp inset from start)", () => {
+  test("52. Inset Divider has ms-4 class (16dp logical inset from start)", () => {
     render(
       <List aria-label="Test">
         <ListItem value="1" headline="Item 1" insetDivider />
@@ -770,7 +770,7 @@ describe("List — insetDivider", () => {
     );
     const item = screen.getByRole("listitem");
     const divider = item.querySelector("hr");
-    expect(divider).toHaveClass("ml-4");
+    expect(divider).toHaveClass("ms-4");
   });
 
   test("53. insetDivider={false} (default): no Divider inside item", () => {
@@ -812,7 +812,7 @@ describe("List — divider composition", () => {
     const list = container.querySelector("[role='list']")!;
     const betweenDivider = list.querySelector(":scope > hr");
     expect(betweenDivider).toBeInTheDocument();
-    expect(betweenDivider).not.toHaveClass("ml-4");
+    expect(betweenDivider).not.toHaveClass("ms-4");
     expect(betweenDivider).toHaveClass("w-full");
   });
 
@@ -824,7 +824,7 @@ describe("List — divider composition", () => {
     );
     const item = screen.getByRole("listitem");
     const divider = item.querySelector("hr");
-    expect(divider).toHaveClass("ml-4");
+    expect(divider).toHaveClass("ms-4");
   });
 });
 


### PR DESCRIPTION
## Summary

- **Styling approach**: replaced `border-*` with a background-fill on a zero-border element (`bg-outline-variant`), matching `@material/web` `MdDivider`. A single `--md-divider-thickness` CSS custom property (default `1px`) now drives thickness for both orientations.
- **RTL-correct insets**: `ml-4`/`mr-4` replaced with logical `ms-4`/`me-4` so insets flip automatically under RTL writing modes.
- **Removed `label` prop**: the subheader variant (text between two rules) was not part of the MD3 divider spec. It has been removed — this is the breaking change that drives the minor bump.
- **Architecture alignment**: `Divider.variants.ts` now follows the documented slot-CVA pattern used by Button and Switch (spec-header JSDoc, array-form base classes, explicit `defaultVariants`).

## Breaking changes

| Change | Migration |
|---|---|
| `label` prop removed | Delete any `<Divider label="..." />` usages. Use a custom layout if a labeled separator is still needed. |
| Insets are now logical | Visual change in RTL layouts only; no migration needed in LTR apps. |

## Changeset

`minor` bump for `@tinybigui/react` (and linked `@tinybigui/tokens`) per the pre-1.0 breaking-change convention.

## Test plan

- [x] 22 unit tests pass (`pnpm test` in `packages/react`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] axe a11y: no violations for horizontal, vertical, and inset variants
- [ ] Verify Storybook renders all stories (Default, Horizontal, Vertical, AllInsetVariants, Thickness, RTLInsets, VerticalInToolbar, LightAndDarkTheme, Playground)
- [ ] Manually verify `--md-divider-thickness` override in browser
- [ ] Verify RTL inset flip in a `dir="rtl"` container