### PR TITLE
feat(textfield)!: rebuild textfield to strict md3 expressive specs

### DIFF
--- a/.changeset/dark-schools-sip.md
+++ b/.changeset/dark-schools-sip.md
@@ -1,0 +1,27 @@
+---
+"@tinybigui/react": minor
+---
+
+feat(textfield)!: rebuild TextField to strict MD3 Expressive specs
+
+**Breaking changes:**
+
+- Removed `size` prop (`"small" | "medium" | "large"`) — MD3 text fields are a fixed 56dp height with no size scale. Remove any `size` prop usage.
+- Removed `TextFieldSize` type export.
+
+**New features:**
+
+- `prefix` prop: inline prefix text (e.g. `"$"`) — rendered before the input value, visible once the label floats.
+- `suffix` prop: inline suffix text (e.g. `"kg"`, `"%"`) — rendered after the input value, visible once the label floats.
+
+**Architecture / styling:**
+
+- Rebuilt on the Variants-vs-States architecture: all interaction states (`hovered`, `focused`, `invalid`, `disabled`, `readonly`) are emitted as `data-*` attributes on the root `group/text-field` element and consumed via `group-data-[x]/text-field:` selectors — state variants removed from CVA.
+- Added MD3 **state layer** (filled variant): `bg-on-surface` overlay at 8% hover / 10% focus opacity.
+- Added MD3 **active indicator** (filled variant): 1px bottom line animating to 2px on focus, `primary` color on focus, `error` on invalid.
+- Added MD3 **notched outline** (outlined variant): `aria-hidden` `<fieldset>/<legend>` that opens a gap in the border for the floating label.
+- Label transitions use MD3 `body-large` → `body-small` typography swap with spring-standard-fast-spatial motion token (replaces `scale-75` transform).
+- All hardcoded `duration-200` replaced with `duration-spring-standard-fast-effects` / `duration-spring-standard-fast-spatial` + matching easing tokens (Standard personality — no Expressive overshoot for utility form UI).
+- Supporting text + character counter now render on **one flex row** (text left, counter right) per MD3 spec.
+- Icon size corrected to 24×24dp (MD3 spec).
+- Field typography: `text-body-large` for input; `text-body-small` for floating label and supporting text.

--- a/packages/react/src/components/TextField/TextField.stories.tsx
+++ b/packages/react/src/components/TextField/TextField.stories.tsx
@@ -1,44 +1,54 @@
 /**
  * TextField Component Stories
  *
- * Storybook stories for the Material Design 3 TextField component.
- * Demonstrates all variants, states, and usage patterns.
+ * Storybook stories for the Material Design 3 Expressive TextField component.
+ * Demonstrates filled and outlined variants, all interaction states, icons,
+ * prefix/suffix affixes, multiline, and character counter.
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { TextField } from "./TextField";
 
-// Sample icons for stories
+// ── Icon helpers ──────────────────────────────────────────────────────────────
+
 const IconEmail = (): React.ReactElement => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
   </svg>
 );
 
 const IconSearch = (): React.ReactElement => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
   </svg>
 );
 
 const IconPerson = (): React.ReactElement => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
   </svg>
 );
 
 const IconVisibility = (): React.ReactElement => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z" />
   </svg>
 );
 
 const IconClear = (): React.ReactElement => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
   </svg>
 );
+
+const IconAttachMoney = (): React.ReactElement => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z" />
+  </svg>
+);
+
+// ── Meta ──────────────────────────────────────────────────────────────────────
 
 const meta: Meta<typeof TextField> = {
   title: "Components/TextField",
@@ -48,7 +58,7 @@ const meta: Meta<typeof TextField> = {
     docs: {
       description: {
         component:
-          "Material Design 3 TextField component with filled and outlined variants, full accessibility support, and comprehensive input features.",
+          "Material Design 3 Expressive TextField — single 56dp height, filled and outlined variants, state layer, active indicator, notched outline, floating label, prefix/suffix, icons, and supporting text + counter row. All interaction states are data-* attribute driven (no state in CVA).",
       },
     },
   },
@@ -57,24 +67,27 @@ const meta: Meta<typeof TextField> = {
     variant: {
       control: "select",
       options: ["filled", "outlined"],
-      description: "Visual style variant",
-    },
-    size: {
-      control: "select",
-      options: ["small", "medium", "large"],
-      description: "TextField size",
+      description: "MD3 visual variant",
     },
     label: {
       control: "text",
-      description: "Label text for the input",
+      description: "Label text (floats on focus/value)",
     },
     description: {
       control: "text",
-      description: "Helper text displayed below the input",
+      description: "Supporting text below the field",
     },
     errorMessage: {
       control: "text",
       description: "Error message when invalid",
+    },
+    prefix: {
+      control: "text",
+      description: "Inline prefix text (visible when label is floated)",
+    },
+    suffix: {
+      control: "text",
+      description: "Inline suffix text (visible when label is floated)",
     },
     isDisabled: {
       control: "boolean",
@@ -90,15 +103,15 @@ const meta: Meta<typeof TextField> = {
     },
     fullWidth: {
       control: "boolean",
-      description: "Make input full width",
+      description: "Expand to fill container",
     },
     multiline: {
       control: "boolean",
-      description: "Enable multiline mode (textarea)",
+      description: "Enable multiline (textarea)",
     },
     characterCount: {
       control: "boolean",
-      description: "Show character counter",
+      description: "Show character counter (requires maxLength)",
     },
   },
 };
@@ -106,17 +119,18 @@ const meta: Meta<typeof TextField> = {
 export default meta;
 type Story = StoryObj<typeof TextField>;
 
-// Default Story
+// ── Default ───────────────────────────────────────────────────────────────────
+
 export const Default: Story = {
   args: {
     label: "Email",
     placeholder: "email@example.com",
     variant: "filled",
-    size: "medium",
   },
 };
 
-// Variants
+// ── Variants ──────────────────────────────────────────────────────────────────
+
 export const Filled: Story = {
   args: {
     label: "Email",
@@ -142,33 +156,49 @@ export const AllVariants: Story = {
   ),
 };
 
-// Sizes
-export const Sizes: Story = {
+// ── States side-by-side ───────────────────────────────────────────────────────
+
+export const AllStates: Story = {
   render: () => (
-    <div className="flex flex-col gap-6" style={{ width: 320 }}>
-      <TextField label="Small" size="small" placeholder="Small input" />
-      <TextField label="Medium (default)" size="medium" placeholder="Medium input" />
-      <TextField label="Large" size="large" placeholder="Large input" />
+    <div className="grid grid-cols-2 gap-6" style={{ width: 680 }}>
+      <p className="text-label-large text-on-surface-variant col-span-2">Filled</p>
+      <TextField label="Default" variant="filled" />
+      <TextField label="With value" variant="filled" defaultValue="Hello world" />
+      <TextField label="With description" variant="filled" description="Supporting text" />
+      <TextField
+        label="Error state"
+        variant="filled"
+        isInvalid
+        errorMessage="This field is required"
+      />
+      <TextField label="Disabled" variant="filled" isDisabled defaultValue="Disabled" />
+      <TextField label="Read-only" variant="filled" isReadOnly defaultValue="Read only" />
+
+      <p className="text-label-large text-on-surface-variant col-span-2 mt-4">Outlined</p>
+      <TextField label="Default" variant="outlined" />
+      <TextField label="With value" variant="outlined" defaultValue="Hello world" />
+      <TextField label="With description" variant="outlined" description="Supporting text" />
+      <TextField
+        label="Error state"
+        variant="outlined"
+        isInvalid
+        errorMessage="This field is required"
+      />
+      <TextField label="Disabled" variant="outlined" isDisabled defaultValue="Disabled" />
+      <TextField label="Read-only" variant="outlined" isReadOnly defaultValue="Read only" />
     </div>
   ),
-};
-
-// With Label
-export const WithLabel: Story = {
-  args: {
-    label: "Email address",
-    placeholder: "email@example.com",
+  parameters: {
+    docs: {
+      description: {
+        story: "All six states for both variants rendered side by side.",
+      },
+    },
   },
 };
 
-export const WithoutLabel: Story = {
-  args: {
-    "aria-label": "Search",
-    placeholder: "Search...",
-  },
-};
+// ── Helper text & errors ──────────────────────────────────────────────────────
 
-// With Helper Text
 export const WithHelperText: Story = {
   args: {
     label: "Email",
@@ -177,7 +207,6 @@ export const WithHelperText: Story = {
   },
 };
 
-// With Error
 export const WithError: Story = {
   args: {
     label: "Email",
@@ -207,7 +236,8 @@ export const ErrorStates: Story = {
   ),
 };
 
-// With Icons
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
 export const WithLeadingIcon: Story = {
   args: {
     label: "Email",
@@ -245,11 +275,67 @@ export const IconExamples: Story = {
         trailingIcon={<IconClear />}
         placeholder="Type to search..."
       />
+      <TextField
+        label="Outlined with icon"
+        variant="outlined"
+        leadingIcon={<IconEmail />}
+        placeholder="email@example.com"
+      />
     </div>
   ),
 };
 
-// Disabled State
+// ── Prefix & Suffix ───────────────────────────────────────────────────────────
+
+export const WithPrefix: Story = {
+  args: {
+    label: "Price",
+    prefix: "$",
+    placeholder: "0.00",
+  },
+};
+
+export const WithSuffix: Story = {
+  args: {
+    label: "Weight",
+    suffix: "kg",
+    placeholder: "0",
+  },
+};
+
+export const PrefixSuffixExamples: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6" style={{ width: 320 }}>
+      <TextField
+        label="Price"
+        prefix="$"
+        suffix="USD"
+        leadingIcon={<IconAttachMoney />}
+        placeholder="0.00"
+        variant="filled"
+      />
+      <TextField
+        label="Website"
+        prefix="https://"
+        suffix=".com"
+        placeholder="example"
+        variant="outlined"
+      />
+      <TextField label="Rate" suffix="%" placeholder="0" type="number" variant="filled" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Prefix and suffix text are only visible when the label has floated (on focus, with a value, placeholder, or a prefix). Prefix also automatically triggers float.",
+      },
+    },
+  },
+};
+
+// ── Disabled ──────────────────────────────────────────────────────────────────
+
 export const Disabled: Story = {
   render: () => (
     <div className="flex flex-col gap-6" style={{ width: 320 }}>
@@ -275,7 +361,8 @@ export const Disabled: Story = {
   ),
 };
 
-// Required Field
+// ── Required ──────────────────────────────────────────────────────────────────
+
 export const RequiredField: Story = {
   args: {
     label: "Email",
@@ -285,7 +372,8 @@ export const RequiredField: Story = {
   },
 };
 
-// Full Width
+// ── Full width ────────────────────────────────────────────────────────────────
+
 export const FullWidth: Story = {
   args: {
     label: "Full width input",
@@ -297,7 +385,8 @@ export const FullWidth: Story = {
   },
 };
 
-// Multiline (Textarea)
+// ── Multiline ─────────────────────────────────────────────────────────────────
+
 export const Multiline: Story = {
   args: {
     label: "Message",
@@ -318,12 +407,14 @@ export const MultilineExamples: Story = {
         rows={4}
         description="Maximum 500 characters"
         placeholder="Enter your bio..."
+        variant="outlined"
       />
     </div>
   ),
 };
 
-// Character Counter
+// ── Character counter ─────────────────────────────────────────────────────────
+
 export const WithCharacterCounter: Story = {
   args: {
     label: "Bio",
@@ -337,33 +428,55 @@ export const WithCharacterCounter: Story = {
 export const CharacterCounterExamples: Story = {
   render: () => (
     <div className="flex flex-col gap-6" style={{ width: 320 }}>
-      <TextField label="Short text" characterCount maxLength={50} placeholder="Max 50 characters" />
+      <TextField
+        label="Short text"
+        characterCount
+        maxLength={50}
+        description="Supporting text + counter on one row"
+        placeholder="Max 50 characters"
+      />
+      <TextField
+        label="Counter only (no description)"
+        characterCount
+        maxLength={50}
+        placeholder="Max 50 characters"
+      />
       <TextField
         label="Bio"
         multiline
         rows={4}
         characterCount
         maxLength={200}
+        description="Tell us about yourself"
         placeholder="Max 200 characters"
+        variant="outlined"
       />
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Supporting text and the character counter live on the same flex row below the field, per MD3 spec. The counter turns error-colored when the limit is exceeded.",
+      },
+    },
+  },
 };
 
-// Interactive Example
+// ── Interactive ───────────────────────────────────────────────────────────────
+
 const InteractiveExample = (): React.ReactElement => {
   const [value, setValue] = useState("");
   const [isValid, setIsValid] = useState(true);
 
   const handleChange = (newValue: string): void => {
     setValue(newValue);
-    // Simple email validation
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     setIsValid(emailRegex.test(newValue) || newValue === "");
   };
 
   return (
-    <div className="flex flex-col items-center gap-4">
+    <div className="flex flex-col items-center gap-4" style={{ width: 320 }}>
       <TextField
         label="Email"
         value={value}
@@ -373,8 +486,9 @@ const InteractiveExample = (): React.ReactElement => {
         leadingIcon={<IconEmail />}
         placeholder="email@example.com"
         description="Enter your email address"
+        fullWidth
       />
-      <div className="text-on-surface-variant text-sm">
+      <div className="text-on-surface-variant text-body-small">
         Value: <code>{value || "(empty)"}</code>
       </div>
     </div>
@@ -386,13 +500,14 @@ export const Interactive: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Interactive example with live validation and state management.",
+        story: "Live validation — watch the label float, error state, and state layer respond.",
       },
     },
   },
 };
 
-// Accessibility
+// ── Accessibility showcase ────────────────────────────────────────────────────
+
 export const Accessibility: Story = {
   render: () => (
     <div className="flex flex-col gap-6" style={{ width: 320 }}>
@@ -417,19 +532,25 @@ export const Accessibility: Story = {
         errorMessage="Error messages are linked via aria-describedby"
         defaultValue="invalid"
       />
+      <TextField
+        label="Outlined with notch"
+        variant="outlined"
+        description="The fieldset/legend notch is aria-hidden — only the visible label is announced"
+      />
     </div>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "All inputs have proper ARIA attributes, labels, and descriptions for screen readers. Focus indicators are visible for keyboard navigation.",
+          "All inputs have proper ARIA attributes from React Aria. The outlined fieldset/legend notch is aria-hidden so it does not interfere with screen readers.",
       },
     },
   },
 };
 
-// Form Example
+// ── Form integration ──────────────────────────────────────────────────────────
+
 const FormExample = (): React.ReactElement => {
   const [formData, setFormData] = useState({
     email: "",
@@ -470,6 +591,7 @@ const FormExample = (): React.ReactElement => {
         trailingIcon={<IconVisibility />}
         isRequired
         description="At least 8 characters"
+        variant="outlined"
       />
       <TextField
         label="Bio"
@@ -480,6 +602,7 @@ const FormExample = (): React.ReactElement => {
         characterCount
         maxLength={200}
         description="Tell us about yourself"
+        variant="outlined"
       />
       <button type="submit" className="bg-primary text-on-primary rounded-full px-6 py-3">
         Submit
@@ -493,33 +616,42 @@ export const FormIntegration: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Example of TextField used in a complete form with validation.",
+        story: "Complete form mixing filled and outlined variants with validation.",
       },
     },
   },
 };
 
-// Input Types
+// ── Input types ───────────────────────────────────────────────────────────────
+
 export const InputTypes: Story = {
   render: () => (
     <div className="flex flex-col gap-6" style={{ width: 320 }}>
       <TextField label="Email" type="email" placeholder="email@example.com" />
       <TextField label="Password" type="password" placeholder="Password" />
-      <TextField label="Number" type="number" placeholder="123" />
+      <TextField label="Number" type="number" prefix="#" placeholder="0" />
       <TextField label="Telephone" type="tel" placeholder="(555) 123-4567" />
-      <TextField label="URL" type="url" placeholder="https://example.com" />
+      <TextField
+        label="URL"
+        type="url"
+        prefix="https://"
+        placeholder="example.com"
+        variant="outlined"
+      />
     </div>
   ),
 };
 
-// Playground
+// ── Playground ────────────────────────────────────────────────────────────────
+
 export const Playground: Story = {
   args: {
     label: "Playground",
     variant: "filled",
-    size: "medium",
     placeholder: "Try changing the props...",
-    description: "This is a helper text",
+    description: "This is helper text",
+    prefix: "",
+    suffix: "",
     isRequired: false,
     isDisabled: false,
     isInvalid: false,
@@ -530,7 +662,7 @@ export const Playground: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Play around with all the component props to see how the TextField behaves.",
+        story: "Play with all props to see how the MD3 TextField behaves.",
       },
     },
   },

--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -1,7 +1,7 @@
 /**
  * TextField Component Tests
  *
- * Comprehensive test suite for the MD3 TextField component.
+ * Comprehensive test suite for the MD3 Expressive TextField component.
  * Follows TDD approach with tests for rendering, variants, states,
  * interactions, accessibility, and edge cases.
  */
@@ -59,35 +59,117 @@ describe("TextField", () => {
 
   describe("Variants", () => {
     test("renders filled variant (default)", () => {
-      render(<TextField label="Email" variant="filled" />);
-      const container = screen.getByRole("textbox").closest("div");
-      expect(container).toHaveClass("bg-surface-container-highest");
+      const { container } = render(<TextField label="Email" variant="filled" />);
+      // The field box (first child of root) carries the filled background
+      const fieldBox = container.querySelector(".bg-surface-container-highest");
+      expect(fieldBox).toBeInTheDocument();
     });
 
-    test("renders outlined variant", () => {
-      render(<TextField label="Email" variant="outlined" />);
-      const container = screen.getByRole("textbox").closest("div");
-      expect(container).toHaveClass("border", "border-outline");
+    test("renders outlined variant with fieldset border", () => {
+      const { container } = render(<TextField label="Email" variant="outlined" />);
+      // Outlined renders an aria-hidden fieldset for the border
+      const fieldset = container.querySelector("fieldset[aria-hidden]");
+      expect(fieldset).toBeInTheDocument();
+      expect(fieldset).toHaveClass("border-outline");
+    });
+
+    test("filled variant renders state layer", () => {
+      const { container } = render(<TextField label="Email" variant="filled" />);
+      // State layer span is present for filled
+      const stateLayer = container.querySelector(".bg-on-surface");
+      expect(stateLayer).toBeInTheDocument();
+    });
+
+    test("filled variant renders active indicator", () => {
+      const { container } = render(<TextField label="Email" variant="filled" />);
+      // Active indicator has h-px bg-on-surface-variant
+      const indicator = container.querySelector(".bg-on-surface-variant");
+      expect(indicator).toBeInTheDocument();
+    });
+
+    test("outlined variant does NOT render active indicator", () => {
+      const { container } = render(<TextField label="Email" variant="outlined" />);
+      // Outlined has no active indicator
+      const indicator = container.querySelector(".h-px.bg-on-surface-variant");
+      expect(indicator).not.toBeInTheDocument();
+    });
+
+    test("outlined variant renders legend notch element", () => {
+      const { container } = render(<TextField label="Email" variant="outlined" />);
+      const legend = container.querySelector("legend");
+      expect(legend).toBeInTheDocument();
     });
   });
 
-  describe("Sizes", () => {
-    test("renders small size", () => {
-      render(<TextField label="Email" size="small" />);
-      const input = screen.getByRole("textbox");
-      expect(input).toHaveClass("h-10");
+  describe("Data Attribute State Model", () => {
+    test("root has group/text-field class", () => {
+      const { container } = render(<TextField label="Email" />);
+      const root = container.firstChild as HTMLElement;
+      expect(root.className).toContain("group/text-field");
     });
 
-    test("renders medium size (default)", () => {
-      render(<TextField label="Email" size="medium" />);
-      const input = screen.getByRole("textbox");
-      expect(input).toHaveClass("h-12");
+    test("root has data-disabled when isDisabled", () => {
+      const { container } = render(<TextField label="Email" isDisabled />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-disabled", "");
     });
 
-    test("renders large size", () => {
-      render(<TextField label="Email" size="large" />);
-      const input = screen.getByRole("textbox");
-      expect(input).toHaveClass("h-14");
+    test("root has data-invalid when isInvalid", () => {
+      const { container } = render(<TextField label="Email" isInvalid />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-invalid", "");
+    });
+
+    test("root has data-readonly when isReadOnly", () => {
+      const { container } = render(<TextField label="Email" isReadOnly />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-readonly", "");
+    });
+
+    test("root has data-with-leading-icon when leadingIcon provided", () => {
+      const { container } = render(
+        <TextField label="Email" leadingIcon={<span data-testid="icon" />} />
+      );
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-with-leading-icon", "");
+    });
+
+    test("root has data-with-trailing-icon when trailingIcon provided", () => {
+      const { container } = render(
+        <TextField label="Email" trailingIcon={<span data-testid="icon" />} />
+      );
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-with-trailing-icon", "");
+    });
+
+    test("root has data-float when placeholder is provided", () => {
+      const { container } = render(<TextField label="Email" placeholder="something" />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-float", "");
+    });
+
+    test("root has data-float when prefix is provided", () => {
+      const { container } = render(<TextField label="Price" prefix="$" />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-float", "");
+    });
+
+    test("root has data-multiline when multiline", () => {
+      const { container } = render(<TextField label="Message" multiline />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-multiline", "");
+    });
+
+    test("root does NOT have data-float when no value/placeholder/prefix", () => {
+      const { container } = render(<TextField label="Email" />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).not.toHaveAttribute("data-float");
+    });
+
+    test("root has data-float when field has a value", () => {
+      const { container } = render(<TextField label="Email" defaultValue="hello" />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-float", "");
     });
   });
 
@@ -96,7 +178,6 @@ describe("TextField", () => {
       render(<TextField label="Email" isDisabled />);
       const input = screen.getByRole("textbox");
       expect(input).toBeDisabled();
-      expect(input).toHaveClass("cursor-not-allowed");
     });
 
     test("renders error state with message", () => {
@@ -119,9 +200,9 @@ describe("TextField", () => {
     });
 
     test("renders full width", () => {
-      render(<TextField label="Email" fullWidth />);
-      const container = screen.getByRole("textbox").closest("div");
-      expect(container).toHaveClass("w-full");
+      const { container } = render(<TextField label="Email" fullWidth />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveClass("w-full");
     });
   });
 
@@ -214,6 +295,12 @@ describe("TextField", () => {
       const input = screen.getByRole("textbox");
       expect(input).toBeRequired();
     });
+
+    test("outlined fieldset is aria-hidden", () => {
+      const { container } = render(<TextField label="Email" variant="outlined" />);
+      const fieldset = container.querySelector("fieldset");
+      expect(fieldset).toHaveAttribute("aria-hidden", "true");
+    });
   });
 
   describe("Icons", () => {
@@ -237,6 +324,30 @@ describe("TextField", () => {
       );
       expect(screen.getByTestId("leading-icon")).toBeInTheDocument();
       expect(screen.getByTestId("trailing-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("Prefix and Suffix", () => {
+    test("renders prefix text", () => {
+      render(<TextField label="Price" prefix="$" />);
+      expect(screen.getByText("$")).toBeInTheDocument();
+    });
+
+    test("renders suffix text", () => {
+      render(<TextField label="Weight" suffix="kg" />);
+      expect(screen.getByText("kg")).toBeInTheDocument();
+    });
+
+    test("renders both prefix and suffix", () => {
+      render(<TextField label="Amount" prefix="$" suffix="USD" />);
+      expect(screen.getByText("$")).toBeInTheDocument();
+      expect(screen.getByText("USD")).toBeInTheDocument();
+    });
+
+    test("prefix causes label to float (data-float attribute)", () => {
+      const { container } = render(<TextField label="Price" prefix="$" />);
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute("data-float", "");
     });
   });
 
@@ -269,7 +380,7 @@ describe("TextField", () => {
   describe("Character Counter", () => {
     test("renders character counter when enabled", () => {
       render(<TextField label="Bio" characterCount maxLength={100} defaultValue="Hello" />);
-      expect(screen.getByText("5 / 100")).toBeInTheDocument();
+      expect(screen.getByText(/5.*100/)).toBeInTheDocument();
     });
 
     test("updates character count on input", async () => {
@@ -279,12 +390,12 @@ describe("TextField", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "Test");
 
-      expect(screen.getByText("4 / 100")).toBeInTheDocument();
+      expect(screen.getByText(/4.*100/)).toBeInTheDocument();
     });
 
     test("does not render counter when characterCount is false", () => {
       render(<TextField label="Bio" characterCount={false} maxLength={100} defaultValue="Hello" />);
-      expect(screen.queryByText("5 / 100")).not.toBeInTheDocument();
+      expect(screen.queryByText(/5.*100/)).not.toBeInTheDocument();
     });
 
     test("enforces maxLength", async () => {
@@ -295,6 +406,44 @@ describe("TextField", () => {
       await user.type(input, "12345678");
 
       expect(input).toHaveValue("12345");
+    });
+
+    test("counter and description appear on the same supporting row", () => {
+      const { container } = render(
+        <TextField
+          label="Bio"
+          description="Tell us about yourself"
+          characterCount
+          maxLength={100}
+        />
+      );
+      // Both are in a single flex row
+      const supportingRow = container.querySelector(".flex.items-start.justify-between");
+      expect(supportingRow).toBeInTheDocument();
+      expect(supportingRow).toContainElement(screen.getByText("Tell us about yourself"));
+      expect(supportingRow).toContainElement(screen.getByText(/\/.*100/));
+    });
+  });
+
+  describe("Supporting Row", () => {
+    test("description and error on the same row slot (error replaces description)", () => {
+      render(
+        <TextField
+          label="Email"
+          description="Enter your email"
+          errorMessage="Email is required"
+          isInvalid
+        />
+      );
+      // When error is shown, description is hidden per MD3 spec
+      expect(screen.queryByText("Enter your email")).not.toBeInTheDocument();
+      expect(screen.getByText("Email is required")).toBeInTheDocument();
+    });
+
+    test("supporting row is not rendered when no description/error/counter", () => {
+      const { container } = render(<TextField label="Email" />);
+      const supportingRow = container.querySelector(".flex.items-start.justify-between");
+      expect(supportingRow).not.toBeInTheDocument();
     });
   });
 
@@ -338,20 +487,6 @@ describe("TextField", () => {
 
       expect(input).toHaveValue("test");
     });
-
-    test("handles both description and error message", () => {
-      render(
-        <TextField
-          label="Email"
-          description="Enter your email"
-          errorMessage="Email is required"
-          isInvalid
-        />
-      );
-      // When error is shown, description is hidden per MD3 spec
-      expect(screen.queryByText("Enter your email")).not.toBeInTheDocument();
-      expect(screen.getByText("Email is required")).toBeInTheDocument();
-    });
   });
 
   describe("Custom Props", () => {
@@ -384,7 +519,7 @@ describe("TextField", () => {
       // the input's id — which React Aria wires automatically via labelProps / inputProps.
       render(<TextField label="Email" />);
       const input = screen.getByRole("textbox");
-      const label = screen.getByText("Email").closest("label");
+      const label = screen.getByText("Email", { selector: "label" });
       expect(label).toBeTruthy();
       expect(label).toHaveAttribute("for", input.id);
     });
@@ -405,6 +540,14 @@ describe("TextField", () => {
       render(<TextFieldHeadless label="Standalone" aria-label="Standalone field" />);
       const input = screen.getByRole("textbox");
       expect(input).toBeInTheDocument();
+    });
+
+    test("no size prop exists on TextField component", () => {
+      // Size was removed in MD3 Expressive refactor — single 56dp height
+      // Verify TypeScript would not accept it by checking the component renders fine
+      // without size (this is a typing concern but we verify render is stable)
+      render(<TextField label="Email" />);
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
     });
   });
 
@@ -481,6 +624,24 @@ describe("TextField", () => {
 
     test("has no axe violations in multiline mode", async () => {
       const { container } = render(<TextField label="Bio" multiline />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no axe violations in outlined variant", async () => {
+      const { container } = render(<TextField label="Email" variant="outlined" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no axe violations with prefix and suffix", async () => {
+      const { container } = render(<TextField label="Price" prefix="$" suffix="USD" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no axe violations with character counter", async () => {
+      const { container } = render(<TextField label="Bio" characterCount maxLength={100} />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -1,33 +1,53 @@
 /**
  * TextField Component (Layer 3)
  *
- * Material Design 3 styled text input component.
+ * Material Design 3 Expressive styled text input component.
  * Composes TextFieldHeadless (Layer 2) via render-prop to obtain all
  * React Aria ARIA props without duplicating accessibility wiring.
+ *
+ * Architecture: Variants vs States
+ * - All interaction/selection states are emitted as data-* attributes on the
+ *   root div (group/text-field) via getInteractionDataAttributes + explicit
+ *   derived content flags. CVA slots read them via group-data-[x]/text-field:.
+ * - CVA variants hold only design-time choices (variant, position).
+ *
+ * MD3 Expressive spec:
+ * - Single 56dp height (no size variants)
+ * - Filled: rounded-top 4dp, surface-container-highest bg, active indicator
+ * - Outlined: rounded 4dp all corners, transparent bg, notched fieldset border
+ * - body-large typography for input, body-small for floating label + supporting text
+ * - Standard fast motion tokens (utility form UI — no Expressive overshoot)
  */
 
 "use client";
 
 import { forwardRef } from "react";
+import { useHover } from "react-aria";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import {
-  textFieldContainerVariants,
-  textFieldWrapperVariants,
-  textFieldInputVariants,
+  textFieldRootVariants,
+  textFieldFieldVariants,
+  textFieldStateLayerVariants,
+  textFieldActiveIndicatorVariants,
+  textFieldOutlineVariants,
+  textFieldNotchVariants,
   textFieldLabelVariants,
+  textFieldInputVariants,
   textFieldIconVariants,
-  textFieldHelperTextVariants,
-  textFieldCharacterCountVariants,
+  textFieldAffixVariants,
+  textFieldSupportingRowVariants,
+  textFieldSupportingTextVariants,
+  textFieldCounterVariants,
 } from "./TextField.variants";
 import { TextFieldHeadless } from "./TextFieldHeadless";
 import type { TextFieldProps } from "./TextField.types";
 
 /**
- * TextField - MD3 Text Input Component
+ * TextField — MD3 Expressive Text Input Component
  *
- * A text input field following Material Design 3 specifications.
- * Supports filled and outlined variants with comprehensive accessibility
- * provided by React Aria via the TextFieldHeadless layer.
+ * A text input field strictly following Material Design 3 Expressive specifications.
+ * Supports filled and outlined variants with full accessibility via React Aria.
  *
  * @example
  * ```tsx
@@ -40,6 +60,14 @@ import type { TextFieldProps } from "./TextField.types";
  *   type="email"
  *   isRequired
  *   errorMessage="Please enter a valid email"
+ * />
+ *
+ * // With icons and affixes
+ * <TextField
+ *   label="Price"
+ *   prefix="$"
+ *   suffix="USD"
+ *   leadingIcon={<IconDollar />}
  * />
  *
  * // Multiline with character counter
@@ -56,12 +84,13 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
   (
     {
       variant = "filled",
-      size = "medium",
       label,
       description,
       errorMessage,
       leadingIcon,
       trailingIcon,
+      prefix,
+      suffix,
       characterCount = false,
       maxLength,
       fullWidth = false,
@@ -89,6 +118,9 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
         : typeof spellCheck === "string"
           ? spellCheck === "true"
           : spellCheck;
+
+    // React Aria hover state for the field box
+    const { isHovered, hoverProps } = useHover({ isDisabled });
 
     // Build headless props, omitting undefined optional values to satisfy exactOptionalPropertyTypes
     const headlessProps = {
@@ -120,149 +152,170 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
           errorMessageProps,
           isInvalid: fieldIsInvalid,
           isFocused,
+          isFocusVisible,
           currentValue,
           inputRef,
         }) => {
           const hasValue = currentValue.length > 0;
-          const shouldFloatLabel = isFocused || hasValue;
+          // Placeholder value — we need it to determine float state
+          const hasPlaceholder = !!(props as { placeholder?: string }).placeholder;
+          const hasPrefix = !!prefix;
+          // Label floats when: focused, has a value, has a placeholder, or has a prefix
+          const shouldFloat = isFocused || hasValue || hasPlaceholder || hasPrefix;
           const characterLength = currentValue.length;
           const isCharacterLimitExceeded = maxLength ? characterLength > maxLength : false;
 
+          const hasLeadingIcon = !!leadingIcon;
+          const hasTrailingIcon = !!trailingIcon;
+          const hasLabel = !!label;
+
+          // Supporting row is shown when description OR counter is present
+          const showDescription = !!description && !fieldIsInvalid;
+          const showError = fieldIsInvalid && !!errorMessage;
+          const showCounter = characterCount && maxLength !== undefined;
+          const showSupportingRow = showDescription || showError || showCounter;
+
           return (
-            <div className={cn(textFieldContainerVariants({ fullWidth }), className)}>
-              {/* Input wrapper with visual styling */}
-              <div
-                className={cn(
-                  textFieldWrapperVariants({
-                    variant,
-                    size,
-                    disabled: isDisabled,
-                    error: fieldIsInvalid,
-                    focused: isFocused,
-                  })
+            <div
+              className={cn(textFieldRootVariants({ fullWidth }), "group/text-field", className)}
+              // ── Interaction data attributes (from React Aria state) ──────
+              {...getInteractionDataAttributes({
+                isHovered,
+                isFocusVisible,
+                isDisabled,
+                isReadOnly,
+                isInvalid: fieldIsInvalid,
+              })}
+              // ── Derived state flags ──────────────────────────────────────
+              data-focused={isFocused ? "" : undefined}
+              data-float={shouldFloat ? "" : undefined}
+              // ── Content flags (structural composition) ───────────────────
+              data-with-leading-icon={hasLeadingIcon ? "" : undefined}
+              data-with-trailing-icon={hasTrailingIcon ? "" : undefined}
+              data-no-label={!hasLabel ? "" : undefined}
+              data-multiline={multiline ? "" : undefined}
+            >
+              {/* Field box — 56dp visual container */}
+              <div {...hoverProps} className={cn(textFieldFieldVariants({ variant }))}>
+                {/* ── State layer (filled variant only) ───────────────────── */}
+                {variant === "filled" && (
+                  <span className={cn(textFieldStateLayerVariants())} aria-hidden="true" />
                 )}
-              >
-                {/* Leading icon */}
+
+                {/* ── Leading icon ────────────────────────────────────────── */}
                 {leadingIcon && (
                   <span
-                    className={textFieldIconVariants({
-                      position: "leading",
-                      size,
-                      disabled: isDisabled,
-                    })}
+                    className={cn(textFieldIconVariants({ position: "leading" }))}
+                    aria-hidden="true"
                   >
                     {leadingIcon}
                   </span>
                 )}
 
-                {/* Floating label — uses labelProps from React Aria for proper htmlFor wiring */}
-                {label && (
-                  <label
-                    {...labelProps}
-                    className={cn(
-                      textFieldLabelVariants({
-                        variant,
-                        size,
-                        floating: shouldFloatLabel,
-                        focused: isFocused,
-                        error: fieldIsInvalid,
-                        disabled: isDisabled,
-                        hasLeadingIcon: !!leadingIcon,
-                      })
-                    )}
-                  >
-                    {label}
-                    {isRequired && " *"}
-                  </label>
-                )}
+                {/* ── Content column (label + prefix + input + suffix) ─────── */}
+                <div className="relative flex h-full min-w-0 flex-1 items-center">
+                  {/* Floating label — uses labelProps from React Aria for htmlFor wiring */}
+                  {label && (
+                    <label {...labelProps} className={cn(textFieldLabelVariants({ variant }))}>
+                      {label}
+                      {isRequired && <span aria-hidden="true">&thinsp;*</span>}
+                    </label>
+                  )}
 
-                {/* Input/Textarea — uses inputProps from React Aria for full ARIA wiring */}
-                {multiline ? (
-                  <textarea
-                    {...inputProps}
-                    ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-                    className={cn(
-                      textFieldInputVariants({
-                        variant,
-                        size,
-                        disabled: isDisabled,
-                        hasLeadingIcon: !!leadingIcon,
-                        hasTrailingIcon: !!trailingIcon,
-                        multiline: true,
-                      }),
-                      label && "placeholder:opacity-0"
-                    )}
-                    rows={rows}
-                    spellCheck={spellCheckProp}
-                  />
-                ) : (
-                  <input
-                    {...inputProps}
-                    ref={inputRef as React.RefObject<HTMLInputElement>}
-                    className={cn(
-                      textFieldInputVariants({
-                        variant,
-                        size,
-                        disabled: isDisabled,
-                        hasLeadingIcon: !!leadingIcon,
-                        hasTrailingIcon: !!trailingIcon,
-                        multiline: false,
-                      }),
-                      label && "placeholder:opacity-0" // Hide placeholder when there's a value to prevent overlap with floating label
-                    )}
-                    spellCheck={spellCheckProp}
-                  />
-                )}
+                  {/* Prefix affix */}
+                  {prefix && (
+                    <span className={cn(textFieldAffixVariants(), "pr-0.5")}>{prefix}</span>
+                  )}
 
-                {/* Trailing icon */}
+                  {/* Input / Textarea */}
+                  {multiline ? (
+                    <textarea
+                      {...inputProps}
+                      ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                      className={cn(textFieldInputVariants({ variant, multiline: true }))}
+                      rows={rows}
+                      spellCheck={spellCheckProp}
+                    />
+                  ) : (
+                    <input
+                      {...inputProps}
+                      ref={inputRef as React.RefObject<HTMLInputElement>}
+                      className={cn(textFieldInputVariants({ variant, multiline: false }))}
+                      spellCheck={spellCheckProp}
+                    />
+                  )}
+
+                  {/* Suffix affix */}
+                  {suffix && (
+                    <span className={cn(textFieldAffixVariants(), "pl-0.5")}>{suffix}</span>
+                  )}
+                </div>
+
+                {/* ── Trailing icon ────────────────────────────────────────── */}
                 {trailingIcon && (
                   <span
-                    className={textFieldIconVariants({
-                      position: "trailing",
-                      size,
-                      disabled: isDisabled,
-                    })}
+                    className={cn(textFieldIconVariants({ position: "trailing" }))}
+                    aria-hidden="true"
                   >
                     {trailingIcon}
                   </span>
                 )}
+
+                {/* ── Active indicator (filled variant only) ───────────────── */}
+                {variant === "filled" && (
+                  <span className={cn(textFieldActiveIndicatorVariants())} aria-hidden="true" />
+                )}
+
+                {/* ── Outlined border with notch ───────────────────────────── */}
+                {variant === "outlined" && (
+                  <fieldset aria-hidden="true" className={cn(textFieldOutlineVariants())}>
+                    <legend className={cn(textFieldNotchVariants())}>
+                      {/* Invisible copy of label drives the notch width */}
+                      {label && (
+                        <span>
+                          {label}
+                          {isRequired && "\u2009*"}
+                        </span>
+                      )}
+                    </legend>
+                  </fieldset>
+                )}
               </div>
 
-              {/* Helper text — only shown when not in error state */}
-              {description && !fieldIsInvalid && (
-                <div
-                  {...descriptionProps}
-                  className={textFieldHelperTextVariants({
-                    type: "description",
-                    disabled: isDisabled,
-                  })}
-                >
-                  {description}
-                </div>
-              )}
+              {/* ── Supporting row (description / error + counter) ──────────── */}
+              {showSupportingRow && (
+                <div className={cn(textFieldSupportingRowVariants())}>
+                  {/* Left: supporting text or error message (flex-1 pushes counter right) */}
+                  <div className="min-w-0 flex-1">
+                    {showDescription && (
+                      <p
+                        {...descriptionProps}
+                        className={cn(textFieldSupportingTextVariants({ type: "description" }))}
+                      >
+                        {description}
+                      </p>
+                    )}
+                    {showError && (
+                      <p
+                        {...errorMessageProps}
+                        className={cn(textFieldSupportingTextVariants({ type: "error" }))}
+                      >
+                        {errorMessage}
+                      </p>
+                    )}
+                  </div>
 
-              {/* Error message */}
-              {fieldIsInvalid && errorMessage && (
-                <div
-                  {...errorMessageProps}
-                  className={textFieldHelperTextVariants({
-                    type: "error",
-                    disabled: isDisabled,
-                  })}
-                >
-                  {errorMessage}
-                </div>
-              )}
-
-              {/* Character counter */}
-              {characterCount && maxLength && (
-                <div
-                  className={textFieldCharacterCountVariants({
-                    exceeded: isCharacterLimitExceeded,
-                    disabled: isDisabled,
-                  })}
-                >
-                  {characterLength} / {maxLength}
+                  {/* Right: character counter */}
+                  {showCounter && (
+                    <span
+                      className={cn(
+                        textFieldCounterVariants({ exceeded: isCharacterLimitExceeded })
+                      )}
+                      aria-live="polite"
+                    >
+                      {characterLength}&thinsp;/&thinsp;{maxLength}
+                    </span>
+                  )}
                 </div>
               )}
             </div>

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -160,6 +160,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
           // Placeholder value — we need it to determine float state
           const hasPlaceholder = !!(props as { placeholder?: string }).placeholder;
           const hasPrefix = !!prefix;
+          const hasSuffix = !!suffix;
           // Label floats when: focused, has a value, has a placeholder, or has a prefix
           const shouldFloat = isFocused || hasValue || hasPlaceholder || hasPrefix;
           const characterLength = currentValue.length;
@@ -192,6 +193,8 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
               // ── Content flags (structural composition) ───────────────────
               data-with-leading-icon={hasLeadingIcon ? "" : undefined}
               data-with-trailing-icon={hasTrailingIcon ? "" : undefined}
+              data-with-prefix={hasPrefix ? "" : undefined}
+              data-with-suffix={hasSuffix ? "" : undefined}
               data-no-label={!hasLabel ? "" : undefined}
               data-multiline={multiline ? "" : undefined}
             >
@@ -224,7 +227,9 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
 
                   {/* Prefix affix */}
                   {prefix && (
-                    <span className={cn(textFieldAffixVariants(), "pr-0.5")}>{prefix}</span>
+                    <span className={cn(textFieldAffixVariants({ variant, position: "prefix" }))}>
+                      {prefix}
+                    </span>
                   )}
 
                   {/* Input / Textarea */}
@@ -247,7 +252,9 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
 
                   {/* Suffix affix */}
                   {suffix && (
-                    <span className={cn(textFieldAffixVariants(), "pl-0.5")}>{suffix}</span>
+                    <span className={cn(textFieldAffixVariants({ variant, position: "suffix" }))}>
+                      {suffix}
+                    </span>
                   )}
                 </div>
 

--- a/packages/react/src/components/TextField/TextField.types.ts
+++ b/packages/react/src/components/TextField/TextField.types.ts
@@ -2,7 +2,7 @@
  * TextField Type Definitions
  *
  * Type definitions for the Material Design 3 TextField component.
- * Supports both filled and outlined variants with full accessibility.
+ * Supports filled and outlined variants with full accessibility via React Aria.
  */
 
 import type {
@@ -15,21 +15,12 @@ import type {
 import type { AriaTextFieldProps } from "react-aria";
 
 /**
- * TextField visual variants
+ * TextField visual variants.
  *
- * - `filled`: Solid background with bottom border (default)
- * - `outlined`: Border around entire field
+ * - `filled`: Solid background (`surface-container-highest`) with active indicator bottom border.
+ * - `outlined`: Transparent with a full rounded border and notched legend for the floating label.
  */
 export type TextFieldVariant = "filled" | "outlined";
-
-/**
- * TextField size variants
- *
- * - `small`: Compact height
- * - `medium`: Standard height (default)
- * - `large`: Larger height
- */
-export type TextFieldSize = "small" | "medium" | "large";
 
 /**
  * Arguments passed to the TextFieldHeadless render-prop children function.
@@ -48,7 +39,7 @@ export interface TextFieldRenderProps {
   errorMessageProps: HTMLAttributes<HTMLElement>;
   /** Whether the field is currently in an invalid state */
   isInvalid: boolean;
-  /** Whether the input currently has focus (keyboard or pointer) */
+  /** Whether the input currently has any focus (keyboard or pointer) */
   isFocused: boolean;
   /** Whether the input has keyboard-visible focus (for focus ring) */
   isFocusVisible: boolean;
@@ -59,7 +50,7 @@ export interface TextFieldRenderProps {
 }
 
 /**
- * Props for the headless TextField component (Layer 2)
+ * Props for the headless TextField component (Layer 2).
  *
  * Extends React Aria's AriaTextFieldProps for accessibility.
  * Provides behavior without styling.
@@ -69,72 +60,72 @@ export interface TextFieldHeadlessProps extends Omit<
   "children" | "onFocus" | "onBlur"
 > {
   /**
-   * Label text for the input
+   * Label text for the input.
    */
   label?: string;
 
   /**
-   * Helper text displayed below the input
+   * Helper text displayed below the input.
    * @example "Enter your email address"
    */
   description?: string;
 
   /**
-   * Error message to display when input is invalid
+   * Error message to display when input is invalid.
    * @example "Email is required"
    */
   errorMessage?: string;
 
   /**
-   * Whether the input should expand to fill its container
+   * Whether the input should expand to fill its container.
    * @default false
    */
   fullWidth?: boolean;
 
   /**
-   * Enable multiline mode (textarea)
+   * Enable multiline mode (textarea).
    * @default false
    */
   multiline?: boolean;
 
   /**
-   * Number of visible rows for multiline input
+   * Number of visible rows for multiline input.
    * @default 3
    */
   rows?: number;
 
   /**
-   * Custom className for the container
+   * Custom className for the container.
    */
   className?: string;
 
   /**
-   * Custom className for the input element
+   * Custom className for the input element.
    */
   inputClassName?: string;
 
   /**
-   * Custom className for the label element
+   * Custom className for the label element.
    */
   labelClassName?: string;
 
   /**
-   * Custom className for the description element
+   * Custom className for the description element.
    */
   descriptionClassName?: string;
 
   /**
-   * Custom className for the error message element
+   * Custom className for the error message element.
    */
   errorClassName?: string;
 
   /**
-   * Handler called when the input is focused
+   * Handler called when the input is focused.
    */
   onFocus?: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 
   /**
-   * Handler called when the input loses focus
+   * Handler called when the input loses focus.
    */
   onBlur?: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 
@@ -145,14 +136,12 @@ export interface TextFieldHeadlessProps extends Omit<
    * React Aria props and derived state so the styled layer can build its
    * own MD3 DOM without duplicating accessibility wiring.
    *
-   * When omitted, the default accessible DOM (label + input + helper text) renders.
-   *
    * @example
    * ```tsx
    * <TextFieldHeadless label="Email" value={value} onChange={onChange}>
    *   {({ labelProps, inputProps, isFocused }) => (
    *     <div>
-   *       <label {...labelProps} className={floating ? 'floating' : ''}>Email</label>
+   *       <label {...labelProps} className={isFocused ? 'focused' : ''}>Email</label>
    *       <input {...inputProps} className="md3-input" />
    *     </div>
    *   )}
@@ -163,45 +152,59 @@ export interface TextFieldHeadlessProps extends Omit<
 }
 
 /**
- * Props for the styled TextField component (Layer 3)
+ * Props for the styled TextField component (Layer 3).
  *
  * Extends TextFieldHeadlessProps with MD3 visual styling options.
+ * Strictly follows MD3 spec: single fixed height (56dp), two variants,
+ * optional icons, prefix/suffix affixes, and supporting text + counter row.
  */
 export interface TextFieldProps extends TextFieldHeadlessProps {
   /**
-   * Visual variant of the text field
+   * Visual variant of the text field.
    * @default 'filled'
    */
   variant?: TextFieldVariant;
 
   /**
-   * Size variant
-   * @default 'medium'
+   * Leading icon rendered at the start of the field.
+   * MD3 Specification: icons should be 24×24dp.
    */
-  size?: TextFieldSize;
+  leadingIcon?: ReactNode;
 
   /**
-   * Leading icon (before input text)
-   * MD3 Specification: Icons should be 18px × 18px
+   * Trailing icon rendered at the end of the field.
+   * MD3 Specification: icons should be 24×24dp.
+   * Automatically colored `error` when the field is invalid.
    */
-  leadingIcon?: React.ReactNode;
+  trailingIcon?: ReactNode;
 
   /**
-   * Trailing icon (after input text)
-   * MD3 Specification: Icons should be 18px × 18px
+   * Inline prefix text rendered before the input value.
+   * Only visible when the label is in its floating (small) position.
+   * Useful for currency symbols, units, etc.
+   * @example "$"
    */
-  trailingIcon?: React.ReactNode;
+  prefix?: ReactNode;
 
   /**
-   * Show character counter below the input
-   * Requires maxLength to be set
+   * Inline suffix text rendered after the input value.
+   * Only visible when the label is in its floating (small) position.
+   * Useful for units, domain suffixes, etc.
+   * @example "kg"
+   */
+  suffix?: ReactNode;
+
+  /**
+   * Show character counter in the supporting row below the field.
+   * Requires `maxLength` to be set.
    * @default false
    */
   characterCount?: boolean;
 
   /**
-   * Maximum number of characters allowed
-   * Enables character counter if characterCount is true
+   * Maximum number of characters allowed.
+   * Enforced on the native input and displayed in the counter when
+   * `characterCount` is true.
    */
   maxLength?: number;
 }

--- a/packages/react/src/components/TextField/TextField.variants.ts
+++ b/packages/react/src/components/TextField/TextField.variants.ts
@@ -301,8 +301,8 @@ export const textFieldInputVariants = cva(
       variant: {
         /**
          * Filled: top padding creates room for floating label (label rests at 8dp).
-         * Horizontal padding: 16dp left (4) / 16dp right (4).
-         * With label: pt-6 pb-2 so label and input text don't overlap.
+         * Horizontal padding: 16dp left / 16dp right — but yielded to prefix/suffix
+         * when they are present so the affix handles the edge spacing instead.
          */
         filled: [
           "pt-6 pb-2 px-4",
@@ -312,10 +312,18 @@ export const textFieldInputVariants = cva(
           "group-data-[with-leading-icon]/text-field:pl-[52px]",
           // Trailing icon horizontal offset
           "group-data-[with-trailing-icon]/text-field:pr-[52px]",
+          // Prefix present: prefix handles left edge — remove input's left padding
+          "group-data-[with-prefix]/text-field:pl-0",
+          // Leading icon + prefix together: compound wins over both singles
+          "group-data-[with-leading-icon]/text-field:group-data-[with-prefix]/text-field:pl-0",
+          // Suffix present: suffix handles right edge — remove input's right padding
+          "group-data-[with-suffix]/text-field:pr-0",
+          // Trailing icon + suffix together: compound wins over both singles
+          "group-data-[with-trailing-icon]/text-field:group-data-[with-suffix]/text-field:pr-0",
         ],
         /**
          * Outlined: label sits on the border, no extra top padding needed.
-         * Horizontal padding: 16dp (px-4).
+         * Horizontal padding: 16dp — yielded to prefix/suffix when present.
          */
         outlined: [
           "py-4 px-4",
@@ -323,6 +331,12 @@ export const textFieldInputVariants = cva(
           "group-data-[with-leading-icon]/text-field:pl-[52px]",
           // Trailing icon horizontal offset
           "group-data-[with-trailing-icon]/text-field:pr-[52px]",
+          // Prefix present: prefix handles left edge
+          "group-data-[with-prefix]/text-field:pl-0",
+          "group-data-[with-leading-icon]/text-field:group-data-[with-prefix]/text-field:pl-0",
+          // Suffix present: suffix handles right edge
+          "group-data-[with-suffix]/text-field:pr-0",
+          "group-data-[with-trailing-icon]/text-field:group-data-[with-suffix]/text-field:pr-0",
         ],
       },
       multiline: {
@@ -376,18 +390,76 @@ export const textFieldIconVariants = cva(
 /**
  * Inline prefix and suffix text — visible only when the field is floated.
  * body-large, on-surface-variant color.
- * Fades in with the floating transition using effects token.
+ *
+ * Vertical alignment:
+ *   Filled  — matches the input's pt-6 pb-2 padding so the text baseline aligns
+ *             with the input text in the lower zone of the 56dp container.
+ *             When no label is present the input uses py-4, so we mirror that.
+ *   Outlined — input uses py-4 which centres text at 28px; naturally-sized affix
+ *             is already centred there by items-center on the content column.
+ *
+ * Horizontal alignment:
+ *   Prefix  — pl-4 aligns its left text edge to the field's 16dp start margin
+ *             (same as label left-4 and the default input pl-4). With a leading
+ *             icon the offset grows to 52dp to clear the icon zone.
+ *             pr-0.5 provides a small gap between the prefix text and the cursor.
+ *   Suffix  — pl-0.5 provides a small gap between the input text and the suffix.
+ *             pr-4 keeps 16dp from the right edge. With a trailing icon the
+ *             offset grows to 52dp to avoid overlapping the icon.
  */
-export const textFieldAffixVariants = cva([
-  "relative z-10 text-body-large text-on-surface-variant select-none",
-  "opacity-0 pointer-events-none",
-  // Visible once label is floated
-  "group-data-[float]/text-field:opacity-100 group-data-[float]/text-field:pointer-events-auto",
-  // Effects transition
-  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
-  // Disabled
-  "group-data-[disabled]/text-field:text-on-surface/38",
-]);
+export const textFieldAffixVariants = cva(
+  [
+    "relative z-10 text-body-large text-on-surface-variant select-none shrink-0",
+    "opacity-0 pointer-events-none",
+    // Visible once label is floated
+    "group-data-[float]/text-field:opacity-100 group-data-[float]/text-field:pointer-events-auto",
+    // Effects transition
+    "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Disabled
+    "group-data-[disabled]/text-field:text-on-surface/38",
+  ],
+  {
+    variants: {
+      variant: {
+        /**
+         * Filled: mirror the input's pt-6 pb-2 so the text sits in the same
+         * vertical zone. When no label is present, the input uses py-4 — match
+         * that too so the affix stays centred with the input text.
+         */
+        filled: [
+          "pt-6 pb-2",
+          "group-data-[no-label]/text-field:pt-4 group-data-[no-label]/text-field:pb-4",
+        ],
+        /**
+         * Outlined: input uses py-4 and h-full; items-center on the content
+         * column already centres the naturally-sized affix at the same 28px
+         * midpoint as the input text. No extra vertical padding needed.
+         */
+        outlined: [],
+      },
+      position: {
+        /**
+         * Prefix: sits before the input in the flex row.
+         * pl-4 aligns the left text edge to the 16dp field margin.
+         * With a leading icon that shifts to 52dp to clear the icon.
+         * pr-0.5 is a small gap between prefix text and the input cursor.
+         */
+        prefix: ["pl-4", "group-data-[with-leading-icon]/text-field:pl-[52px]", "pr-0.5"],
+        /**
+         * Suffix: sits after the input in the flex row.
+         * pl-0.5 is a small gap between the input text and the suffix.
+         * pr-4 keeps 16dp from the right field edge.
+         * With a trailing icon that shifts to 52dp to avoid overlap.
+         */
+        suffix: ["pl-0.5", "pr-4", "group-data-[with-trailing-icon]/text-field:pr-[52px]"],
+      },
+    },
+    defaultVariants: {
+      variant: "filled",
+      position: "prefix",
+    },
+  }
+);
 
 // ─── SUPPORTING ROW ───────────────────────────────────────────────────────────
 
@@ -455,5 +527,6 @@ export type TextFieldFieldVariants = VariantProps<typeof textFieldFieldVariants>
 export type TextFieldLabelVariants = VariantProps<typeof textFieldLabelVariants>;
 export type TextFieldInputVariants = VariantProps<typeof textFieldInputVariants>;
 export type TextFieldIconVariants = VariantProps<typeof textFieldIconVariants>;
+export type TextFieldAffixVariants = VariantProps<typeof textFieldAffixVariants>;
 export type TextFieldSupportingTextVariants = VariantProps<typeof textFieldSupportingTextVariants>;
 export type TextFieldCounterVariants = VariantProps<typeof textFieldCounterVariants>;

--- a/packages/react/src/components/TextField/TextField.variants.ts
+++ b/packages/react/src/components/TextField/TextField.variants.ts
@@ -1,282 +1,415 @@
 /**
  * TextField Variants
  *
- * CVA (class-variance-authority) variant definitions for Material Design 3 TextField.
- * Supports filled and outlined variants with comprehensive state management.
+ * CVA (class-variance-authority) variant definitions for the MD3 TextField.
+ *
+ * Architecture: Variants vs States
+ * - CVA holds design-time choices only (variant, position, type).
+ * - All interaction/selection states are driven by data-* attributes on the
+ *   root via group-data-[x]/text-field Tailwind selectors in each slot's
+ *   base classes — no state variants or state compoundVariants in CVA.
+ *
+ * Slot responsibilities:
+ *   textFieldRootVariants          — outer wrapper; carries group/text-field; fullWidth
+ *   textFieldFieldVariants         — 56dp visual box; variant-specific shape & bg
+ *   textFieldStateLayerVariants    — filled-only hover/focus/pressed opacity ring
+ *   textFieldActiveIndicatorVariants — filled-only bottom line (height + color)
+ *   textFieldOutlineVariants       — outlined-only <fieldset> border
+ *   textFieldNotchVariants         — outlined-only <legend> that creates the gap
+ *   textFieldLabelVariants         — floating label; position differs per variant
+ *   textFieldInputVariants         — <input> / <textarea>; layout adjustments per variant
+ *   textFieldIconVariants          — leading / trailing icon wrapper
+ *   textFieldAffixVariants         — prefix / suffix text
+ *   textFieldSupportingRowVariants — flex row below field (text + counter)
+ *   textFieldSupportingTextVariants — supporting / error text (left slot)
+ *   textFieldCounterVariants       — character counter (right slot)
+ *
+ * MD3 Spec:
+ *   Field height:   56dp (h-14)
+ *   Shape filled:   top corners 4dp (rounded-t-xs), bottom none
+ *   Shape outlined: all corners 4dp (rounded-xs)
+ *   Typography:     body-large for input/label-resting/prefix/suffix
+ *                   body-small for label-floating / supporting text / counter
+ *   State layers:   hover 8% | focus 10% | pressed 10%
+ *   Disabled:       container bg-on-surface/4, content text-on-surface/38
+ *   Motion:         Standard fast (utility UI, no Expressive overshoot)
  */
 
 import { cva, type VariantProps } from "class-variance-authority";
 
-/**
- * Container variants for the TextField wrapper
- *
- * Handles layout, width, and positioning
- */
-export const textFieldContainerVariants = cva(
-  [
-    // Base container styles
-    "relative inline-flex flex-col",
-  ],
-  {
-    variants: {
-      fullWidth: {
-        true: "w-full",
-        false: "w-auto",
-      },
-    },
-    defaultVariants: {
-      fullWidth: false,
-    },
-  }
-);
+// ─── ROOT ─────────────────────────────────────────────────────────────────────
 
 /**
- * Input wrapper variants (the visual container around the input)
- *
- * Handles MD3 filled and outlined variants with all states
+ * Outer wrapper div — carries `group/text-field` and `fullWidth`.
+ * All data-* attributes are set here so every child slot can read them
+ * via `group-data-[x]/text-field:` selectors.
  */
-export const textFieldWrapperVariants = cva(
+export const textFieldRootVariants = cva(["relative inline-flex flex-col"], {
+  variants: {
+    fullWidth: {
+      true: "w-full",
+      false: "w-auto",
+    },
+  },
+  defaultVariants: {
+    fullWidth: false,
+  },
+});
+
+// ─── FIELD BOX ────────────────────────────────────────────────────────────────
+
+/**
+ * The 56dp visual container that wraps the input and icons.
+ * Filled: top-rounded, background from surface-container-highest.
+ * Outlined: all-rounded, transparent background, no indicator line.
+ *
+ * overflow-hidden is deliberately NOT set here — the focus outline on the
+ * outlined variant and the state layer on the filled variant need it on their
+ * own elements to avoid clipping issues.
+ */
+export const textFieldFieldVariants = cva(
   [
-    // Base wrapper styles
-    "relative inline-flex items-center w-full",
-    "transition-all duration-200",
-    "rounded-t",
+    "relative flex items-center w-full min-h-14",
+    // Cursor — disabled via group-data
+    "group-data-[disabled]/text-field:cursor-not-allowed",
+    "group-data-[disabled]/text-field:pointer-events-none",
   ],
   {
     variants: {
       variant: {
-        filled: ["bg-surface-container-highest", "border-b-2 border-on-surface-variant"],
-        outlined: ["bg-transparent", "border border-outline", "rounded-b"],
-      },
-      size: {
-        small: "min-h-10",
-        medium: "min-h-12",
-        large: "min-h-14",
-      },
-      disabled: {
-        true: ["cursor-not-allowed", "opacity-38"],
-        false: "",
-      },
-      error: {
-        true: "",
-        false: "",
-      },
-      focused: {
-        true: "",
-        false: "",
+        filled: [
+          "rounded-t-xs bg-surface-container-highest",
+          // Disabled: background fades to on-surface/4
+          "group-data-[disabled]/text-field:bg-on-surface/4",
+        ],
+        outlined: ["rounded-xs bg-transparent"],
       },
     },
-    compoundVariants: [
-      // FILLED VARIANT - Focused state
-      {
-        variant: "filled",
-        focused: true,
-        error: false,
-        className: "border-primary",
-      },
-      // FILLED VARIANT - Error state
-      {
-        variant: "filled",
-        error: true,
-        className: "border-error",
-      },
-      // FILLED VARIANT - Hover state (handled via group-hover in parent)
-      {
-        variant: "filled",
-        disabled: false,
-        className: "hover:bg-on-surface/[0.08]",
-      },
-
-      // OUTLINED VARIANT - Focused state
-      {
-        variant: "outlined",
-        focused: true,
-        error: false,
-        className: "border-2 border-primary",
-      },
-      // OUTLINED VARIANT - Error state
-      {
-        variant: "outlined",
-        error: true,
-        className: "border-2 border-error",
-      },
-      // OUTLINED VARIANT - Hover state
-      {
-        variant: "outlined",
-        disabled: false,
-        className: "hover:border-on-surface",
-      },
-    ],
     defaultVariants: {
       variant: "filled",
-      size: "medium",
-      disabled: false,
-      error: false,
-      focused: false,
     },
   }
 );
 
+// ─── STATE LAYER (filled only) ────────────────────────────────────────────────
+
 /**
- * Input element variants
+ * Hover/focus/pressed opacity ring — filled variant only.
+ * absolute inset-0 so it covers the entire field box.
+ * overflow-hidden + rounded-[inherit] clips to the field shape.
+ * Color: on-surface at rest; opacities applied per interaction state.
+ */
+export const textFieldStateLayerVariants = cva([
+  "absolute inset-0 rounded-t-xs pointer-events-none opacity-0",
+  "bg-on-surface",
+  // Effects transition — no spatial overshoot on opacity
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Hover: 8%
+  "group-data-[hovered]/text-field:opacity-8",
+  // Focus: 10% (focus wins over hover via cascade order — placed after)
+  "group-data-[focused]/text-field:opacity-10",
+  // No state layer when disabled
+  "group-data-[disabled]/text-field:hidden",
+]);
+
+// ─── ACTIVE INDICATOR (filled only) ──────────────────────────────────────────
+
+/**
+ * The bottom border line for the filled variant.
  *
- * Styles for the actual input/textarea element
+ * Height: 1px at rest → 2px focused/invalid (spatial token — height is spatial).
+ * Color transitions use effects token.
+ *
+ * Uses CSS variables so both height and color can be driven independently.
+ */
+export const textFieldActiveIndicatorVariants = cva([
+  "absolute bottom-0 left-0 right-0 pointer-events-none",
+  // Spatial transition: height is a spatial property
+  "transition-[height,background-color]",
+  "duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+  // Base
+  "h-px bg-on-surface-variant",
+  // Hover
+  "group-data-[hovered]/text-field:bg-on-surface",
+  // Focused — 2px + primary color (focused placed after hovered to win cascade)
+  "group-data-[focused]/text-field:h-0.5 group-data-[focused]/text-field:bg-primary",
+  // Invalid
+  "group-data-[invalid]/text-field:bg-error",
+  // Invalid + focused
+  "group-data-[invalid]/text-field:group-data-[focused]/text-field:bg-error",
+  // Disabled: hidden
+  "group-data-[disabled]/text-field:hidden",
+]);
+
+// ─── OUTLINE (outlined only) ──────────────────────────────────────────────────
+
+/**
+ * The <fieldset> border for the outlined variant.
+ *
+ * Sits absolutely to fill the field box. The legend inside creates the notch.
+ * pointer-events-none so clicks fall through to the input.
+ *
+ * Border width: 1px base → 2px focused/invalid (spatial — border-width is spatial).
+ * Color uses effects token.
+ */
+export const textFieldOutlineVariants = cva([
+  "absolute inset-0 rounded-xs m-0 px-2 pointer-events-none",
+  "border border-outline",
+  // Effects transition for color; spatial for border-width
+  "transition-[border-color,border-width]",
+  "duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Hover
+  "group-data-[hovered]/text-field:border-on-surface",
+  // Focused — 2px + primary color
+  "group-data-[focused]/text-field:border-2 group-data-[focused]/text-field:border-primary",
+  // Invalid
+  "group-data-[invalid]/text-field:border-error",
+  // Invalid + focused
+  "group-data-[invalid]/text-field:group-data-[focused]/text-field:border-2",
+  "group-data-[invalid]/text-field:group-data-[focused]/text-field:border-error",
+  // Disabled
+  "group-data-[disabled]/text-field:border-on-surface/12",
+]);
+
+// ─── NOTCH (outlined label gap) ───────────────────────────────────────────────
+
+/**
+ * The <legend> element inside the outlined fieldset that creates the gap for
+ * the floating label. aria-hidden on the fieldset.
+ *
+ * At rest (label not floating): max-w-0 / opacity-0 so the border is unbroken.
+ * When label floats (data-float): max-w grows to the measured label width.
+ *
+ * Because we cannot measure label width with pure CSS, we use a text-transparent
+ * copy of the label inside the legend that takes up space — this is the standard
+ * MUI/MD web approach.
+ */
+export const textFieldNotchVariants = cva([
+  "invisible whitespace-nowrap text-body-small px-1",
+  // 0 width when not floating (no gap)
+  "max-w-0 overflow-hidden",
+  // Full width when floating (gap opens)
+  "group-data-[float]/text-field:max-w-full",
+  // Spatial transition for max-width change
+  "transition-[max-width] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+]);
+
+// ─── LABEL ────────────────────────────────────────────────────────────────────
+
+/**
+ * Floating label.
+ *
+ * Resting state:  body-large, centered vertically inside the field (via absolute top-1/2)
+ * Floating state: body-small, translated up to sit at the top edge
+ *
+ * Filled:   floating label rests in top 8dp padding zone
+ * Outlined: floating label sits on top of the border (translateY(-50%) from top edge)
+ *
+ * Color:
+ *   rest:     on-surface-variant
+ *   focused:  primary
+ *   invalid:  error
+ *   disabled: on-surface/38
+ *
+ * The transform (translate) is spatial; color is effects.
+ * We use a single transition-all with the spatial token since the spatial
+ * token uses a standard (no-overshoot) spring — safe for text.
+ */
+export const textFieldLabelVariants = cva(
+  [
+    "absolute pointer-events-none origin-top-left select-none",
+    "text-body-large text-on-surface-variant",
+    // Spatial + effects both use standard fast — no overshoot on font/color
+    "transition-[transform,font-size,color,line-height]",
+    "duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+    // Disabled
+    "group-data-[disabled]/text-field:text-on-surface/38",
+    // Invalid (placed after default, before focused so focused invalid wins)
+    "group-data-[invalid]/text-field:text-error",
+    // Focused (singly-chained wins by cascade order)
+    "group-data-[focused]/text-field:text-primary",
+    // Invalid + focused — doubly-chained, wins over single-chained focused
+    "group-data-[invalid]/text-field:group-data-[focused]/text-field:text-error",
+  ],
+  {
+    variants: {
+      variant: {
+        /**
+         * Filled: label rests at center (top-1/2 -translate-y-1/2).
+         * When floating: moves up to top-2 (8dp) with body-small size.
+         */
+        filled: [
+          "top-1/2 -translate-y-1/2 left-4",
+          // Floated position — sits in the top 8dp zone
+          "group-data-[float]/text-field:top-2 group-data-[float]/text-field:-translate-y-0",
+          "group-data-[float]/text-field:text-body-small",
+          // Leading-icon offset
+          "group-data-[with-leading-icon]/text-field:left-[52px]",
+        ],
+        /**
+         * Outlined: label rests at center (top-1/2 -translate-y-1/2).
+         * When floating: moves up to sit on the top border (-translate-y-1/2 from top-0).
+         */
+        outlined: [
+          "top-1/2 -translate-y-1/2 left-3",
+          // bg-surface ensures label text punches through the border
+          "bg-surface px-1",
+          // Floated: sits on the top border
+          "group-data-[float]/text-field:top-0 group-data-[float]/text-field:-translate-y-1/2",
+          "group-data-[float]/text-field:text-body-small",
+          // Leading-icon offset
+          "group-data-[with-leading-icon]/text-field:left-[52px]",
+        ],
+      },
+    },
+    defaultVariants: {
+      variant: "filled",
+    },
+  }
+);
+
+// ─── INPUT / TEXTAREA ─────────────────────────────────────────────────────────
+
+/**
+ * The actual <input> or <textarea> element.
+ *
+ * body-large, on-surface text, transparent background so the field box shows.
+ * padding-top pushes text down to make room for the floating label in the
+ * filled variant (when label is present).
+ *
+ * placeholder is hidden by default (opacity-0) and shown only when label is
+ * not present or has floated — so there's no text overlap.
  */
 export const textFieldInputVariants = cva(
   [
-    // Base input styles
-    "w-full bg-transparent outline-none",
-    "text-on-surface text-base",
-    "placeholder:text-on-surface-variant placeholder:opacity-60",
-    "transition-colors duration-200",
+    "relative z-10 w-full bg-transparent outline-none border-none",
+    "text-body-large text-on-surface",
+    "placeholder:text-on-surface-variant",
+    // Placeholder hidden unless field is floating (avoids overlap with label)
+    "placeholder:opacity-0",
+    "group-data-[float]/text-field:placeholder:opacity-100",
+    // Disabled
+    "group-data-[disabled]/text-field:text-on-surface/38",
+    "group-data-[disabled]/text-field:cursor-not-allowed",
+    // Readonly
+    "group-data-[readonly]/text-field:cursor-default",
+    // Effects transition for color
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
   ],
   {
     variants: {
       variant: {
-        filled: "px-4",
-        outlined: "px-4",
-      },
-      size: {
-        small: "h-10 py-2 text-sm",
-        medium: "h-12 py-3 text-base",
-        large: "h-14 py-4 text-lg",
-      },
-      disabled: {
-        true: "cursor-not-allowed",
-        false: "",
-      },
-      hasLeadingIcon: {
-        true: "pl-12",
-        false: "",
-      },
-      hasTrailingIcon: {
-        true: "pr-12",
-        false: "",
+        /**
+         * Filled: top padding creates room for floating label (label rests at 8dp).
+         * Horizontal padding: 16dp left (4) / 16dp right (4).
+         * With label: pt-6 pb-2 so label and input text don't overlap.
+         */
+        filled: [
+          "pt-6 pb-2 px-4",
+          // No label present: vertically center
+          "group-data-[no-label]/text-field:py-4",
+          // Leading icon horizontal offset
+          "group-data-[with-leading-icon]/text-field:pl-[52px]",
+          // Trailing icon horizontal offset
+          "group-data-[with-trailing-icon]/text-field:pr-[52px]",
+        ],
+        /**
+         * Outlined: label sits on the border, no extra top padding needed.
+         * Horizontal padding: 16dp (px-4).
+         */
+        outlined: [
+          "py-4 px-4",
+          // Leading icon horizontal offset
+          "group-data-[with-leading-icon]/text-field:pl-[52px]",
+          // Trailing icon horizontal offset
+          "group-data-[with-trailing-icon]/text-field:pr-[52px]",
+        ],
       },
       multiline: {
-        true: "resize-y",
-        false: "",
+        true: "resize-y min-h-[1.5rem]",
+        false: "h-full",
       },
     },
     defaultVariants: {
       variant: "filled",
-      size: "medium",
-      disabled: false,
-      hasLeadingIcon: false,
-      hasTrailingIcon: false,
       multiline: false,
     },
   }
 );
 
-/**
- * Label variants
- *
- * Handles floating label behavior for MD3 text fields
- */
-export const textFieldLabelVariants = cva(
-  [
-    // Base label styles
-    "absolute left-4 transition-all duration-200 pointer-events-none",
-    "text-on-surface-variant origin-top-left",
-  ],
-  {
-    variants: {
-      variant: {
-        filled: "top-2.5",
-        outlined: "top-2.5 bg-surface px-1",
-      },
-      size: {
-        small: "text-sm",
-        medium: "text-base",
-        large: "text-lg",
-      },
-      floating: {
-        true: "-translate-y-5 scale-75",
-        false: "scale-100",
-      },
-      focused: {
-        true: "text-primary",
-        false: "",
-      },
-      error: {
-        true: "text-error",
-        false: "",
-      },
-      disabled: {
-        true: "text-on-surface/38",
-        false: "",
-      },
-      hasLeadingIcon: {
-        true: "left-12",
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Outlined variant floating label positioning
-      {
-        variant: "outlined",
-        floating: true,
-        className: "top-2.5",
-      },
-    ],
-    defaultVariants: {
-      variant: "filled",
-      size: "medium",
-      floating: false,
-      focused: false,
-      error: false,
-      disabled: false,
-      hasLeadingIcon: false,
-    },
-  }
-);
+// ─── ICON ─────────────────────────────────────────────────────────────────────
 
 /**
- * Icon container variants
+ * Leading / trailing icon wrapper.
  *
- * Styles for leading and trailing icon containers
+ * MD3 spec: icons are 24×24dp, 12dp from the edge (left-3 / right-3).
+ * Color: on-surface-variant; trailing icon → error when invalid.
  */
 export const textFieldIconVariants = cva(
   [
-    // Base icon styles
-    "absolute flex items-center justify-center",
-    "text-on-surface-variant transition-colors duration-200",
-    "pointer-events-none",
+    "absolute z-10 flex items-center justify-center size-6 pointer-events-none",
+    "text-on-surface-variant",
+    // Effects transition
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Disabled
+    "group-data-[disabled]/text-field:text-on-surface/38",
   ],
   {
     variants: {
       position: {
         leading: "left-3",
-        trailing: "right-3",
-      },
-      size: {
-        small: "w-5 h-5",
-        medium: "w-6 h-6",
-        large: "w-7 h-7",
-      },
-      disabled: {
-        true: "opacity-38",
-        false: "",
+        trailing: [
+          "right-3",
+          // Trailing → error color when invalid
+          "group-data-[invalid]/text-field:text-error",
+        ],
       },
     },
     defaultVariants: {
       position: "leading",
-      size: "medium",
-      disabled: false,
     },
   }
 );
 
+// ─── AFFIX (prefix / suffix) ──────────────────────────────────────────────────
+
 /**
- * Helper text variants (description and error messages)
- *
- * Styles for text below the input field
+ * Inline prefix and suffix text — visible only when the field is floated.
+ * body-large, on-surface-variant color.
+ * Fades in with the floating transition using effects token.
  */
-export const textFieldHelperTextVariants = cva(
+export const textFieldAffixVariants = cva([
+  "relative z-10 text-body-large text-on-surface-variant select-none",
+  "opacity-0 pointer-events-none",
+  // Visible once label is floated
+  "group-data-[float]/text-field:opacity-100 group-data-[float]/text-field:pointer-events-auto",
+  // Effects transition
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Disabled
+  "group-data-[disabled]/text-field:text-on-surface/38",
+]);
+
+// ─── SUPPORTING ROW ───────────────────────────────────────────────────────────
+
+/**
+ * The row below the field box containing supporting text (left) and
+ * character counter (right) on the same line — matching MD3 spec.
+ */
+export const textFieldSupportingRowVariants = cva([
+  "flex items-start justify-between w-full gap-4 px-4 pt-1",
+]);
+
+// ─── SUPPORTING TEXT ──────────────────────────────────────────────────────────
+
+/**
+ * Supporting / error text — left slot of the supporting row.
+ * body-small per MD3.
+ */
+export const textFieldSupportingTextVariants = cva(
   [
-    // Base helper text styles
-    "text-xs mt-1 px-4 transition-colors duration-200",
+    "text-body-small",
+    // Effects transition for color
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
   ],
   {
     variants: {
@@ -284,51 +417,43 @@ export const textFieldHelperTextVariants = cva(
         description: "text-on-surface-variant",
         error: "text-error",
       },
-      disabled: {
-        true: "opacity-38",
-        false: "",
-      },
     },
     defaultVariants: {
       type: "description",
-      disabled: false,
     },
   }
 );
 
+// ─── CHARACTER COUNTER ────────────────────────────────────────────────────────
+
 /**
- * Character counter variants
- *
- * Styles for the character count display
+ * Character counter — right slot of the supporting row.
+ * body-small, right-aligned, on-surface-variant; turns error color when exceeded.
  */
-export const textFieldCharacterCountVariants = cva(
+export const textFieldCounterVariants = cva(
   [
-    // Base character counter styles
-    "text-xs mt-1 px-4 text-right text-on-surface-variant transition-colors duration-200",
+    "text-body-small shrink-0 text-right",
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
   ],
   {
     variants: {
       exceeded: {
         true: "text-error",
-        false: "",
-      },
-      disabled: {
-        true: "opacity-38",
-        false: "",
+        false: "text-on-surface-variant",
       },
     },
     defaultVariants: {
       exceeded: false,
-      disabled: false,
     },
   }
 );
 
-// Export variant types
-export type TextFieldContainerVariants = VariantProps<typeof textFieldContainerVariants>;
-export type TextFieldWrapperVariants = VariantProps<typeof textFieldWrapperVariants>;
-export type TextFieldInputVariants = VariantProps<typeof textFieldInputVariants>;
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
+export type TextFieldRootVariants = VariantProps<typeof textFieldRootVariants>;
+export type TextFieldFieldVariants = VariantProps<typeof textFieldFieldVariants>;
 export type TextFieldLabelVariants = VariantProps<typeof textFieldLabelVariants>;
+export type TextFieldInputVariants = VariantProps<typeof textFieldInputVariants>;
 export type TextFieldIconVariants = VariantProps<typeof textFieldIconVariants>;
-export type TextFieldHelperTextVariants = VariantProps<typeof textFieldHelperTextVariants>;
-export type TextFieldCharacterCountVariants = VariantProps<typeof textFieldCharacterCountVariants>;
+export type TextFieldSupportingTextVariants = VariantProps<typeof textFieldSupportingTextVariants>;
+export type TextFieldCounterVariants = VariantProps<typeof textFieldCounterVariants>;

--- a/packages/react/src/components/TextField/index.ts
+++ b/packages/react/src/components/TextField/index.ts
@@ -1,7 +1,7 @@
 /**
  * TextField Component Exports
  *
- * Barrel exports for the TextField component and related types.
+ * Barrel exports for the MD3 TextField component and related types.
  */
 
 // Layer 3: MD3 Styled Component (most users use this)
@@ -10,25 +10,31 @@ export { TextField } from "./TextField";
 // Layer 2: Headless Component (for advanced customization)
 export { TextFieldHeadless } from "./TextFieldHeadless";
 
-// CVA Variants
+// CVA Variants (all slots)
 export {
-  textFieldContainerVariants,
-  textFieldWrapperVariants,
-  textFieldInputVariants,
+  textFieldRootVariants,
+  textFieldFieldVariants,
+  textFieldStateLayerVariants,
+  textFieldActiveIndicatorVariants,
+  textFieldOutlineVariants,
+  textFieldNotchVariants,
   textFieldLabelVariants,
+  textFieldInputVariants,
   textFieldIconVariants,
-  textFieldHelperTextVariants,
-  textFieldCharacterCountVariants,
+  textFieldAffixVariants,
+  textFieldSupportingRowVariants,
+  textFieldSupportingTextVariants,
+  textFieldCounterVariants,
 } from "./TextField.variants";
 
 export type {
-  TextFieldContainerVariants,
-  TextFieldWrapperVariants,
-  TextFieldInputVariants,
+  TextFieldRootVariants,
+  TextFieldFieldVariants,
   TextFieldLabelVariants,
+  TextFieldInputVariants,
   TextFieldIconVariants,
-  TextFieldHelperTextVariants,
-  TextFieldCharacterCountVariants,
+  TextFieldSupportingTextVariants,
+  TextFieldCounterVariants,
 } from "./TextField.variants";
 
 // Types
@@ -37,5 +43,4 @@ export type {
   TextFieldHeadlessProps,
   TextFieldRenderProps,
   TextFieldVariant,
-  TextFieldSize,
 } from "./TextField.types";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -16,7 +16,7 @@ export { FAB, FABHeadless } from "./FAB";
 export type { FABProps, FABSize, FABColor, FABHeadlessProps } from "./FAB";
 
 export { TextField } from "./TextField";
-export type { TextFieldProps, TextFieldVariant, TextFieldSize } from "./TextField";
+export type { TextFieldProps, TextFieldVariant } from "./TextField";
 
 export { Checkbox } from "./Checkbox";
 export type { CheckboxProps } from "./Checkbox";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -82,7 +82,7 @@ export { FAB, FABHeadless } from "./components/FAB";
 export type { FABProps, FABSize, FABColor, FABHeadlessProps } from "./components/FAB";
 
 export { TextField } from "./components/TextField";
-export type { TextFieldProps, TextFieldVariant, TextFieldSize } from "./components/TextField";
+export type { TextFieldProps, TextFieldVariant } from "./components/TextField";
 
 export { Checkbox } from "./components/Checkbox";
 export type { CheckboxProps } from "./components/Checkbox";


### PR DESCRIPTION
## Summary

- **Breaking**: removed `size` prop and `TextFieldSize` type — MD3 text fields are a fixed 56dp height with no size scale
- **New**: `prefix` and `suffix` inline affix props (visible once label floats)
- **Refactor**: full Variants-vs-States architecture, MD3 state layer + active indicator (filled), notched fieldset outline (outlined), body-large/body-small typography, spring-standard-fast motion tokens, one-row supporting text + counter

## Breaking changes

| What | Action required |
|---|---|
| `size` prop removed (`"small" \| "medium" \| "large"`) | Delete any `size` usage — all fields now render at 56dp (MD3 spec) |
| `TextFieldSize` type removed | Remove imports of this type |

## What changed

**Architecture (Variants-vs-States)**
- All interaction/selection states (`hovered`, `focused`, `invalid`, `disabled`, `readonly`) emitted as `data-*` attributes on the root `group/text-field` div via `getInteractionDataAttributes` + explicit derived flags (`data-float`, `data-focused`, `data-with-leading-icon`, etc.)
- CVA slot classes read states via `group-data-[x]/text-field:` selectors — no state variants or compound variants in CVA

**MD3 Expressive spec compliance**
- Field height: `h-14` (56dp), single fixed height
- Filled: `rounded-t-xs` top corners, `bg-surface-container-highest`, state layer (`bg-on-surface` at 8% hover / 10% focus), active indicator (1px → 2px on focus, `primary` / `error` color)
- Outlined: `rounded-xs` all corners, `aria-hidden` `<fieldset>/<legend>` notch for the floating label, border animates width and color on focus/invalid
- Label: `text-body-large` at rest → `text-body-small` floating; spatial motion token for the position/size transition
- Input typography: `text-body-large`, `text-body-small` for supporting text + counter
- Icon size: corrected to 24×24dp
- Motion: all `duration-200` replaced with `duration-spring-standard-fast-effects` / `duration-spring-standard-fast-spatial` + matching `ease-spring-standard-fast-*` (Standard personality — no Expressive overshoot for utility form UI)
- Supporting text + counter: single flex row (text left, counter right) per MD3 spec

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 2065 tests pass (0 failures)
- [x] `pnpm lint` — clean
- [x] Removed `Sizes` describe block from tests (size prop gone)
- [x] New tests: variant class assertions, data-* state attributes, state layer, notch/fieldset, prefix/suffix, supporting row structure, axe coverage for outlined + prefix/suffix + counter