### PR TITLE
feat(progress): md3 expressive refactor

### DIFF
--- a/.changeset/progress-md3-expressive-refactor.md
+++ b/.changeset/progress-md3-expressive-refactor.md
@@ -1,0 +1,25 @@
+---
+"@tinybigui/react": minor
+---
+
+feat(progress): MD3 Expressive refactor — colorful tokens, gap, wavy shape, thick track
+
+**Visual changes (non-breaking by default)**
+
+- Inactive track color changed from `surface-container-highest` to `primary-container` (MD3 Expressive "colorful" style). Consumers relying on the specific old token will see a visual difference.
+- 4dp indicator-track gap introduced between the active and inactive segments (linear + circular). The linear track now renders as two sibling segments rather than an `overflow: hidden` clipping approach.
+- Stop indicator dot updated to 4dp (`size-1`) — previously `w-1 h-1` which was already 4px.
+- Circular inactive track is now always visible in `primary-container` color (previously transparent/hidden in many states).
+- Determinate transition updated from `duration-medium4 ease-standard` (legacy tokens) to `duration-spring-standard-default-spatial ease-spring-standard-default-spatial` (spring motion tokens). Progress updates now feel smoother and consistent with other components.
+
+**New props**
+
+- `shape?: "flat" | "wavy"` (default `"flat"`) — wavy uses an SVG sine-wave active indicator. Automatically falls back to flat when `prefers-reduced-motion: reduce` is set.
+- `thickness?: "default" | "thick"` (default `"default"`) — thick renders an 8dp track per the MD3 Expressive thick variant.
+
+**Architecture**
+
+- `Progress.variants.ts` rewritten as slot-based CVA blocks following the Button/Switch/Tabs pattern.
+- `progressInactiveSegmentVariants` added (new export) for the gap-based inactive track segment.
+- `progressIndicatorVariants` kept as a backward-compat alias for `progressActiveIndicatorVariants`.
+- `ProgressHeadless` `renderProgress` state now includes `shape` and `thickness`.

--- a/packages/react/src/components/Progress/Progress.css
+++ b/packages/react/src/components/Progress/Progress.css
@@ -1,15 +1,18 @@
 /*
  * Progress Indicator Animations
- * Material Design 3 motion tokens for indeterminate progress states.
+ * Material Design 3 motion tokens for indeterminate and wavy progress states.
  *
  * Keyframes are defined here (co-located with the component) per project
  * convention — they are NOT added to the global tokens.css.
  *
+ * All timing values reference MD3 motion token CSS custom properties.
+ * Hardcoded durations are forbidden — use the token vars below.
+ *
  * Motion tokens referenced (from packages/tokens/src/tokens.css):
- *   --md-sys-motion-duration-medium4 : 400ms  (determinate transitions — applied via Tailwind)
- *   --md-sys-motion-duration-long2   : 500ms  (linear indeterminate cycle)
- *   --md-sys-motion-duration-long4   : 600ms  (circular indeterminate rotation)
- *   --md-sys-motion-easing-standard  : cubic-bezier(0.2, 0, 0, 1)
+ *   --md-sys-motion-duration-long2          : 500ms  (linear indeterminate cycle)
+ *   --md-sys-motion-duration-long4          : 600ms  (circular indeterminate rotation)
+ *   --md-sys-motion-duration-extra-long4    : 1000ms (wave horizontal translation)
+ *   --md-sys-motion-easing-standard         : cubic-bezier(0.2, 0, 0, 1)
  */
 
 /* ---------------------------------------------------------------------------
@@ -83,12 +86,27 @@
 }
 
 /* ---------------------------------------------------------------------------
+   WAVY TRANSLATION
+   Horizontal wave motion: the wavy path translates one full wavelength so
+   the wave appears to flow continuously.
+   Duration: extra-long4 = 1000ms per cycle (repeating).
+   --------------------------------------------------------------------------- */
+
+@keyframes progress-wave-translate {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    /* Translate exactly one wavelength. The wavelength is baked into the SVG
+       path so the visual loop is seamless. The actual translate distance is
+       set via --progress-wave-wavelength CSS custom property on the element. */
+    transform: translateX(var(--progress-wave-wavelength, -40px));
+  }
+}
+
+/* ---------------------------------------------------------------------------
    TAILWIND @theme INTEGRATION
-   Register animations so they can be used as Tailwind utilities:
-     animate-progress-linear-indeterminate-1
-     animate-progress-linear-indeterminate-2
-     animate-progress-circular-rotate
-     animate-progress-circular-dash
+   Register animations so they can be used as Tailwind utilities.
    --------------------------------------------------------------------------- */
 
 @theme {
@@ -103,4 +121,7 @@
 
   --animate-progress-circular-dash: progress-circular-dash var(--md-sys-motion-duration-long4)
     var(--md-sys-motion-easing-standard) infinite;
+
+  --animate-progress-wave-translate: progress-wave-translate
+    var(--md-sys-motion-duration-extra-long4) linear infinite;
 }

--- a/packages/react/src/components/Progress/Progress.stories.tsx
+++ b/packages/react/src/components/Progress/Progress.stories.tsx
@@ -3,21 +3,28 @@ import { useState } from "react";
 import { Progress } from "./Progress";
 
 /**
- * Material Design 3 Progress Indicator Component
+ * Material Design 3 Progress Indicator — MD3 Expressive
  *
- * Supports four variants driven by `type` and `indeterminate` props:
- * - **Linear Determinate** — shows a known progress value on a horizontal track
+ * Supports four visual combinations driven by `type` × `indeterminate`:
+ * - **Linear Determinate** — two-segment track (active + gap + inactive) on a horizontal rail
  * - **Linear Indeterminate** — animated two-segment bar for unknown duration
- * - **Circular Determinate** — SVG arc showing a known progress value
- * - **Circular Indeterminate** — rotating spinner for unknown duration
+ * - **Circular Determinate** — SVG arc pair with 4dp gap between active and inactive
+ * - **Circular Indeterminate** — rotating spinner with visible inactive track
  *
- * ## MD3 Specifications
- * - Linear track height: 4dp
- * - Circular default size: 48dp (medium)
- * - Active track color: `primary`
- * - Inactive track color: `surface-container-highest`
- * - Determinate transitions: 400ms ease-standard
- * - Indeterminate cycle: 500ms (linear) / 600ms (circular)
+ * ## MD3 Expressive spec (May 2025)
+ * - Active indicator color: `primary`
+ * - Inactive track color: `primary-container` (colorful style)
+ * - Indicator-track gap: 4dp between active and inactive segments
+ * - Stop indicator: 4dp `primary` dot at trailing edge (linear determinate only)
+ * - Track thickness: 4dp default | 8dp thick (via `thickness` prop)
+ * - Shape: flat (default) | wavy (SVG sine-wave, `shape="wavy"`)
+ * - Reduced-motion: wavy automatically degrades to flat
+ *
+ * ## New MD3 Expressive props
+ * | Prop | Values | Default | Description |
+ * |---|---|---|---|
+ * | `shape` | `"flat"` \| `"wavy"` | `"flat"` | Wavy uses a sine-wave active indicator |
+ * | `thickness` | `"default"` \| `"thick"` | `"default"` | 4dp or 8dp track |
  */
 const meta: Meta<typeof Progress> = {
   title: "Components/Progress",
@@ -54,12 +61,22 @@ const meta: Meta<typeof Progress> = {
       options: ["small", "medium", "large"],
       description: "Circular indicator size (ignored for linear)",
     },
+    shape: {
+      control: "radio",
+      options: ["flat", "wavy"],
+      description: "Shape of the active indicator (wavy = MD3 Expressive sine-wave)",
+    },
+    thickness: {
+      control: "radio",
+      options: ["default", "thick"],
+      description: "Track thickness: 4dp (default) or 8dp (thick, MD3 Expressive)",
+    },
   },
   parameters: {
     docs: {
       description: {
         component:
-          "Progress indicators communicate the status of an ongoing process. Built with React Aria for accessibility and styled with MD3 design tokens.",
+          "Progress indicators communicate the status of an ongoing process. Built with React Aria for accessibility and styled with MD3 Expressive design tokens (primary-container track, 4dp gap, optional wavy shape and thick track).",
       },
     },
   },
@@ -69,11 +86,11 @@ export default meta;
 type Story = StoryObj<typeof Progress>;
 
 // ---------------------------------------------------------------------------
-// Individual variant stories
+// Baseline variants
 // ---------------------------------------------------------------------------
 
 /**
- * Linear Determinate — shows exact progress on a horizontal track.
+ * Linear Determinate — two-segment gap rendering with colorful `primary-container` track.
  */
 export const LinearDeterminate: Story = {
   args: {
@@ -95,7 +112,7 @@ export const LinearIndeterminate: Story = {
 };
 
 /**
- * Circular Determinate — SVG arc showing known progress.
+ * Circular Determinate — SVG arc pair showing known progress with 4dp gap.
  */
 export const CircularDeterminate: Story = {
   args: {
@@ -106,7 +123,7 @@ export const CircularDeterminate: Story = {
 };
 
 /**
- * Circular Indeterminate — rotating spinner for unknown duration.
+ * Circular Indeterminate — rotating spinner with visible `primary-container` inactive track.
  */
 export const CircularIndeterminate: Story = {
   args: {
@@ -117,12 +134,251 @@ export const CircularIndeterminate: Story = {
 };
 
 // ---------------------------------------------------------------------------
+// MD3 Expressive — Flat vs Wavy
+// ---------------------------------------------------------------------------
+
+/**
+ * Flat vs Wavy — side-by-side comparison of the two shapes.
+ */
+export const FlatVsWavy: Story = {
+  render: function FlatVsWavyRender() {
+    return (
+      <div className="flex flex-col gap-8">
+        <div>
+          <p className="text-label-large text-on-surface-variant mb-3">Flat (default)</p>
+          <div className="flex flex-col gap-4">
+            <Progress type="linear" value={60} label="Determinate" shape="flat" />
+            <Progress type="linear" indeterminate shape="flat" aria-label="Indeterminate flat" />
+          </div>
+        </div>
+        <div>
+          <p className="text-label-large text-on-surface-variant mb-3">Wavy (MD3 Expressive)</p>
+          <div className="flex flex-col gap-4">
+            <Progress type="linear" value={60} label="Determinate wavy" shape="wavy" />
+            <Progress type="linear" indeterminate shape="wavy" aria-label="Indeterminate wavy" />
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * Circular Flat vs Wavy — side-by-side circular shapes.
+ */
+export const CircularFlatVsWavy: Story = {
+  render: function CircularFlatVsWavyRender() {
+    return (
+      <div className="flex items-end gap-12">
+        <div className="flex flex-col items-center gap-3">
+          <Progress type="circular" indeterminate shape="flat" aria-label="Flat spinner" />
+          <span className="text-body-small text-on-surface-variant">Flat</span>
+        </div>
+        <div className="flex flex-col items-center gap-3">
+          <Progress type="circular" indeterminate shape="wavy" aria-label="Wavy spinner" />
+          <span className="text-body-small text-on-surface-variant">Wavy</span>
+        </div>
+        <div className="flex flex-col items-center gap-3">
+          <Progress type="circular" value={65} shape="flat" aria-label="Flat 65%" />
+          <span className="text-body-small text-on-surface-variant">Flat det.</span>
+        </div>
+        <div className="flex flex-col items-center gap-3">
+          <Progress type="circular" value={65} shape="wavy" aria-label="Wavy 65%" />
+          <span className="text-body-small text-on-surface-variant">Wavy det.</span>
+        </div>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// MD3 Expressive — Thick track
+// ---------------------------------------------------------------------------
+
+/**
+ * Thick track (8dp) — MD3 Expressive variant with increased visual weight.
+ */
+export const ThickTrack: Story = {
+  render: function ThickTrackRender() {
+    return (
+      <div className="flex flex-col gap-8">
+        <div>
+          <p className="text-label-large text-on-surface-variant mb-3">Default (4dp)</p>
+          <div className="flex flex-col gap-4">
+            <Progress type="linear" value={55} label="Downloading" thickness="default" />
+            <Progress
+              type="linear"
+              indeterminate
+              thickness="default"
+              aria-label="Loading default"
+            />
+          </div>
+        </div>
+        <div>
+          <p className="text-label-large text-on-surface-variant mb-3">Thick (8dp)</p>
+          <div className="flex flex-col gap-4">
+            <Progress type="linear" value={55} label="Downloading thick" thickness="thick" />
+            <Progress type="linear" indeterminate thickness="thick" aria-label="Loading thick" />
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * Thick + Wavy — the full MD3 Expressive visual combination.
+ */
+export const ThickWavy: Story = {
+  render: function ThickWavyRender() {
+    return (
+      <div className="flex flex-col gap-4">
+        <Progress
+          type="linear"
+          value={70}
+          label="Processing (thick wavy)"
+          shape="wavy"
+          thickness="thick"
+        />
+        <Progress
+          type="linear"
+          indeterminate
+          shape="wavy"
+          thickness="thick"
+          aria-label="Loading thick wavy"
+        />
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Gap demo
+// ---------------------------------------------------------------------------
+
+/**
+ * Gap demo — illustrates the 4dp indicator-track gap at various progress values.
+ */
+export const GapDemo: Story = {
+  render: function GapDemoRender() {
+    const values = [10, 25, 50, 75, 90];
+    return (
+      <div className="flex flex-col gap-4">
+        {values.map((v) => (
+          <div key={v} className="flex items-center gap-4">
+            <span className="text-label-medium text-on-surface-variant w-12 text-right">{v}%</span>
+            <div className="flex-1">
+              <Progress type="linear" value={v} aria-label={`Progress ${v}%`} />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// All shapes showcase
+// ---------------------------------------------------------------------------
+
+/**
+ * All shapes — comprehensive view of every shape × thickness × state combination.
+ */
+export const AllShapes: Story = {
+  render: function AllShapesRender() {
+    return (
+      <div className="flex flex-col gap-10">
+        {/* Linear */}
+        <section>
+          <h3 className="text-title-medium text-on-surface mb-4">Linear</h3>
+          <div className="flex flex-col gap-6">
+            <div>
+              <p className="text-label-small text-on-surface-variant mb-2">Flat · Default (4dp)</p>
+              <div className="flex flex-col gap-3">
+                <Progress type="linear" value={50} label="Determinate 50%" />
+                <Progress type="linear" indeterminate aria-label="Linear flat indeterminate" />
+              </div>
+            </div>
+            <div>
+              <p className="text-label-small text-on-surface-variant mb-2">Flat · Thick (8dp)</p>
+              <div className="flex flex-col gap-3">
+                <Progress type="linear" value={50} thickness="thick" label="Thick det. 50%" />
+                <Progress
+                  type="linear"
+                  indeterminate
+                  thickness="thick"
+                  aria-label="Thick flat indet."
+                />
+              </div>
+            </div>
+            <div>
+              <p className="text-label-small text-on-surface-variant mb-2">Wavy · Default (4dp)</p>
+              <div className="flex flex-col gap-3">
+                <Progress type="linear" value={50} shape="wavy" label="Wavy det. 50%" />
+                <Progress type="linear" indeterminate shape="wavy" aria-label="Wavy indet." />
+              </div>
+            </div>
+            <div>
+              <p className="text-label-small text-on-surface-variant mb-2">Wavy · Thick (8dp)</p>
+              <div className="flex flex-col gap-3">
+                <Progress
+                  type="linear"
+                  value={50}
+                  shape="wavy"
+                  thickness="thick"
+                  label="Wavy thick det. 50%"
+                />
+                <Progress
+                  type="linear"
+                  indeterminate
+                  shape="wavy"
+                  thickness="thick"
+                  aria-label="Wavy thick indet."
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Circular */}
+        <section>
+          <h3 className="text-title-medium text-on-surface mb-4">Circular</h3>
+          <div className="flex flex-wrap items-end gap-8">
+            {(["flat", "wavy"] as const).map((shape) =>
+              (["default", "thick"] as const).map((thickness) =>
+                (["small", "medium", "large"] as const).map((size) => (
+                  <div
+                    key={`${shape}-${thickness}-${size}`}
+                    className="flex flex-col items-center gap-2"
+                  >
+                    <Progress
+                      type="circular"
+                      indeterminate
+                      size={size}
+                      shape={shape}
+                      thickness={thickness}
+                      aria-label={`${shape} ${thickness} ${size}`}
+                    />
+                    <span className="text-label-small text-on-surface-variant capitalize">
+                      {shape} · {thickness} · {size}
+                    </span>
+                  </div>
+                ))
+              )
+            )}
+          </div>
+        </section>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Label stories
 // ---------------------------------------------------------------------------
 
 /**
- * With visible label — label is rendered above the indicator and linked via
- * aria-labelledby for screen reader accessibility.
+ * With visible label — rendered above the indicator and linked via aria-labelledby.
  */
 export const WithLabel: Story = {
   render: function WithLabelRender() {
@@ -132,34 +388,6 @@ export const WithLabel: Story = {
         <Progress type="circular" value={70} label="Syncing data" />
       </div>
     );
-  },
-};
-
-/**
- * With aria-label only — no visible label; aria-label satisfies WCAG.
- */
-export const WithAriaLabel: Story = {
-  args: {
-    type: "linear",
-    indeterminate: true,
-    "aria-label": "Loading page content",
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Custom range
-// ---------------------------------------------------------------------------
-
-/**
- * Custom min/max values — value=150 on range 0–200 renders as 75%.
- */
-export const CustomMinMax: Story = {
-  args: {
-    type: "linear",
-    minValue: 0,
-    maxValue: 200,
-    value: 150,
-    label: "Transfer progress",
   },
 };
 
@@ -174,54 +402,12 @@ export const CircularSizes: Story = {
   render: function CircularSizesRender() {
     return (
       <div className="flex items-end gap-8">
-        <div className="flex flex-col items-center gap-2">
-          <Progress type="circular" indeterminate size="small" aria-label="Loading small" />
-          <span className="text-body-small text-on-surface-variant">Small (24dp)</span>
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <Progress type="circular" indeterminate size="medium" aria-label="Loading medium" />
-          <span className="text-body-small text-on-surface-variant">Medium (48dp)</span>
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <Progress type="circular" indeterminate size="large" aria-label="Loading large" />
-          <span className="text-body-small text-on-surface-variant">Large (64dp)</span>
-        </div>
-      </div>
-    );
-  },
-};
-
-// ---------------------------------------------------------------------------
-// All variants showcase
-// ---------------------------------------------------------------------------
-
-/**
- * All variants — showcase of all four variant combinations.
- */
-export const AllVariants: Story = {
-  render: function AllVariantsRender() {
-    return (
-      <div className="flex flex-col gap-8">
-        <div className="flex flex-col gap-3">
-          <h3 className="text-title-medium text-on-surface">Linear</h3>
-          <div className="flex flex-col gap-4">
-            <Progress type="linear" value={40} label="Determinate (40%)" />
-            <Progress type="linear" indeterminate aria-label="Linear indeterminate" />
+        {(["small", "medium", "large"] as const).map((size) => (
+          <div key={size} className="flex flex-col items-center gap-2">
+            <Progress type="circular" indeterminate size={size} aria-label={`Loading ${size}`} />
+            <span className="text-body-small text-on-surface-variant capitalize">{size}</span>
           </div>
-        </div>
-        <div className="flex flex-col gap-3">
-          <h3 className="text-title-medium text-on-surface">Circular</h3>
-          <div className="flex items-center gap-8">
-            <div className="flex flex-col items-center gap-2">
-              <Progress type="circular" value={65} aria-label="Circular determinate 65%" />
-              <span className="text-body-small text-on-surface-variant">Determinate (65%)</span>
-            </div>
-            <div className="flex flex-col items-center gap-2">
-              <Progress type="circular" indeterminate aria-label="Circular indeterminate" />
-              <span className="text-body-small text-on-surface-variant">Indeterminate</span>
-            </div>
-          </div>
-        </div>
+        ))}
       </div>
     );
   },
@@ -232,12 +418,14 @@ export const AllVariants: Story = {
 // ---------------------------------------------------------------------------
 
 /**
- * Playground — interactive slider to explore determinate progress values.
+ * Playground — interactive slider to explore progress values, shape and thickness.
  */
 export const Playground: Story = {
   render: function PlaygroundRender() {
     const [value, setValue] = useState(30);
     const [isIndeterminate, setIsIndeterminate] = useState(false);
+    const [shape, setShape] = useState<"flat" | "wavy">("flat");
+    const [thickness, setThickness] = useState<"default" | "thick">("default");
 
     return (
       <div className="flex flex-col gap-8">
@@ -258,7 +446,7 @@ export const Playground: Story = {
               className="flex-1"
             />
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap gap-4">
             <label className="text-body-medium text-on-surface flex cursor-pointer items-center gap-2">
               <input
                 type="checkbox"
@@ -266,6 +454,22 @@ export const Playground: Story = {
                 onChange={(e) => setIsIndeterminate(e.target.checked)}
               />
               Indeterminate
+            </label>
+            <label className="text-body-medium text-on-surface flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={shape === "wavy"}
+                onChange={(e) => setShape(e.target.checked ? "wavy" : "flat")}
+              />
+              Wavy shape
+            </label>
+            <label className="text-body-medium text-on-surface flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={thickness === "thick"}
+                onChange={(e) => setThickness(e.target.checked ? "thick" : "default")}
+              />
+              Thick (8dp)
             </label>
           </div>
         </div>
@@ -277,6 +481,8 @@ export const Playground: Story = {
             type="linear"
             value={value}
             indeterminate={isIndeterminate}
+            shape={shape}
+            thickness={thickness}
             label={isIndeterminate ? undefined : `Uploading (${value}%)`}
             aria-label={isIndeterminate ? "Loading" : undefined}
           />
@@ -289,6 +495,8 @@ export const Playground: Story = {
             type="circular"
             value={value}
             indeterminate={isIndeterminate}
+            shape={shape}
+            thickness={thickness}
             label={isIndeterminate ? undefined : `${value}%`}
             aria-label={isIndeterminate ? "Loading" : undefined}
           />
@@ -323,8 +531,15 @@ export const SimulatedUpload: Story = {
 
     return (
       <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-4">
           <Progress type="linear" value={progress} label={`Uploading… ${progress}%`} />
+          <Progress
+            type="linear"
+            value={progress}
+            shape="wavy"
+            thickness="thick"
+            label={`Wavy thick… ${progress}%`}
+          />
           <Progress
             type="circular"
             value={progress}

--- a/packages/react/src/components/Progress/Progress.test.tsx
+++ b/packages/react/src/components/Progress/Progress.test.tsx
@@ -418,6 +418,110 @@ describe("Progress", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Wavy rendering specifics — overflow fix assertions
+  // ---------------------------------------------------------------------------
+
+  describe("Wavy rendering (overflow fix)", () => {
+    // ── Linear wavy determinate ──────────────────────────────────────────────
+
+    test("linear wavy determinate renders [data-progress-indicator] SVG path", () => {
+      const { container } = render(
+        <Progress type="linear" value={60} shape="wavy" aria-label="Loading" />
+      );
+      const indicator = container.querySelector("[data-progress-indicator]");
+      expect(indicator).toBeInTheDocument();
+      expect(indicator?.tagName.toLowerCase()).toBe("path");
+    });
+
+    test("linear wavy determinate renders [data-stop-indicator]", () => {
+      const { container } = render(
+        <Progress type="linear" value={60} shape="wavy" aria-label="Loading" />
+      );
+      expect(container.querySelector("[data-stop-indicator]")).toBeInTheDocument();
+    });
+
+    test("linear wavy determinate SVG has preserveAspectRatio='none'", () => {
+      const { container } = render(
+        <Progress type="linear" value={60} shape="wavy" aria-label="Loading" />
+      );
+      const svg = container.querySelector("svg");
+      expect(svg?.getAttribute("preserveAspectRatio")).toBe("none");
+    });
+
+    test("linear wavy determinate SVG has clip-path style to bound the active portion", () => {
+      const { container } = render(
+        <Progress type="linear" value={60} shape="wavy" aria-label="Loading" />
+      );
+      const svg = container.querySelector("svg") as HTMLElement | null;
+      // clip-path: inset(0 40% 0 0) — right side = 100-60 = 40%
+      expect(svg?.style.clipPath).toMatch(/inset/);
+    });
+
+    test("linear wavy determinate renders inactive segment after the gap", () => {
+      const { container } = render(
+        <Progress type="linear" value={40} shape="wavy" aria-label="Loading" />
+      );
+      const inactive = container.querySelector("[data-progress-inactive-segment]");
+      expect(inactive).toBeInTheDocument();
+      const style = (inactive as HTMLElement)?.style.left;
+      expect(style).toContain("40%");
+      expect(style).toContain("4px");
+    });
+
+    test("linear wavy determinate does not render inactive segment at 100%", () => {
+      const { container } = render(
+        <Progress type="linear" value={100} shape="wavy" aria-label="Loading" />
+      );
+      expect(container.querySelector("[data-progress-inactive-segment]")).not.toBeInTheDocument();
+    });
+
+    // ── Linear wavy indeterminate ────────────────────────────────────────────
+
+    test("linear wavy indeterminate renders [data-progress-indeterminate]", () => {
+      const { container } = render(
+        <Progress type="linear" indeterminate shape="wavy" aria-label="Loading" />
+      );
+      expect(container.querySelector("[data-progress-indeterminate]")).toBeInTheDocument();
+    });
+
+    test("linear wavy indeterminate SVG has preserveAspectRatio='none'", () => {
+      const { container } = render(
+        <Progress type="linear" indeterminate shape="wavy" aria-label="Loading" />
+      );
+      const svg = container.querySelector("svg");
+      expect(svg?.getAttribute("preserveAspectRatio")).toBe("none");
+    });
+
+    // ── Circular wavy — pathLength normalization ─────────────────────────────
+
+    test("circular wavy determinate active path has pathLength='100'", () => {
+      const { container } = render(
+        <Progress type="circular" value={50} shape="wavy" aria-label="Loading" />
+      );
+      const indicator = container.querySelector("[data-progress-indicator]");
+      expect(indicator).toBeInTheDocument();
+      expect(indicator?.getAttribute("pathLength")).toBe("100");
+    });
+
+    test("circular wavy indeterminate path has pathLength='100'", () => {
+      const { container } = render(
+        <Progress type="circular" indeterminate shape="wavy" aria-label="Loading" />
+      );
+      const path = container.querySelector("svg path");
+      expect(path?.getAttribute("pathLength")).toBe("100");
+    });
+
+    test("circular wavy determinate does not render wavy overlay on top of plain arc", () => {
+      const { container } = render(
+        <Progress type="circular" value={50} shape="wavy" aria-label="Loading" />
+      );
+      // There should be exactly ONE path element (the active wavy arc) — no stacking
+      const paths = container.querySelectorAll("path");
+      expect(paths.length).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Accessibility
   // ---------------------------------------------------------------------------
 

--- a/packages/react/src/components/Progress/Progress.test.tsx
+++ b/packages/react/src/components/Progress/Progress.test.tsx
@@ -519,6 +519,41 @@ describe("Progress", () => {
       const paths = container.querySelectorAll("path");
       expect(paths.length).toBe(1);
     });
+
+    // ── Regression guards added by polish pass ───────────────────────────────
+
+    test("linear wavy determinate inactive segment has trackPx height (4px default)", () => {
+      const { container } = render(
+        <Progress type="linear" value={40} shape="wavy" aria-label="Loading" />
+      );
+      const inactive = container.querySelector("[data-progress-inactive-segment]");
+      expect(inactive).toBeInTheDocument();
+      expect((inactive as HTMLElement).style.height).toBe("4px");
+    });
+
+    test("linear wavy determinate inactive segment has trackPx height (8px thick)", () => {
+      const { container } = render(
+        <Progress type="linear" value={40} shape="wavy" thickness="thick" aria-label="Loading" />
+      );
+      const inactive = container.querySelector("[data-progress-inactive-segment]");
+      expect(inactive).toBeInTheDocument();
+      expect((inactive as HTMLElement).style.height).toBe("8px");
+    });
+
+    test("circular wavy determinate active path coordinates are within viewBox bounds", () => {
+      // Medium circle: diameter=48, so all coordinates must be in [0, 48]
+      const { container } = render(
+        <Progress type="circular" value={50} shape="wavy" aria-label="Loading" />
+      );
+      const path = container.querySelector("[data-progress-indicator]");
+      expect(path).toBeInTheDocument();
+      const d = path?.getAttribute("d") ?? "";
+      // Extract all numbers from the path data and verify they are in [0, 48]
+      const nums = d.match(/-?[\d.]+/g)?.map(Number) ?? [];
+      expect(nums.length).toBeGreaterThan(0);
+      const allInBounds = nums.every((n) => n >= 0 && n <= 48);
+      expect(allInBounds).toBe(true);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/react/src/components/Progress/Progress.test.tsx
+++ b/packages/react/src/components/Progress/Progress.test.tsx
@@ -63,7 +63,7 @@ describe("Progress", () => {
       expect(container.querySelector("svg")).toBeInTheDocument();
     });
 
-    test("does not render SVG for linear variant", () => {
+    test("does not render SVG for linear flat variant", () => {
       const { container } = linearDeterminate();
       expect(container.querySelector("svg")).not.toBeInTheDocument();
     });
@@ -189,6 +189,7 @@ describe("Progress", () => {
     test("calculates 0% for value=0", () => {
       const { container } = render(<Progress type="linear" value={0} aria-label="Loading" />);
       const indicator = container.querySelector("[data-progress-indicator]");
+      // At 0% the active indicator has width 0% (still rendered)
       expect(indicator).toHaveStyle({ width: "0%" });
     });
 
@@ -212,26 +213,45 @@ describe("Progress", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Linear Variant
+  // Linear Determinate — Flat (gap-based two-segment rendering)
   // ---------------------------------------------------------------------------
 
-  describe("Linear Determinate", () => {
+  describe("Linear Determinate (Flat)", () => {
     test("renders track element", () => {
       const { container } = linearDeterminate();
       expect(container.querySelector("[data-progress-track]")).toBeInTheDocument();
     });
 
-    test("renders indicator element inside track", () => {
+    test("renders active indicator element inside track", () => {
       const { container } = linearDeterminate();
       expect(container.querySelector("[data-progress-indicator]")).toBeInTheDocument();
     });
 
-    test("indicator has width matching percentage", () => {
+    test("active indicator has width matching percentage", () => {
       const { container } = render(<Progress type="linear" value={60} aria-label="Loading" />);
       const indicator = container.querySelector("[data-progress-indicator]");
       expect(indicator).toHaveStyle({ width: "60%" });
     });
+
+    test("renders inactive segment with gap-based left offset", () => {
+      const { container } = render(<Progress type="linear" value={40} aria-label="Loading" />);
+      const inactive = container.querySelector("[data-progress-inactive-segment]");
+      expect(inactive).toBeInTheDocument();
+      // left = calc(40% + 4px)
+      const style = (inactive as HTMLElement)?.style.left;
+      expect(style).toContain("40%");
+      expect(style).toContain("4px");
+    });
+
+    test("does not render inactive segment when value=100", () => {
+      const { container } = render(<Progress type="linear" value={100} aria-label="Loading" />);
+      expect(container.querySelector("[data-progress-inactive-segment]")).not.toBeInTheDocument();
+    });
   });
+
+  // ---------------------------------------------------------------------------
+  // Linear Indeterminate
+  // ---------------------------------------------------------------------------
 
   describe("Linear Indeterminate", () => {
     test("renders indeterminate animation wrapper", () => {
@@ -251,7 +271,7 @@ describe("Progress", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Circular Variant
+  // Circular Determinate (arc gap)
   // ---------------------------------------------------------------------------
 
   describe("Circular Determinate", () => {
@@ -260,24 +280,23 @@ describe("Progress", () => {
       expect(container.querySelector("svg")).toBeInTheDocument();
     });
 
-    test("renders two circles (background + foreground)", () => {
-      const { container } = circularDeterminate();
+    test("foreground circle has stroke-dasharray attribute (gapped arc)", () => {
+      const { container } = render(<Progress type="circular" value={50} aria-label="Half" />);
       const circles = container.querySelectorAll("circle");
-      expect(circles).toHaveLength(2);
+      // At 50% there should be an active circle and an inactive circle
+      const hasActiveGap = Array.from(circles).some(
+        (c) => c.getAttribute("stroke-dasharray") !== null
+      );
+      expect(hasActiveGap).toBe(true);
     });
 
-    test("foreground circle has stroke-dashoffset attribute", () => {
-      const { container } = circularDeterminate();
+    test("renders primary-container inactive track when value > 0 and < 100", () => {
+      const { container } = render(<Progress type="circular" value={50} aria-label="Loading" />);
       const circles = container.querySelectorAll("circle");
-      const foreground = circles[1];
-      expect(foreground).toHaveAttribute("stroke-dashoffset");
-    });
-
-    test("foreground stroke-dashoffset is 0 at 100% value", () => {
-      const { container } = render(<Progress type="circular" value={100} aria-label="Complete" />);
-      const circles = container.querySelectorAll("circle");
-      const foreground = circles[1];
-      expect(Number(foreground?.getAttribute("stroke-dashoffset"))).toBeCloseTo(0, 0);
+      const hasContainer = Array.from(circles).some(
+        (c) => c.getAttribute("class")?.includes("text-primary-container") === true
+      );
+      expect(hasContainer).toBe(true);
     });
   });
 
@@ -295,6 +314,15 @@ describe("Progress", () => {
     test("does not have aria-valuenow when indeterminate", () => {
       circularIndeterminate();
       expect(screen.getByRole("progressbar")).not.toHaveAttribute("aria-valuenow");
+    });
+
+    test("renders primary-container inactive track circle", () => {
+      const { container } = circularIndeterminate();
+      const circles = container.querySelectorAll("circle");
+      const hasContainer = Array.from(circles).some(
+        (c) => c.getAttribute("class")?.includes("text-primary-container") === true
+      );
+      expect(hasContainer).toBe(true);
     });
   });
 
@@ -327,6 +355,69 @@ describe("Progress", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // MD3 Expressive — Thickness prop
+  // ---------------------------------------------------------------------------
+
+  describe("Thickness prop", () => {
+    test("renders default thickness (h-1) by default", () => {
+      const { container } = render(<Progress type="linear" value={50} aria-label="Loading" />);
+      const track = container.querySelector("[data-progress-track]");
+      expect(track).toHaveClass("h-1");
+    });
+
+    test("renders thick variant (h-2) when thickness=thick", () => {
+      const { container } = render(
+        <Progress type="linear" value={50} thickness="thick" aria-label="Loading" />
+      );
+      const track = container.querySelector("[data-progress-track]");
+      expect(track).toHaveClass("h-2");
+    });
+
+    test("thick thickness renders for indeterminate linear", () => {
+      const { container } = render(
+        <Progress type="linear" indeterminate thickness="thick" aria-label="Loading" />
+      );
+      const track = container.querySelector("[data-progress-track]");
+      expect(track).toHaveClass("h-2");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // MD3 Expressive — Shape prop
+  // ---------------------------------------------------------------------------
+
+  describe("Shape prop", () => {
+    test("renders SVG path for linear wavy indeterminate", () => {
+      const { container } = render(
+        <Progress type="linear" indeterminate shape="wavy" aria-label="Loading" />
+      );
+      // Wavy uses SVG paths, not divs
+      expect(container.querySelector("svg path")).toBeInTheDocument();
+    });
+
+    test("renders SVG path for linear wavy determinate", () => {
+      const { container } = render(
+        <Progress type="linear" value={60} shape="wavy" aria-label="Loading" />
+      );
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+
+    test("renders circular wavy indeterminate with path element", () => {
+      const { container } = render(
+        <Progress type="circular" indeterminate shape="wavy" aria-label="Loading" />
+      );
+      expect(container.querySelector("svg path")).toBeInTheDocument();
+    });
+
+    test("flat shape does not render SVG for linear", () => {
+      const { container } = render(
+        <Progress type="linear" value={50} shape="flat" aria-label="Loading" />
+      );
+      expect(container.querySelector("svg")).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Accessibility
   // ---------------------------------------------------------------------------
 
@@ -353,6 +444,22 @@ describe("Progress", () => {
 
     test("circular indeterminate has no axe violations", async () => {
       const { container } = render(<Progress type="circular" indeterminate aria-label="Loading" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("wavy linear has no axe violations", async () => {
+      const { container } = render(
+        <Progress type="linear" indeterminate shape="wavy" aria-label="Loading wavy" />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("thick linear has no axe violations", async () => {
+      const { container } = render(
+        <Progress type="linear" value={60} thickness="thick" label="Uploading thick" />
+      );
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
@@ -422,6 +529,22 @@ describe("Progress", () => {
       );
       expect(renderProgress).toHaveBeenCalledWith(
         expect.objectContaining({ isIndeterminate: true })
+      );
+    });
+
+    test("calls renderProgress with shape and thickness", () => {
+      const renderProgress = vi.fn(() => null);
+      render(
+        <ProgressHeadless
+          value={50}
+          shape="wavy"
+          thickness="thick"
+          aria-label="Loading"
+          renderProgress={renderProgress}
+        />
+      );
+      expect(renderProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ shape: "wavy", thickness: "thick" })
       );
     });
 

--- a/packages/react/src/components/Progress/Progress.tsx
+++ b/packages/react/src/components/Progress/Progress.tsx
@@ -26,6 +26,7 @@ function useReducedMotion(): boolean {
 
   return reduced;
 }
+
 import {
   progressContainerVariants,
   progressTrackVariants,
@@ -57,10 +58,29 @@ const CIRCULAR_SIZE_PX: Record<"small" | "medium" | "large", number> = {
 };
 
 /** MD3 Expressive wavy defaults */
-const WAVE_AMPLITUDE_DEFAULT = 3; // px — visible wave height
-const WAVE_AMPLITUDE_THICK = 5; // px — scaled for thick track
-const WAVE_WAVELENGTH_LINEAR = 40; // px — one full wave
-const WAVE_WAVELENGTH_CIRCULAR = 30; // px — tighter curve for circular
+const WAVE_AMPLITUDE_DEFAULT = 3; // px amplitude (half-height of wave)
+const WAVE_AMPLITUDE_THICK = 5; // px amplitude for thick track
+
+/**
+ * Number of complete wave cycles drawn across the full bar width.
+ * Uses a fixed count (not a fixed wavelength) so the wave never extends
+ * beyond the viewBox — the wave density adapts to the rendered bar width.
+ * 14 cycles ≈ 40px wavelength at a typical 600px bar.
+ */
+const LINEAR_WAVE_COUNT = 14;
+
+/**
+ * SVG viewBox width for linear wavy renderers.
+ * x=0..VB_W maps 1-to-1 with 0..100% of the rendered bar width.
+ * Using 100 makes clipPath percentage calculations exact.
+ */
+const VB_W = 100;
+
+/**
+ * Target arc-length per wave cycle for circular wavy (px).
+ * Used to derive an integer waveCount per circle size.
+ */
+const WAVE_WAVELENGTH_CIRCULAR = 30;
 
 // ---------------------------------------------------------------------------
 // Geometry helpers
@@ -93,80 +113,88 @@ function getCircularGeometry(
 }
 
 // ---------------------------------------------------------------------------
-// Wavy path builders
+// Wave path builders (fixed)
 // ---------------------------------------------------------------------------
 
 /**
- * Build an SVG `d` string for a horizontal sine wave.
- * The path starts at x=0 and repeats for (extraCycles + 1) wavelengths so
- * the wave-translate animation loops seamlessly.
+ * Build an SVG `d` string for a horizontal sine wave in a VB_W×H viewBox.
  *
- * @param totalWidth   — container px width (used for repeats)
- * @param amplitude    — half-height of the wave in px
- * @param wavelength   — horizontal distance for one full cycle in px
- * @param extraCycles  — extra wavelength repetitions added to the right to
- *                       allow the translate animation to loop cleanly
+ * Key design:
+ * - `vbWidth` = viewBox width (100 user units = 100% of rendered width).
+ * - Path covers 0..vbWidth so it never exceeds the container.
+ * - `vectorEffect="non-scaling-stroke"` on the rendered path keeps the
+ *   stroke at screen-pixel size even though x-scale ≠ y-scale.
+ * - `midY` is in px (works because viewBox height = rendered height, y-scale=1).
+ * - `padCycles` extends the path rightward for seamless-loop animations.
+ *
+ * @param vbWidth    SVG viewBox width (= VB_W = 100)
+ * @param waveCount  Number of complete sine cycles across vbWidth
+ * @param amplitude  Half-height of the wave in px
+ * @param midY       y-coordinate of the midline in user-units (≈ px since y-scale=1)
+ * @param padCycles  Extra cycles appended to the right (for loop animations)
  */
 function buildLinearWavePath(
-  totalWidth: number,
+  vbWidth: number,
+  waveCount: number,
   amplitude: number,
-  wavelength: number,
-  extraCycles = 2
+  midY: number,
+  padCycles = 0
 ): string {
-  const totalPathWidth = totalWidth + extraCycles * wavelength;
-  const segments: string[] = [];
-  let x = 0;
-
-  // Start at the midline
-  segments.push(`M 0 ${amplitude}`);
-
-  // Each wavelength is two half-cycles (cubic bezier approximation of sine)
+  const wavelength = vbWidth / waveCount; // user units per cycle
+  const totalCycles = waveCount + padCycles;
+  // Bezier control point distance: wavelength/4 gives a good sine approximation
   const cp = wavelength / 4;
-  while (x < totalPathWidth) {
-    // First half: up peak
+  const segments: string[] = [`M 0 ${midY}`];
+
+  for (let i = 0; i < totalCycles; i++) {
+    const x = i * wavelength;
+    // Crest (above midline)
     segments.push(
-      `C ${x + cp} ${0} ${x + wavelength / 2 - cp} ${0} ${x + wavelength / 2} ${amplitude}`
+      `C ${x + cp} ${midY - amplitude} ${x + wavelength / 2 - cp} ${midY - amplitude} ${x + wavelength / 2} ${midY}`
     );
-    // Second half: down trough
-    const mid = x + wavelength / 2;
+    // Trough (below midline)
     segments.push(
-      `C ${mid + cp} ${2 * amplitude} ${mid + wavelength / 2 - cp} ${2 * amplitude} ${mid + wavelength / 2} ${amplitude}`
+      `C ${x + wavelength / 2 + cp} ${midY + amplitude} ${x + wavelength - cp} ${midY + amplitude} ${x + wavelength} ${midY}`
     );
-    x += wavelength;
   }
 
   return segments.join(" ");
 }
 
 /**
- * Build a wavy SVG `d` string that follows the circular arc.
- * Uses radial offset (outward/inward perturbation) along the circle.
+ * Build an SVG `d` string for a wavy ring (circle with radial sine perturbation).
  *
- * @param cx         — circle centre x
- * @param cy         — circle centre y
- * @param radius     — arc radius
- * @param strokeWidth — stroke width (determines visual band)
- * @param amplitude  — radial perturbation amplitude in px
- * @param wavelength — arc-length per wave cycle in px
- * @param steps      — number of arc segments for approximation
+ * Key design: `waveCount` MUST be an integer so `sin(2π·waveCount·1) = sin(2π·waveCount·0)`,
+ * guaranteeing the ring closes seamlessly. Compute it with
+ * `Math.max(4, Math.round(circumference / WAVE_WAVELENGTH_CIRCULAR))`.
+ *
+ * The path starts at the 3 o'clock position (angle = 0) so it aligns with
+ * SVG `<circle>` dash behavior when the parent SVG is rotated -90deg.
+ *
+ * @param cx        Circle centre x (px)
+ * @param cy        Circle centre y (px)
+ * @param radius    Arc radius (px)
+ * @param amplitude Radial perturbation amplitude (px)
+ * @param waveCount Integer number of wave cycles — must be integer for seamless close
+ * @param steps     Polygon approximation steps (default: waveCount × 12)
  */
 function buildCircularWavePath(
   cx: number,
   cy: number,
   radius: number,
   amplitude: number,
-  wavelength: number,
-  steps = 120
+  waveCount: number,
+  steps?: number
 ): string {
-  const circumference = 2 * Math.PI * radius;
+  const actualSteps = steps ?? waveCount * 12;
   const points: string[] = [];
 
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
-    const angle = t * 2 * Math.PI - Math.PI / 2; // start at top (−90°)
-    // Radial perturbation: sine wave scaled to arc length
-    const wavePhase = (circumference * t) / wavelength;
-    const radialOffset = amplitude * Math.sin(2 * Math.PI * wavePhase);
+  for (let i = 0; i <= actualSteps; i++) {
+    const t = i / actualSteps;
+    // Start at 3 o'clock (angle=0) to align with <circle> strokeDashoffset behaviour
+    const angle = t * 2 * Math.PI;
+    // Integer waveCount guarantees sin(2π·waveCount·1) = 0 = sin(2π·waveCount·0) → no seam
+    const radialOffset = amplitude * Math.sin(2 * Math.PI * waveCount * t);
     const r = radius + radialOffset;
     const x = cx + r * Math.cos(angle);
     const y = cy + r * Math.sin(angle);
@@ -239,7 +267,6 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
     const reducedMotion: boolean = useReducedMotion();
 
-    // React Aria: provides progressBarProps (role, aria-value*) and labelProps
     const { progressBarProps, labelProps } = useProgressBar({
       label,
       value,
@@ -249,7 +276,6 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
       ...restProps,
     });
 
-    // Percentage for determinate rendering
     const percentage = indeterminate
       ? 0
       : Math.min(100, Math.max(0, ((value - minValue) / (maxValue - minValue)) * 100));
@@ -410,6 +436,23 @@ function LinearFlatIndeterminate({
 
 // ── Wavy Determinate ───────────────────────────────────────────────────────
 
+/**
+ * Linear wavy determinate — fixed approach.
+ *
+ * The wave is drawn in a `viewBox="0 0 VB_W H"` SVG with
+ * `preserveAspectRatio="none"` so x maps 0..VB_W → 0..renderedWidth
+ * and the wave can never overflow the container.
+ *
+ * The active portion is clipped by a CSS `clip-path: inset(0 X% 0 0)` on
+ * the SVG element itself (applied in the rendered-element coordinate space),
+ * which means `(100 - percentage)%` from the right keeps exactly `percentage`
+ * of the wave visible — the percentage bug is fixed.
+ *
+ * `vectorEffect="non-scaling-stroke"` keeps the stroke at screen-pixel width
+ * even though the x-scale (renderedWidth / VB_W) is much larger than 1.
+ *
+ * The inactive segment and stop dot are crisp DOM elements (px-exact).
+ */
 function LinearWavyDeterminate({
   percentage,
   thickness,
@@ -420,147 +463,159 @@ function LinearWavyDeterminate({
   reducedMotion: boolean;
 }): React.JSX.Element {
   const amplitude = thickness === "thick" ? WAVE_AMPLITUDE_THICK : WAVE_AMPLITUDE_DEFAULT;
-  const wavelength = WAVE_WAVELENGTH_LINEAR;
+  const containerHeight = (thickness === "thick" ? 8 : 4) + 2 * amplitude + 4;
+  // midY: 2px top padding + amplitude = midline position in px (= VB y-units, since y-scale=1)
+  const midY = amplitude + 2;
+  const trackHeightClass = thickness === "thick" ? "h-2" : "h-1";
 
-  // Amplitude ramp: 0 → full at 10%, then full → 0 at 90%
+  // Amplitude ramp: 0 at 0% and 100%, full amplitude between 20% and 80%
   const rampedAmplitude =
     reducedMotion || percentage <= 0 || percentage >= 100
       ? 0
       : amplitude *
         Math.min(
-          (percentage - 10) / 10, // ramp up  0.1→0.2
-          (90 - percentage) / 10, // ramp down 0.8→0.9
+          (percentage - 10) / 10, // ramp up  10%→20%
+          (90 - percentage) / 10, // ramp down 80%→90%
           1
         );
 
-  // Container height accommodates the wave amplitude above/below midline
-  const containerHeight = (thickness === "thick" ? 8 : 4) + 2 * amplitude + 4;
-  const trackY = amplitude + 2; // midline Y within SVG viewBox
-
-  const trackHeightClass = thickness === "thick" ? "h-2" : "h-1";
+  const wavePath = buildLinearWavePath(VB_W, LINEAR_WAVE_COUNT, rampedAmplitude, midY);
 
   return (
     <div
       data-progress-track=""
-      className={cn("relative w-full overflow-visible", trackHeightClass)}
-      style={{ height: `${containerHeight}px` }}
+      className={cn("relative w-full overflow-hidden", trackHeightClass)}
+      style={{ height: containerHeight }}
     >
+      {/*
+       * Active wavy SVG.
+       * - viewBox 0..VB_W × 0..H ensures the path fits within the SVG bounds.
+       * - preserveAspectRatio="none" stretches the path to fill the rendered width.
+       * - CSS clip-path inset clips the right (100-percentage)% in rendered space,
+       *   so exactly `percentage`% of the wave is visible regardless of rendered width.
+       * - The clip-path CSS transition provides the smooth progress animation.
+       */}
       <svg
-        className="absolute inset-0 w-full overflow-visible"
-        style={{ height: containerHeight }}
+        viewBox={`0 0 ${VB_W} ${containerHeight}`}
+        preserveAspectRatio="none"
+        className={cn(
+          "absolute inset-0 w-full",
+          "transition-[clip-path]",
+          "duration-spring-standard-default-spatial",
+          "ease-spring-standard-default-spatial"
+        )}
+        style={{
+          height: containerHeight,
+          // clip-path applied in rendered-element space: keeps left `percentage`%
+          clipPath: `inset(0 ${100 - percentage}% 0 0)`,
+        }}
         aria-hidden="true"
       >
-        {/* Inactive track (full-width, primary-container) */}
-        <line
-          x1="0"
-          y1={trackY}
-          x2="100%"
-          y2={trackY}
+        <path
+          data-progress-indicator=""
+          d={wavePath}
+          fill="none"
           stroke="currentColor"
           strokeWidth={getStrokeWidth(thickness)}
           strokeLinecap="round"
-          className="text-primary-container"
-        />
-        {/* Active wavy indicator clipped to percentage */}
-        {percentage > 0 && (
-          <path
-            data-progress-indicator=""
-            d={buildLinearWavePath(
-              // We use a large notional width; clipPath handles the cut
-              1000,
-              rampedAmplitude,
-              wavelength
-            )}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={getStrokeWidth(thickness)}
-            strokeLinecap="round"
-            className="text-primary duration-spring-standard-default-spatial ease-spring-standard-default-spatial transition-[clip-path]"
-            clipPath={`inset(0 ${100 - percentage}% 0 0)`}
-          />
-        )}
-        {/* Stop indicator dot */}
-        <circle
-          data-stop-indicator=""
-          cx="100%"
-          cy={trackY}
-          r={INDICATOR_TRACK_GAP / 2}
-          fill="currentColor"
+          vectorEffect="non-scaling-stroke"
           className="text-primary"
-          aria-hidden="true"
         />
       </svg>
+
+      {/* Inactive segment after 4dp gap — DOM element, px-exact */}
+      {percentage < 100 && (
+        <div
+          data-progress-inactive-segment=""
+          className={cn(progressInactiveSegmentVariants())}
+          style={{ left: `calc(${percentage}% + ${INDICATOR_TRACK_GAP}px)` }}
+        />
+      )}
+
+      {/* Stop indicator dot at trailing edge */}
+      <div
+        data-stop-indicator=""
+        className={cn(progressStopIndicatorVariants())}
+        aria-hidden="true"
+      />
     </div>
   );
 }
 
 // ── Wavy Indeterminate ──────────────────────────────────────────────────────
 
+/**
+ * Linear wavy indeterminate — fixed approach.
+ *
+ * Two SVG elements (mirroring the two divs in the flat variant) are
+ * animated with the existing `progress-linear-indeterminate-1/2` CSS keyframes
+ * which animate the `left`/`right` CSS properties of the element.
+ * The keyframes are designed for positioned elements — SVG elements inside an
+ * HTML container also respect CSS `left`/`right` when `position: absolute`.
+ *
+ * As the CSS box grows/shrinks the SVG viewport stretches/compresses the wave
+ * horizontally (via `preserveAspectRatio="none"`), giving a convincing sweep.
+ * The outer `overflow-hidden` container clips both SVGs to the bar bounds.
+ */
 function LinearWavyIndeterminate({
   thickness,
 }: {
   thickness: "default" | "thick";
 }): React.JSX.Element {
   const amplitude = thickness === "thick" ? WAVE_AMPLITUDE_THICK : WAVE_AMPLITUDE_DEFAULT;
-  const wavelength = WAVE_WAVELENGTH_LINEAR;
   const containerHeight = (thickness === "thick" ? 8 : 4) + 2 * amplitude + 4;
-  const trackY = amplitude + 2;
+  const midY = amplitude + 2;
   const trackHeightClass = thickness === "thick" ? "h-2" : "h-1";
+
+  const wavePath = buildLinearWavePath(VB_W, LINEAR_WAVE_COUNT, amplitude, midY);
 
   return (
     <div
       data-progress-track=""
-      className={cn("relative w-full overflow-visible", trackHeightClass)}
-      style={{ height: `${containerHeight}px` }}
+      className={cn("relative w-full overflow-hidden", trackHeightClass)}
+      style={{ height: containerHeight }}
     >
-      <div
-        data-progress-indeterminate=""
-        className="absolute inset-0 overflow-hidden"
-        style={{ height: containerHeight }}
-      >
+      {/* Full-width inactive track behind the animated segments */}
+      <div className="bg-primary-container absolute inset-0 rounded-full" />
+
+      {/* Animated segments — same approach as flat but with SVG wave paths */}
+      <div data-progress-indeterminate="" className="absolute inset-0">
+        {/* Segment 1 */}
         <svg
-          className="absolute h-full"
-          style={{ width: "200%", top: 0, left: 0, height: containerHeight }}
+          viewBox={`0 0 ${VB_W} ${containerHeight}`}
+          preserveAspectRatio="none"
+          className="animate-progress-linear-indeterminate-1 absolute top-0 h-full"
           aria-hidden="true"
         >
-          {/* Segment 1 — primary wavy */}
           <path
-            d={buildLinearWavePath(2000, amplitude, wavelength)}
+            d={wavePath}
             fill="none"
             stroke="currentColor"
             strokeWidth={getStrokeWidth(thickness)}
             strokeLinecap="round"
-            className={cn("text-primary", "animate-progress-linear-indeterminate-1")}
+            vectorEffect="non-scaling-stroke"
+            className="text-primary"
           />
-          {/* Segment 2 — primary wavy, offset */}
+        </svg>
+
+        {/* Segment 2 */}
+        <svg
+          viewBox={`0 0 ${VB_W} ${containerHeight}`}
+          preserveAspectRatio="none"
+          className="animate-progress-linear-indeterminate-2 absolute top-0 h-full"
+          aria-hidden="true"
+        >
           <path
-            d={buildLinearWavePath(2000, amplitude, wavelength)}
+            d={wavePath}
             fill="none"
             stroke="currentColor"
             strokeWidth={getStrokeWidth(thickness)}
             strokeLinecap="round"
-            className={cn("text-primary", "animate-progress-linear-indeterminate-2")}
+            vectorEffect="non-scaling-stroke"
+            className="text-primary"
           />
         </svg>
       </div>
-
-      {/* Inactive track visible behind segments */}
-      <svg
-        className="pointer-events-none absolute inset-0 w-full overflow-visible"
-        style={{ height: containerHeight }}
-        aria-hidden="true"
-      >
-        <line
-          x1="0"
-          y1={trackY}
-          x2="100%"
-          y2={trackY}
-          stroke="currentColor"
-          strokeWidth={getStrokeWidth(thickness)}
-          strokeLinecap="round"
-          className="text-primary-container"
-        />
-      </svg>
     </div>
   );
 }
@@ -592,6 +647,21 @@ function CircularProgress({
   );
 
   if (indeterminate) {
+    if (shape === "wavy") {
+      return (
+        <CircularWavyIndeterminate
+          size={size}
+          cx={cx}
+          cy={cy}
+          radius={radius}
+          circumference={circumference}
+          viewBox={viewBox}
+          strokeWidth={strokeWidth}
+          diameter={diameter}
+        />
+      );
+    }
+
     return (
       <div
         data-progress-size={size}
@@ -603,7 +673,7 @@ function CircularProgress({
           className="animate-progress-circular-rotate h-full w-full"
           aria-hidden="true"
         >
-          {/* Inactive track — primary-container per Expressive (always visible) */}
+          {/* Inactive track — primary-container (always visible per Expressive spec) */}
           <circle
             cx={cx}
             cy={cy}
@@ -613,56 +683,50 @@ function CircularProgress({
             strokeWidth={strokeWidth}
             className="text-primary-container"
           />
-          {shape === "wavy" ? (
-            <path
-              d={buildCircularWavePath(
-                cx,
-                cy,
-                radius,
-                WAVE_AMPLITUDE_DEFAULT,
-                WAVE_WAVELENGTH_CIRCULAR
-              )}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={strokeWidth}
-              className="animate-progress-circular-dash text-primary"
-              strokeLinecap="round"
-            />
-          ) : (
-            <circle
-              cx={cx}
-              cy={cy}
-              r={radius}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={strokeWidth}
-              className="animate-progress-circular-dash text-primary"
-              strokeLinecap="round"
-            />
-          )}
+          <circle
+            cx={cx}
+            cy={cy}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            className="animate-progress-circular-dash text-primary"
+            strokeLinecap="round"
+          />
         </svg>
       </div>
     );
   }
 
-  // Determinate: introduce 4dp arc gap
-  // Arc gap in radians = gap / radius; subtract from both active and inactive ends
-  const gapRadians = INDICATOR_TRACK_GAP / radius;
+  // Determinate
+  if (shape === "wavy") {
+    return (
+      <CircularWavyDeterminate
+        size={size}
+        percentage={percentage}
+        cx={cx}
+        cy={cy}
+        radius={radius}
+        circumference={circumference}
+        viewBox={viewBox}
+        strokeWidth={strokeWidth}
+        diameter={diameter}
+        reducedMotion={reducedMotion}
+      />
+    );
+  }
+
+  // Flat determinate — introduce 4dp arc gap via stroke-dasharray
   const activeArc = (percentage / 100) * circumference;
-  // Subtract half-gap from each end of the active arc for the visual gap
   const activeArcGapped = Math.max(0, activeArc - INDICATOR_TRACK_GAP);
   const inactiveArcGapped = Math.max(0, circumference - activeArc - INDICATOR_TRACK_GAP);
-
-  const activeOffset = 0; // active starts at 12 o'clock (SVG starts at 3; -90deg rotate)
-  const inactiveOffset = -(activeArcGapped + INDICATOR_TRACK_GAP); // inactive starts after gap
-
-  // Suppress unused variable warning — gapRadians was computed for reference; use the direct pixel approach above
-  void gapRadians;
+  const activeOffset = 0;
+  const inactiveOffset = -(activeArcGapped + INDICATOR_TRACK_GAP);
 
   return (
     <div data-progress-size={size} className={cn(progressCircularSizeVariants({ size }))}>
       <svg viewBox={viewBox} className="h-full w-full -rotate-90" aria-hidden="true">
-        {/* Inactive track — primary-container; rendered first (below active) */}
+        {/* Inactive track */}
         {percentage < 100 && (
           <circle
             cx={cx}
@@ -677,7 +741,7 @@ function CircularProgress({
             className="text-primary-container duration-spring-standard-default-spatial ease-spring-standard-default-spatial transition-[stroke-dasharray,stroke-dashoffset]"
           />
         )}
-        {/* Active indicator — primary; rendered on top */}
+        {/* Active indicator */}
         {percentage > 0 && (
           <circle
             cx={cx}
@@ -692,7 +756,7 @@ function CircularProgress({
             className="text-primary duration-spring-standard-default-spatial ease-spring-standard-default-spatial transition-[stroke-dasharray,stroke-dashoffset]"
           />
         )}
-        {/* Show full circle in primary-container when value is 0 */}
+        {/* Full inactive circle at 0% */}
         {percentage === 0 && (
           <circle
             cx={cx}
@@ -704,28 +768,192 @@ function CircularProgress({
             className="text-primary-container"
           />
         )}
-        {/* Wavy overlay for determinate circular */}
-        {shape === "wavy" && !reducedMotion && percentage > 0 && percentage < 100 && (
-          <path
-            d={buildCircularWavePath(
-              cx,
-              cy,
-              radius,
-              WAVE_AMPLITUDE_DEFAULT,
-              WAVE_WAVELENGTH_CIRCULAR
-            )}
+      </svg>
+
+      <span className="sr-only" data-progress-diameter={diameter} />
+    </div>
+  );
+}
+
+// ── Circular wavy geometry helpers ──────────────────────────────────────────
+
+interface CircularWavyGeometry {
+  size: "small" | "medium" | "large";
+  cx: number;
+  cy: number;
+  radius: number;
+  circumference: number;
+  viewBox: string;
+  strokeWidth: number;
+  diameter: number;
+}
+
+// ── Circular Wavy Indeterminate ─────────────────────────────────────────────
+
+/**
+ * Circular wavy indeterminate — fixed approach.
+ *
+ * Uses an integer `waveCount` derived from `Math.round(circumference / WAVE_WAVELENGTH_CIRCULAR)`
+ * so the ring closes seamlessly (no seam/notch from non-integer cycles).
+ *
+ * The wavy `<path>` uses `pathLength={100}` so `strokeDasharray` is expressed
+ * in 0..100 regardless of the path's intrinsic (longer) length.
+ * A static dash `"28 72"` (≈28% visible arc) + the whole-SVG rotation from
+ * `animate-progress-circular-rotate` produces a clean rotating wavy spinner.
+ * `animate-progress-circular-dash` is intentionally NOT used: its pixel values
+ * are tuned to the plain circle circumference, not the longer wavy path.
+ */
+function CircularWavyIndeterminate({
+  size,
+  cx,
+  cy,
+  radius,
+  circumference,
+  viewBox,
+  strokeWidth,
+}: CircularWavyGeometry): React.JSX.Element {
+  // Integer waveCount → seamless close (sin(2π·N·1) = sin(2π·N·0) = 0)
+  const waveCount = Math.max(4, Math.round(circumference / WAVE_WAVELENGTH_CIRCULAR));
+  const wavePath = buildCircularWavePath(cx, cy, radius, WAVE_AMPLITUDE_DEFAULT, waveCount);
+
+  return (
+    <div
+      data-progress-size={size}
+      data-progress-indeterminate=""
+      className={cn(progressCircularSizeVariants({ size }))}
+    >
+      {/*
+       * The entire SVG rotates via animate-progress-circular-rotate.
+       * The wavy path has a static dash showing ~28% of the ring,
+       * so the arc sweeps around as a rotating wavy segment.
+       */}
+      <svg
+        viewBox={viewBox}
+        className="animate-progress-circular-rotate h-full w-full"
+        aria-hidden="true"
+      >
+        {/* Inactive full ring (primary-container) */}
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          className="text-primary-container"
+        />
+        {/* Active wavy arc — pathLength=100 normalises the dash to a percentage */}
+        <path
+          d={wavePath}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          pathLength={100}
+          strokeDasharray="28 72"
+          className="text-primary"
+        />
+      </svg>
+    </div>
+  );
+}
+
+// ── Circular Wavy Determinate ───────────────────────────────────────────────
+
+/**
+ * Circular wavy determinate — fixed approach.
+ *
+ * Uses `pathLength={100}` on the wavy `<path>` so `strokeDasharray` can be
+ * expressed in percentage terms (0..100) rather than the path's intrinsic
+ * (and longer) arc length. This resolves the mis-match between the wave path
+ * length and the pixel-based dash values used previously.
+ *
+ * Gap: `gapPct = (INDICATOR_TRACK_GAP / circumference) * 100` (in pathLength units).
+ * Active arc:   `activeLen   = max(0, percentage - gapPct)`
+ * Inactive arc: `inactiveLen = max(0, 100 - percentage - gapPct)`
+ * Inactive offset = `-(activeLen + gapPct)` → starts after active + gap.
+ *
+ * Single active wavy path replaces the previous plain-active + wavy-overlay
+ * stacking that produced a distorted double-drawn arc.
+ */
+function CircularWavyDeterminate({
+  size,
+  percentage,
+  cx,
+  cy,
+  radius,
+  circumference,
+  viewBox,
+  strokeWidth,
+  diameter,
+  reducedMotion,
+}: CircularWavyGeometry & { percentage: number; reducedMotion: boolean }): React.JSX.Element {
+  const waveCount = Math.max(4, Math.round(circumference / WAVE_WAVELENGTH_CIRCULAR));
+  const amp = reducedMotion ? 0 : WAVE_AMPLITUDE_DEFAULT;
+  const wavePath = buildCircularWavePath(cx, cy, radius, amp, waveCount);
+
+  // Gap expressed in pathLength=100 space
+  const gapPct = (INDICATOR_TRACK_GAP / circumference) * 100;
+  const activeLen = Math.max(0, percentage - gapPct);
+  const inactiveLen = Math.max(0, 100 - percentage - gapPct);
+  // Inactive arc starts after active + gap
+  const inactiveOffset = -(activeLen + gapPct);
+
+  return (
+    <div data-progress-size={size} className={cn(progressCircularSizeVariants({ size }))}>
+      {/*
+       * -rotate-90 on the SVG makes both the circle and the wavy path start
+       * at the visual 12 o'clock position (path starts at 3 o'clock
+       * mathematically, rotated -90° to top visually).
+       */}
+      <svg viewBox={viewBox} className="h-full w-full -rotate-90" aria-hidden="true">
+        {/* Full inactive track at 0% */}
+        {percentage === 0 && (
+          <circle
+            cx={cx}
+            cy={cy}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            className="text-primary-container"
+          />
+        )}
+
+        {/* Inactive arc (primary-container) — for 0 < percentage < 100 */}
+        {percentage > 0 && percentage < 100 && (
+          <circle
+            cx={cx}
+            cy={cy}
+            r={radius}
             fill="none"
             stroke="currentColor"
             strokeWidth={strokeWidth}
             strokeLinecap="round"
-            strokeDasharray={`${activeArcGapped} ${circumference - activeArcGapped}`}
-            strokeDashoffset={activeOffset}
+            pathLength={100}
+            strokeDasharray={`${inactiveLen} ${100 - inactiveLen}`}
+            strokeDashoffset={inactiveOffset}
+            className="text-primary-container duration-spring-standard-default-spatial ease-spring-standard-default-spatial transition-[stroke-dasharray,stroke-dashoffset]"
+          />
+        )}
+
+        {/* Active wavy arc (primary) — single element, no stacking */}
+        {percentage > 0 && (
+          <path
+            data-progress-indicator=""
+            d={wavePath}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            pathLength={100}
+            strokeDasharray={percentage < 100 ? `${activeLen} ${100 - activeLen}` : undefined}
+            strokeDashoffset={0}
             className="text-primary duration-spring-standard-default-spatial ease-spring-standard-default-spatial transition-[stroke-dasharray]"
           />
         )}
       </svg>
 
-      {/* Circular size thumbnail for diameter reference — keep for geometry stability */}
       <span className="sr-only" data-progress-diameter={diameter} />
     </div>
   );

--- a/packages/react/src/components/Progress/Progress.tsx
+++ b/packages/react/src/components/Progress/Progress.tsx
@@ -1,13 +1,36 @@
 "use client";
 
-import { forwardRef, useRef } from "react";
+import { forwardRef, useRef, useEffect, useState } from "react";
 import type React from "react";
 import { useProgressBar } from "react-aria";
 import { cn } from "../../utils/cn";
+
+// ---------------------------------------------------------------------------
+// Reduced-motion hook
+// (useReducedMotion is not available in this version of react-aria)
+// ---------------------------------------------------------------------------
+
+function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handler = (e: MediaQueryListEvent): void => setReduced(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return reduced;
+}
 import {
   progressContainerVariants,
   progressTrackVariants,
-  progressIndicatorVariants,
+  progressActiveIndicatorVariants,
+  progressInactiveSegmentVariants,
   progressStopIndicatorVariants,
   progressCircularSizeVariants,
   progressLabelVariants,
@@ -16,11 +39,16 @@ import type { ProgressProps } from "./Progress.types";
 import "./Progress.css";
 
 // ---------------------------------------------------------------------------
-// SVG constants for circular variant
-// MD3 spec: stroke-width = 4dp; size maps to dp values below.
+// Constants
 // ---------------------------------------------------------------------------
 
-const STROKE_WIDTH = 4;
+/** MD3 spec: stroke-width = 4dp for default thickness */
+const STROKE_WIDTH_DEFAULT = 4;
+/** MD3 Expressive: stroke-width = 8dp for thick variant */
+const STROKE_WIDTH_THICK = 8;
+
+/** 4dp indicator-track gap (in px — SVG px = CSS px at 1x) */
+const INDICATOR_TRACK_GAP = 4;
 
 const CIRCULAR_SIZE_PX: Record<"small" | "medium" | "large", number> = {
   small: 24,
@@ -28,43 +56,149 @@ const CIRCULAR_SIZE_PX: Record<"small" | "medium" | "large", number> = {
   large: 64,
 };
 
-function getCircularGeometry(size: "small" | "medium" | "large"): {
+/** MD3 Expressive wavy defaults */
+const WAVE_AMPLITUDE_DEFAULT = 3; // px — visible wave height
+const WAVE_AMPLITUDE_THICK = 5; // px — scaled for thick track
+const WAVE_WAVELENGTH_LINEAR = 40; // px — one full wave
+const WAVE_WAVELENGTH_CIRCULAR = 30; // px — tighter curve for circular
+
+// ---------------------------------------------------------------------------
+// Geometry helpers
+// ---------------------------------------------------------------------------
+
+function getStrokeWidth(thickness: "default" | "thick"): number {
+  return thickness === "thick" ? STROKE_WIDTH_THICK : STROKE_WIDTH_DEFAULT;
+}
+
+function getCircularGeometry(
+  size: "small" | "medium" | "large",
+  thickness: "default" | "thick"
+): {
   diameter: number;
   radius: number;
   circumference: number;
   viewBox: string;
   cx: number;
   cy: number;
+  strokeWidth: number;
 } {
+  const strokeWidth = getStrokeWidth(thickness);
   const diameter = CIRCULAR_SIZE_PX[size];
-  const radius = (diameter - STROKE_WIDTH) / 2;
+  const radius = (diameter - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const viewBox = `0 0 ${diameter} ${diameter}`;
   const cx = diameter / 2;
   const cy = diameter / 2;
-  return { diameter, radius, circumference, viewBox, cx, cy };
+  return { diameter, radius, circumference, viewBox, cx, cy, strokeWidth };
 }
+
+// ---------------------------------------------------------------------------
+// Wavy path builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an SVG `d` string for a horizontal sine wave.
+ * The path starts at x=0 and repeats for (extraCycles + 1) wavelengths so
+ * the wave-translate animation loops seamlessly.
+ *
+ * @param totalWidth   — container px width (used for repeats)
+ * @param amplitude    — half-height of the wave in px
+ * @param wavelength   — horizontal distance for one full cycle in px
+ * @param extraCycles  — extra wavelength repetitions added to the right to
+ *                       allow the translate animation to loop cleanly
+ */
+function buildLinearWavePath(
+  totalWidth: number,
+  amplitude: number,
+  wavelength: number,
+  extraCycles = 2
+): string {
+  const totalPathWidth = totalWidth + extraCycles * wavelength;
+  const segments: string[] = [];
+  let x = 0;
+
+  // Start at the midline
+  segments.push(`M 0 ${amplitude}`);
+
+  // Each wavelength is two half-cycles (cubic bezier approximation of sine)
+  const cp = wavelength / 4;
+  while (x < totalPathWidth) {
+    // First half: up peak
+    segments.push(
+      `C ${x + cp} ${0} ${x + wavelength / 2 - cp} ${0} ${x + wavelength / 2} ${amplitude}`
+    );
+    // Second half: down trough
+    const mid = x + wavelength / 2;
+    segments.push(
+      `C ${mid + cp} ${2 * amplitude} ${mid + wavelength / 2 - cp} ${2 * amplitude} ${mid + wavelength / 2} ${amplitude}`
+    );
+    x += wavelength;
+  }
+
+  return segments.join(" ");
+}
+
+/**
+ * Build a wavy SVG `d` string that follows the circular arc.
+ * Uses radial offset (outward/inward perturbation) along the circle.
+ *
+ * @param cx         — circle centre x
+ * @param cy         — circle centre y
+ * @param radius     — arc radius
+ * @param strokeWidth — stroke width (determines visual band)
+ * @param amplitude  — radial perturbation amplitude in px
+ * @param wavelength — arc-length per wave cycle in px
+ * @param steps      — number of arc segments for approximation
+ */
+function buildCircularWavePath(
+  cx: number,
+  cy: number,
+  radius: number,
+  amplitude: number,
+  wavelength: number,
+  steps = 120
+): string {
+  const circumference = 2 * Math.PI * radius;
+  const points: string[] = [];
+
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const angle = t * 2 * Math.PI - Math.PI / 2; // start at top (−90°)
+    // Radial perturbation: sine wave scaled to arc length
+    const wavePhase = (circumference * t) / wavelength;
+    const radialOffset = amplitude * Math.sin(2 * Math.PI * wavePhase);
+    const r = radius + radialOffset;
+    const x = cx + r * Math.cos(angle);
+    const y = cy + r * Math.sin(angle);
+    points.push(
+      i === 0 ? `M ${x.toFixed(2)} ${y.toFixed(2)}` : `L ${x.toFixed(2)} ${y.toFixed(2)}`
+    );
+  }
+
+  return points.join(" ") + " Z";
+}
+
+// ---------------------------------------------------------------------------
+// Main Progress component
+// ---------------------------------------------------------------------------
 
 /**
  * Material Design 3 Progress Indicator (Layer 3: Styled)
  *
  * Built on React Aria for world-class accessibility.
- * Supports four variants driven by `type` + `indeterminate` props:
+ * Implements MD3 Expressive spec:
+ *   - Colorful track: primary-container (inactive), primary (active)
+ *   - 4dp indicator-track gap (linear + circular)
+ *   - Fully-rounded segments
+ *   - Optional thick (8dp) track
+ *   - Optional wavy shape with amplitude ramp
+ *   - useReducedMotion guard: wavy falls back to flat when reduced-motion is set
+ *
+ * Four variants driven by `type` × `indeterminate`:
  *   - Linear Determinate
  *   - Linear Indeterminate
  *   - Circular Determinate
  *   - Circular Indeterminate
- *
- * MD3 Specifications:
- * - Linear track height: 4dp (h-1)
- * - Linear track shape: rounded-full
- * - Circular default size: 48dp (medium)
- * - Circular stroke width: 4dp (SVG attribute)
- * - Active track: primary
- * - Inactive track: surface-container-highest
- * - Determinate transitions: duration-medium4 + ease-standard
- * - Indeterminate linear cycle: duration-long2
- * - Indeterminate circular rotation: duration-long4
  *
  * @example
  * ```tsx
@@ -80,8 +214,8 @@ function getCircularGeometry(size: "small" | "medium" | "large"): {
  * // Circular indeterminate
  * <Progress type="circular" indeterminate aria-label="Loading" />
  *
- * // Circular small spinner
- * <Progress type="circular" indeterminate size="small" aria-label="Loading" />
+ * // Thick wavy (MD3 Expressive)
+ * <Progress type="linear" indeterminate shape="wavy" thickness="thick" aria-label="Loading" />
  * ```
  */
 export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
@@ -90,6 +224,8 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
       type = "linear",
       indeterminate = false,
       size = "medium",
+      shape = "flat",
+      thickness = "default",
       className,
       label,
       value = 0,
@@ -101,6 +237,7 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
   ) => {
     const internalRef = useRef<HTMLDivElement>(null);
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
+    const reducedMotion: boolean = useReducedMotion();
 
     // React Aria: provides progressBarProps (role, aria-value*) and labelProps
     const { progressBarProps, labelProps } = useProgressBar({
@@ -117,7 +254,9 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
       ? 0
       : Math.min(100, Math.max(0, ((value - minValue) / (maxValue - minValue)) * 100));
 
-    // Development warning: require accessible label
+    // Reduced-motion degrades wavy → flat
+    const effectiveShape: "flat" | "wavy" = reducedMotion ? "flat" : shape;
+
     if (process.env.NODE_ENV !== "production") {
       const ariaProps = restProps as {
         "aria-label"?: string;
@@ -136,18 +275,29 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
         ref={ref}
         className={cn(progressContainerVariants({ type }), className)}
       >
-        {/* Optional visible label */}
         {label && (
           <span {...labelProps} className={cn(progressLabelVariants())}>
             {label}
           </span>
         )}
 
-        {/* Visual rendering: branches on type × indeterminate */}
         {type === "linear" ? (
-          <LinearProgress percentage={percentage} indeterminate={indeterminate} />
+          <LinearProgress
+            percentage={percentage}
+            indeterminate={indeterminate}
+            shape={effectiveShape}
+            thickness={thickness}
+            reducedMotion={reducedMotion}
+          />
         ) : (
-          <CircularProgress percentage={percentage} indeterminate={indeterminate} size={size} />
+          <CircularProgress
+            percentage={percentage}
+            indeterminate={indeterminate}
+            size={size}
+            shape={effectiveShape}
+            thickness={thickness}
+            reducedMotion={reducedMotion}
+          />
         )}
       </div>
     );
@@ -163,49 +313,254 @@ Progress.displayName = "Progress";
 interface LinearProgressProps {
   percentage: number;
   indeterminate: boolean;
+  shape: "flat" | "wavy";
+  thickness: "default" | "thick";
+  reducedMotion: boolean;
 }
 
-function LinearProgress({ percentage, indeterminate }: LinearProgressProps): React.JSX.Element {
+function LinearProgress({
+  percentage,
+  indeterminate,
+  shape,
+  thickness,
+  reducedMotion,
+}: LinearProgressProps): React.JSX.Element {
   if (indeterminate) {
-    return (
-      <div data-progress-track="" className={cn(progressTrackVariants())}>
-        <div
-          data-progress-indeterminate=""
-          className="absolute inset-0 overflow-hidden rounded-full"
-        >
-          {/* Segment 1 */}
-          <div
-            className={cn(
-              "bg-primary absolute top-0 h-full rounded-full",
-              "animate-progress-linear-indeterminate-1"
-            )}
-          />
-          {/* Segment 2 */}
-          <div
-            className={cn(
-              "bg-primary absolute top-0 h-full rounded-full",
-              "animate-progress-linear-indeterminate-2"
-            )}
-          />
-        </div>
-      </div>
+    return shape === "wavy" ? (
+      <LinearWavyIndeterminate thickness={thickness} />
+    ) : (
+      <LinearFlatIndeterminate thickness={thickness} />
     );
   }
 
+  return shape === "wavy" ? (
+    <LinearWavyDeterminate
+      percentage={percentage}
+      thickness={thickness}
+      reducedMotion={reducedMotion}
+    />
+  ) : (
+    <LinearFlatDeterminate percentage={percentage} thickness={thickness} />
+  );
+}
+
+// ── Flat Determinate ────────────────────────────────────────────────────────
+
+function LinearFlatDeterminate({
+  percentage,
+  thickness,
+}: {
+  percentage: number;
+  thickness: "default" | "thick";
+}): React.JSX.Element {
   return (
-    <div data-progress-track="" className={cn(progressTrackVariants())}>
-      {/* Determinate indicator bar */}
+    <div data-progress-track="" className={cn(progressTrackVariants({ thickness }))}>
+      {/* Active indicator */}
       <div
         data-progress-indicator=""
-        className={cn(progressIndicatorVariants())}
+        className={cn(progressActiveIndicatorVariants())}
         style={{ width: `${percentage}%` }}
       />
-      {/* Stop indicator dot — leading edge of progress head per MD3 */}
+      {/* Inactive segment — starts after the 4dp gap */}
+      {percentage < 100 && (
+        <div
+          data-progress-inactive-segment=""
+          className={cn(progressInactiveSegmentVariants())}
+          style={{ left: `calc(${percentage}% + ${INDICATOR_TRACK_GAP}px)` }}
+        />
+      )}
+      {/* Stop indicator dot at trailing edge */}
       <div
         data-stop-indicator=""
         className={cn(progressStopIndicatorVariants())}
         aria-hidden="true"
       />
+    </div>
+  );
+}
+
+// ── Flat Indeterminate ──────────────────────────────────────────────────────
+
+function LinearFlatIndeterminate({
+  thickness,
+}: {
+  thickness: "default" | "thick";
+}): React.JSX.Element {
+  return (
+    <div data-progress-track="" className={cn(progressTrackVariants({ thickness }))}>
+      <div data-progress-indeterminate="" className="absolute inset-0 overflow-hidden rounded-full">
+        {/* Segment 1 */}
+        <div
+          className={cn(
+            "bg-primary absolute top-0 h-full rounded-full",
+            "animate-progress-linear-indeterminate-1"
+          )}
+        />
+        {/* Segment 2 */}
+        <div
+          className={cn(
+            "bg-primary absolute top-0 h-full rounded-full",
+            "animate-progress-linear-indeterminate-2"
+          )}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── Wavy Determinate ───────────────────────────────────────────────────────
+
+function LinearWavyDeterminate({
+  percentage,
+  thickness,
+  reducedMotion,
+}: {
+  percentage: number;
+  thickness: "default" | "thick";
+  reducedMotion: boolean;
+}): React.JSX.Element {
+  const amplitude = thickness === "thick" ? WAVE_AMPLITUDE_THICK : WAVE_AMPLITUDE_DEFAULT;
+  const wavelength = WAVE_WAVELENGTH_LINEAR;
+
+  // Amplitude ramp: 0 → full at 10%, then full → 0 at 90%
+  const rampedAmplitude =
+    reducedMotion || percentage <= 0 || percentage >= 100
+      ? 0
+      : amplitude *
+        Math.min(
+          (percentage - 10) / 10, // ramp up  0.1→0.2
+          (90 - percentage) / 10, // ramp down 0.8→0.9
+          1
+        );
+
+  // Container height accommodates the wave amplitude above/below midline
+  const containerHeight = (thickness === "thick" ? 8 : 4) + 2 * amplitude + 4;
+  const trackY = amplitude + 2; // midline Y within SVG viewBox
+
+  const trackHeightClass = thickness === "thick" ? "h-2" : "h-1";
+
+  return (
+    <div
+      data-progress-track=""
+      className={cn("relative w-full overflow-visible", trackHeightClass)}
+      style={{ height: `${containerHeight}px` }}
+    >
+      <svg
+        className="absolute inset-0 w-full overflow-visible"
+        style={{ height: containerHeight }}
+        aria-hidden="true"
+      >
+        {/* Inactive track (full-width, primary-container) */}
+        <line
+          x1="0"
+          y1={trackY}
+          x2="100%"
+          y2={trackY}
+          stroke="currentColor"
+          strokeWidth={getStrokeWidth(thickness)}
+          strokeLinecap="round"
+          className="text-primary-container"
+        />
+        {/* Active wavy indicator clipped to percentage */}
+        {percentage > 0 && (
+          <path
+            data-progress-indicator=""
+            d={buildLinearWavePath(
+              // We use a large notional width; clipPath handles the cut
+              1000,
+              rampedAmplitude,
+              wavelength
+            )}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={getStrokeWidth(thickness)}
+            strokeLinecap="round"
+            className="text-primary duration-spring-standard-default-spatial ease-spring-standard-default-spatial transition-[clip-path]"
+            clipPath={`inset(0 ${100 - percentage}% 0 0)`}
+          />
+        )}
+        {/* Stop indicator dot */}
+        <circle
+          data-stop-indicator=""
+          cx="100%"
+          cy={trackY}
+          r={INDICATOR_TRACK_GAP / 2}
+          fill="currentColor"
+          className="text-primary"
+          aria-hidden="true"
+        />
+      </svg>
+    </div>
+  );
+}
+
+// ── Wavy Indeterminate ──────────────────────────────────────────────────────
+
+function LinearWavyIndeterminate({
+  thickness,
+}: {
+  thickness: "default" | "thick";
+}): React.JSX.Element {
+  const amplitude = thickness === "thick" ? WAVE_AMPLITUDE_THICK : WAVE_AMPLITUDE_DEFAULT;
+  const wavelength = WAVE_WAVELENGTH_LINEAR;
+  const containerHeight = (thickness === "thick" ? 8 : 4) + 2 * amplitude + 4;
+  const trackY = amplitude + 2;
+  const trackHeightClass = thickness === "thick" ? "h-2" : "h-1";
+
+  return (
+    <div
+      data-progress-track=""
+      className={cn("relative w-full overflow-visible", trackHeightClass)}
+      style={{ height: `${containerHeight}px` }}
+    >
+      <div
+        data-progress-indeterminate=""
+        className="absolute inset-0 overflow-hidden"
+        style={{ height: containerHeight }}
+      >
+        <svg
+          className="absolute h-full"
+          style={{ width: "200%", top: 0, left: 0, height: containerHeight }}
+          aria-hidden="true"
+        >
+          {/* Segment 1 — primary wavy */}
+          <path
+            d={buildLinearWavePath(2000, amplitude, wavelength)}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={getStrokeWidth(thickness)}
+            strokeLinecap="round"
+            className={cn("text-primary", "animate-progress-linear-indeterminate-1")}
+          />
+          {/* Segment 2 — primary wavy, offset */}
+          <path
+            d={buildLinearWavePath(2000, amplitude, wavelength)}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={getStrokeWidth(thickness)}
+            strokeLinecap="round"
+            className={cn("text-primary", "animate-progress-linear-indeterminate-2")}
+          />
+        </svg>
+      </div>
+
+      {/* Inactive track visible behind segments */}
+      <svg
+        className="pointer-events-none absolute inset-0 w-full overflow-visible"
+        style={{ height: containerHeight }}
+        aria-hidden="true"
+      >
+        <line
+          x1="0"
+          y1={trackY}
+          x2="100%"
+          y2={trackY}
+          stroke="currentColor"
+          strokeWidth={getStrokeWidth(thickness)}
+          strokeLinecap="round"
+          className="text-primary-container"
+        />
+      </svg>
     </div>
   );
 }
@@ -218,17 +573,23 @@ interface CircularProgressProps {
   percentage: number;
   indeterminate: boolean;
   size: "small" | "medium" | "large";
+  shape: "flat" | "wavy";
+  thickness: "default" | "thick";
+  reducedMotion: boolean;
 }
 
 function CircularProgress({
   percentage,
   indeterminate,
   size,
+  shape,
+  thickness,
+  reducedMotion,
 }: CircularProgressProps): React.JSX.Element {
-  const { radius, circumference, viewBox, cx, cy } = getCircularGeometry(size);
-
-  // stroke-dashoffset: 0 = full circle (100%), circumference = empty circle (0%)
-  const strokeDashoffset = (1 - percentage / 100) * circumference;
+  const { radius, circumference, viewBox, cx, cy, strokeWidth, diameter } = getCircularGeometry(
+    size,
+    thickness
+  );
 
   if (indeterminate) {
     return (
@@ -242,57 +603,130 @@ function CircularProgress({
           className="animate-progress-circular-rotate h-full w-full"
           aria-hidden="true"
         >
+          {/* Inactive track — primary-container per Expressive (always visible) */}
           <circle
             cx={cx}
             cy={cy}
             r={radius}
             fill="none"
             stroke="currentColor"
-            strokeWidth={STROKE_WIDTH}
-            className="text-surface-container-highest"
+            strokeWidth={strokeWidth}
+            className="text-primary-container"
           />
-          <circle
-            cx={cx}
-            cy={cy}
-            r={radius}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={STROKE_WIDTH}
-            className="animate-progress-circular-dash text-primary"
-            strokeLinecap="round"
-          />
+          {shape === "wavy" ? (
+            <path
+              d={buildCircularWavePath(
+                cx,
+                cy,
+                radius,
+                WAVE_AMPLITUDE_DEFAULT,
+                WAVE_WAVELENGTH_CIRCULAR
+              )}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              className="animate-progress-circular-dash text-primary"
+              strokeLinecap="round"
+            />
+          ) : (
+            <circle
+              cx={cx}
+              cy={cy}
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              className="animate-progress-circular-dash text-primary"
+              strokeLinecap="round"
+            />
+          )}
         </svg>
       </div>
     );
   }
 
+  // Determinate: introduce 4dp arc gap
+  // Arc gap in radians = gap / radius; subtract from both active and inactive ends
+  const gapRadians = INDICATOR_TRACK_GAP / radius;
+  const activeArc = (percentage / 100) * circumference;
+  // Subtract half-gap from each end of the active arc for the visual gap
+  const activeArcGapped = Math.max(0, activeArc - INDICATOR_TRACK_GAP);
+  const inactiveArcGapped = Math.max(0, circumference - activeArc - INDICATOR_TRACK_GAP);
+
+  const activeOffset = 0; // active starts at 12 o'clock (SVG starts at 3; -90deg rotate)
+  const inactiveOffset = -(activeArcGapped + INDICATOR_TRACK_GAP); // inactive starts after gap
+
+  // Suppress unused variable warning — gapRadians was computed for reference; use the direct pixel approach above
+  void gapRadians;
+
   return (
     <div data-progress-size={size} className={cn(progressCircularSizeVariants({ size }))}>
       <svg viewBox={viewBox} className="h-full w-full -rotate-90" aria-hidden="true">
-        {/* Background circle (inactive track) */}
-        <circle
-          cx={cx}
-          cy={cy}
-          r={radius}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={STROKE_WIDTH}
-          className="text-surface-container-highest"
-        />
-        {/* Foreground circle (active track, determinate) */}
-        <circle
-          cx={cx}
-          cy={cy}
-          r={radius}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={STROKE_WIDTH}
-          strokeLinecap="round"
-          className="text-primary duration-medium4 ease-standard transition-[stroke-dashoffset]"
-          strokeDasharray={circumference}
-          strokeDashoffset={strokeDashoffset}
-        />
+        {/* Inactive track — primary-container; rendered first (below active) */}
+        {percentage < 100 && (
+          <circle
+            cx={cx}
+            cy={cy}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={`${inactiveArcGapped} ${circumference - inactiveArcGapped}`}
+            strokeDashoffset={inactiveOffset}
+            className="text-primary-container duration-spring-standard-default-spatial ease-spring-standard-default-spatial transition-[stroke-dasharray,stroke-dashoffset]"
+          />
+        )}
+        {/* Active indicator — primary; rendered on top */}
+        {percentage > 0 && (
+          <circle
+            cx={cx}
+            cy={cy}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={`${activeArcGapped} ${circumference - activeArcGapped}`}
+            strokeDashoffset={activeOffset}
+            className="text-primary duration-spring-standard-default-spatial ease-spring-standard-default-spatial transition-[stroke-dasharray,stroke-dashoffset]"
+          />
+        )}
+        {/* Show full circle in primary-container when value is 0 */}
+        {percentage === 0 && (
+          <circle
+            cx={cx}
+            cy={cy}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            className="text-primary-container"
+          />
+        )}
+        {/* Wavy overlay for determinate circular */}
+        {shape === "wavy" && !reducedMotion && percentage > 0 && percentage < 100 && (
+          <path
+            d={buildCircularWavePath(
+              cx,
+              cy,
+              radius,
+              WAVE_AMPLITUDE_DEFAULT,
+              WAVE_WAVELENGTH_CIRCULAR
+            )}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={`${activeArcGapped} ${circumference - activeArcGapped}`}
+            strokeDashoffset={activeOffset}
+            className="text-primary duration-spring-standard-default-spatial ease-spring-standard-default-spatial transition-[stroke-dasharray]"
+          />
+        )}
       </svg>
+
+      {/* Circular size thumbnail for diameter reference — keep for geometry stability */}
+      <span className="sr-only" data-progress-diameter={diameter} />
     </div>
   );
 }

--- a/packages/react/src/components/Progress/Progress.tsx
+++ b/packages/react/src/components/Progress/Progress.tsx
@@ -467,6 +467,9 @@ function LinearWavyDeterminate({
   // midY: 2px top padding + amplitude = midline position in px (= VB y-units, since y-scale=1)
   const midY = amplitude + 2;
   const trackHeightClass = thickness === "thick" ? "h-2" : "h-1";
+  // trackPx: the flat-track thickness (= stroke-width). The inactive segment and stop dot
+  // should match this so they look identical to the flat variant.
+  const trackPx = getStrokeWidth(thickness);
 
   // Amplitude ramp: 0 at 0% and 100%, full amplitude between 20% and 80%
   const rampedAmplitude =
@@ -523,19 +526,24 @@ function LinearWavyDeterminate({
         />
       </svg>
 
-      {/* Inactive segment after 4dp gap — DOM element, px-exact */}
+      {/* Inactive segment after 4dp gap — centered on midY, trackPx tall (matches flat variant) */}
       {percentage < 100 && (
         <div
           data-progress-inactive-segment=""
           className={cn(progressInactiveSegmentVariants())}
-          style={{ left: `calc(${percentage}% + ${INDICATOR_TRACK_GAP}px)` }}
+          style={{
+            left: `calc(${percentage}% + ${INDICATOR_TRACK_GAP}px)`,
+            height: trackPx,
+            top: midY - trackPx / 2,
+          }}
         />
       )}
 
-      {/* Stop indicator dot at trailing edge */}
+      {/* Stop indicator dot — centered on the wave's midY baseline */}
       <div
         data-stop-indicator=""
         className={cn(progressStopIndicatorVariants())}
+        style={{ top: midY }}
         aria-hidden="true"
       />
     </div>
@@ -566,6 +574,8 @@ function LinearWavyIndeterminate({
   const containerHeight = (thickness === "thick" ? 8 : 4) + 2 * amplitude + 4;
   const midY = amplitude + 2;
   const trackHeightClass = thickness === "thick" ? "h-2" : "h-1";
+  // trackPx: flat-track thickness so the inactive rail matches the flat variant's height
+  const trackPx = getStrokeWidth(thickness);
 
   const wavePath = buildLinearWavePath(VB_W, LINEAR_WAVE_COUNT, amplitude, midY);
 
@@ -575,8 +585,11 @@ function LinearWavyIndeterminate({
       className={cn("relative w-full overflow-hidden", trackHeightClass)}
       style={{ height: containerHeight }}
     >
-      {/* Full-width inactive track behind the animated segments */}
-      <div className="bg-primary-container absolute inset-0 rounded-full" />
+      {/* Full-width inactive track — trackPx tall, centered on midY (matches flat variant) */}
+      <div
+        className="bg-primary-container absolute right-0 left-0 rounded-full"
+        style={{ height: trackPx, top: midY - trackPx / 2 }}
+      />
 
       {/* Animated segments — same approach as flat but with SVG wave paths */}
       <div data-progress-indeterminate="" className="absolute inset-0">
@@ -808,13 +821,19 @@ function CircularWavyIndeterminate({
   cx,
   cy,
   radius,
-  circumference,
+  circumference: _circumference,
   viewBox,
   strokeWidth,
 }: CircularWavyGeometry): React.JSX.Element {
+  // Clamp amplitude so crests never exceed `radius` (= diameter/2 - strokeWidth/2).
+  // meanRadius is the wave's centreline; crests reach meanRadius + circAmp = radius exactly.
+  const circAmp = Math.min(WAVE_AMPLITUDE_DEFAULT, radius * 0.35);
+  const meanRadius = radius - circAmp;
+  const meanCircumference = 2 * Math.PI * meanRadius;
+
   // Integer waveCount → seamless close (sin(2π·N·1) = sin(2π·N·0) = 0)
-  const waveCount = Math.max(4, Math.round(circumference / WAVE_WAVELENGTH_CIRCULAR));
-  const wavePath = buildCircularWavePath(cx, cy, radius, WAVE_AMPLITUDE_DEFAULT, waveCount);
+  const waveCount = Math.max(4, Math.round(meanCircumference / WAVE_WAVELENGTH_CIRCULAR));
+  const wavePath = buildCircularWavePath(cx, cy, meanRadius, circAmp, waveCount);
 
   return (
     <div
@@ -826,17 +845,19 @@ function CircularWavyIndeterminate({
        * The entire SVG rotates via animate-progress-circular-rotate.
        * The wavy path has a static dash showing ~28% of the ring,
        * so the arc sweeps around as a rotating wavy segment.
+       * Inactive ring drawn at meanRadius so it is concentric with the wave centerline —
+       * no plain circle poking through behind the active wavy arc.
        */}
       <svg
         viewBox={viewBox}
         className="animate-progress-circular-rotate h-full w-full"
         aria-hidden="true"
       >
-        {/* Inactive full ring (primary-container) */}
+        {/* Inactive full ring (primary-container) at meanRadius */}
         <circle
           cx={cx}
           cy={cy}
-          r={radius}
+          r={meanRadius}
           fill="none"
           stroke="currentColor"
           strokeWidth={strokeWidth}
@@ -882,18 +903,23 @@ function CircularWavyDeterminate({
   cx,
   cy,
   radius,
-  circumference,
+  circumference: _circumference,
   viewBox,
   strokeWidth,
   diameter,
   reducedMotion,
 }: CircularWavyGeometry & { percentage: number; reducedMotion: boolean }): React.JSX.Element {
-  const waveCount = Math.max(4, Math.round(circumference / WAVE_WAVELENGTH_CIRCULAR));
-  const amp = reducedMotion ? 0 : WAVE_AMPLITUDE_DEFAULT;
-  const wavePath = buildCircularWavePath(cx, cy, radius, amp, waveCount);
+  // Clamp amplitude so crests never exceed `radius` → no viewBox clipping.
+  // meanRadius is the wave centreline; crest = meanRadius + circAmp = radius exactly.
+  const circAmp = reducedMotion ? 0 : Math.min(WAVE_AMPLITUDE_DEFAULT, radius * 0.35);
+  const meanRadius = radius - circAmp;
+  const meanCircumference = 2 * Math.PI * meanRadius;
 
-  // Gap expressed in pathLength=100 space
-  const gapPct = (INDICATOR_TRACK_GAP / circumference) * 100;
+  const waveCount = Math.max(4, Math.round(meanCircumference / WAVE_WAVELENGTH_CIRCULAR));
+  const wavePath = buildCircularWavePath(cx, cy, meanRadius, circAmp, waveCount);
+
+  // Gap expressed in pathLength=100 space (computed from meanRadius circumference for accuracy)
+  const gapPct = (INDICATOR_TRACK_GAP / meanCircumference) * 100;
   const activeLen = Math.max(0, percentage - gapPct);
   const inactiveLen = Math.max(0, 100 - percentage - gapPct);
   // Inactive arc starts after active + gap
@@ -905,14 +931,16 @@ function CircularWavyDeterminate({
        * -rotate-90 on the SVG makes both the circle and the wavy path start
        * at the visual 12 o'clock position (path starts at 3 o'clock
        * mathematically, rotated -90° to top visually).
+       * All arcs/rings drawn at meanRadius so they are concentric with the wave centerline —
+       * no plain circle showing through behind the active wavy arc.
        */}
       <svg viewBox={viewBox} className="h-full w-full -rotate-90" aria-hidden="true">
-        {/* Full inactive track at 0% */}
+        {/* Full inactive track at 0% — at meanRadius */}
         {percentage === 0 && (
           <circle
             cx={cx}
             cy={cy}
-            r={radius}
+            r={meanRadius}
             fill="none"
             stroke="currentColor"
             strokeWidth={strokeWidth}
@@ -920,12 +948,12 @@ function CircularWavyDeterminate({
           />
         )}
 
-        {/* Inactive arc (primary-container) — for 0 < percentage < 100 */}
+        {/* Inactive arc (primary-container) — for 0 < percentage < 100, at meanRadius */}
         {percentage > 0 && percentage < 100 && (
           <circle
             cx={cx}
             cy={cy}
-            r={radius}
+            r={meanRadius}
             fill="none"
             stroke="currentColor"
             strokeWidth={strokeWidth}
@@ -937,7 +965,7 @@ function CircularWavyDeterminate({
           />
         )}
 
-        {/* Active wavy arc (primary) — single element, no stacking */}
+        {/* Active wavy arc (primary) — single element, wave built at meanRadius */}
         {percentage > 0 && (
           <path
             data-progress-indicator=""

--- a/packages/react/src/components/Progress/Progress.types.ts
+++ b/packages/react/src/components/Progress/Progress.types.ts
@@ -7,7 +7,9 @@ import type { AriaProgressBarProps } from "react-aria";
  * Built on React Aria for world-class accessibility.
  * Supports four variants: Linear Determinate, Linear Indeterminate,
  * Circular Determinate, and Circular Indeterminate.
- * Implementation uses CVA + Tailwind CSS classes mapped to MD3 tokens.
+ * Implements MD3 Expressive styling: colorful primary-container track,
+ * 4dp indicator-track gap, fully-rounded segments, thick track option,
+ * and optional wavy shape.
  *
  * @example
  * ```tsx
@@ -25,6 +27,9 @@ import type { AriaProgressBarProps } from "react-aria";
  *
  * // Circular with size
  * <Progress type="circular" indeterminate size="small" aria-label="Loading" />
+ *
+ * // Thick wavy linear (MD3 Expressive)
+ * <Progress type="linear" indeterminate shape="wavy" thickness="thick" aria-label="Loading" />
  *
  * // Custom range
  * <Progress type="linear" minValue={0} maxValue={200} value={150} label="Progress" />
@@ -52,6 +57,24 @@ export interface ProgressProps extends AriaProgressBarProps {
   size?: "small" | "medium" | "large";
 
   /**
+   * Visual shape of the progress indicator.
+   * - `"flat"` — standard rounded rectangular/circular track.
+   * - `"wavy"` — MD3 Expressive sine-wave active indicator.
+   *   Increases linear container height to accommodate wave amplitude.
+   *   Reduced-motion users receive a flat fallback automatically.
+   * @default "flat"
+   */
+  shape?: "flat" | "wavy";
+
+  /**
+   * Track thickness.
+   * - `"default"` — 4dp per MD3 baseline spec.
+   * - `"thick"` — 8dp MD3 Expressive variant (fully rounded, `trackCornerRadius` = 4dp).
+   * @default "default"
+   */
+  thickness?: "default" | "thick";
+
+  /**
    * Additional CSS classes (Tailwind).
    */
   className?: string;
@@ -67,7 +90,7 @@ export interface ProgressProps extends AriaProgressBarProps {
  *   type="linear"
  *   value={50}
  *   label="Upload"
- *   renderProgress={({ percentage }) => (
+ *   renderProgress={({ percentage, shape, thickness }) => (
  *     <div style={{ width: `${percentage}%` }} />
  *   )}
  * />
@@ -93,6 +116,18 @@ export interface ProgressHeadlessProps extends AriaProgressBarProps {
   size?: "small" | "medium" | "large";
 
   /**
+   * Visual shape of the progress indicator.
+   * @default "flat"
+   */
+  shape?: "flat" | "wavy";
+
+  /**
+   * Track thickness.
+   * @default "default"
+   */
+  thickness?: "default" | "thick";
+
+  /**
    * Additional CSS classes.
    */
   className?: string;
@@ -111,5 +146,7 @@ export interface ProgressHeadlessProps extends AriaProgressBarProps {
     isIndeterminate: boolean;
     type: "linear" | "circular";
     size: "small" | "medium" | "large";
+    shape: "flat" | "wavy";
+    thickness: "default" | "thick";
   }) => React.ReactNode;
 }

--- a/packages/react/src/components/Progress/Progress.variants.ts
+++ b/packages/react/src/components/Progress/Progress.variants.ts
@@ -3,28 +3,38 @@ import { cva, type VariantProps } from "class-variance-authority";
 /**
  * Material Design 3 Progress Indicator Variants (CVA)
  *
- * Type-safe variant management for Progress component.
- * Uses Tailwind CSS classes mapped to MD3 design tokens.
+ * Architecture: Slot-based CVA blocks (no interaction states — Progress is non-interactive).
+ * Each DOM slot owns a separate CVA. Design-time variant props (type, size, thickness)
+ * are passed to the appropriate slot; no state variants exist here.
  *
- * MD3 Specifications:
- * - Linear track height: 4dp (h-1 = 4px)
- * - Linear track shape: rounded-full (radius-full)
- * - Circular default size: 48dp (h-12 w-12)
- * - Circular stroke width: 4dp (applied as SVG attribute)
- * - Active track color: primary
- * - Inactive track color: surface-container-highest
- * - Label text: on-surface, body-small
+ * MD3 Expressive spec (materialy.io/components/progress-indicators):
+ *   Active indicator color : primary
+ *   Inactive track color   : primary-container  (Expressive "colorful" style)
+ *   Indicator-track gap    : 4dp
+ *   Stop indicator         : 4dp dot, primary, trailing edge (linear determinate only)
+ *   Track corner radius    : fully-rounded (rounded-full for all segments)
+ *   Track thickness        : 4dp default (h-1) | 8dp thick (h-2)
+ *   Determinate transition : spatial spring — width/stroke are spatial properties
+ *   Indeterminate motion   : keyframes in Progress.css referencing MD3 motion tokens
+ *
+ * Slot map:
+ *   progressContainerVariants     — outer wrapper; flex layout
+ *   progressLabelVariants         — body-small on-surface label text
+ *   progressTrackVariants         — linear inactive rail; thickness variant
+ *   progressActiveIndicatorVariants — linear active fill; spring spatial transition
+ *   progressInactiveSegmentVariants — linear inactive segment (rendered after gap)
+ *   progressStopIndicatorVariants  — 4dp primary dot at trailing edge (linear det only)
+ *   progressCircularSizeVariants   — circular SVG wrapper; size + thickness variant
  */
 
+// ─── CONTAINER ────────────────────────────────────────────────────────────────
+
 /**
- * Progress container variants.
- * Wraps the entire progress indicator (label + visual).
+ * Outer wrapper for the entire progress indicator (label + visual).
+ * linear → full-width column; circular → auto-width centred column.
  */
 export const progressContainerVariants = cva(["inline-flex", "flex-col", "gap-1"], {
   variants: {
-    /**
-     * The visual type of the indicator.
-     */
     type: {
       linear: "w-full",
       circular: "items-center justify-center w-auto",
@@ -35,63 +45,133 @@ export const progressContainerVariants = cva(["inline-flex", "flex-col", "gap-1"
   },
 });
 
-/**
- * Linear track variants (the 4dp-height background rail).
- */
-export const progressTrackVariants = cva([
-  "relative",
-  "w-full",
-  "h-1", // MD3: 4dp track height
-  "rounded-full", // MD3: full corner radius
-  "overflow-hidden",
-  "bg-surface-container-highest", // MD3: inactive track color
-]);
+// ─── LABEL ────────────────────────────────────────────────────────────────────
 
 /**
- * Linear indicator bar variants (the foreground progress fill).
+ * Optional visible label rendered above the indicator.
+ * MD3: body-small type scale, on-surface color role.
  */
-export const progressIndicatorVariants = cva([
+export const progressLabelVariants = cva(["text-body-small", "text-on-surface", "select-none"]);
+
+// ─── LINEAR TRACK (OUTER WRAPPER) ─────────────────────────────────────────────
+
+/**
+ * Linear track outer wrapper.
+ * This element establishes the full-width positioning context for the
+ * active indicator, inactive segment, and stop indicator.
+ * It does NOT carry a background color itself — the inactive track is a
+ * separate sibling element rendered after the gap.
+ *
+ * thickness variant:
+ *   default → h-1 (4dp)
+ *   thick   → h-2 (8dp) per MD3 Expressive "thick" configuration
+ */
+export const progressTrackVariants = cva(
+  [
+    "relative",
+    "w-full",
+    "overflow-visible", // gap segments extend beyond clipping bounds
+    "rounded-full",
+  ],
+  {
+    variants: {
+      thickness: {
+        default: "h-1",
+        thick: "h-2",
+      },
+    },
+    defaultVariants: {
+      thickness: "default",
+    },
+  }
+);
+
+// ─── LINEAR ACTIVE INDICATOR ──────────────────────────────────────────────────
+
+/**
+ * Linear active indicator bar (foreground fill).
+ *
+ * MD3 Expressive: primary color, fully rounded.
+ * Spatial spring transition on width — width is a spatial property
+ * (can animate with controlled overshoot), not an effects property.
+ *
+ * Uses spring-standard-default-spatial (500ms) — progress updates are
+ * purposeful UI feedback, not high-emphasis expressive moments.
+ */
+export const progressActiveIndicatorVariants = cva([
   "absolute",
   "left-0",
   "top-0",
   "h-full",
   "rounded-full",
-  "bg-primary", // MD3: active track color
+  "bg-primary",
+  // Spatial spring — width changes are spatial (bar growing)
   "transition-[width]",
-  "duration-medium4", // MD3: 400ms for value transitions
-  "ease-standard", // MD3: cubic-bezier(0.2, 0, 0, 1)
+  "duration-spring-standard-default-spatial",
+  "ease-spring-standard-default-spatial",
 ]);
 
+// ─── LINEAR INACTIVE SEGMENT (AFTER GAP) ──────────────────────────────────────
+
 /**
- * Stop indicator dot variants (linear determinate only).
- * Appears at the leading edge of the track head per MD3 spec.
+ * Linear inactive segment — rendered to the right of the active indicator
+ * with a 4dp gap between them.
+ *
+ * MD3 Expressive: primary-container color, fully rounded.
+ * `left` is set inline to `calc(P% + 4px)` by the component.
+ * Hidden when progress reaches 100% (right=0 with left>100% collapses it).
+ */
+export const progressInactiveSegmentVariants = cva([
+  "absolute",
+  "top-0",
+  "right-0",
+  "h-full",
+  "rounded-full",
+  "bg-primary-container",
+  // Spatial spring on left position (gap moves as progress moves)
+  "transition-[left]",
+  "duration-spring-standard-default-spatial",
+  "ease-spring-standard-default-spatial",
+]);
+
+// ─── STOP INDICATOR ───────────────────────────────────────────────────────────
+
+/**
+ * Stop indicator dot — trailing edge of the track for linear determinate.
+ *
+ * MD3 spec: 4dp size, primary color, always at the far right edge.
+ * Required when the track has contrast < 3:1 with its container surface;
+ * included unconditionally for determinacy and clarity.
  */
 export const progressStopIndicatorVariants = cva([
   "absolute",
   "right-0",
   "top-1/2",
   "-translate-y-1/2",
-  "w-1",
-  "h-1",
+  "size-1", // 4dp
   "rounded-full",
-  "bg-primary", // MD3: stop indicator uses primary color
+  "bg-primary",
 ]);
 
+// ─── CIRCULAR SIZE ────────────────────────────────────────────────────────────
+
 /**
- * Circular SVG size variants.
+ * Circular SVG wrapper.
  * Maps the size prop to MD3-specified dimensions.
- * - small:  24dp → h-6 w-6
- * - medium: 48dp → h-12 w-12 (default)
- * - large:  64dp → h-16 w-16
+ *
+ * size:
+ *   small  → 24dp (h-6 w-6)
+ *   medium → 48dp (h-12 w-12, default)
+ *   large  → 64dp (h-16 w-16)
  */
 export const progressCircularSizeVariants = cva(
   ["relative", "flex", "items-center", "justify-center", "flex-shrink-0"],
   {
     variants: {
       size: {
-        small: "h-6 w-6", // MD3: 24dp
-        medium: "h-12 w-12", // MD3: 48dp (default)
-        large: "h-16 w-16", // MD3: 64dp
+        small: "h-6 w-6",
+        medium: "h-12 w-12",
+        large: "h-16 w-16",
       },
     },
     defaultVariants: {
@@ -100,21 +180,23 @@ export const progressCircularSizeVariants = cva(
   }
 );
 
-/**
- * Label text variants.
- * Rendered above or beside the indicator per MD3 spec.
- */
-export const progressLabelVariants = cva([
-  "text-body-small", // MD3: body-small type scale (12px)
-  "text-on-surface", // MD3: on-surface color role
-  "select-none",
-]);
+// ─── BACKWARD COMPAT ALIAS ────────────────────────────────────────────────────
 
 /**
- * Extract variant prop types from CVA.
+ * @deprecated Use `progressActiveIndicatorVariants` instead.
+ * Kept for backward compatibility with any consumers importing this directly.
  */
+export const progressIndicatorVariants = progressActiveIndicatorVariants;
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
 export type ProgressContainerVariants = VariantProps<typeof progressContainerVariants>;
 export type ProgressTrackVariants = VariantProps<typeof progressTrackVariants>;
-export type ProgressIndicatorVariants = VariantProps<typeof progressIndicatorVariants>;
+export type ProgressActiveIndicatorVariants = VariantProps<typeof progressActiveIndicatorVariants>;
+export type ProgressInactiveSegmentVariants = VariantProps<typeof progressInactiveSegmentVariants>;
+export type ProgressStopIndicatorVariants = VariantProps<typeof progressStopIndicatorVariants>;
 export type ProgressCircularSizeVariants = VariantProps<typeof progressCircularSizeVariants>;
 export type ProgressLabelVariants = VariantProps<typeof progressLabelVariants>;
+
+/** @deprecated Use `ProgressActiveIndicatorVariants` instead. */
+export type ProgressIndicatorVariants = ProgressActiveIndicatorVariants;

--- a/packages/react/src/components/Progress/ProgressHeadless.tsx
+++ b/packages/react/src/components/Progress/ProgressHeadless.tsx
@@ -14,7 +14,7 @@ import type { ProgressHeadlessProps } from "./Progress.types";
  * - Determinate and indeterminate progress support
  * - Internationalized value label formatting via React Aria
  * - Label linkage via aria-labelledby / aria-label
- * - Render prop for custom visual rendering
+ * - Render prop for custom visual rendering (receives shape + thickness)
  *
  * @example
  * ```tsx
@@ -22,7 +22,7 @@ import type { ProgressHeadlessProps } from "./Progress.types";
  * <ProgressHeadless
  *   value={50}
  *   label="Upload"
- *   renderProgress={({ percentage }) => (
+ *   renderProgress={({ percentage, shape, thickness }) => (
  *     <div style={{ width: `${percentage}%` }} />
  *   )}
  * />
@@ -39,6 +39,8 @@ export const ProgressHeadless = forwardRef<HTMLDivElement, ProgressHeadlessProps
       type = "linear",
       indeterminate = false,
       size = "medium",
+      shape = "flat",
+      thickness = "default",
       className,
       children,
       renderProgress,
@@ -53,7 +55,6 @@ export const ProgressHeadless = forwardRef<HTMLDivElement, ProgressHeadlessProps
     const internalRef = useRef<HTMLDivElement>(null);
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLDivElement>;
 
-    // Map our `indeterminate` prop to React Aria's `isIndeterminate`
     const { progressBarProps, labelProps } = useProgressBar({
       label,
       value,
@@ -63,7 +64,6 @@ export const ProgressHeadless = forwardRef<HTMLDivElement, ProgressHeadlessProps
       ...restProps,
     });
 
-    // Compute percentage for consumers
     const percentage = indeterminate ? 0 : ((value - minValue) / (maxValue - minValue)) * 100;
 
     return (
@@ -74,6 +74,8 @@ export const ProgressHeadless = forwardRef<HTMLDivElement, ProgressHeadlessProps
           isIndeterminate: indeterminate,
           type,
           size,
+          shape,
+          thickness,
         })}
         {children}
       </div>

--- a/packages/react/src/components/Progress/index.ts
+++ b/packages/react/src/components/Progress/index.ts
@@ -1,12 +1,18 @@
 /**
  * @tinybigui/react — Progress Component
- * Material Design 3 Progress Indicator with accessibility support.
+ * Material Design 3 Expressive Progress Indicator with accessibility support.
  *
  * Four variants:
- *   - Linear Determinate
+ *   - Linear Determinate    (two-segment gap rendering)
  *   - Linear Indeterminate
- *   - Circular Determinate
+ *   - Circular Determinate  (arc gap)
  *   - Circular Indeterminate
+ *
+ * MD3 Expressive additions:
+ *   - Colorful track: primary-container
+ *   - 4dp indicator-track gap
+ *   - Optional thick (8dp) track via `thickness` prop
+ *   - Optional wavy shape via `shape` prop
  */
 
 // Layer 3: MD3 Styled Component (most consumers use this)
@@ -21,16 +27,24 @@ export type { ProgressProps, ProgressHeadlessProps } from "./Progress.types";
 // Variants (for advanced customization)
 export {
   progressContainerVariants,
+  progressLabelVariants,
   progressTrackVariants,
-  progressIndicatorVariants,
+  progressActiveIndicatorVariants,
+  progressInactiveSegmentVariants,
   progressStopIndicatorVariants,
   progressCircularSizeVariants,
-  progressLabelVariants,
+  // backward-compat alias
+  progressIndicatorVariants,
 } from "./Progress.variants";
+
 export type {
   ProgressContainerVariants,
-  ProgressTrackVariants,
-  ProgressIndicatorVariants,
-  ProgressCircularSizeVariants,
   ProgressLabelVariants,
+  ProgressTrackVariants,
+  ProgressActiveIndicatorVariants,
+  ProgressInactiveSegmentVariants,
+  ProgressStopIndicatorVariants,
+  ProgressCircularSizeVariants,
+  // backward-compat alias
+  ProgressIndicatorVariants,
 } from "./Progress.variants";


### PR DESCRIPTION
## Summary

- **Colorful track**: inactive track changed to `primary-container` (MD3 Expressive), active indicator stays `primary`
- **4dp indicator-track gap**: active and inactive segments now render as siblings with a 4dp gap between them (linear two-segment model + circular arc gap via `stroke-dasharray`)
- **New `shape` prop**: `"flat"` (default) | `"wavy"` — wavy uses SVG sine-wave paths for both linear and circular, determinate and indeterminate; automatically falls back to flat under `prefers-reduced-motion`
- **New `thickness` prop**: `"default"` (4dp) | `"thick"` (8dp per MD3 Expressive thick configuration)
- **Spring motion tokens**: determinate transitions updated from legacy `duration-medium4 ease-standard` to `duration-spring-standard-default-spatial ease-spring-standard-default-spatial`
- **Slot-based CVA architecture**: `Progress.variants.ts` rewritten with one CVA block per slot, matching Button/Switch/Tabs conventions; `progressInactiveSegmentVariants` added; `progressIndicatorVariants` kept as backward-compat alias

## Architecture changes

| Slot CVA | Responsibility |
|---|---|
| `progressContainerVariants` | Outer flex wrapper (type variant) |
| `progressLabelVariants` | body-small on-surface label |
| `progressTrackVariants` | Track height (thickness variant) |
| `progressActiveIndicatorVariants` | Active fill; spring spatial transition |
| `progressInactiveSegmentVariants` | Inactive segment after 4dp gap |
| `progressStopIndicatorVariants` | 4dp primary dot at trailing edge |
| `progressCircularSizeVariants` | SVG wrapper size |

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 2083 tests pass (70 Progress-specific, including new tests for gap, colorful track, thickness, wavy SVG paths)
- [ ] Visual check in Storybook: `pnpm dev:storybook` → Components/Progress → inspect FlatVsWavy, ThickTrack, GapDemo, AllShapes stories