### PR TITLE
refactor(radio): md3 expressive variants-vs-states architecture

### DIFF
--- a/.changeset/radio-md3-expressive-refactor.md
+++ b/.changeset/radio-md3-expressive-refactor.md
@@ -1,0 +1,12 @@
+---
+"@tinybigui/react": minor
+---
+
+Radio: align styling with MD3 Expressive variants-vs-states architecture
+
+Rewrites the Radio component visual layer to match the Switch component's architecture:
+
+- All interaction/selection/error states are now driven by `group-data-[x]/radio` Tailwind selectors on the root label — no state variants or compoundVariants in CVA.
+- Replaces the SVG + `animate-pulse` focus ring with div-based slots (state layer, outer ring, inner dot, MD3 focus ring) using proper MD3 spring motion token pairs (`spring-standard-fast-effects` for color/opacity, `spring-standard-fast-spatial` for dot scale).
+- Fixes `isInvalid` forwarding in `RadioGroup` so `data-invalid` is correctly emitted on individual Radio elements.
+- Inner dot animates scale 0→1 on selection using the spatial spring token.

--- a/packages/react/src/components/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/Radio/Radio.stories.tsx
@@ -87,6 +87,46 @@ export default meta;
 type Story = StoryObj<typeof RadioGroup>;
 
 /**
+ * All visual states of a Radio button at a glance.
+ * Demonstrates unselected, selected, error, and disabled states.
+ */
+export const States: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <RadioGroup label="Unselected">
+        <Radio value="a">Unselected</Radio>
+      </RadioGroup>
+
+      <RadioGroup label="Selected" defaultValue="a">
+        <Radio value="a">Selected</Radio>
+      </RadioGroup>
+
+      <RadioGroup label="Error state (isInvalid)" isInvalid>
+        <Radio value="a">Unselected (error)</Radio>
+        <Radio value="b">Option B</Radio>
+      </RadioGroup>
+
+      <RadioGroup label="Error state selected (isInvalid)" isInvalid defaultValue="a">
+        <Radio value="a">Selected (error)</Radio>
+        <Radio value="b">Option B</Radio>
+      </RadioGroup>
+
+      <RadioGroup label="Disabled group" isDisabled defaultValue="a">
+        <Radio value="a">Disabled selected</Radio>
+        <Radio value="b">Disabled unselected</Radio>
+      </RadioGroup>
+
+      <RadioGroup label="Individual disabled">
+        <Radio value="a">Enabled</Radio>
+        <Radio value="b" isDisabled>
+          Individual disabled
+        </Radio>
+      </RadioGroup>
+    </div>
+  ),
+};
+
+/**
  * Default vertical radio group with three options
  */
 export const Default: Story = {

--- a/packages/react/src/components/Radio/Radio.test.tsx
+++ b/packages/react/src/components/Radio/Radio.test.tsx
@@ -117,9 +117,75 @@ describe("RadioGroup", () => {
       const radioA = screen.getByRole("radio", { name: "A" });
       const _radioB = screen.getByRole("radio", { name: "B (Disabled)" });
       expect(radioA).not.toBeDisabled();
-      // Individual radio disabled state - check via visual styling since React Aria handles it differently
+      // Individual radio disabled state — root label receives data-disabled attribute
       const labelB = screen.getByText("B (Disabled)").closest("label");
-      expect(labelB).toHaveClass("opacity-38");
+      expect(labelB).toHaveAttribute("data-disabled", "");
+    });
+  });
+
+  describe("Data Attributes", () => {
+    test("sets data-selected on the label when radio is selected", async () => {
+      const user = userEvent.setup();
+      render(
+        <RadioGroup label="Options">
+          <Radio value="a">A</Radio>
+          <Radio value="b">B</Radio>
+        </RadioGroup>
+      );
+
+      const radioA = screen.getByRole("radio", { name: "A" });
+      await user.click(radioA);
+
+      const labelA = screen.getByText("A").closest("label");
+      expect(labelA).toHaveAttribute("data-selected", "");
+
+      const labelB = screen.getByText("B").closest("label");
+      expect(labelB).not.toHaveAttribute("data-selected");
+    });
+
+    test("sets data-disabled on label for individually disabled radio", () => {
+      render(
+        <RadioGroup label="Options">
+          <Radio value="a">A</Radio>
+          <Radio value="b" isDisabled>
+            B Disabled
+          </Radio>
+        </RadioGroup>
+      );
+
+      const labelA = screen.getByText("A").closest("label");
+      expect(labelA).not.toHaveAttribute("data-disabled");
+
+      const labelB = screen.getByText("B Disabled").closest("label");
+      expect(labelB).toHaveAttribute("data-disabled", "");
+    });
+
+    test("sets data-disabled on all labels when group is disabled", () => {
+      render(
+        <RadioGroup label="Options" isDisabled>
+          <Radio value="a">A</Radio>
+          <Radio value="b">B</Radio>
+        </RadioGroup>
+      );
+
+      const labelA = screen.getByText("A").closest("label");
+      const labelB = screen.getByText("B").closest("label");
+      expect(labelA).toHaveAttribute("data-disabled", "");
+      expect(labelB).toHaveAttribute("data-disabled", "");
+    });
+
+    test("sets data-invalid on radio labels when group isInvalid", () => {
+      render(
+        <RadioGroup label="Options" isInvalid>
+          <Radio value="a">A</Radio>
+          <Radio value="b">B</Radio>
+        </RadioGroup>
+      );
+
+      const labelA = screen.getByText("A").closest("label");
+      const labelB = screen.getByText("B").closest("label");
+      expect(labelA).toHaveAttribute("data-invalid", "");
+      expect(labelB).toHaveAttribute("data-invalid", "");
     });
   });
 

--- a/packages/react/src/components/Radio/Radio.tsx
+++ b/packages/react/src/components/Radio/Radio.tsx
@@ -2,15 +2,19 @@
 
 import { forwardRef, useRef, useContext } from "react";
 import type React from "react";
-import { useRadio, useFocusRing, mergeProps, VisuallyHidden } from "react-aria";
+import { useRadio, useFocusRing, useHover, mergeProps, VisuallyHidden } from "react-aria";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
 import { RadioGroupContext } from "./RadioGroupHeadless";
 import {
-  radioVariants,
-  radioContainerVariants,
-  radioIconOuterVariants,
-  radioIconInnerVariants,
+  radioRootVariants,
+  radioControlVariants,
+  radioFocusRingVariants,
+  radioTargetVariants,
+  radioStateLayerVariants,
+  radioRingVariants,
+  radioDotVariants,
   radioLabelVariants,
 } from "./Radio.variants";
 import type { RadioProps } from "./Radio.types";
@@ -19,25 +23,25 @@ import type { RadioProps } from "./Radio.types";
  * Material Design 3 Radio Component (Layer 3: Styled)
  *
  * Built on React Aria for world-class accessibility.
- * Uses CVA for type-safe variant management.
- * Styled with Tailwind CSS using MD3 design tokens.
- * Must be used within a RadioGroup for proper functionality.
+ * Implements the Variants-vs-States architecture: all interaction/selection/error
+ * states are expressed as data-* attributes on the root and consumed by each
+ * slot via group-data-[x]/radio Tailwind selectors — no state variants in CVA.
  *
  * Features:
- * - ✅ 2 states: unselected, selected
+ * - ✅ Unselected / selected states
+ * - ✅ Error/invalid state (via RadioGroup isInvalid)
  * - ✅ Ripple effect (Material Design)
  * - ✅ Full keyboard accessibility (via React Aria)
  * - ✅ Screen reader support (via React Aria)
- * - ✅ Focus management (via React Aria)
+ * - ✅ Focus management with MD3 focus ring (no animate-pulse)
  * - ✅ Form integration (name, value props from RadioGroup)
  *
  * MD3 Specifications:
- * - Radio icon: 20x20dp (within 40x40dp touch target)
- * - Outer circle: 20px
- * - Inner dot: 10px (selected state)
- * - Outline width: 2dp
- * - State layers: 8% hover, 12% focus/pressed
- * - Disabled: 38% opacity
+ * - Radio icon: 20×20dp (within 40×40dp touch target)
+ * - Outer circle border: 2dp
+ * - Inner dot: 10dp (selected state, scale 0→1)
+ * - State layers: 8% hover, 10% focus/pressed
+ * - Disabled: 38% opacity (on root)
  * - Label spacing: 16px (ml-4)
  *
  * @example
@@ -58,191 +62,110 @@ import type { RadioProps } from "./Radio.types";
  *   <Radio value="a">Enabled</Radio>
  *   <Radio value="b" isDisabled>Disabled</Radio>
  * </RadioGroup>
- *
- * // Custom styling
- * <Radio value="custom" className="my-custom-class">
- *   Custom
- * </Radio>
  * ```
  */
 export const Radio = forwardRef<HTMLInputElement, RadioProps>(
-  (
-    {
-      // Content props
-      children,
-
-      // State props
-      disableRipple = false,
-      isDisabled = false,
-
-      // Styling
-      className,
-
-      // Other props
-      ...props
-    },
-    forwardedRef
-  ) => {
-    // Get RadioGroup state from context
+  ({ children, disableRipple = false, isDisabled = false, className, ...props }, forwardedRef) => {
     const state = useContext(RadioGroupContext);
 
     if (!state) {
       throw new Error("Radio must be used within a RadioGroup");
     }
 
-    // Internal ref for React Aria
     const internalRef = useRef<HTMLInputElement>(null);
-
-    // Merge internal ref with forwarded ref
     const ref = (forwardedRef ?? internalRef) as React.RefObject<HTMLInputElement>;
 
-    // Extract data-testid and other HTML attributes
+    // Extract passthrough HTML attributes that React Aria doesn't understand
     const htmlAttrs = props as Record<string, unknown>;
     const dataTestId = htmlAttrs["data-testid"] as string | undefined;
     const htmlId = htmlAttrs.id as string | undefined;
     const htmlTitle = htmlAttrs.title as string | undefined;
 
-    // Remove HTML attributes from props for React Aria
     const {
       "data-testid": _dataTestId,
       id: _htmlId,
       title: _htmlTitle,
-      ...restPropsWithoutHtmlAttrs
+      ...ariaProps
     } = props as Record<string, unknown>;
 
-    // React Aria hooks - pass props without HTML attributes
+    // React Aria hooks — behavior + interaction states
     const {
       inputProps,
       isSelected,
       isDisabled: radioIsDisabled,
+      isPressed,
     } = useRadio(
-      {
-        ...restPropsWithoutHtmlAttrs,
-        value: props.value,
-      } as Parameters<typeof useRadio>[0],
+      { ...ariaProps, value: props.value } as Parameters<typeof useRadio>[0],
       state,
       ref
     );
     const { isFocusVisible, focusProps } = useFocusRing();
-
-    // Determine final disabled state (group or individual)
     const finalIsDisabled = isDisabled || radioIsDisabled;
+    const { isHovered, hoverProps } = useHover({ isDisabled: finalIsDisabled });
 
-    // Determine visual state
-    const visualState = isSelected ? "selected" : "unselected";
+    // Error/invalid state from RadioGroup
+    const isInvalid = state.validationState === "invalid";
 
-    // Ripple effect
+    // Ripple on the target (40dp area)
     const { onMouseDown: handleRipple, ripples } = useRipple({
       disabled: finalIsDisabled || disableRipple,
     });
 
-    // Development warnings
     if (process.env.NODE_ENV === "development") {
-      const ariaProps = restPropsWithoutHtmlAttrs as {
-        "aria-label"?: string;
-        "aria-labelledby"?: string;
-      };
-      if (!children && !ariaProps["aria-label"] && !ariaProps["aria-labelledby"]) {
-        console.warn(
-          "[Radio] Radio should have a label (children) or aria-label for accessibility."
-        );
+      const a = ariaProps as { "aria-label"?: string; "aria-labelledby"?: string };
+      if (!children && !a["aria-label"] && !a["aria-labelledby"]) {
+        console.warn("[Radio] Provide a label via children or aria-label for accessibility.");
       }
     }
 
-    // Get isInvalid from RadioGroup state if available
-    const isInvalid = state.validationState === "invalid";
-
     return (
       <label
-        className={cn(
-          radioVariants({
-            disabled: finalIsDisabled,
-          }),
-          className
-        )}
+        {...mergeProps(hoverProps)}
+        className={cn(radioRootVariants(), "group/radio", className)}
         data-testid={dataTestId}
         title={htmlTitle}
+        // ── Interaction + selection + error data attributes ─────────────
+        {...getInteractionDataAttributes({
+          isHovered,
+          isFocusVisible,
+          isPressed,
+          isSelected,
+          isDisabled: finalIsDisabled,
+          isInvalid,
+        })}
       >
-        {/* Visually hidden native input for accessibility */}
+        {/* Visually hidden native input — handles all accessibility */}
         <VisuallyHidden>
           <input {...mergeProps(inputProps, focusProps)} ref={ref} id={htmlId} />
         </VisuallyHidden>
 
-        {/* Visual radio container */}
-        <div
-          role="presentation"
-          className={cn(
-            radioContainerVariants({
-              state: visualState,
-              isInvalid,
-              disabled: finalIsDisabled,
-            })
-          )}
-          onMouseDown={handleRipple}
-        >
-          {/* Ripple effect */}
-          {ripples}
+        {/*
+         * Control wrapper — relative 40dp container.
+         * Hosts focus ring (sibling of target, not clipped) and the
+         * overflow-hidden target that clips the state layer.
+         */}
+        <div role="presentation" className={cn(radioControlVariants())}>
+          {/* Focus ring — sibling of target, never clipped by overflow-hidden */}
+          <div className={cn(radioFocusRingVariants())} aria-hidden="true" />
 
-          {/* SVG Radio Visual */}
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 20 20"
-            aria-hidden="true"
-            className="relative z-10"
-          >
-            {/* Outer circle (20x20) */}
-            <circle
-              cx="10"
-              cy="10"
-              r="9"
-              className={cn(
-                radioIconOuterVariants({
-                  state: visualState,
-                  disabled: finalIsDisabled,
-                })
-              )}
-            />
+          {/* Target — overflow-hidden clips state layer to the circle */}
+          <div role="presentation" className={cn(radioTargetVariants())} onMouseDown={handleRipple}>
+            {/* Ripple */}
+            {ripples}
 
-            {/* Inner dot (10px diameter = 5px radius, shown when selected) */}
-            <circle
-              cx="10"
-              cy="10"
-              r="5"
-              className={cn(
-                radioIconInnerVariants({
-                  visible: isSelected,
-                })
-              )}
-            />
+            {/* State layer — hover/focus/pressed opacity ring */}
+            <span className={cn(radioStateLayerVariants())} aria-hidden="true" />
 
-            {/* Focus ring (visible on keyboard focus) */}
-            {isFocusVisible && (
-              <circle
-                cx="10"
-                cy="10"
-                r="13"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                className="animate-pulse"
-              />
-            )}
-          </svg>
+            {/* Outer ring — 20dp circle with 2dp border */}
+            <div className={cn(radioRingVariants())} aria-hidden="true">
+              {/* Inner dot — scales 0→1 when selected */}
+              <div className={cn(radioDotVariants())} aria-hidden="true" />
+            </div>
+          </div>
         </div>
 
-        {/* Label text */}
-        {children && (
-          <span
-            className={cn(
-              radioLabelVariants({
-                disabled: finalIsDisabled,
-              })
-            )}
-          >
-            {children}
-          </span>
-        )}
+        {/* Text label */}
+        {children && <span className={cn(radioLabelVariants())}>{children}</span>}
       </label>
     );
   }

--- a/packages/react/src/components/Radio/Radio.variants.ts
+++ b/packages/react/src/components/Radio/Radio.variants.ts
@@ -1,265 +1,221 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 RadioGroup Variants (CVA)
+ * Material Design 3 Radio Variants
  *
- * Type-safe variant management for RadioGroup component.
- * Uses Tailwind CSS classes mapped to MD3 design tokens.
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no state variants, no state compoundVariants).
+ * - All interaction/selection/error states are driven by data-* attributes on the root via
+ *   group-data-[x]/radio Tailwind selectors in each slot's base classes.
+ * - Content flags are set explicitly by the component.
  *
- * MD3 Specifications:
- * - Radio icon: 20x20dp (within 40x40dp touch target)
- * - Outline width: 2dp
- * - State layers: 8% hover, 12% focus/pressed
- * - Disabled: 38% opacity
- * - Radio spacing: 16px gap between radios
+ * Slot responsibilities:
+ *   radioRootVariants        — label wrapper; carries `group/radio`; disabled cursor/opacity
+ *   radioControlVariants     — relative 40dp touch-target + state-layer host
+ *   radioFocusRingVariants   — keyboard focus ring (sibling of radioTarget, not clipped)
+ *   radioTargetVariants      — overflow-hidden rounded-full; clips state layer to circle shape
+ *   radioStateLayerVariants  — hover/focus/pressed opacity ring (color + opacity transitions)
+ *   radioRingVariants        — 20dp outer ring; owns border color (unselected/selected/error/disabled)
+ *   radioDotVariants         — 10dp inner filled dot; scale 0→1 when selected
+ *   radioLabelVariants       — text label next to control
+ *   radioGroupVariants       — flex container for the group
+ *   radioGroupLabelVariants  — group label text
+ *
+ * MD3 Spec:
+ *   Outer ring: 20×20dp, 2dp border
+ *   Inner dot: 10dp diameter (when selected)
+ *   Touch/state-layer target: 40dp
+ *   Colors:
+ *     Unselected ring:          on-surface-variant
+ *     Selected ring + dot:      primary
+ *     Error ring + dot:         error
+ *     Disabled ring + dot:      on-surface/38
+ *   State-layer:
+ *     Unselected color:         on-surface
+ *     Selected color:           primary
+ *     Error color:              error
+ *     Hover opacity:            8%
+ *     Focus/pressed opacity:    10%
+ *     Disabled:                 hidden
+ *   Label: body-medium, on-surface
+ */
+
+// ─── ROOT ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Root label wrapper — carries `group/radio`.
+ * Disabled state targets itself with data-[disabled]: selectors so children
+ * don't need to handle cursor separately.
+ */
+export const radioRootVariants = cva([
+  "relative inline-flex items-center cursor-pointer select-none",
+  // Disabled state — self-targeting so children inherit via group
+  "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+  "data-[disabled]:opacity-38",
+]);
+
+// ─── CONTROL ──────────────────────────────────────────────────────────────────
+
+/**
+ * Control wrapper — provides the 40dp relative positioning context.
+ * Hosts the focus ring (as a sibling) and the overflow-hidden target.
+ */
+export const radioControlVariants = cva([
+  "relative flex items-center justify-center flex-shrink-0",
+  "size-10", // 40dp touch target (MD3 spec)
+]);
+
+// ─── FOCUS RING ───────────────────────────────────────────────────────────────
+
+/**
+ * Focus ring — absolutely positioned sibling of the target div.
+ * Must live outside the overflow-hidden target so it is not clipped.
+ * Transitions from opacity-0 to opacity-100 on keyboard focus.
+ */
+export const radioFocusRingVariants = cva([
+  "pointer-events-none absolute inset-0 rounded-full",
+  "outline outline-2 outline-offset-2 outline-secondary",
+  // Effects transition for opacity
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/radio:opacity-100",
+]);
+
+// ─── TARGET ───────────────────────────────────────────────────────────────────
+
+/**
+ * Target — the 40dp overflow-hidden rounded circle that clips the state-layer
+ * and hosts the ripple. Not positioned (no translate), just centered in the control.
+ */
+export const radioTargetVariants = cva([
+  "absolute inset-0 rounded-full overflow-hidden",
+  "flex items-center justify-center",
+]);
+
+// ─── STATE LAYER ─────────────────────────────────────────────────────────────
+
+/**
+ * State layer — semi-transparent ring for hover/focus/press feedback.
+ *
+ * Color: on-surface (unselected) → primary (selected) → error (invalid).
+ * Opacity: 0 at rest, 8% hover, 10% focus/pressed, hidden when disabled.
+ * Uses effects tokens — opacity and background-color must not overshoot.
+ */
+export const radioStateLayerVariants = cva([
+  "absolute inset-0 rounded-full pointer-events-none opacity-0",
+  // Base state-layer color (unselected)
+  "bg-on-surface",
+  // Effects transition for opacity + color
+  "transition-[opacity,background-color] duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Selected state-layer color
+  "group-data-[selected]/radio:bg-primary",
+  // Error state-layer color (overrides selected via cascade position)
+  "group-data-[invalid]/radio:bg-error",
+  // Interaction opacities (MD3: hover 8%, focus/pressed 10%)
+  "group-data-[hovered]/radio:opacity-8",
+  "group-data-[focus-visible]/radio:opacity-10",
+  "group-data-[pressed]/radio:opacity-10",
+  // No state layer when disabled
+  "group-data-[disabled]/radio:hidden",
+]);
+
+// ─── RING ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Outer ring — the 20×20dp visible radio circle (2dp border).
+ * Owns border color; no fill.
+ * Uses effects tokens because color changes don't have spatial movement.
+ */
+export const radioRingVariants = cva([
+  "relative z-10 size-5 rounded-full border-2 flex items-center justify-center flex-shrink-0",
+  // Base (unselected, enabled)
+  "border-on-surface-variant",
+  // Effects transition for border-color
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Selected — border becomes primary
+  "group-data-[selected]/radio:border-primary",
+  // Error — placed after selected so it overrides by cascade order
+  "group-data-[invalid]/radio:border-error",
+  // Disabled — on-surface/38 opacity value
+  "group-data-[disabled]/radio:border-on-surface/38",
+]);
+
+// ─── DOT ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Inner dot — 10dp filled circle, centered in the ring.
+ * Animates from scale-0 (unselected) to scale-100 (selected).
+ * Uses spatial tokens because scale is a transform (can overshoot intentionally).
+ */
+export const radioDotVariants = cva([
+  "size-2.5 rounded-full origin-center",
+  // Spatial transition for scale — springs may overshoot (intentional)
+  "transition-transform duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+  // Base fill color (shown when selected)
+  "bg-primary",
+  // Hidden when unselected
+  "scale-0",
+  // Visible when selected
+  "group-data-[selected]/radio:scale-100",
+  // Error — error fill color (placed after selected by cascade)
+  "group-data-[invalid]/radio:bg-error",
+  // Disabled — use on-surface/38 opacity
+  "group-data-[disabled]/radio:bg-on-surface/38",
+]);
+
+// ─── LABEL ────────────────────────────────────────────────────────────────────
+
+/**
+ * Text label next to the radio control.
+ * Disabled opacity is inherited from root's data-[disabled]:opacity-38.
+ */
+export const radioLabelVariants = cva(["text-body-medium text-on-surface select-none ml-4"]);
+
+// ─── GROUP ────────────────────────────────────────────────────────────────────
+
+/**
+ * RadioGroup container — flex layout with orientation support.
  */
 export const radioGroupVariants = cva(
-  [
-    // Base classes (always applied to group wrapper)
-    "flex",
-    "gap-4", // 16px spacing between radios (MD3 standard)
-  ],
+  ["flex", "gap-1"], // 4dp gap — padding around each 40dp control handles visual spacing
   {
     variants: {
       /**
        * Layout orientation
+       * @default "vertical"
        */
       orientation: {
         vertical: "flex-col",
         horizontal: "flex-row flex-wrap",
       },
-
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "",
-        false: "",
-      },
     },
     defaultVariants: {
       orientation: "vertical",
-      disabled: false,
     },
   }
 );
 
 /**
- * RadioGroup label variants
+ * RadioGroup label text.
+ * Disabled opacity is applied via `data-disabled` attribute set directly on
+ * the label element by the component (not via group selector).
  */
-export const radioGroupLabelVariants = cva(
-  [
-    "text-sm font-medium", // MD3: Body Medium
-    "text-on-surface",
-    "mb-3", // Spacing below label (12px)
-  ],
-  {
-    variants: {
-      disabled: {
-        true: "opacity-38",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      disabled: false,
-    },
-  }
-);
+export const radioGroupLabelVariants = cva([
+  "text-body-medium font-medium",
+  "text-on-surface",
+  "mb-3",
+  "data-[disabled]:opacity-38",
+]);
 
-/**
- * Material Design 3 Radio Variants (CVA)
- *
- * Type-safe variant management for Radio component.
- * Uses Tailwind CSS classes mapped to MD3 design tokens.
- *
- * MD3 Specifications:
- * - Radio icon: 20x20dp (within 40x40dp touch target)
- * - Outline width: 2dp
- * - Inner dot: 10px (selected state)
- * - State layers: 8% hover, 12% focus/pressed
- * - Disabled: 38% opacity
- * - Label spacing: 16px (ml-4)
- */
-export const radioVariants = cva(
-  [
-    // Base classes (always applied to label wrapper)
-    "relative inline-flex items-center cursor-pointer select-none",
-    "transition-opacity duration-200",
-  ],
-  {
-    variants: {
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "opacity-38 cursor-not-allowed pointer-events-none",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      disabled: false,
-    },
-  }
-);
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
 
-/**
- * Radio container variants (for the visual radio circle)
- */
-export const radioContainerVariants = cva(
-  [
-    // Base classes for radio visual container
-    "relative inline-flex items-center justify-center",
-    "w-10 h-10", // 40x40dp touch target (MD3 spec)
-    "flex-shrink-0",
-    "transition-all duration-200",
-    "m-1", // 4px margin around radio for spacing (total 8px gap between radios)
-    // State layer (hover, focus, active) - MD3 spec: 8%/12%/12% opacity
-    "before:absolute before:inset-0 before:rounded-full before:transition-opacity before:duration-200",
-    "before:bg-current before:opacity-0",
-    "hover:before:opacity-8",
-    "active:before:opacity-12",
-  ],
-  {
-    variants: {
-      /**
-       * Radio state (determines visual appearance)
-       */
-      state: {
-        unselected: "text-on-surface-variant",
-        selected: "text-primary",
-      },
-
-      /**
-       * Error/invalid state
-       */
-      isInvalid: {
-        true: "text-error",
-        false: "",
-      },
-
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: "text-on-surface pointer-events-none",
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Error state overrides normal colors for all states
-      {
-        state: "unselected",
-        isInvalid: true,
-        disabled: false,
-        className: "text-error",
-      },
-      {
-        state: "selected",
-        isInvalid: true,
-        disabled: false,
-        className: "text-error",
-      },
-    ],
-    defaultVariants: {
-      state: "unselected",
-      isInvalid: false,
-      disabled: false,
-    },
-  }
-);
-
-/**
- * Radio icon outer circle variants (the 20x20dp circle)
- */
-export const radioIconOuterVariants = cva(
-  [
-    // Base classes for the radio outer circle
-    "transition-all duration-200 stroke-current stroke-2 fill-transparent",
-  ],
-  {
-    variants: {
-      /**
-       * Radio state
-       */
-      state: {
-        unselected: [],
-        selected: [],
-      },
-
-      /**
-       * Disabled state
-       */
-      disabled: {
-        true: ["fill-transparent", "stroke-current", "stroke-2"],
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Disabled + selected state overrides fill
-      {
-        state: "selected",
-        disabled: true,
-        className: "fill-current stroke-none",
-      },
-    ],
-    defaultVariants: {
-      state: "unselected",
-      disabled: false,
-    },
-  }
-);
-
-/**
- * Radio icon inner dot variants (the 10px center dot when selected)
- */
-export const radioIconInnerVariants = cva(["transition-all origin-center duration-200"], {
-  variants: {
-    /**
-     * Visibility based on state
-     */
-    state: {
-      selected: ["fill-current"],
-      unselected: ["fill-transparent"],
-    },
-    visible: {
-      true: "opacity-100 scale-100 fill-current",
-      false: "opacity-0 scale-0",
-    },
-  },
-  defaultVariants: {
-    visible: false,
-  },
-});
-
-/**
- * Radio label text variants
- */
-export const radioLabelVariants = cva(
-  [
-    "text-sm", // MD3: Body Medium (14px)
-    "text-on-surface",
-    "select-none",
-  ],
-  {
-    variants: {
-      disabled: {
-        true: "",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      disabled: false,
-    },
-  }
-);
-
-/**
- * Extract variant prop types from CVA
- */
+export type RadioRootVariants = VariantProps<typeof radioRootVariants>;
+export type RadioControlVariants = VariantProps<typeof radioControlVariants>;
+export type RadioFocusRingVariants = VariantProps<typeof radioFocusRingVariants>;
+export type RadioTargetVariants = VariantProps<typeof radioTargetVariants>;
+export type RadioStateLayerVariants = VariantProps<typeof radioStateLayerVariants>;
+export type RadioRingVariants = VariantProps<typeof radioRingVariants>;
+export type RadioDotVariants = VariantProps<typeof radioDotVariants>;
+export type RadioLabelVariants = VariantProps<typeof radioLabelVariants>;
 export type RadioGroupVariants = VariantProps<typeof radioGroupVariants>;
 export type RadioGroupLabelVariants = VariantProps<typeof radioGroupLabelVariants>;
-export type RadioVariants = VariantProps<typeof radioVariants>;
-export type RadioContainerVariants = VariantProps<typeof radioContainerVariants>;
-export type RadioIconOuterVariants = VariantProps<typeof radioIconOuterVariants>;
-export type RadioIconInnerVariants = VariantProps<typeof radioIconInnerVariants>;
-export type RadioLabelVariants = VariantProps<typeof radioLabelVariants>;

--- a/packages/react/src/components/Radio/RadioGroup.tsx
+++ b/packages/react/src/components/Radio/RadioGroup.tsx
@@ -70,7 +70,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
 
       // State props
       orientation = "vertical",
-      isInvalid: _isInvalid = false,
+      isInvalid = false,
       isDisabled = false,
 
       // Styling
@@ -109,17 +109,15 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       <RadioGroupHeadless
         {...restPropsWithoutHtmlAttrs}
         isDisabled={isDisabled}
+        isInvalid={isInvalid}
         ref={ref}
         className={cn("flex flex-col", className)}
         data-testid={dataTestId}
         renderLabel={(labelProps) => (
           <div
             {...labelProps}
-            className={cn(
-              radioGroupLabelVariants({
-                disabled: isDisabled,
-              })
-            )}
+            data-disabled={isDisabled ? "" : undefined}
+            className={cn(radioGroupLabelVariants())}
           >
             {props.label}
           </div>
@@ -130,7 +128,6 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
           className={cn(
             radioGroupVariants({
               orientation,
-              disabled: isDisabled,
             })
           )}
         >

--- a/packages/react/src/components/Radio/index.ts
+++ b/packages/react/src/components/Radio/index.ts
@@ -26,13 +26,16 @@ export type {
   RadioGroupHeadlessProps,
 } from "./Radio.types";
 
-// Variants (for external customization if needed)
+// Variant types (for external customization if needed)
 export type {
-  RadioVariants,
-  RadioGroupVariants,
-  RadioContainerVariants,
-  RadioIconOuterVariants,
-  RadioIconInnerVariants,
+  RadioRootVariants,
+  RadioControlVariants,
+  RadioFocusRingVariants,
+  RadioTargetVariants,
+  RadioStateLayerVariants,
+  RadioRingVariants,
+  RadioDotVariants,
   RadioLabelVariants,
+  RadioGroupVariants,
   RadioGroupLabelVariants,
 } from "./Radio.variants";


### PR DESCRIPTION
## Summary

- **Slot-based CVA**: All 8 previous CVA variant blocks (which used state variants/compoundVariants) are replaced with 8 named slot blocks (`radioRootVariants`, `radioControlVariants`, `radioFocusRingVariants`, `radioTargetVariants`, `radioStateLayerVariants`, `radioRingVariants`, `radioDotVariants`, `radioLabelVariants`) whose state logic lives entirely in `group-data-[x]/radio` Tailwind selectors — no state variants, no state compoundVariants.
- **`Radio.tsx` rewrite**: Adds `useHover`; wires `getInteractionDataAttributes` with all 6 states (`isHovered`, `isFocusVisible`, `isPressed`, `isSelected`, `isDisabled`, `isInvalid`). Replaces the SVG + `animate-pulse` focus ring with div-based slots. MD3 spring token pairs applied: `spring-standard-fast-effects` for color/opacity, `spring-standard-fast-spatial` for dot scale.
- **Bug fix — `isInvalid`**: `RadioGroup.tsx` was discarding `isInvalid` (`_isInvalid = false`), so `state.validationState` was never `"invalid"`. Fixed by forwarding `isInvalid` to `RadioGroupHeadless`.

## Test plan

- [ ] All 51 Radio tests pass (`pnpm vitest run Radio.test`)
- [ ] All 2101 tests pass (`pnpm vitest run`)
- [ ] `pnpm lint` clean
- [ ] `pnpm typecheck` clean
- [ ] Storybook: verify States story shows correct visual states for unselected/selected/error/disabled
- [ ] Keyboard navigation: Tab into group, Arrow keys select, Space selects — focus ring visible (outline, not pulse)