### PR TITLE
refactor(list): migrate to variants-vs-states architecture with md3 expressive styling

### DIFF
--- a/.changeset/list-md3-expressive-refactor.md
+++ b/.changeset/list-md3-expressive-refactor.md
@@ -1,0 +1,16 @@
+---
+"@tinybigui/react": minor
+---
+
+Refactor List to Variants-vs-States architecture with MD3 state layers, focus ring, and spring motion
+
+- Move all interaction/selection state out of CVA variant keys into data-\* attributes + group-data-[x]/list-item slot selectors (matches Button, Tabs, Switch pattern)
+- Add dedicated state layer span with MD3 spring-standard-fast-effects motion (opacity 8/10/10 for hover/focus/pressed)
+- Add keyboard focus ring span (outline-secondary, inset-0, opacity transition)
+- Replace scoped `group` with named `group/list-item` to prevent style leakage
+- Use `getInteractionDataAttributes` helper for consistent presence-based encoding
+- Propagate selected/disabled colors to leading, trailing, overline, headline, and supporting text slots via group-data selectors
+- Convert ListItemLeading, ListItemTrailing, ListItemText to slot CVAs
+- Fix ListDensity JSDoc: correct min-heights to 56/72/88dp (was 48/64dp)
+- Remove unused per-item `onAction` from `ListItemProps` (List-level `onAction` is the correct API)
+- Export all new slot CVA variants and VariantProps types

--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -904,6 +904,59 @@ export const SettingsList: Story = {
   },
 };
 
+// ─── States story ─────────────────────────────────────────────────────────────
+
+const StatesExample = (): React.ReactElement => {
+  const [selected, setSelected] = useState<Selection>(new Set<string>(["selected"]));
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="text-label-medium text-on-surface-variant mb-2">Interactive states</p>
+        <List
+          aria-label="List states"
+          selectionMode="single"
+          selectedKeys={selected}
+          onSelectionChange={setSelected}
+        >
+          <ListItem value="default" headline="Default (at rest)" />
+          <ListItem
+            value="selected"
+            headline="Selected"
+            supportingText="bg-secondary-container, on-secondary-container text/icons"
+          />
+          <ListItem
+            value="disabled"
+            headline="Disabled"
+            supportingText="38% opacity, pointer-events none"
+            isDisabled
+          />
+          <ListItem
+            value="with-slots"
+            headline="With slots (hover / focus / press to see state layer)"
+            leadingType="icon"
+            leadingSlot={<IconWifi />}
+            trailingType="icon"
+            trailingSlot={<IconChevronRight />}
+          />
+        </List>
+      </div>
+    </div>
+  );
+};
+
+export const States: Story = {
+  render: () => <StatesExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows the four key states: at rest, selected (`bg-secondary-container`), disabled (38% opacity), and a slotted item to demonstrate the hover/focus/pressed state layer. State layer uses `bg-on-surface` with 8% (hover) / 10% (focus, pressed) opacity via `group-data-[x]/list-item` selectors — no state stored in CVA variants.",
+      },
+    },
+  },
+};
+
 // ─── Playground ───────────────────────────────────────────────────────────────
 
 export const Playground: Story = {

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -123,7 +123,6 @@ describe("ListHeadless — interactive (single select)", () => {
       </ListHeadless>
     );
     const options = screen.getAllByRole("option");
-    // Focus the last item, then move up
     await user.tab();
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{ArrowDown}");
@@ -401,7 +400,7 @@ describe("List — styled density classes", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Token classes
+// Token classes — Variants-vs-States architecture
 // ---------------------------------------------------------------------------
 
 describe("List — styled token classes", () => {
@@ -415,7 +414,7 @@ describe("List — styled token classes", () => {
     expect(list).toHaveClass("bg-surface");
   });
 
-  test("30. Selected item has bg-secondary-container", async () => {
+  test("30. Selected item carries data-selected attribute", async () => {
     const user = userEvent.setup();
     render(
       <List aria-label="Test" selectionMode="single">
@@ -424,83 +423,157 @@ describe("List — styled token classes", () => {
       </List>
     );
     await user.click(screen.getByRole("option", { name: "Item 1" }));
-    expect(screen.getByRole("option", { name: "Item 1" })).toHaveClass("bg-secondary-container");
+    expect(screen.getByRole("option", { name: "Item 1" })).toHaveAttribute("data-selected", "");
   });
 
-  test("31. Unselected item has no bg-secondary-container", () => {
+  test("31. Unselected item does not carry data-selected attribute", () => {
     render(
       <List aria-label="Test" selectionMode="single">
         <ListItem value="1" headline="Item 1" />
       </List>
     );
     const item = screen.getByRole("option", { name: "Item 1" });
-    expect(item).not.toHaveClass("bg-secondary-container");
+    expect(item).not.toHaveAttribute("data-selected");
   });
 
-  test("32. Disabled item has opacity-38 and pointer-events-none", () => {
+  test("32. Disabled item carries data-disabled attribute", () => {
     render(
       <List aria-label="Test" selectionMode="single">
         <ListItem value="1" headline="Item 1" isDisabled />
       </List>
     );
     const item = screen.getByRole("option", { name: "Item 1" });
-    expect(item).toHaveClass("opacity-38");
-    expect(item).toHaveClass("pointer-events-none");
+    expect(item).toHaveAttribute("data-disabled", "");
   });
 });
 
 // ---------------------------------------------------------------------------
-// State layer
+// Variants-vs-States architecture — group/list-item + data-* attributes
+// ---------------------------------------------------------------------------
+
+describe("List — Variants-vs-States architecture", () => {
+  test("33. Interactive item root has group/list-item class", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    expect(item.className).toContain("group/list-item");
+  });
+
+  test("34. Interactive item root has data-interactive attribute", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    expect(item).toHaveAttribute("data-interactive", "");
+  });
+
+  test("35. Static item root does NOT have data-interactive attribute", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    expect(item).not.toHaveAttribute("data-interactive");
+  });
+
+  test("35a. data-with-leading content flag set when leadingSlot provided", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" leadingSlot={<span>★</span>} leadingType="icon" />
+      </List>
+    );
+    // Accessible name includes slot text — use positional query since only one option
+    const item = screen.getAllByRole("option")[0];
+    expect(item).toHaveAttribute("data-with-leading", "");
+  });
+
+  test("35b. data-with-trailing content flag set when trailingSlot provided", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" trailingSlot={<span>→</span>} trailingType="icon" />
+      </List>
+    );
+    // Accessible name includes slot text — use positional query since only one option
+    const item = screen.getAllByRole("option")[0];
+    expect(item).toHaveAttribute("data-with-trailing", "");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State layer — MD3 spring motion tokens
 // ---------------------------------------------------------------------------
 
 describe("List — state layer", () => {
-  test("33. State layer div present with opacity-0 and group-hover:opacity-8", () => {
+  test("33b. State layer span present in interactive list item", () => {
     render(
       <List aria-label="Test" selectionMode="single">
         <ListItem value="1" headline="Item 1" />
       </List>
     );
     const item = screen.getByRole("option", { name: "Item 1" });
-    const stateLayer = item.querySelector(".bg-on-surface");
+    const stateLayer = item.querySelector(".bg-on-surface.opacity-0");
     expect(stateLayer).toBeInTheDocument();
-    expect(stateLayer).toHaveClass("opacity-0");
-    expect(stateLayer).toHaveClass("group-hover:opacity-8");
   });
 
-  test("34. transition-[background-color] duration-short4 ease-standard on item root", () => {
+  test("34b. State layer has spring-standard-fast-effects motion tokens", () => {
     render(
       <List aria-label="Test" selectionMode="single">
         <ListItem value="1" headline="Item 1" />
       </List>
     );
     const item = screen.getByRole("option", { name: "Item 1" });
-    expect(item).toHaveClass("transition-[background-color]");
-    expect(item).toHaveClass("duration-short4");
-    expect(item).toHaveClass("ease-standard");
-  });
-
-  test("35a. State layer has transition-opacity duration-short2 ease-standard", () => {
-    render(
-      <List aria-label="Test" selectionMode="single">
-        <ListItem value="1" headline="Item 1" />
-      </List>
-    );
-    const item = screen.getByRole("option", { name: "Item 1" });
-    const stateLayer = item.querySelector(".bg-on-surface");
+    const stateLayer = item.querySelector(".bg-on-surface.opacity-0");
     expect(stateLayer).toHaveClass("transition-opacity");
-    expect(stateLayer).toHaveClass("duration-short2");
-    expect(stateLayer).toHaveClass("ease-standard");
+    expect(stateLayer).toHaveClass("duration-spring-standard-fast-effects");
+    expect(stateLayer).toHaveClass("ease-spring-standard-fast-effects");
   });
 
-  test("35b. State layer has group-active:opacity-12 for press state", () => {
+  test("35c. State layer is NOT present in static list item", () => {
+    render(
+      <List aria-label="Test">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("listitem");
+    // Static item has no state layer span
+    const stateLayer = item.querySelector(".bg-on-surface.opacity-0");
+    expect(stateLayer).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Focus ring
+// ---------------------------------------------------------------------------
+
+describe("List — focus ring", () => {
+  test("36. Focus ring span present in interactive list item", () => {
     render(
       <List aria-label="Test" selectionMode="single">
         <ListItem value="1" headline="Item 1" />
       </List>
     );
     const item = screen.getByRole("option", { name: "Item 1" });
-    const stateLayer = item.querySelector(".bg-on-surface");
-    expect(stateLayer).toHaveClass("group-active:opacity-12");
+    const focusRing = item.querySelector(".outline-secondary.opacity-0");
+    expect(focusRing).toBeInTheDocument();
+  });
+
+  test("36b. Focus ring has spring-standard-fast-effects motion tokens", () => {
+    render(
+      <List aria-label="Test" selectionMode="single">
+        <ListItem value="1" headline="Item 1" />
+      </List>
+    );
+    const item = screen.getByRole("option", { name: "Item 1" });
+    const focusRing = item.querySelector(".outline-secondary.opacity-0");
+    expect(focusRing).toHaveClass("transition-opacity");
+    expect(focusRing).toHaveClass("duration-spring-standard-fast-effects");
+    expect(focusRing).toHaveClass("ease-spring-standard-fast-effects");
   });
 });
 
@@ -509,7 +582,7 @@ describe("List — state layer", () => {
 // ---------------------------------------------------------------------------
 
 describe("List — leading slot", () => {
-  test("35. type='icon': renders with size-6 text-on-surface-variant", () => {
+  test("37. type='icon': renders with size-6 text-on-surface-variant", () => {
     render(
       <List aria-label="Test">
         <ListItem
@@ -526,7 +599,7 @@ describe("List — leading slot", () => {
     expect(container).toHaveClass("text-on-surface-variant");
   });
 
-  test("36. type='avatar': renders with size-10 rounded-full", () => {
+  test("38. type='avatar': renders with size-10 rounded-full", () => {
     render(
       <List aria-label="Test">
         <ListItem
@@ -543,7 +616,7 @@ describe("List — leading slot", () => {
     expect(container).toHaveClass("rounded-full");
   });
 
-  test("37. type='checkbox': inner control wrapper has aria-hidden='true'", () => {
+  test("39. type='checkbox': inner control wrapper has aria-hidden='true'", () => {
     render(
       <List aria-label="Test" selectionMode="multiple">
         <ListItem
@@ -558,7 +631,7 @@ describe("List — leading slot", () => {
     expect(cb.closest("[aria-hidden='true']")).toBeInTheDocument();
   });
 
-  test("38. type='radio': inner control wrapper has aria-hidden='true' and tabIndex={-1}", () => {
+  test("40. type='radio': inner control wrapper has aria-hidden='true' and tabIndex={-1}", () => {
     render(
       <List aria-label="Test" selectionMode="single">
         <ListItem
@@ -581,7 +654,7 @@ describe("List — leading slot", () => {
 // ---------------------------------------------------------------------------
 
 describe("List — trailing slot", () => {
-  test("39. type='text': renders with text-label-small text-on-surface-variant", () => {
+  test("41. type='text': renders with text-label-small text-on-surface-variant", () => {
     render(
       <List aria-label="Test">
         <ListItem
@@ -598,7 +671,7 @@ describe("List — trailing slot", () => {
     expect(container).toHaveClass("text-on-surface-variant");
   });
 
-  test("40. type='icon': renders with size-6", () => {
+  test("42. type='icon': renders with size-6", () => {
     render(
       <List aria-label="Test">
         <ListItem
@@ -620,7 +693,7 @@ describe("List — trailing slot", () => {
 // ---------------------------------------------------------------------------
 
 describe("List — text sub-component", () => {
-  test("41. Headline has text-body-large text-on-surface", () => {
+  test("43. Headline has text-body-large text-on-surface", () => {
     render(
       <List aria-label="Test">
         <ListItem value="1" headline="Headline" />
@@ -631,7 +704,7 @@ describe("List — text sub-component", () => {
     expect(headline).toHaveClass("text-on-surface");
   });
 
-  test("42. Supporting text has text-body-medium text-on-surface-variant", () => {
+  test("44. Supporting text has text-body-medium text-on-surface-variant", () => {
     render(
       <List aria-label="Test">
         <ListItem value="1" headline="Title" supportingText="Sub" />
@@ -642,7 +715,7 @@ describe("List — text sub-component", () => {
     expect(supporting).toHaveClass("text-on-surface-variant");
   });
 
-  test("43. Overline has text-label-small text-on-surface-variant", () => {
+  test("45. Overline has text-label-small text-on-surface-variant", () => {
     render(
       <List aria-label="Test">
         <ListItem value="1" headline="Title" overline="OVERLINE" supportingText="Sub" />
@@ -659,7 +732,7 @@ describe("List — text sub-component", () => {
 // ---------------------------------------------------------------------------
 
 describe("List — ripple", () => {
-  test("44. Ripple container present in interactive list item", () => {
+  test("46. Ripple container present in interactive list item", () => {
     render(
       <List aria-label="Test" selectionMode="single">
         <ListItem value="1" headline="Item 1" />
@@ -669,7 +742,7 @@ describe("List — ripple", () => {
     expect(item.querySelector("[data-ripple-container]")).toBeInTheDocument();
   });
 
-  test("45. Ripple NOT present in static list item", () => {
+  test("47. Ripple NOT present in static list item", () => {
     render(
       <List aria-label="Test">
         <ListItem value="1" headline="Item 1" />
@@ -681,7 +754,7 @@ describe("List — ripple", () => {
 });
 
 // ===========================================================================
-// Divider Integration Tests (46–59)
+// Divider Integration Tests (48–59)
 // ===========================================================================
 
 // ---------------------------------------------------------------------------
@@ -689,7 +762,7 @@ describe("List — ripple", () => {
 // ---------------------------------------------------------------------------
 
 describe("List — showDividers", () => {
-  test("46. showDividers={true} renders Divider elements between list items", () => {
+  test("48. showDividers={true} renders Divider elements between list items", () => {
     const { container } = render(
       <List aria-label="Test" showDividers>
         <ListItem value="1" headline="Item 1" />
@@ -701,7 +774,7 @@ describe("List — showDividers", () => {
     expect(dividers.length).toBeGreaterThan(0);
   });
 
-  test("47. With 3 items and showDividers={true}: renders exactly 2 Dividers", () => {
+  test("49. With 3 items and showDividers={true}: renders exactly 2 Dividers", () => {
     const { container } = render(
       <List aria-label="Test" showDividers>
         <ListItem value="1" headline="Item 1" />
@@ -713,7 +786,7 @@ describe("List — showDividers", () => {
     expect(dividers).toHaveLength(2);
   });
 
-  test("48. With 1 item and showDividers={true}: renders NO Dividers", () => {
+  test("50. With 1 item and showDividers={true}: renders NO Dividers", () => {
     const { container } = render(
       <List aria-label="Test" showDividers>
         <ListItem value="1" headline="Item 1" />
@@ -723,7 +796,7 @@ describe("List — showDividers", () => {
     expect(dividers).toHaveLength(0);
   });
 
-  test("49. Divider has border-outline-variant class (token compliance)", () => {
+  test("51. Divider has border-outline-variant class (token compliance)", () => {
     const { container } = render(
       <List aria-label="Test" showDividers>
         <ListItem value="1" headline="Item 1" />
@@ -734,7 +807,7 @@ describe("List — showDividers", () => {
     expect(divider).toHaveClass("border-outline-variant");
   });
 
-  test("50. showDividers={false} (default): renders no Dividers", () => {
+  test("52. showDividers={false} (default): renders no Dividers", () => {
     const { container } = render(
       <List aria-label="Test">
         <ListItem value="1" headline="Item 1" />
@@ -751,7 +824,7 @@ describe("List — showDividers", () => {
 // ---------------------------------------------------------------------------
 
 describe("List — insetDivider", () => {
-  test("51. insetDivider={true} renders a Divider at the bottom of the item", () => {
+  test("53. insetDivider={true} renders a Divider at the bottom of the item", () => {
     render(
       <List aria-label="Test">
         <ListItem value="1" headline="Item 1" insetDivider />
@@ -762,7 +835,7 @@ describe("List — insetDivider", () => {
     expect(divider).toBeInTheDocument();
   });
 
-  test("52. Inset Divider has ms-4 class (16dp logical inset from start)", () => {
+  test("54. Inset Divider has ms-4 class (16dp logical inset from start)", () => {
     render(
       <List aria-label="Test">
         <ListItem value="1" headline="Item 1" insetDivider />
@@ -773,7 +846,7 @@ describe("List — insetDivider", () => {
     expect(divider).toHaveClass("ms-4");
   });
 
-  test("53. insetDivider={false} (default): no Divider inside item", () => {
+  test("55. insetDivider={false} (default): no Divider inside item", () => {
     render(
       <List aria-label="Test">
         <ListItem value="1" headline="Item 1" />
@@ -790,7 +863,7 @@ describe("List — insetDivider", () => {
 // ---------------------------------------------------------------------------
 
 describe("List — divider composition", () => {
-  test("54. showDividers and insetDivider can coexist without duplicate dividers at the same boundary", () => {
+  test("56. showDividers and insetDivider can coexist without duplicate dividers at the same boundary", () => {
     const { container } = render(
       <List aria-label="Test" showDividers>
         <ListItem value="1" headline="Item 1" insetDivider />
@@ -802,7 +875,7 @@ describe("List — divider composition", () => {
     expect(allDividers).toHaveLength(3);
   });
 
-  test("55. Divider in showDividers mode uses inset='none' (full-width)", () => {
+  test("57. Divider in showDividers mode uses inset='none' (full-width)", () => {
     const { container } = render(
       <List aria-label="Test" showDividers>
         <ListItem value="1" headline="Item 1" />
@@ -816,7 +889,7 @@ describe("List — divider composition", () => {
     expect(betweenDivider).toHaveClass("w-full");
   });
 
-  test("56. Divider in insetDivider mode uses inset='start' (leading inset)", () => {
+  test("58. Divider in insetDivider mode uses inset='start' (leading inset)", () => {
     render(
       <List aria-label="Test">
         <ListItem value="1" headline="Item 1" insetDivider />
@@ -833,7 +906,7 @@ describe("List — divider composition", () => {
 // ---------------------------------------------------------------------------
 
 describe("List — divider accessibility", () => {
-  test("57. axe check — list with showDividers={true}, no violations", async () => {
+  test("59. axe check — list with showDividers={true}, no violations", async () => {
     const { container } = render(
       <List aria-label="Settings" showDividers>
         <ListItem value="wifi" headline="Wi-Fi" />
@@ -845,7 +918,7 @@ describe("List — divider accessibility", () => {
     expect(results).toHaveNoViolations();
   });
 
-  test("58. axe check — list with insetDivider={true}, no violations", async () => {
+  test("60. axe check — list with insetDivider={true}, no violations", async () => {
     const { container } = render(
       <List aria-label="Settings">
         <ListItem value="wifi" headline="Wi-Fi" insetDivider />
@@ -856,7 +929,7 @@ describe("List — divider accessibility", () => {
     expect(results).toHaveNoViolations();
   });
 
-  test("59. <hr> elements from Dividers do not break listbox/list accessibility roles", async () => {
+  test("61. <hr> elements from Dividers do not break listbox/list accessibility roles", async () => {
     const { container } = render(
       <List aria-label="Settings" showDividers>
         <ListItem value="wifi" headline="Wi-Fi" insetDivider />

--- a/packages/react/src/components/List/List.types.ts
+++ b/packages/react/src/components/List/List.types.ts
@@ -4,9 +4,9 @@ import type { Key, Selection, SelectionMode } from "react-stately";
 /**
  * Visual density based on content lines (MD3 List)
  *
- * - `one-line`: headline only (48dp)
- * - `two-line`: headline + supporting text (64dp)
- * - `three-line`: overline + headline + supporting text (88dp)
+ * - `one-line`: headline only (56dp min-height)
+ * - `two-line`: headline + supporting text (72dp min-height)
+ * - `three-line`: overline + headline + supporting text (88dp min-height)
  */
 export type ListDensity = "one-line" | "two-line" | "three-line";
 
@@ -135,9 +135,6 @@ export interface ListItemProps {
 
   /** Additional CSS classes */
   className?: string;
-
-  /** Item-specific action callback */
-  onAction?: (value: string | number) => void;
 }
 
 /**

--- a/packages/react/src/components/List/List.variants.ts
+++ b/packages/react/src/components/List/List.variants.ts
@@ -1,53 +1,287 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * MD3 List container CVA variants.
+ * Material Design 3 List Variants
+ *
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (density, slot type).
+ * - All interaction/selection states are driven by data-* attributes on the root <li>
+ *   via group-data-[x]/list-item Tailwind selectors in each slot's base classes.
+ * - Content flags (data-with-leading, data-with-trailing) are set explicitly by ListItem.
+ *
+ * Slot responsibilities:
+ *   listVariants               — container <ul>; bg-surface
+ *   listItemVariants           — root <li>; group/list-item; density height; cursor; disabled
+ *   listItemStateLayerVariants — absolute inset overlay; hover/focus/pressed opacity ring
+ *   listItemFocusRingVariants  — keyboard focus indicator outline
+ *   listItemLeadingVariants    — leading slot wrapper; type-specific size/shape + color states
+ *   listItemTrailingVariants   — trailing slot wrapper; type-specific size/shape + color states
+ *   listItemOverlineVariants   — overline text; color reacts to selected/disabled
+ *   listItemHeadlineVariants   — headline text; color reacts to selected/disabled
+ *   listItemSupportingTextVariants — supporting text; color reacts to selected/disabled
+ *
+ * MD3 Spec (lists/specs):
+ *   One-line:   56dp min-height
+ *   Two-line:   72dp min-height
+ *   Three-line: 88dp min-height (leading/trailing top-aligned)
+ *   Padding: 16dp horizontal, 8dp vertical
+ *   Leading icon: 24dp, text-on-surface-variant
+ *   Leading avatar: 40dp circle
+ *   State-layer opacities: hover 8% | focus 10% | pressed 10%
+ *   Disabled: content 38% opacity, pointer-events none
+ *   Selected: bg-secondary-container, text/icons on-secondary-container
+ */
+
+// ─── LIST CONTAINER ───────────────────────────────────────────────────────────
+
+/**
+ * List container (<ul>).
+ * MD3: Lists use `surface` color role for their container.
  */
 export const listVariants = cva("w-full bg-surface");
 
+// ─── LIST ITEM ROOT ───────────────────────────────────────────────────────────
+
 /**
- * MD3 ListItem CVA variants.
+ * Root <li> element — carries `group/list-item` and emits data-* interaction attributes.
  *
- * Density is auto-derived from content (overline / supportingText), not a user prop.
- * Three-line items use `items-start` so leading/trailing slots top-align.
+ * Design-time variant: `density` only.
+ * All interaction/selection states are driven via group-data-[x]/list-item selectors
+ * in the slot CVAs below — NOT as CVA variant keys here.
+ *
+ *   one-line:   56dp (min-h-14)
+ *   two-line:   72dp (min-h-18)
+ *   three-line: 88dp (min-h-22, items-start for top-aligned slots)
+ *
+ * Selected background: group-data-[selected]/list-item:bg-secondary-container
+ * Interactive cursor: data-[interactive]:cursor-pointer
+ * Disabled: self-targeting data-[disabled]: selectors (38% + no pointer)
  */
 export const listItemVariants = cva(
   [
-    "group relative flex items-center overflow-hidden px-4 py-2 cursor-pointer",
-    "transition-[background-color] duration-short4 ease-standard",
+    // Layout
+    "relative flex items-center overflow-hidden px-4 py-2 select-none",
+    // Color transition — effects spring (no spatial overshoot on color)
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Cursor: non-interactive base; data-[interactive] overrides
+    "cursor-default",
+    "data-[interactive]:cursor-pointer",
+    // Selected: secondary-container background
+    "group-data-[selected]/list-item:bg-secondary-container",
+    // Disabled: self-targeting selectors (not group, since root is the group)
+    "data-[disabled]:opacity-38 data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed",
   ],
   {
     variants: {
+      /**
+       * Visual density — derived from content, not a user prop.
+       * one-line:   headline only (56dp)
+       * two-line:   headline + supportingText (72dp)
+       * three-line: overline + headline + supportingText (88dp)
+       */
       density: {
         "one-line": "min-h-14",
         "two-line": "min-h-18",
         "three-line": "min-h-22 items-start",
       },
-
-      isSelected: {
-        true: "bg-secondary-container text-on-secondary-container",
-        false: "",
-      },
-
-      isDisabled: {
-        true: "opacity-38 pointer-events-none",
-        false: "",
-      },
-
-      isInteractive: {
-        true: "",
-        false: "cursor-default",
-      },
     },
 
     defaultVariants: {
       density: "one-line",
-      isSelected: false,
-      isDisabled: false,
-      isInteractive: true,
     },
   }
 );
 
+// ─── STATE LAYER ─────────────────────────────────────────────────────────────
+
+/**
+ * State layer — absolute inset overlay that transitions opacity on interaction.
+ *
+ * Color: bg-on-surface (matches MD3 list item state layer color on surface).
+ * On selected items (bg-secondary-container), MD3 uses on-secondary-container
+ * for the state layer. We keep bg-on-surface and let the background provide context.
+ *
+ * Opacity:
+ *   0 at rest
+ *   8% hover  (group-data-[hovered]/list-item:)
+ *   10% focus (group-data-[focus-visible]/list-item:)
+ *   10% pressed — doubled selector wins over hover at same cascade position
+ *   hidden when disabled
+ */
+export const listItemStateLayerVariants = cva([
+  "absolute inset-0 pointer-events-none opacity-0",
+  "bg-on-surface",
+  // Effects transition for opacity — no spatial overshoot
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Hover: 8%
+  "group-data-[hovered]/list-item:opacity-8",
+  // Focus: 10%
+  "group-data-[focus-visible]/list-item:opacity-10",
+  // Pressed: 10%, doubled selector beats hover
+  "group-data-[pressed]/list-item:group-data-[pressed]/list-item:opacity-10",
+  // No state layer when disabled
+  "group-data-[disabled]/list-item:hidden",
+]);
+
+// ─── FOCUS RING ───────────────────────────────────────────────────────────────
+
+/**
+ * Focus ring — absolute inset outline for keyboard/programmatic focus.
+ *
+ * Uses an inset outline (not a box-shadow or extra padding) so it stays
+ * clipped to the list item bounds. opacity transitions rather than display
+ * toggling allows smooth animation.
+ */
+export const listItemFocusRingVariants = cva([
+  "pointer-events-none absolute inset-0",
+  "outline outline-2 -outline-offset-2 outline-secondary",
+  // Effects transition — opacity must NOT overshoot
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/list-item:opacity-100",
+]);
+
+// ─── LEADING SLOT ─────────────────────────────────────────────────────────────
+
+/**
+ * Leading slot wrapper.
+ *
+ * type-specific styling:
+ *   icon   — 24dp, text-on-surface-variant at rest, reacts to selected/disabled
+ *   avatar — 40dp circle, overflow-hidden (no color tokens, content provides color)
+ *   checkbox / radio — no sizing; slot is purely a layout wrapper
+ *
+ * For checkbox/radio, selection semantics come from the parent <li>'s useOption
+ * (aria-selected), so these slots are wrapped in aria-hidden by ListItemLeading.
+ */
+export const listItemLeadingVariants = cva(
+  [
+    "mr-4 flex shrink-0 items-center",
+    // Effects transition for icon color changes
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  ],
+  {
+    variants: {
+      type: {
+        icon: [
+          "size-6",
+          "text-on-surface-variant",
+          // Selected: icon color changes to on-secondary-container
+          "group-data-[selected]/list-item:text-on-secondary-container",
+          // Disabled: 38% (inherited from root opacity-38, but also explicit for color accuracy)
+          "group-data-[disabled]/list-item:text-on-surface/38",
+        ],
+        avatar: [
+          "size-10 overflow-hidden rounded-full",
+          // Avatar color provided by content; no token overrides needed
+        ],
+        checkbox: [],
+        radio: [],
+      },
+    },
+    defaultVariants: {
+      type: "icon",
+    },
+  }
+);
+
+// ─── TRAILING SLOT ────────────────────────────────────────────────────────────
+
+/**
+ * Trailing slot wrapper.
+ *
+ * type-specific styling:
+ *   icon   — 24dp, text-on-surface-variant, reacts to selected/disabled
+ *   text   — label-small typography, text-on-surface-variant, reacts to selected/disabled
+ *   checkbox / radio — no sizing; selection semantics come from useOption
+ */
+export const listItemTrailingVariants = cva(
+  [
+    "ml-auto flex shrink-0 items-center",
+    // Effects transition for color changes
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  ],
+  {
+    variants: {
+      type: {
+        icon: [
+          "size-6",
+          "text-on-surface-variant",
+          "group-data-[selected]/list-item:text-on-secondary-container",
+          "group-data-[disabled]/list-item:text-on-surface/38",
+        ],
+        text: [
+          "text-label-small",
+          "text-on-surface-variant",
+          "group-data-[selected]/list-item:text-on-secondary-container",
+          "group-data-[disabled]/list-item:text-on-surface/38",
+        ],
+        checkbox: [],
+        radio: [],
+      },
+    },
+    defaultVariants: {
+      type: "icon",
+    },
+  }
+);
+
+// ─── TEXT SLOTS ───────────────────────────────────────────────────────────────
+
+/**
+ * Overline text — appears above the headline in three-line density.
+ * MD3: label-small typography, on-surface-variant color at rest.
+ */
+export const listItemOverlineVariants = cva([
+  "text-label-small",
+  "text-on-surface-variant",
+  // Effects transition for color
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Selected: on-secondary-container
+  "group-data-[selected]/list-item:text-on-secondary-container",
+  // Disabled: opacity inherited from root; explicit for color
+  "group-data-[disabled]/list-item:text-on-surface/38",
+]);
+
+/**
+ * Headline text — primary list item label.
+ * MD3: body-large typography, on-surface color at rest.
+ */
+export const listItemHeadlineVariants = cva([
+  "text-body-large",
+  "text-on-surface",
+  // Effects transition for color
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Selected: on-secondary-container
+  "group-data-[selected]/list-item:text-on-secondary-container",
+  // Disabled: 38% color via CSS (opacity-38 on root handles all descendants, but
+  // explicit token ensures predictable rendering when color is specified).
+  "group-data-[disabled]/list-item:text-on-surface/38",
+]);
+
+/**
+ * Supporting text — secondary label below the headline.
+ * MD3: body-medium typography, on-surface-variant color at rest.
+ */
+export const listItemSupportingTextVariants = cva([
+  "text-body-medium",
+  "text-on-surface-variant",
+  // Effects transition for color
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Selected: on-secondary-container
+  "group-data-[selected]/list-item:text-on-secondary-container",
+  // Disabled: 38% color
+  "group-data-[disabled]/list-item:text-on-surface/38",
+]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
 export type ListVariants = VariantProps<typeof listVariants>;
 export type ListItemVariants = VariantProps<typeof listItemVariants>;
+export type ListItemStateLayerVariants = VariantProps<typeof listItemStateLayerVariants>;
+export type ListItemFocusRingVariants = VariantProps<typeof listItemFocusRingVariants>;
+export type ListItemLeadingVariants = VariantProps<typeof listItemLeadingVariants>;
+export type ListItemTrailingVariants = VariantProps<typeof listItemTrailingVariants>;
+export type ListItemOverlineVariants = VariantProps<typeof listItemOverlineVariants>;
+export type ListItemHeadlineVariants = VariantProps<typeof listItemHeadlineVariants>;
+export type ListItemSupportingTextVariants = VariantProps<typeof listItemSupportingTextVariants>;

--- a/packages/react/src/components/List/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem.tsx
@@ -2,13 +2,18 @@
 
 import { forwardRef, useRef } from "react";
 import type React from "react";
-import { useOption } from "react-aria";
+import { useOption, useHover } from "react-aria";
 import { mergeProps } from "@react-aria/utils";
 import type { ListState } from "react-stately";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
 import { Divider } from "../Divider";
-import { listItemVariants } from "./List.variants";
+import {
+  listItemVariants,
+  listItemStateLayerVariants,
+  listItemFocusRingVariants,
+} from "./List.variants";
 import { ListItemLeading } from "./ListItemLeading";
 import { ListItemTrailing } from "./ListItemTrailing";
 import { ListItemText } from "./ListItemText";
@@ -28,18 +33,35 @@ function getDensity(overline?: string, supportingText?: string): ListDensity {
 /**
  * Material Design 3 List Item (Layer 3: Styled)
  *
- * Renders an accessible list item with MD3 visual treatment:
- * state layer, ripple, density-driven height, and slot-based layout.
+ * Architecture: Variants-vs-States
+ * - Design-time variant: `density` (auto-derived from content).
+ * - All interaction/selection states are expressed as data-* attributes on the root <li>
+ *   via `getInteractionDataAttributes`, consumed by each slot via group-data-[x]/list-item.
+ * - Content flags (`data-with-leading`, `data-with-trailing`) describe structure, set explicitly.
  *
- * - **Interactive mode** (inside a `List` with `selectionMode` or `onAction`):
- *   uses `useOption` for ARIA semantics, renders state layer + ripple.
- * - **Static mode**: renders `<li role="listitem">` without interactive
- *   affordances.
+ * Two operating modes:
+ * - **Interactive** (inside a `List` with `selectionMode` or `onAction`):
+ *   uses `useOption` for ARIA semantics, renders state layer + focus ring + ripple.
+ * - **Static**: renders `<li role="listitem">`, no interactive affordances.
  *
  * Density is auto-derived from content:
- * - one-line (56dp) — headline only
- * - two-line (72dp) — headline + supportingText
+ * - one-line (56dp)   — headline only
+ * - two-line (72dp)   — headline + supportingText
  * - three-line (88dp) — overline present
+ *
+ * @example
+ * ```tsx
+ * // Static
+ * <List aria-label="Settings">
+ *   <ListItem value="wifi" headline="Wi-Fi" supportingText="Connected" leadingType="icon" leadingSlot={<IconWifi />} />
+ * </List>
+ *
+ * // Interactive single-select
+ * <List aria-label="Alignment" selectionMode="single">
+ *   <ListItem value="left" headline="Left" />
+ *   <ListItem value="center" headline="Center" />
+ * </List>
+ * ```
  */
 export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(function ListItem(
   {
@@ -81,40 +103,95 @@ export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(function ListIt
   }
 
   return (
-    <li
+    <StaticStyledListItem
       ref={forwardedRef}
-      role="listitem"
-      className={cn(
-        listItemVariants({
-          density,
-          isSelected: false,
-          isDisabled,
-          isInteractive: false,
-        }),
-        className
-      )}
-    >
-      {leadingSlot && <ListItemLeading type={leadingType ?? "icon"}>{leadingSlot}</ListItemLeading>}
-      <ListItemText
-        headline={headline}
-        {...(supportingText !== undefined ? { supportingText } : {})}
-        {...(overline !== undefined ? { overline } : {})}
-      />
-      {trailingSlot && (
-        <ListItemTrailing type={trailingType ?? "icon"}>{trailingSlot}</ListItemTrailing>
-      )}
-      {insetDivider && (
-        <Divider
-          orientation="horizontal"
-          inset="start"
-          className="absolute right-0 bottom-0 left-0"
-        />
-      )}
-    </li>
+      value={value}
+      headline={headline}
+      {...(supportingText !== undefined ? { supportingText } : {})}
+      {...(overline !== undefined ? { overline } : {})}
+      {...(leadingSlot !== undefined ? { leadingSlot } : {})}
+      {...(leadingType !== undefined ? { leadingType } : {})}
+      {...(trailingSlot !== undefined ? { trailingSlot } : {})}
+      {...(trailingType !== undefined ? { trailingType } : {})}
+      density={density}
+      isDisabled={isDisabled}
+      insetDivider={insetDivider}
+      {...(className !== undefined ? { className } : {})}
+    />
   );
 });
 
 ListItem.displayName = "ListItem";
+
+// ─── StaticStyledListItem (internal) ─────────────────────────────────────────
+
+interface StaticStyledListItemInternalProps {
+  value: string | number;
+  headline: string;
+  supportingText?: string;
+  overline?: string;
+  leadingSlot?: React.ReactNode;
+  leadingType?: ListItemProps["leadingType"];
+  trailingSlot?: React.ReactNode;
+  trailingType?: ListItemProps["trailingType"];
+  density: ListDensity;
+  isDisabled: boolean;
+  insetDivider: boolean;
+  className?: string;
+}
+
+/**
+ * Static list item — non-interactive; no state layer, focus ring, or ripple.
+ * Still propagates data-disabled so slot color tokens respond correctly.
+ */
+const StaticStyledListItem = forwardRef<HTMLLIElement, StaticStyledListItemInternalProps>(
+  function StaticStyledListItem(
+    {
+      headline,
+      supportingText,
+      overline,
+      leadingSlot,
+      leadingType,
+      trailingSlot,
+      trailingType,
+      density,
+      isDisabled,
+      insetDivider,
+      className,
+    },
+    ref
+  ) {
+    return (
+      <li
+        ref={ref}
+        role="listitem"
+        className={cn(listItemVariants({ density }), "group/list-item", className)}
+        {...getInteractionDataAttributes({ isDisabled })}
+      >
+        {leadingSlot && (
+          <ListItemLeading type={leadingType ?? "icon"}>{leadingSlot}</ListItemLeading>
+        )}
+        <ListItemText
+          headline={headline}
+          {...(supportingText !== undefined ? { supportingText } : {})}
+          {...(overline !== undefined ? { overline } : {})}
+        />
+        {trailingSlot && (
+          <ListItemTrailing type={trailingType ?? "icon"}>{trailingSlot}</ListItemTrailing>
+        )}
+        {insetDivider && (
+          <Divider
+            orientation="horizontal"
+            inset="start"
+            className="absolute right-0 bottom-0 left-0"
+          />
+        )}
+      </li>
+    );
+  }
+);
+
+StaticStyledListItem.displayName = "StaticStyledListItem";
 
 // ─── InteractiveStyledListItem (internal) ─────────────────────────────────────
 
@@ -136,6 +213,9 @@ interface InteractiveStyledListItemInternalProps {
 /**
  * Internal interactive list item — separated so `useOption` is always
  * called unconditionally (Rules of Hooks).
+ *
+ * Emits `group/list-item` on the root so all slot CVAs can consume
+ * `group-data-[x]/list-item:` selectors without style leakage to sibling groups.
  */
 const InteractiveStyledListItem = forwardRef<HTMLLIElement, InteractiveStyledListItemInternalProps>(
   function InteractiveStyledListItem(
@@ -158,35 +238,50 @@ const InteractiveStyledListItem = forwardRef<HTMLLIElement, InteractiveStyledLis
     const internalRef = useRef<HTMLLIElement>(null);
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLLIElement>;
 
-    const { optionProps, isSelected, isDisabled } = useOption({ key: value }, state, ref);
+    // React Aria: provides ARIA semantics + isSelected, isDisabled, isPressed, isFocusVisible
+    const { optionProps, isSelected, isDisabled, isPressed, isFocusVisible } = useOption(
+      { key: value },
+      state,
+      ref
+    );
 
-    const { onMouseDown: handleRipple, ripples } = useRipple({
-      disabled: isDisabled,
-    });
+    // Hover state for state-layer (useOption does not provide isHovered)
+    const { isHovered, hoverProps } = useHover({ isDisabled });
 
-    const mergedProps = mergeProps(optionProps, { onMouseDown: handleRipple });
+    // Ripple effect
+    const { onMouseDown: handleRipple, ripples } = useRipple({ disabled: isDisabled });
+
+    const mergedProps = mergeProps(optionProps, hoverProps, { onMouseDown: handleRipple });
+
+    const hasLeading = !!leadingSlot;
+    const hasTrailing = !!trailingSlot;
 
     return (
       <li
         {...mergedProps}
         ref={ref}
-        className={cn(
-          listItemVariants({
-            density,
-            isSelected,
-            isDisabled,
-            isInteractive: true,
-          }),
-          className
-        )}
-        data-selected={isSelected || undefined}
-        data-disabled={isDisabled || undefined}
+        className={cn(listItemVariants({ density }), "group/list-item", className)}
+        // ── Interaction data attributes (from React Aria state) ──────────
+        {...getInteractionDataAttributes({
+          isHovered,
+          isFocusVisible,
+          isPressed,
+          isSelected,
+          isDisabled,
+        })}
+        // ── Structural flags (describe content, NOT interaction state) ───
+        data-interactive=""
+        data-with-leading={hasLeading ? "" : undefined}
+        data-with-trailing={hasTrailing ? "" : undefined}
       >
-        <div
-          aria-hidden="true"
-          className="bg-on-surface duration-short2 ease-standard pointer-events-none absolute inset-0 opacity-0 transition-opacity group-hover:opacity-8 group-active:opacity-12"
-        />
+        {/* Ripple */}
         {ripples}
+
+        {/* State layer — hover/focus/pressed opacity ring */}
+        <span aria-hidden="true" className={cn(listItemStateLayerVariants())} />
+
+        {/* Focus ring — keyboard focus indicator */}
+        <span aria-hidden="true" className={cn(listItemFocusRingVariants())} />
 
         {leadingSlot && (
           <ListItemLeading type={leadingType ?? "icon"}>{leadingSlot}</ListItemLeading>

--- a/packages/react/src/components/List/ListItemLeading.tsx
+++ b/packages/react/src/components/List/ListItemLeading.tsx
@@ -1,16 +1,13 @@
 import { forwardRef } from "react";
 import { cn } from "../../utils/cn";
+import { listItemLeadingVariants } from "./List.variants";
 import type { ListItemLeadingProps } from "./List.types";
-
-const typeClasses: Record<string, string> = {
-  icon: "size-6 text-on-surface-variant",
-  avatar: "size-10 overflow-hidden rounded-full",
-  checkbox: "",
-  radio: "",
-};
 
 /**
  * MD3 ListItem leading slot.
+ *
+ * Uses `listItemLeadingVariants` CVA so icon/text colors automatically react to
+ * the parent `group/list-item` data-selected and data-disabled attributes.
  *
  * For `checkbox` and `radio` types the children are wrapped with
  * `aria-hidden="true"` and `tabIndex={-1}` because the parent
@@ -22,10 +19,7 @@ export const ListItemLeading = forwardRef<HTMLDivElement, ListItemLeadingProps>(
     const isControl = type === "checkbox" || type === "radio";
 
     return (
-      <div
-        ref={ref}
-        className={cn("mr-4 flex shrink-0 items-center", typeClasses[type], className)}
-      >
+      <div ref={ref} className={cn(listItemLeadingVariants({ type }), className)}>
         {isControl ? (
           <span aria-hidden="true" tabIndex={-1}>
             {children}

--- a/packages/react/src/components/List/ListItemText.tsx
+++ b/packages/react/src/components/List/ListItemText.tsx
@@ -1,9 +1,17 @@
 import { forwardRef } from "react";
 import { cn } from "../../utils/cn";
+import {
+  listItemOverlineVariants,
+  listItemHeadlineVariants,
+  listItemSupportingTextVariants,
+} from "./List.variants";
 import type { ListItemTextProps } from "./List.types";
 
 /**
  * MD3 ListItem text block — overline + headline + supporting text.
+ *
+ * Each text element uses its own slot CVA so colors automatically react to
+ * the parent `group/list-item` data-selected and data-disabled attributes.
  *
  * Uses `min-w-0` to allow text truncation inside flex containers.
  */
@@ -13,11 +21,9 @@ export const ListItemText = forwardRef<HTMLDivElement, ListItemTextProps>(functi
 ) {
   return (
     <div ref={ref} className={cn("min-w-0 flex-1", className)}>
-      {overline && <p className="text-on-surface-variant text-label-small">{overline}</p>}
-      <p className="text-on-surface text-body-large">{headline}</p>
-      {supportingText && (
-        <p className="text-on-surface-variant text-body-medium">{supportingText}</p>
-      )}
+      {overline && <p className={cn(listItemOverlineVariants())}>{overline}</p>}
+      <p className={cn(listItemHeadlineVariants())}>{headline}</p>
+      {supportingText && <p className={cn(listItemSupportingTextVariants())}>{supportingText}</p>}
     </div>
   );
 });

--- a/packages/react/src/components/List/ListItemTrailing.tsx
+++ b/packages/react/src/components/List/ListItemTrailing.tsx
@@ -1,16 +1,13 @@
 import { forwardRef } from "react";
 import { cn } from "../../utils/cn";
+import { listItemTrailingVariants } from "./List.variants";
 import type { ListItemTrailingProps } from "./List.types";
-
-const typeClasses: Record<string, string> = {
-  icon: "size-6 text-on-surface-variant",
-  text: "text-on-surface-variant text-label-small",
-  checkbox: "",
-  radio: "",
-};
 
 /**
  * MD3 ListItem trailing slot.
+ *
+ * Uses `listItemTrailingVariants` CVA so icon/text colors automatically react to
+ * the parent `group/list-item` data-selected and data-disabled attributes.
  *
  * For `checkbox` and `radio` types the children are wrapped with
  * `aria-hidden="true"` and `tabIndex={-1}` — selection semantics
@@ -21,10 +18,7 @@ export const ListItemTrailing = forwardRef<HTMLDivElement, ListItemTrailingProps
     const isControl = type === "checkbox" || type === "radio";
 
     return (
-      <div
-        ref={ref}
-        className={cn("ml-auto flex shrink-0 items-center", typeClasses[type], className)}
-      >
+      <div ref={ref} className={cn(listItemTrailingVariants({ type }), className)}>
         {isControl ? (
           <span aria-hidden="true" tabIndex={-1}>
             {children}

--- a/packages/react/src/components/List/index.ts
+++ b/packages/react/src/components/List/index.ts
@@ -12,8 +12,22 @@ export { ListHeadless, ListItemHeadless } from "./ListHeadless";
 export {
   listVariants,
   listItemVariants,
+  listItemStateLayerVariants,
+  listItemFocusRingVariants,
+  listItemLeadingVariants,
+  listItemTrailingVariants,
+  listItemOverlineVariants,
+  listItemHeadlineVariants,
+  listItemSupportingTextVariants,
   type ListVariants,
   type ListItemVariants,
+  type ListItemStateLayerVariants,
+  type ListItemFocusRingVariants,
+  type ListItemLeadingVariants,
+  type ListItemTrailingVariants,
+  type ListItemOverlineVariants,
+  type ListItemHeadlineVariants,
+  type ListItemSupportingTextVariants,
 } from "./List.variants";
 
 // Types


### PR DESCRIPTION
## Summary

- Migrates `List` / `ListItem` from CVA-state-variants to the project's Variants-vs-States architecture (matching Button, Tabs, Switch)
- Adds proper MD3 state layer span, keyboard focus ring, and spring-standard-fast-effects motion tokens
- Propagates selected/disabled color tokens to all sub-slots (leading, trailing, overline, headline, supporting text) via `group-data-[x]/list-item` selectors

## Changes

### `List.variants.ts` — full rewrite
- `listItemVariants`: density-only CVA; drops `isSelected`/`isDisabled`/`isInteractive` variant keys
- New slot CVAs: `listItemStateLayerVariants`, `listItemFocusRingVariants`, `listItemLeadingVariants`, `listItemTrailingVariants`, `listItemOverlineVariants`, `listItemHeadlineVariants`, `listItemSupportingTextVariants`
- All interaction states driven by `group-data-[hovered/focus-visible/pressed/selected/disabled]/list-item:` selectors

### `ListItem.tsx`
- `InteractiveStyledListItem`: wires `useOption` + `useHover`, uses `getInteractionDataAttributes`, emits `data-interactive` + `data-with-leading/trailing` content flags
- Renders state layer `<span>` and focus ring `<span>` before slot content
- Static branch: keeps `role="listitem"`, emits `data-disabled` for correct slot color

### `ListItemLeading / ListItemTrailing / ListItemText`
- Converted from `Record<string,string>` class maps to `listItemLeadingVariants({ type })` / `listItemTrailingVariants({ type })` / per-element slot CVAs

### `List.types.ts`
- Fix `ListDensity` JSDoc: 56/72/88dp (was 48/64dp)
- Remove unused per-item `onAction` (breaking — List-level `onAction` is the correct API)

### `index.ts`
- Export all new slot variants and `VariantProps` types

### Tests + Stories
- Rewrite state layer and selection tests to target `data-*` attributes and spring-motion class names
- Add `States` story showing rest / selected / disabled / slotted states

## Test plan

- [x] `pnpm --filter @tinybigui/react typecheck` — passes
- [x] `pnpm --filter @tinybigui/react lint` — passes
- [x] `pnpm --filter @tinybigui/react test` — 2071/2071 pass
- [ ] Visual check in Storybook: hover / focus / selected / disabled states on all densities