### PR TITLE
refactor(search): md3 expressive variants-vs-states architecture

### DIFF
--- a/.changeset/search-md3-expressive-refactor.md
+++ b/.changeset/search-md3-expressive-refactor.md
@@ -1,5 +1,5 @@
 ---
-"@tinybigui/react": patch
+"@tinybigui/react": minor
 ---
 
 refactor(search): md3 expressive variants-vs-states architecture

--- a/.changeset/search-md3-expressive-refactor.md
+++ b/.changeset/search-md3-expressive-refactor.md
@@ -1,0 +1,14 @@
+---
+"@tinybigui/react": patch
+---
+
+refactor(search): md3 expressive variants-vs-states architecture
+
+Aligns the Search component with the project-wide Variants-vs-States architecture used by Button and Switch:
+
+- Rebuilds `Search.variants.ts` into per-slot CVAs (root, stateLayer, focusRing, leadingIcon, trailingAction, avatar, input for the bar; container, header, backButton, clearButton, input, divider, content for the view). Removes interaction-state CVA variants (`focused`, `disabled`, `noActions`) — all states now driven by `data-*` attributes via `group-data-[x]/search` selectors.
+- Refactors `SearchBar.tsx` to use React Aria `useHover` + `useFocusRing({ within: true })` + `getInteractionDataAttributes`, with a sibling focus-ring span (outside `overflow-hidden`) matching the Button/Switch pattern. The M3 Expressive pane-margin transition (24dp → 12dp on focus) now uses the correct Expressive fast spatial spring token, guarded by `useReducedMotion`.
+- Refactors `SearchView.tsx` to apply per-slot CVAs directly instead of descendant-selector `[&>[data-slot=...]]` blobs and the `getHeaderClasses()` helper. Enter motion is layout-aware: docked → `animate-md-scale-in`, fullscreen → `animate-md-fade-in`.
+- Replaces literal `←` back glyph and `✕` clear glyph in `SearchHeadless.tsx` with inline MD3 SVG icons (24×24, `currentColor`, `aria-hidden`).
+- Updates `SearchViewHeadless` to accept per-slot `className` props so styled classes are applied directly on each element.
+- Updates tests to assert on the new slot elements and data-attribute–driven class names.

--- a/packages/react/src/components/Search/Search.stories.tsx
+++ b/packages/react/src/components/Search/Search.stories.tsx
@@ -56,20 +56,33 @@ const InitialsAvatar = ({
   </span>
 );
 
+// ─── Shared trigger button ────────────────────────────────────────────────────
+
+interface OpenSearchButtonProps {
+  onClick: () => void;
+}
+
+const OpenSearchButton = ({ onClick }: OpenSearchButtonProps): JSX.Element => (
+  <button
+    type="button"
+    className="bg-primary text-on-primary text-label-large rounded-full px-6 py-2.5"
+    onClick={onClick}
+  >
+    Open search
+  </button>
+);
+
 // ─── Named component wrappers for stateful stories ───────────────────────────
+// All SearchView stories default to isOpen={false} so that:
+// 1. Storybook autodocs renders the full story list without a fullscreen overlay locking it.
+// 2. Clicking the back arrow returns to the trigger button, not a blank page.
 
 function ContainedFullScreenExample(): JSX.Element {
-  const [isOpen, setIsOpen] = React.useState(true);
+  const [isOpen, setIsOpen] = React.useState(false);
   const [value, setValue] = React.useState("Ping");
   return (
-    <div className="bg-surface min-h-screen">
-      <button
-        type="button"
-        className="bg-primary text-on-primary text-label-large m-4 rounded-full px-4 py-2"
-        onClick={() => setIsOpen(true)}
-      >
-        Open Search
-      </button>
+    <div className="bg-surface flex min-h-screen flex-col items-center justify-center gap-4 p-4">
+      {!isOpen && <OpenSearchButton onClick={() => setIsOpen(true)} />}
       <SearchView
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
@@ -110,10 +123,11 @@ function ContainedFullScreenExample(): JSX.Element {
 }
 
 function ContainedDockedExample(): JSX.Element {
-  const [isOpen, setIsOpen] = React.useState(true);
+  const [isOpen, setIsOpen] = React.useState(false);
   const [value, setValue] = React.useState("Eli");
   return (
-    <div className="bg-surface flex min-h-[400px] items-start justify-center p-8">
+    <div className="bg-surface flex min-h-[480px] flex-col items-center justify-start gap-4 p-8">
+      {!isOpen && <OpenSearchButton onClick={() => setIsOpen(true)} />}
       <SearchView
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
@@ -147,37 +161,41 @@ function ContainedDockedExample(): JSX.Element {
 }
 
 function DividedFullScreenExample(): JSX.Element {
-  const [isOpen, setIsOpen] = React.useState(true);
+  const [isOpen, setIsOpen] = React.useState(false);
   const [value, setValue] = React.useState("Eli");
   return (
-    <SearchView
-      isOpen={isOpen}
-      onClose={() => setIsOpen(false)}
-      value={value}
-      onChange={setValue}
-      placeholder="Search"
-      aria-label="Search"
-      searchStyle="divided"
-      layout="fullscreen"
-    >
-      <List aria-label="Search results">
-        <ListItem
-          value="eli"
-          headline="Eli, me"
-          supportingText="Adopt a pup? The pet adoption..."
-        />
-        <ListItem value="zita" headline="Zita, Odette, Dagmar" supportingText="Movie marathon" />
-        <ListItem value="in" headline="In, Aki" supportingText="Museum field trip" />
-      </List>
-    </SearchView>
+    <div className="bg-surface flex min-h-screen flex-col items-center justify-center gap-4 p-4">
+      {!isOpen && <OpenSearchButton onClick={() => setIsOpen(true)} />}
+      <SearchView
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        value={value}
+        onChange={setValue}
+        placeholder="Search"
+        aria-label="Search"
+        searchStyle="divided"
+        layout="fullscreen"
+      >
+        <List aria-label="Search results">
+          <ListItem
+            value="eli"
+            headline="Eli, me"
+            supportingText="Adopt a pup? The pet adoption..."
+          />
+          <ListItem value="zita" headline="Zita, Odette, Dagmar" supportingText="Movie marathon" />
+          <ListItem value="in" headline="In, Aki" supportingText="Museum field trip" />
+        </List>
+      </SearchView>
+    </div>
   );
 }
 
 function DividedDockedExample(): JSX.Element {
-  const [isOpen, setIsOpen] = React.useState(true);
+  const [isOpen, setIsOpen] = React.useState(false);
   const [value, setValue] = React.useState("Eli");
   return (
-    <div className="bg-surface flex min-h-[400px] items-start justify-center p-8">
+    <div className="bg-surface flex min-h-[480px] flex-col items-center justify-start gap-4 p-8">
+      {!isOpen && <OpenSearchButton onClick={() => setIsOpen(true)} />}
       <SearchView
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
@@ -244,10 +262,11 @@ function SearchBarToViewExample(): JSX.Element {
 }
 
 function GroupedResultsExample(): JSX.Element {
-  const [isOpen, setIsOpen] = React.useState(true);
+  const [isOpen, setIsOpen] = React.useState(false);
   const [value, setValue] = React.useState("m");
   return (
-    <div className="bg-surface flex min-h-[500px] items-start justify-center p-8">
+    <div className="bg-surface flex min-h-[500px] flex-col items-center justify-start gap-4 p-8">
+      {!isOpen && <OpenSearchButton onClick={() => setIsOpen(true)} />}
       <SearchView
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}

--- a/packages/react/src/components/Search/Search.test.tsx
+++ b/packages/react/src/components/Search/Search.test.tsx
@@ -407,6 +407,42 @@ describe("SearchBar (Styled)", () => {
     expect(screen.getByTestId("mic-btn")).toBeInTheDocument();
     expect(screen.getByTestId("avatar-img")).toBeInTheDocument();
   });
+
+  test("bar input carries flex-1, outline-none, and webkit-cancel-hide classes", () => {
+    render(<SearchBar placeholder="Search" />);
+    const input = document.querySelector("[data-slot='input']");
+    expect(input).toBeInTheDocument();
+    expect(input?.className).toContain("flex-1");
+    expect(input?.className).toContain("outline-none");
+    expect(input?.className).toContain("[&::-webkit-search-cancel-button]:appearance-none");
+  });
+
+  test("trailing-actions wrapper has 'flex' class when trailing actions provided", () => {
+    render(
+      <SearchBar
+        placeholder="Search"
+        trailingActions={[
+          <button key="mic" aria-label="mic">
+            mic
+          </button>,
+          <button key="more" aria-label="more">
+            more
+          </button>,
+        ]}
+      />
+    );
+    const trailingGroup = document.querySelector("[data-slot='trailing-actions']");
+    expect(trailingGroup).toBeInTheDocument();
+    expect(trailingGroup?.className).toContain("flex");
+  });
+
+  test("renders a default MD3 search icon when no leadingIcon prop is given", () => {
+    render(<SearchBar placeholder="Search" />);
+    // The default icon is a 24×24 SVG with a search path inside the leading-icon slot
+    const leadingSlot = document.querySelector("[data-slot='leading-icon']");
+    expect(leadingSlot).toBeInTheDocument();
+    expect(leadingSlot?.querySelector("svg")).toBeInTheDocument();
+  });
 });
 
 describe("SearchView (Styled)", () => {
@@ -584,5 +620,50 @@ describe("SearchView (Styled)", () => {
     const content = screen.getByRole("search").querySelector("[data-slot=content]");
     expect(content).toBeInTheDocument();
     expect(screen.getByTestId("search-result")).toBeInTheDocument();
+  });
+
+  test("docked layout renders inline (searchbox is findable via getByRole)", () => {
+    render(
+      <SearchView isOpen onClose={() => {}} aria-label="Search" layout="docked">
+        <p>results</p>
+      </SearchView>
+    );
+    // Docked renders in normal document flow, not in a portal — the search view
+    // must still be queryable by role so tests and consumers can interact with it.
+    expect(screen.getByRole("search", { name: "Search" })).toBeInTheDocument();
+  });
+
+  test("view input slot carries outline-none and webkit-cancel-hide classes", () => {
+    render(
+      <SearchView isOpen onClose={() => {}} aria-label="Search">
+        <p>results</p>
+      </SearchView>
+    );
+    const input = screen.getByRole("search").querySelector("[data-slot='input']");
+    expect(input).toBeInTheDocument();
+    expect(input?.className).toContain("outline-none");
+    expect(input?.className).toContain("[&::-webkit-search-cancel-button]:appearance-none");
+  });
+
+  test("view trailing-actions wrapper has flex class when trailing actions provided", () => {
+    render(
+      <SearchView
+        isOpen
+        onClose={() => {}}
+        aria-label="Search"
+        trailingActions={[
+          <button key="mic" aria-label="mic">
+            mic
+          </button>,
+        ]}
+      >
+        <p>results</p>
+      </SearchView>
+    );
+    const trailingGroup = screen
+      .getByRole("search")
+      .querySelector("[data-slot='trailing-actions']");
+    expect(trailingGroup).toBeInTheDocument();
+    expect(trailingGroup?.className).toContain("flex");
   });
 });

--- a/packages/react/src/components/Search/Search.test.tsx
+++ b/packages/react/src/components/Search/Search.test.tsx
@@ -310,11 +310,12 @@ describe("SearchBar (Styled)", () => {
     expect(container?.className).toContain("gap-4");
   });
 
-  test("state layer has hover:opacity-8 class", () => {
+  test("state layer has group-data-[hovered]/search:opacity-8 class", () => {
     render(<SearchBar placeholder="Search" />);
     const stateLayer = document.querySelector("[data-slot=state-layer]");
     expect(stateLayer).toBeInTheDocument();
-    expect(stateLayer?.className).toContain("group-hover:opacity-8");
+    // Hover state driven by data-* attribute from React Aria useHover, not :hover pseudo-class
+    expect(stateLayer?.className).toContain("group-data-[hovered]/search:opacity-8");
   });
 
   test("state layer uses spring motion tokens for opacity transition", () => {
@@ -336,10 +337,15 @@ describe("SearchBar (Styled)", () => {
     expect(rippleContainer).toBeInTheDocument();
   });
 
-  test("focus indicator ring applied to container via has-[:focus-visible]", () => {
+  test("focus indicator ring span rendered as sibling with outline-secondary class", () => {
     render(<SearchBar placeholder="Search" />);
-    const container = screen.getByRole("search").parentElement;
-    expect(container?.className).toContain("ring-secondary");
+    // Focus ring is an absolutely-positioned sibling span (outside overflow-hidden)
+    // with outline-secondary — not a ring- class on the container.
+    const container = screen.getByRole("search").closest("[class*=group\\/search]");
+    const relativeWrapper = container?.parentElement;
+    const focusRingSpan = relativeWrapper?.querySelector("span[aria-hidden]");
+    expect(focusRingSpan).toBeInTheDocument();
+    expect(focusRingSpan?.className).toContain("outline-secondary");
   });
 
   test("avatar only (Config 1) renders in trailing slot at 30dp size", () => {
@@ -454,14 +460,18 @@ describe("SearchView (Styled)", () => {
     expect(view.className).toContain("bg-surface-container-high");
   });
 
-  test("divided style renders border-outline divider", () => {
+  test("divided style renders border-outline divider on the hr element", () => {
     render(
       <SearchView isOpen onClose={() => {}} aria-label="Search" searchStyle="divided">
         <p>results</p>
       </SearchView>
     );
     const view = screen.getByRole("search", { name: "Search" });
-    expect(view.className).toContain("border-outline");
+    // Divider is an <hr data-slot="divider"> with the border-outline class,
+    // not on the container itself.
+    const divider = view.querySelector("hr[data-slot='divider']");
+    expect(divider).toBeInTheDocument();
+    expect(divider?.className).toContain("border-outline");
   });
 
   test("docked layout has min-w-[360px] and max-w-[720px] constraint classes", () => {
@@ -475,7 +485,7 @@ describe("SearchView (Styled)", () => {
     expect(view.className).toContain("max-w-[720px]");
   });
 
-  test("divided+fullscreen header has h-[72px] class", () => {
+  test("divided+fullscreen header has h-[72px] class on the header element", () => {
     render(
       <SearchView
         isOpen
@@ -488,7 +498,10 @@ describe("SearchView (Styled)", () => {
       </SearchView>
     );
     const view = screen.getByRole("search", { name: "Search" });
-    expect(view.className).toContain("h-[72px]");
+    // h-[72px] is applied to the header slot element, not the container.
+    const header = view.querySelector("[data-slot='header']");
+    expect(header).toBeInTheDocument();
+    expect(header?.className).toContain("h-[72px]");
   });
 
   test("divided+fullscreen has bg-surface-container-high class", () => {
@@ -540,13 +553,25 @@ describe("SearchView (Styled)", () => {
     expect(view.className).toContain("gap-0.5");
   });
 
-  test("has animate-md-scale-in class on mount", () => {
+  test("fullscreen layout has animate-md-fade-in class on mount", () => {
     render(
-      <SearchView isOpen onClose={() => {}} aria-label="Search">
+      <SearchView isOpen onClose={() => {}} aria-label="Search" layout="fullscreen">
         <p>results</p>
       </SearchView>
     );
     const view = screen.getByRole("search", { name: "Search" });
+    // Fullscreen uses fade-in (no scale distortion on full viewport coverage).
+    expect(view.className).toContain("animate-md-fade-in");
+  });
+
+  test("docked layout has animate-md-scale-in class on mount", () => {
+    render(
+      <SearchView isOpen onClose={() => {}} aria-label="Search" layout="docked">
+        <p>results</p>
+      </SearchView>
+    );
+    const view = screen.getByRole("search", { name: "Search" });
+    // Docked uses scale-in (feels like a popover appearing).
     expect(view.className).toContain("animate-md-scale-in");
   });
 

--- a/packages/react/src/components/Search/Search.types.ts
+++ b/packages/react/src/components/Search/Search.types.ts
@@ -209,4 +209,15 @@ export interface SearchBarHeadlessProps extends SearchBarProps {
 export interface SearchViewHeadlessProps extends SearchViewProps {
   /** Ref forwarded to the view container div */
   ref?: React.Ref<HTMLDivElement>;
+  /**
+   * Slot class names applied directly to inner headless elements.
+   * Passed by SearchView so per-slot CVA classes can be applied
+   * without descendant-selector blobs.
+   */
+  headerClassName?: string;
+  backButtonClassName?: string;
+  clearButtonClassName?: string;
+  inputClassName?: string;
+  dividerClassName?: string;
+  contentClassName?: string;
 }

--- a/packages/react/src/components/Search/Search.types.ts
+++ b/packages/react/src/components/Search/Search.types.ts
@@ -203,6 +203,12 @@ export interface SearchProps extends Omit<SearchBarProps, "onFocus"> {
 export interface SearchBarHeadlessProps extends SearchBarProps {
   /** Ref forwarded to the form element */
   ref?: React.Ref<HTMLFormElement>;
+  /**
+   * Slot class names applied directly to the bar's inner elements.
+   * Passed from SearchBar so per-slot CVA classes apply without descendant selectors.
+   */
+  inputClassName?: string | undefined;
+  trailingActionsClassName?: string | undefined;
 }
 
 /** Props for SearchViewHeadless — the headless primitive for the view */
@@ -218,6 +224,7 @@ export interface SearchViewHeadlessProps extends SearchViewProps {
   backButtonClassName?: string;
   clearButtonClassName?: string;
   inputClassName?: string;
+  trailingActionsClassName?: string | undefined;
   dividerClassName?: string;
   contentClassName?: string;
 }

--- a/packages/react/src/components/Search/Search.variants.ts
+++ b/packages/react/src/components/Search/Search.variants.ts
@@ -14,17 +14,19 @@ import { cva, type VariantProps } from "class-variance-authority";
  *   searchBarStateLayerVariants  — hover/pressed opacity overlay (inside overflow-hidden)
  *   searchBarFocusRingVariants   — keyboard focus outline (outside overflow-hidden)
  *   searchBarLeadingIconVariants — 48dp tap target wrapping 24dp icon, on-surface
- *   searchBarTrailingActionVariants — 48dp tap target for each trailing icon, on-surface-variant
- *   searchBarAvatarVariants      — 48dp tap target wrapping 30dp rounded-full avatar
- *   searchBarInputVariants       — flex-1 text input inside the bar
+ *   searchBarTrailingActionVariants  — 48dp tap target for each trailing icon, on-surface-variant
+ *   searchBarTrailingActionsVariants — flex row wrapper for all trailing actions
+ *   searchBarAvatarVariants          — 48dp tap target wrapping 30dp rounded-full avatar
+ *   searchBarInputVariants           — flex-1 text input inside the bar
  *
  * Search View slot responsibilities:
  *   searchViewVariants           — container; style × layout compound variants
  *   searchViewHeaderVariants     — header row; style × layout heights/padding
  *   searchViewBackButtonVariants — 48dp back-arrow tap target, on-surface
  *   searchViewClearButtonVariants — 48dp clear tap target, on-surface-variant
- *   searchViewTrailingActionVariants — 48dp trailing action in view header
- *   searchViewInputVariants      — flex-1 text input inside the view header
+ *   searchViewTrailingActionVariants  — 48dp trailing action in view header
+ *   searchViewTrailingActionsVariants — flex row wrapper for all view trailing actions
+ *   searchViewInputVariants           — flex-1 text input inside the view header
  *   searchViewDividerVariants    — horizontal rule (divided style only)
  *   searchViewContentVariants    — scrollable results/suggestions area
  *
@@ -168,18 +170,33 @@ export const searchBarTrailingActionVariants = cva([
  */
 export const searchBarAvatarVariants = cva(["flex size-12 shrink-0 items-center justify-center"]);
 
+// ─── SEARCH BAR TRAILING ACTIONS GROUP ────────────────────────────────────────
+
+/**
+ * Trailing actions group wrapper — lays out multiple trailing icon slots in a row.
+ * gap = 0 per MD3 spec (contained trailing-actions gap token = 0dp).
+ */
+export const searchBarTrailingActionsVariants = cva(["flex items-center"]);
+
 // ─── SEARCH BAR INPUT ─────────────────────────────────────────────────────────
 
 /**
  * Text input inside the search bar.
  * Typography: body-large (MD3 supporting text / input text font).
  * Colors: on-surface for input, on-surface-variant for placeholder.
+ *
+ * `min-w-0` is required so `flex-1` can shrink when trailing actions are present.
+ * The native browser search cancel button and decoration are hidden so only our
+ * MD3 clear button (in SearchView) controls clearing.
  */
 export const searchBarInputVariants = cva([
-  "flex-1 bg-transparent outline-none",
+  "flex-1 min-w-0 bg-transparent outline-none",
   "text-body-large text-on-surface",
   "placeholder:text-on-surface-variant",
   "focus-visible:outline-none",
+  // Hide native browser search affordances — our MD3 clear button handles clearing
+  "[&::-webkit-search-cancel-button]:appearance-none",
+  "[&::-webkit-search-decoration]:appearance-none",
 ]);
 
 // ─── SEARCH VIEW CONTAINER ────────────────────────────────────────────────────
@@ -303,18 +320,32 @@ export const searchViewTrailingActionVariants = cva([
   "flex size-12 shrink-0 items-center justify-center text-on-surface-variant",
 ]);
 
+// ─── SEARCH VIEW TRAILING ACTIONS GROUP ───────────────────────────────────────
+
+/**
+ * Trailing actions group wrapper in the view header — lays out multiple action
+ * slots in a row. gap = 0 per MD3 spec.
+ */
+export const searchViewTrailingActionsVariants = cva(["flex items-center"]);
+
 // ─── SEARCH VIEW INPUT ────────────────────────────────────────────────────────
 
 /**
  * Text input inside the view header.
  * Typography: body-large.
  * Colors: on-surface for input text, on-surface-variant for placeholder.
+ *
+ * `min-w-0` lets `flex-1` shrink when clear/trailing buttons are present.
+ * Native search affordances hidden — MD3 clear button controls clearing.
  */
 export const searchViewInputVariants = cva([
-  "flex-1 bg-transparent outline-none",
+  "flex-1 min-w-0 bg-transparent outline-none",
   "text-body-large text-on-surface",
   "placeholder:text-on-surface-variant",
   "focus-visible:outline-none",
+  // Hide native browser search affordances
+  "[&::-webkit-search-cancel-button]:appearance-none",
+  "[&::-webkit-search-decoration]:appearance-none",
 ]);
 
 // ─── SEARCH VIEW DIVIDER ──────────────────────────────────────────────────────
@@ -341,6 +372,9 @@ export type SearchBarStateLayerVariants = VariantProps<typeof searchBarStateLaye
 export type SearchBarFocusRingVariants = VariantProps<typeof searchBarFocusRingVariants>;
 export type SearchBarLeadingIconVariants = VariantProps<typeof searchBarLeadingIconVariants>;
 export type SearchBarTrailingActionVariants = VariantProps<typeof searchBarTrailingActionVariants>;
+export type SearchBarTrailingActionsVariants = VariantProps<
+  typeof searchBarTrailingActionsVariants
+>;
 export type SearchBarAvatarVariants = VariantProps<typeof searchBarAvatarVariants>;
 export type SearchBarInputVariants = VariantProps<typeof searchBarInputVariants>;
 export type SearchViewVariants = VariantProps<typeof searchViewVariants>;
@@ -349,6 +383,9 @@ export type SearchViewBackButtonVariants = VariantProps<typeof searchViewBackBut
 export type SearchViewClearButtonVariants = VariantProps<typeof searchViewClearButtonVariants>;
 export type SearchViewTrailingActionVariants = VariantProps<
   typeof searchViewTrailingActionVariants
+>;
+export type SearchViewTrailingActionsVariants = VariantProps<
+  typeof searchViewTrailingActionsVariants
 >;
 export type SearchViewInputVariants = VariantProps<typeof searchViewInputVariants>;
 export type SearchViewDividerVariants = VariantProps<typeof searchViewDividerVariants>;

--- a/packages/react/src/components/Search/Search.variants.ts
+++ b/packages/react/src/components/Search/Search.variants.ts
@@ -1,72 +1,199 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 Search Bar container variants (CVA).
+ * Material Design 3 Search Variants
  *
- * Base: 56dp height, full rounded pill, surface-container-high background,
- * level-3 elevation, body-large typography.
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no focused/disabled/noActions state variants).
+ * - All interaction states are driven by data-* attributes on the root via
+ *   group-data-[x]/search Tailwind selectors in each slot's base classes.
+ * - Content flags (data-with-actions) are set explicitly by the component.
  *
- * Spacing follows MD3 Search spec:
- * - Contained (expressive): 4dp leading/trailing with trailing actions
- * - Contained (no actions): 16dp leading/trailing
- * - Divided (baseline): 16dp leading/trailing, 16dp icon-label gap
+ * Search Bar slot responsibilities:
+ *   searchBarRootVariants        — container pill; shape, color, elevation, spacing by style
+ *   searchBarStateLayerVariants  — hover/pressed opacity overlay (inside overflow-hidden)
+ *   searchBarFocusRingVariants   — keyboard focus outline (outside overflow-hidden)
+ *   searchBarLeadingIconVariants — 48dp tap target wrapping 24dp icon, on-surface
+ *   searchBarTrailingActionVariants — 48dp tap target for each trailing icon, on-surface-variant
+ *   searchBarAvatarVariants      — 48dp tap target wrapping 30dp rounded-full avatar
+ *   searchBarInputVariants       — flex-1 text input inside the bar
+ *
+ * Search View slot responsibilities:
+ *   searchViewVariants           — container; style × layout compound variants
+ *   searchViewHeaderVariants     — header row; style × layout heights/padding
+ *   searchViewBackButtonVariants — 48dp back-arrow tap target, on-surface
+ *   searchViewClearButtonVariants — 48dp clear tap target, on-surface-variant
+ *   searchViewTrailingActionVariants — 48dp trailing action in view header
+ *   searchViewInputVariants      — flex-1 text input inside the view header
+ *   searchViewDividerVariants    — horizontal rule (divided style only)
+ *   searchViewContentVariants    — scrollable results/suggestions area
+ *
+ * MD3 Token References:
+ *   Container color:   SurfaceContainerHigh
+ *   Contained bg (fullscreen view): SurfaceContainerLow
+ *   Container elevation: Level 3 (6dp)
+ *   Leading icon:      OnSurface
+ *   Trailing icon:     OnSurfaceVariant
+ *   Placeholder:       OnSurfaceVariant
+ *   Input text:        OnSurface
+ *   Focus indicator:   Secondary, 3dp
+ *   Hover opacity:     8%   (MD3 state.hover.state-layer-opacity)
+ *   Pressed opacity:   10%  (MD3 state.pressed.state-layer-opacity)
+ *   Disabled:          opacity-38 on container
  *
  * @see docs/md3-components/search/tokens/layout-text.md
+ * @see docs/md3-components/search/tokens/color-tokens-light.md
  */
-export const searchBarVariants = cva(
+
+// ─── SEARCH BAR ROOT ─────────────────────────────────────────────────────────
+
+/**
+ * Search bar container pill.
+ *
+ * Spacing follows MD3 Search Bar spec:
+ *   Contained + with actions:    px-1 gap-1   (4dp leading/trailing per spec)
+ *   Contained + no actions:      px-4         (16dp leading/trailing)
+ *   Divided:                     px-4 gap-4   (16dp leading/trailing, 16dp icon-label gap)
+ *
+ * The `contained` variant uses `data-[with-actions]` on the root (a content flag set by the
+ * component) to switch from 16dp → 4dp spacing — no CVA variant needed for this.
+ *
+ * Disabled is self-targeting (data-[disabled]:) because the root carries the data attr.
+ * overflow-hidden intentionally NOT here — the focus ring span sits outside via a sibling
+ * wrapper, so we preserve full ring visibility (same pattern as Button).
+ */
+export const searchBarRootVariants = cva(
   [
-    "relative flex items-center h-14 rounded-full bg-surface-container-high",
-    "shadow-elevation-3 w-full text-body-large cursor-text",
+    "relative flex items-center h-14 rounded-full",
+    "bg-surface-container-high shadow-elevation-3",
+    "w-full text-body-large cursor-text",
+    // Disabled — self-targeting; pointer-events lets ripple/hover stop cleanly
+    "data-[disabled]:opacity-38 data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed",
   ],
   {
     variants: {
+      /**
+       * Visual style of the search bar.
+       * - contained: M3 Expressive — fills container, expressive motion, adjustable spacing
+       * - divided: Baseline — 16dp fixed spacing, no expressive motion
+       */
       style: {
-        contained: "",
+        /**
+         * Contained (Expressive): spacing governed by data-[with-actions] content flag.
+         *   With actions:    px-1 gap-1 (4dp each)
+         *   Without actions: px-4      (16dp each)
+         */
+        contained: [
+          "px-4", // default: no-actions 16dp
+          "data-[with-actions]:px-1 data-[with-actions]:gap-1", // with-actions: 4dp
+        ],
+        /**
+         * Divided (Baseline): fixed 16dp side padding, 16dp icon-label gap.
+         */
         divided: "px-4 gap-4",
       },
-      noActions: {
-        true: "",
-        false: "",
-      },
-      focused: {
-        true: "",
-        false: "",
-      },
-      disabled: {
-        true: "opacity-38 pointer-events-none",
-        false: "",
-      },
     },
-    compoundVariants: [
-      {
-        style: "contained",
-        noActions: false,
-        class: "px-1 gap-1",
-      },
-      {
-        style: "contained",
-        noActions: true,
-        class: "px-4",
-      },
-    ],
-    defaultVariants: {
-      style: "contained",
-      noActions: false,
-      focused: false,
-      disabled: false,
-    },
+    defaultVariants: { style: "contained" },
   }
 );
 
+// ─── SEARCH BAR STATE LAYER ──────────────────────────────────────────────────
+
 /**
- * Material Design 3 Search View container variants (CVA).
+ * State layer — absolute inset overlay inside the bar container.
  *
- * Compound variants express all 4 style+layout combinations:
- * - Contained + fullscreen: surface-container-low, no rounding
- * - Contained + docked: surface-container-high, rounded-xl (12dp)
- * - Divided + fullscreen: surface-container-high, no rounding
- * - Divided + docked: surface-container-high, rounded-[28px] (extra-large)
+ * Must be inside overflow-hidden (placed on the same pill via the root's inner wrapper).
+ * Color: on-surface (MD3 search bar state layer color).
+ * Opacities: hover 8%, pressed 10% (doubled selector wins over hover).
+ * Hidden when disabled (no state affordance on non-interactive element).
+ */
+export const searchBarStateLayerVariants = cva([
+  "absolute inset-0 rounded-full pointer-events-none opacity-0",
+  "bg-on-surface",
+  // Effects transition — no overshoot on opacity
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Hover: 8%
+  "group-data-[hovered]/search:opacity-8",
+  // Pressed: 10%, doubled selector wins over hover at equal cascade position
+  "group-data-[pressed]/search:group-data-[pressed]/search:opacity-10",
+  // No state layer when disabled
+  "group-data-[disabled]/search:hidden",
+]);
+
+// ─── SEARCH BAR FOCUS RING ────────────────────────────────────────────────────
+
+/**
+ * Focus ring overlay.
  *
+ * Rendered outside the overflow-hidden container (as a sibling, in a relative wrapper)
+ * so it can extend 3px beyond the pill boundary and remain fully visible.
+ * Color: Secondary (MD3 focus indicator color).
+ * Thickness: 3dp (MD3 state.focus-indicator.thickness).
+ */
+export const searchBarFocusRingVariants = cva([
+  "pointer-events-none absolute inset-[-3px] rounded-full",
+  "outline outline-[3px] outline-offset-0 outline-secondary",
+  // Effects transition
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/search:opacity-100",
+]);
+
+// ─── SEARCH BAR LEADING ICON ──────────────────────────────────────────────────
+
+/**
+ * Leading icon wrapper — 48dp tap target with centered 24dp icon.
+ * Color: on-surface (MD3 leading icon color).
+ */
+export const searchBarLeadingIconVariants = cva([
+  "flex size-12 shrink-0 items-center justify-center text-on-surface",
+]);
+
+// ─── SEARCH BAR TRAILING ACTION ───────────────────────────────────────────────
+
+/**
+ * Trailing action wrapper — 48dp tap target for each trailing icon button.
+ * Color: on-surface-variant (MD3 trailing icon color).
+ */
+export const searchBarTrailingActionVariants = cva([
+  "flex size-12 shrink-0 items-center justify-center text-on-surface-variant",
+]);
+
+// ─── SEARCH BAR AVATAR ────────────────────────────────────────────────────────
+
+/**
+ * Avatar wrapper — 48dp tap target containing a 30dp rounded-full image/element.
+ * Shape: CornerFull (MD3 avatar shape).
+ * Size: 30dp (MD3 avatar size).
+ */
+export const searchBarAvatarVariants = cva(["flex size-12 shrink-0 items-center justify-center"]);
+
+// ─── SEARCH BAR INPUT ─────────────────────────────────────────────────────────
+
+/**
+ * Text input inside the search bar.
+ * Typography: body-large (MD3 supporting text / input text font).
+ * Colors: on-surface for input, on-surface-variant for placeholder.
+ */
+export const searchBarInputVariants = cva([
+  "flex-1 bg-transparent outline-none",
+  "text-body-large text-on-surface",
+  "placeholder:text-on-surface-variant",
+  "focus-visible:outline-none",
+]);
+
+// ─── SEARCH VIEW CONTAINER ────────────────────────────────────────────────────
+
+/**
+ * Search view container — the expanded/focused search surface.
+ *
+ * All 4 style × layout combinations via compound variants:
+ *   contained + fullscreen: surface-container-low,  no rounding
+ *   contained + docked:     surface-container-high, rounded-xl (12dp), 2dp gap
+ *   divided   + fullscreen: surface-container-high, no rounding
+ *   divided   + docked:     surface-container-high, rounded-[28px] (extra-large)
+ *
+ * @see docs/md3-components/search/tokens/layout-text.md
  * @see docs/md3-components/search/tokens/color-tokens-light.md
  */
 export const searchViewVariants = cva(["flex flex-col shadow-elevation-3 z-50 overflow-hidden"], {
@@ -81,40 +208,43 @@ export const searchViewVariants = cva(["flex flex-col shadow-elevation-3 z-50 ov
     },
   },
   compoundVariants: [
+    // Contained + fullscreen: surface-container-low, square corners
     {
       style: "contained",
       layout: "fullscreen",
       class: "bg-surface-container-low rounded-none",
     },
+    // Contained + docked: surface-container-high, 12dp results rounding, 2dp gap
     {
       style: "contained",
       layout: "docked",
       class: "bg-surface-container-high rounded-xl gap-0.5",
     },
+    // Divided + fullscreen: surface-container-high, square corners
     {
       style: "divided",
       layout: "fullscreen",
       class: "bg-surface-container-high rounded-none",
     },
+    // Divided + docked: surface-container-high, extra-large rounding (28dp)
     {
       style: "divided",
       layout: "docked",
       class: "bg-surface-container-high rounded-[28px]",
     },
   ],
-  defaultVariants: {
-    style: "contained",
-    layout: "fullscreen",
-  },
+  defaultVariants: { style: "contained", layout: "fullscreen" },
 });
 
+// ─── SEARCH VIEW HEADER ───────────────────────────────────────────────────────
+
 /**
- * Material Design 3 Search View header variants (CVA).
+ * Search view header row.
  *
- * Heights per style + layout:
- * - Contained: 56dp (both layouts)
- * - Divided + fullscreen: 72dp
- * - Divided + docked: 56dp (overridden by docked variant)
+ * Heights per MD3 spec:
+ *   Contained (both layouts):  56dp (h-14), 12dp side padding (px-3)
+ *   Divided + fullscreen:      72dp (h-[72px]), 16dp side padding (px-4)
+ *   Divided + docked:          56dp (h-14), overridden by docked layout variant
  *
  * @see docs/md3-components/search/tokens/layout-text.md
  */
@@ -127,17 +257,99 @@ export const searchViewHeaderVariants = cva(
         divided: "h-[72px] px-4",
       },
       layout: {
+        // Docked overrides height to 56dp regardless of style
         docked: "h-14",
         fullscreen: "",
       },
     },
-    defaultVariants: {
-      style: "contained",
-      layout: "fullscreen",
-    },
+    defaultVariants: { style: "contained", layout: "fullscreen" },
   }
 );
 
-export type SearchBarVariants = VariantProps<typeof searchBarVariants>;
-export type SearchViewVariantsType = VariantProps<typeof searchViewVariants>;
-export type SearchViewHeaderVariantsType = VariantProps<typeof searchViewHeaderVariants>;
+// ─── SEARCH VIEW BACK BUTTON ──────────────────────────────────────────────────
+
+/**
+ * Back arrow button wrapper — 48dp tap target.
+ * Color: on-surface (MD3 header leading icon color).
+ * Includes visual state layer for hover/focus feedback (button handles its own states).
+ */
+export const searchViewBackButtonVariants = cva([
+  "flex size-12 shrink-0 items-center justify-center",
+  "text-on-surface rounded-full",
+  "cursor-pointer",
+]);
+
+// ─── SEARCH VIEW CLEAR BUTTON ─────────────────────────────────────────────────
+
+/**
+ * Clear (✕) button wrapper — 48dp tap target.
+ * Color: on-surface-variant (MD3 trailing icon color).
+ * Transitions opacity when shown/hidden (Standard fast effects).
+ */
+export const searchViewClearButtonVariants = cva([
+  "flex size-12 shrink-0 items-center justify-center",
+  "text-on-surface-variant rounded-full",
+  "cursor-pointer",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+]);
+
+// ─── SEARCH VIEW TRAILING ACTION ──────────────────────────────────────────────
+
+/**
+ * Trailing action wrapper in the view header — 48dp tap target.
+ * Color: on-surface-variant (MD3 trailing icon color).
+ */
+export const searchViewTrailingActionVariants = cva([
+  "flex size-12 shrink-0 items-center justify-center text-on-surface-variant",
+]);
+
+// ─── SEARCH VIEW INPUT ────────────────────────────────────────────────────────
+
+/**
+ * Text input inside the view header.
+ * Typography: body-large.
+ * Colors: on-surface for input text, on-surface-variant for placeholder.
+ */
+export const searchViewInputVariants = cva([
+  "flex-1 bg-transparent outline-none",
+  "text-body-large text-on-surface",
+  "placeholder:text-on-surface-variant",
+  "focus-visible:outline-none",
+]);
+
+// ─── SEARCH VIEW DIVIDER ──────────────────────────────────────────────────────
+
+/**
+ * Horizontal divider between the view header and results area.
+ * Color: outline (MD3 divider color).
+ * Only rendered when searchStyle="divided".
+ */
+export const searchViewDividerVariants = cva(["border-t border-outline w-full"]);
+
+// ─── SEARCH VIEW CONTENT AREA ─────────────────────────────────────────────────
+
+/**
+ * Results / suggestions content area.
+ * flex-1 to fill remaining height; overflow-y-auto for independent scroll.
+ */
+export const searchViewContentVariants = cva(["flex-1 overflow-y-auto"]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
+export type SearchBarRootVariants = VariantProps<typeof searchBarRootVariants>;
+export type SearchBarStateLayerVariants = VariantProps<typeof searchBarStateLayerVariants>;
+export type SearchBarFocusRingVariants = VariantProps<typeof searchBarFocusRingVariants>;
+export type SearchBarLeadingIconVariants = VariantProps<typeof searchBarLeadingIconVariants>;
+export type SearchBarTrailingActionVariants = VariantProps<typeof searchBarTrailingActionVariants>;
+export type SearchBarAvatarVariants = VariantProps<typeof searchBarAvatarVariants>;
+export type SearchBarInputVariants = VariantProps<typeof searchBarInputVariants>;
+export type SearchViewVariants = VariantProps<typeof searchViewVariants>;
+export type SearchViewHeaderVariants = VariantProps<typeof searchViewHeaderVariants>;
+export type SearchViewBackButtonVariants = VariantProps<typeof searchViewBackButtonVariants>;
+export type SearchViewClearButtonVariants = VariantProps<typeof searchViewClearButtonVariants>;
+export type SearchViewTrailingActionVariants = VariantProps<
+  typeof searchViewTrailingActionVariants
+>;
+export type SearchViewInputVariants = VariantProps<typeof searchViewInputVariants>;
+export type SearchViewDividerVariants = VariantProps<typeof searchViewDividerVariants>;
+export type SearchViewContentVariants = VariantProps<typeof searchViewContentVariants>;

--- a/packages/react/src/components/Search/SearchBar.tsx
+++ b/packages/react/src/components/Search/SearchBar.tsx
@@ -10,13 +10,33 @@ import {
   searchBarFocusRingVariants,
   searchBarLeadingIconVariants,
   searchBarTrailingActionVariants,
+  searchBarTrailingActionsVariants,
   searchBarAvatarVariants,
+  searchBarInputVariants,
 } from "./Search.variants";
 import { cn } from "../../utils/cn";
 import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
 import { useReducedMotion } from "../../hooks/useReducedMotion";
 import type { SearchBarProps } from "./Search.types";
+
+/**
+ * MD3 default leading search icon — shown when no `leadingIcon` prop is provided.
+ * Matches the MD3 Search Bar spec which states the leading slot defaults to a search icon.
+ * 24×24, currentColor (inherits `text-on-surface` from the leading-icon slot wrapper).
+ */
+const DefaultSearchIcon = (): React.ReactElement => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+  </svg>
+);
 
 /**
  * Material Design 3 Search Bar Component (Layer 3: Styled)
@@ -107,12 +127,16 @@ export const SearchBar = forwardRef<HTMLFormElement, SearchBarProps>(
     const handleMouseUp = useCallback(() => setIsPressed(false), []);
 
     // ── Slot content ───────────────────────────────────────────────────────────
-    const styledLeadingIcon = leadingIcon ? (
+    // Leading icon: use the provided icon or fall back to the MD3 default search icon.
+    // Both are wrapped in the 48dp tap-target + on-surface color slot.
+    const styledLeadingIcon = (
       <span className={cn(searchBarLeadingIconVariants())}>
-        <span className="size-6">{leadingIcon}</span>
+        <span className="size-6">{leadingIcon ?? <DefaultSearchIcon />}</span>
       </span>
-    ) : undefined;
+    );
 
+    // Each action pre-styled with 48dp tap target; the group flex wrapper is applied
+    // via trailingActionsClassName on the <span data-slot="trailing-actions"> in headless.
     const styledTrailingActions = trailingActions?.map((action, index) => (
       <span key={index} className={cn(searchBarTrailingActionVariants())}>
         {action}
@@ -187,7 +211,7 @@ export const SearchBar = forwardRef<HTMLFormElement, SearchBarProps>(
               {...(onSubmit !== undefined ? { onSubmit } : {})}
               {...(onClear !== undefined ? { onClear } : {})}
               {...(placeholder !== undefined ? { placeholder } : {})}
-              {...(styledLeadingIcon !== undefined ? { leadingIcon: styledLeadingIcon } : {})}
+              leadingIcon={styledLeadingIcon}
               {...(styledTrailingActions !== undefined
                 ? { trailingActions: styledTrailingActions }
                 : {})}
@@ -197,6 +221,8 @@ export const SearchBar = forwardRef<HTMLFormElement, SearchBarProps>(
               onFocus={handleFocusInternal}
               onBlur={handleBlurInternal}
               className="relative z-0 flex h-full w-full items-center"
+              inputClassName={cn(searchBarInputVariants())}
+              trailingActionsClassName={cn(searchBarTrailingActionsVariants())}
             />
           </div>
         </div>

--- a/packages/react/src/components/Search/SearchBar.tsx
+++ b/packages/react/src/components/Search/SearchBar.tsx
@@ -1,35 +1,49 @@
 "use client";
 
 import { forwardRef, useState, useCallback } from "react";
-import { useReducedMotion } from "../../hooks/useReducedMotion";
+import type React from "react";
+import { useHover, useFocusRing, mergeProps } from "react-aria";
 import { SearchBarHeadless } from "./SearchHeadless";
-import { searchBarVariants } from "./Search.variants";
+import {
+  searchBarRootVariants,
+  searchBarStateLayerVariants,
+  searchBarFocusRingVariants,
+  searchBarLeadingIconVariants,
+  searchBarTrailingActionVariants,
+  searchBarAvatarVariants,
+} from "./Search.variants";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { useRipple } from "../../hooks/useRipple";
+import { useReducedMotion } from "../../hooks/useReducedMotion";
 import type { SearchBarProps } from "./Search.types";
 
 /**
  * Material Design 3 Search Bar Component (Layer 3: Styled)
  *
- * The collapsed/maximized state search affordance that transitions
- * to Focused State (SearchView) on click/focus.
+ * The collapsed/maximized search affordance that transitions to Focused State
+ * (SearchView) on click/focus.
+ *
+ * Implements the Variants-vs-States architecture: all interaction states are
+ * expressed as data-* attributes on the root via `getInteractionDataAttributes`
+ * and consumed by each slot via `group-data-[x]/search` Tailwind selectors.
  *
  * Anatomy:
- *   [Container] [Leading icon] [Supporting text/input] [Trailing actions] [Avatar]
+ *   [Leading icon] [Input / placeholder] [Trailing actions] [Avatar]
  *
  * Features:
- * - MD3 state layer with hover/active opacity transitions
- * - Ripple effect on press (Material Design state 4)
- * - Focus indicator: 3dp ring in secondary color
- * - M3 Expressive pane margin transition (24dp → 12dp on focus)
- * - Automatic `noActions` variant when no trailing actions/avatar
+ * - MD3 state layer: hover 8% / pressed 10% opacity (Standard fast effects spring)
+ * - Ripple effect on press (Material Design press state)
+ * - Focus ring: Secondary color, 3dp, rendered outside overflow-hidden (sibling pattern)
+ * - M3 Expressive pane margin: 24dp → 12dp on focus (Expressive fast spatial spring)
+ * - Content flag `data-with-actions` switches container spacing: 16dp → 4dp
  *
  * @example
  * ```tsx
  * <SearchBar
  *   placeholder="Search messages"
  *   leadingIcon={<SearchIcon />}
- *   trailingActions={[<IconButton key="mic" icon={<MicIcon />} aria-label="Voice search" />]}
+ *   trailingActions={[<IconButton key="mic" aria-label="Voice search"><MicIcon /></IconButton>]}
  *   onFocus={() => setOpen(true)}
  * />
  * ```
@@ -55,9 +69,11 @@ export const SearchBar = forwardRef<HTMLFormElement, SearchBarProps>(
     },
     ref
   ) => {
-    const hasNoActions = (!trailingActions || trailingActions.length === 0) && !avatar;
-
+    const hasActions = (trailingActions != null && trailingActions.length > 0) || !!avatar;
     const reducedMotion = useReducedMotion();
+
+    // Track focus for the M3 Expressive pane-margin transition.
+    // This is a content/layout state, not an interaction data-attr, so local state is correct.
     const [isFocused, setIsFocused] = useState(false);
 
     const handleFocusInternal = useCallback(() => {
@@ -70,88 +86,119 @@ export const SearchBar = forwardRef<HTMLFormElement, SearchBarProps>(
       onBlur?.();
     }, [onBlur]);
 
-    const { onMouseDown: handleRipple, ripples } = useRipple({
-      disabled: isDisabled,
-    });
+    // ── React Aria interaction state hooks ─────────────────────────────────────
+    // useFocusRing with within:true tracks keyboard focus on any descendant.
+    // focusProps spread on the container div lets isFocusVisible flow correctly.
+    const { isHovered, hoverProps } = useHover({ isDisabled });
+    const { isFocusVisible, focusProps } = useFocusRing({ within: true });
+    const [isPressed, setIsPressed] = useState(false);
 
+    // Ripple effect
+    const { onMouseDown: handleRipple, ripples } = useRipple({ disabled: isDisabled });
+
+    const handleMouseDown = useCallback(
+      (e: React.MouseEvent<HTMLElement>) => {
+        setIsPressed(true);
+        handleRipple(e);
+      },
+      [handleRipple]
+    );
+
+    const handleMouseUp = useCallback(() => setIsPressed(false), []);
+
+    // ── Slot content ───────────────────────────────────────────────────────────
     const styledLeadingIcon = leadingIcon ? (
-      <span className="text-on-surface flex size-12 shrink-0 items-center justify-center">
+      <span className={cn(searchBarLeadingIconVariants())}>
         <span className="size-6">{leadingIcon}</span>
       </span>
     ) : undefined;
 
     const styledTrailingActions = trailingActions?.map((action, index) => (
-      <span
-        key={index}
-        className="text-on-surface-variant flex size-12 shrink-0 items-center justify-center"
-      >
+      <span key={index} className={cn(searchBarTrailingActionVariants())}>
         {action}
       </span>
     ));
 
     const styledAvatar = avatar ? (
-      <span className="flex size-12 shrink-0 items-center justify-center">
+      <span className={cn(searchBarAvatarVariants())}>
         <span className="size-[30px] overflow-hidden rounded-full">{avatar}</span>
       </span>
     ) : undefined;
 
+    // ── M3 Expressive pane margin transition ────────────────────────────────────
+    // Contained style only: margins shrink from 24dp → 12dp on focus.
+    // Divided style uses fixed static margins (non-Expressive, no animation).
+    const paneMarginClass = searchStyle === "contained" ? (isFocused ? "mx-3" : "mx-6") : "";
+
+    const paneTransitionClass =
+      searchStyle === "contained" && !reducedMotion
+        ? "transition-[margin] duration-expressive-fast-spatial ease-expressive-fast-spatial"
+        : "";
+
     return (
       <div
-        className={cn(
-          reducedMotion ? "" : "duration-short4 ease-standard transition-[margin]",
-          isFocused ? "mx-3" : "mx-6"
-        )}
+        role="presentation"
+        {...mergeProps(hoverProps, focusProps)}
+        className={cn(paneTransitionClass, paneMarginClass)}
+        onMouseUp={handleMouseUp}
       >
-        <div
-          role="presentation"
-          className={cn(
-            "group relative overflow-hidden rounded-full",
-            "has-[:focus-visible]:ring-secondary has-[:focus-visible]:ring-3",
-            searchBarVariants({
-              style: searchStyle,
-              noActions: hasNoActions,
-              disabled: isDisabled,
-            }),
-            className
-          )}
-          onMouseDown={handleRipple}
-        >
-          <span
-            data-slot="state-layer"
-            className={cn(
-              "bg-on-surface pointer-events-none absolute inset-0 rounded-full opacity-0",
-              "group-hover:opacity-8 group-active:opacity-10",
-              "duration-spring-standard-fast-effects ease-spring-standard-fast-effects transition-opacity"
-            )}
-          />
+        {/*
+         * Relative wrapper — provides an absolute positioning context for the focus ring
+         * that sits outside the inner container's overflow-hidden, so the 3dp ring
+         * is never clipped. (Same sibling pattern as Button and Switch.)
+         */}
+        <div role="presentation" className="relative">
+          {/* Focus ring — sibling of inner container, extends 3px beyond pill boundary */}
+          <span className={cn(searchBarFocusRingVariants())} aria-hidden="true" />
 
-          <SearchBarHeadless
-            ref={ref}
-            {...(value !== undefined ? { value } : {})}
-            {...(defaultValue !== undefined ? { defaultValue } : {})}
-            {...(onChange !== undefined ? { onChange } : {})}
-            {...(onSubmit !== undefined ? { onSubmit } : {})}
-            {...(onClear !== undefined ? { onClear } : {})}
-            {...(placeholder !== undefined ? { placeholder } : {})}
-            {...(styledLeadingIcon !== undefined ? { leadingIcon: styledLeadingIcon } : {})}
-            {...(styledTrailingActions !== undefined
-              ? { trailingActions: styledTrailingActions }
-              : {})}
-            {...(styledAvatar !== undefined ? { avatar: styledAvatar } : {})}
-            {...(isDisabled !== undefined ? { isDisabled } : {})}
-            {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
-            onFocus={handleFocusInternal}
-            onBlur={handleBlurInternal}
+          {/* Inner container — group/search anchor for data-* selectors */}
+          <div
+            role="presentation"
+            {...getInteractionDataAttributes({
+              isHovered,
+              isFocusVisible,
+              isPressed,
+              isDisabled,
+            })}
+            data-with-actions={hasActions ? "" : undefined}
             className={cn(
-              "relative z-0 flex h-full w-full items-center",
-              "[&_input]:flex-1 [&_input]:bg-transparent [&_input]:outline-none",
-              "[&_input]:text-body-large [&_input]:text-on-surface",
-              "[&_input]:placeholder:text-on-surface-variant",
-              "[&_input]:focus-visible:outline-none"
+              "group/search overflow-hidden",
+              searchBarRootVariants({ style: searchStyle }),
+              className
             )}
-          />
+            onMouseDown={(e) => handleMouseDown(e as React.MouseEvent<HTMLElement>)}
+          >
+            {/* State layer — clipped to pill shape by parent overflow-hidden */}
+            <span
+              data-slot="state-layer"
+              className={cn(searchBarStateLayerVariants())}
+              aria-hidden="true"
+            />
 
-          {ripples}
+            {/* Ripple */}
+            {ripples}
+
+            {/* Headless form+input — carries all a11y wiring via React Aria */}
+            <SearchBarHeadless
+              ref={ref}
+              {...(value !== undefined ? { value } : {})}
+              {...(defaultValue !== undefined ? { defaultValue } : {})}
+              {...(onChange !== undefined ? { onChange } : {})}
+              {...(onSubmit !== undefined ? { onSubmit } : {})}
+              {...(onClear !== undefined ? { onClear } : {})}
+              {...(placeholder !== undefined ? { placeholder } : {})}
+              {...(styledLeadingIcon !== undefined ? { leadingIcon: styledLeadingIcon } : {})}
+              {...(styledTrailingActions !== undefined
+                ? { trailingActions: styledTrailingActions }
+                : {})}
+              {...(styledAvatar !== undefined ? { avatar: styledAvatar } : {})}
+              isDisabled={isDisabled}
+              {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+              onFocus={handleFocusInternal}
+              onBlur={handleBlurInternal}
+              className="relative z-0 flex h-full w-full items-center"
+            />
+          </div>
         </div>
       </div>
     );

--- a/packages/react/src/components/Search/SearchHeadless.tsx
+++ b/packages/react/src/components/Search/SearchHeadless.tsx
@@ -1,10 +1,49 @@
 "use client";
 
 import { forwardRef, useRef, useCallback } from "react";
+import type React from "react";
 import { createPortal } from "react-dom";
 import { useSearchField, useOverlay, usePreventScroll, useButton, FocusScope } from "react-aria";
 import { useSearchFieldState } from "react-stately";
 import type { SearchBarHeadlessProps, SearchViewHeadlessProps } from "./Search.types";
+
+// ─── MD3 Icons ────────────────────────────────────────────────────────────────
+
+/**
+ * MD3 Arrow Back icon — 24×24, currentColor, aria-hidden.
+ * Used as the leading button in Search View to close/collapse back to bar.
+ */
+const ArrowBackIcon = (): React.ReactElement => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+  </svg>
+);
+
+/**
+ * MD3 Close icon — 24×24, currentColor, aria-hidden.
+ * Used as the clear button in Search View to reset input text.
+ */
+const CloseIcon = (): React.ReactElement => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+  </svg>
+);
+
+// ─── SearchBarHeadless ────────────────────────────────────────────────────────
 
 /**
  * SearchBarHeadless — Layer 2 headless primitive for the MD3 Search bar.
@@ -103,6 +142,8 @@ export const SearchBarHeadless = forwardRef<HTMLFormElement, SearchBarHeadlessPr
 
 SearchBarHeadless.displayName = "SearchBarHeadless";
 
+// ─── SearchViewHeadless ───────────────────────────────────────────────────────
+
 /**
  * SearchViewHeadless — Layer 2 headless primitive for the MD3 Search view.
  *
@@ -116,7 +157,11 @@ SearchBarHeadless.displayName = "SearchBarHeadless";
  * - Body scroll lock when open
  * - Focus trap with auto-focus and restore on close
  * - aria-live region for autosuggest announcements
- * - Back arrow (leading icon) + input + clear button header
+ * - Back arrow (MD3 SVG icon) + input + clear button (MD3 SVG icon) header
+ *
+ * Slot class names (`headerClassName`, `backButtonClassName`, etc.) are passed
+ * from the styled `SearchView` layer so per-slot CVA classes apply directly to
+ * each element — no descendant-selector blobs needed.
  *
  * @example
  * ```tsx
@@ -145,6 +190,12 @@ export const SearchViewHeadless = forwardRef<HTMLDivElement, SearchViewHeadlessP
       leadingIcon,
       trailingActions,
       showDivider,
+      headerClassName,
+      backButtonClassName,
+      clearButtonClassName,
+      inputClassName,
+      dividerClassName,
+      contentClassName,
     },
     forwardedRef
   ) => {
@@ -166,6 +217,12 @@ export const SearchViewHeadless = forwardRef<HTMLDivElement, SearchViewHeadlessP
         {...(onChange !== undefined ? { onChange } : {})}
         {...(onSubmit !== undefined ? { onSubmit } : {})}
         {...(placeholder !== undefined ? { placeholder } : {})}
+        headerClassName={headerClassName}
+        backButtonClassName={backButtonClassName}
+        clearButtonClassName={clearButtonClassName}
+        inputClassName={inputClassName}
+        dividerClassName={dividerClassName}
+        contentClassName={contentClassName}
       >
         {children}
       </SearchViewPanel>,
@@ -176,7 +233,7 @@ export const SearchViewHeadless = forwardRef<HTMLDivElement, SearchViewHeadlessP
 
 SearchViewHeadless.displayName = "SearchViewHeadless";
 
-// ─── SearchViewPanel (internal) ──────────────────────────────────────────────
+// ─── SearchViewPanel (internal) ───────────────────────────────────────────────
 
 interface SearchViewPanelProps {
   onClose: () => void;
@@ -191,6 +248,13 @@ interface SearchViewPanelProps {
   leadingIcon?: React.ReactNode;
   trailingActions?: React.ReactNode[];
   showDivider?: boolean;
+  // Slot class names from the styled layer
+  headerClassName?: string | undefined;
+  backButtonClassName?: string | undefined;
+  clearButtonClassName?: string | undefined;
+  inputClassName?: string | undefined;
+  dividerClassName?: string | undefined;
+  contentClassName?: string | undefined;
 }
 
 /**
@@ -213,6 +277,12 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
       leadingIcon,
       trailingActions,
       showDivider,
+      headerClassName,
+      backButtonClassName,
+      clearButtonClassName,
+      inputClassName,
+      dividerClassName,
+      contentClassName,
     },
     forwardedRef
   ) => {
@@ -259,12 +329,21 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
       onClose();
     }, [onClose]);
 
-    const defaultBackArrow = (
-      <button type="button" aria-label="Back" onClick={handleBackClick} data-slot="back-button">
-        ←
+    // MD3 SVG back arrow — replaces the former literal "←" glyph
+    const defaultBackButton = (
+      <button
+        type="button"
+        aria-label="Back"
+        onClick={handleBackClick}
+        data-slot="back-button"
+        className={backButtonClassName}
+      >
+        <ArrowBackIcon />
       </button>
     );
 
+    // MD3 SVG close icon — replaces the former literal "✕" glyph
+    // Visible only when input has a value (controlled by state.value)
     const clearButton = state.value ? (
       <button
         {...clearBtnDomProps}
@@ -272,18 +351,32 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
         type="button"
         aria-label="Clear search"
         data-slot="clear-button"
+        className={clearButtonClassName}
       >
-        ✕
+        <CloseIcon />
       </button>
     ) : null;
 
     return (
       <FocusScope contain restoreFocus autoFocus>
         <div {...overlayProps} ref={ref} role="search" aria-label={ariaLabel} className={className}>
-          <div data-slot="header">
-            <span data-slot="leading-icon">{leadingIcon ?? defaultBackArrow}</span>
-            <input {...inputProps} ref={inputRef} role="searchbox" />
+          <div data-slot="header" className={headerClassName}>
+            {/* Leading icon: custom override or default MD3 back arrow */}
+            {leadingIcon ?? defaultBackButton}
+
+            {/* Search input */}
+            <input
+              {...inputProps}
+              ref={inputRef}
+              role="searchbox"
+              data-slot="input"
+              className={inputClassName}
+            />
+
+            {/* Clear button */}
             {clearButton}
+
+            {/* Trailing actions (view-state only) */}
             {trailingActions && trailingActions.length > 0 && (
               <span data-slot="trailing-actions">
                 {trailingActions.map((action, index) => (
@@ -294,8 +387,12 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
               </span>
             )}
           </div>
-          {showDivider && <hr data-slot="divider" />}
-          <div data-slot="content" aria-live="polite">
+
+          {/* Divider (divided style only) */}
+          {showDivider && <hr data-slot="divider" className={dividerClassName} />}
+
+          {/* Results / suggestions content area */}
+          <div data-slot="content" aria-live="polite" className={contentClassName}>
             {children}
           </div>
         </div>

--- a/packages/react/src/components/Search/SearchHeadless.tsx
+++ b/packages/react/src/components/Search/SearchHeadless.tsx
@@ -11,7 +11,7 @@ import type { SearchBarHeadlessProps, SearchViewHeadlessProps } from "./Search.t
 
 /**
  * MD3 Arrow Back icon — 24×24, currentColor, aria-hidden.
- * Used as the leading button in Search View to close/collapse back to bar.
+ * Used as the leading button in Search View to collapse back to the bar.
  */
 const ArrowBackIcon = (): React.ReactElement => (
   <svg
@@ -28,7 +28,7 @@ const ArrowBackIcon = (): React.ReactElement => (
 
 /**
  * MD3 Close icon — 24×24, currentColor, aria-hidden.
- * Used as the clear button in Search View to reset input text.
+ * Used as the clear button in Search View to reset the input text.
  */
 const CloseIcon = (): React.ReactElement => (
   <svg
@@ -57,6 +57,7 @@ const CloseIcon = (): React.ReactElement => (
  * - Keyboard: Enter → onSubmit, Escape (with value) → onClear
  * - Leading icon, trailing actions, and avatar slots
  * - aria-label falls back to placeholder per MD3 labeling spec
+ * - `inputClassName` and `trailingActionsClassName` applied directly to inner elements
  *
  * @example
  * ```tsx
@@ -84,6 +85,8 @@ export const SearchBarHeadless = forwardRef<HTMLFormElement, SearchBarHeadlessPr
       className,
       onFocus,
       onBlur,
+      inputClassName,
+      trailingActionsClassName,
     },
     forwardedRef
   ) => {
@@ -124,14 +127,16 @@ export const SearchBarHeadless = forwardRef<HTMLFormElement, SearchBarHeadlessPr
     return (
       <form ref={formRef} role="search" className={className} onSubmit={handleFormSubmit}>
         {leadingIcon && <span data-slot="leading-icon">{leadingIcon}</span>}
-        <input {...inputProps} ref={inputRef} role="searchbox" />
+        <input
+          {...inputProps}
+          ref={inputRef}
+          role="searchbox"
+          data-slot="input"
+          className={inputClassName}
+        />
         {trailingActions && trailingActions.length > 0 && (
-          <span data-slot="trailing-actions">
-            {trailingActions.map((action, index) => (
-              <span key={index} data-slot="trailing-action">
-                {action}
-              </span>
-            ))}
+          <span data-slot="trailing-actions" className={trailingActionsClassName}>
+            {trailingActions}
           </span>
         )}
         {avatar && <span data-slot="avatar">{avatar}</span>}
@@ -147,21 +152,18 @@ SearchBarHeadless.displayName = "SearchBarHeadless";
 /**
  * SearchViewHeadless — Layer 2 headless primitive for the MD3 Search view.
  *
- * Renders in a portal when `isOpen={true}`. Does not render when closed.
- * Uses `useOverlay` for Escape-key dismissal, `usePreventScroll` to lock
- * body scrolling, and `FocusScope` for focus trapping.
+ * Rendering strategy by layout:
+ * - `fullscreen`: renders in a portal (`createPortal`) with `usePreventScroll` and
+ *   `FocusScope contain` — the view covers the full viewport.
+ * - `docked`: renders inline (no portal) with `FocusScope restoreFocus autoFocus` only —
+ *   the card sits in normal document flow so it can be centered by its wrapper.
+ *
+ * Both layouts use `useOverlay` so Escape key and click-outside dismiss correctly.
  *
  * Features:
- * - Portal rendering via `createPortal`
- * - Escape key → onClose
- * - Body scroll lock when open
- * - Focus trap with auto-focus and restore on close
+ * - Back arrow (MD3 ArrowBack SVG) + input + MD3 Close SVG clear button in header
  * - aria-live region for autosuggest announcements
- * - Back arrow (MD3 SVG icon) + input + clear button (MD3 SVG icon) header
- *
- * Slot class names (`headerClassName`, `backButtonClassName`, etc.) are passed
- * from the styled `SearchView` layer so per-slot CVA classes apply directly to
- * each element — no descendant-selector blobs needed.
+ * - Slot class names from the styled SearchView layer applied directly on elements
  *
  * @example
  * ```tsx
@@ -190,10 +192,12 @@ export const SearchViewHeadless = forwardRef<HTMLDivElement, SearchViewHeadlessP
       leadingIcon,
       trailingActions,
       showDivider,
+      layout = "fullscreen",
       headerClassName,
       backButtonClassName,
       clearButtonClassName,
       inputClassName,
+      trailingActionsClassName,
       dividerClassName,
       contentClassName,
     },
@@ -203,31 +207,38 @@ export const SearchViewHeadless = forwardRef<HTMLDivElement, SearchViewHeadlessP
       return null;
     }
 
-    return createPortal(
-      <SearchViewPanel
-        ref={forwardedRef}
-        onClose={onClose}
-        ariaLabel={ariaLabel}
-        {...(className !== undefined ? { className } : {})}
-        {...(leadingIcon !== undefined ? { leadingIcon } : {})}
-        {...(trailingActions !== undefined ? { trailingActions } : {})}
-        {...(showDivider !== undefined ? { showDivider } : {})}
-        {...(value !== undefined ? { value } : {})}
-        {...(defaultValue !== undefined ? { defaultValue } : {})}
-        {...(onChange !== undefined ? { onChange } : {})}
-        {...(onSubmit !== undefined ? { onSubmit } : {})}
-        {...(placeholder !== undefined ? { placeholder } : {})}
-        headerClassName={headerClassName}
-        backButtonClassName={backButtonClassName}
-        clearButtonClassName={clearButtonClassName}
-        inputClassName={inputClassName}
-        dividerClassName={dividerClassName}
-        contentClassName={contentClassName}
-      >
-        {children}
-      </SearchViewPanel>,
-      document.body
-    );
+    const panelProps = {
+      onClose,
+      ariaLabel,
+      layout,
+      children,
+      ...(className !== undefined ? { className } : {}),
+      ...(leadingIcon !== undefined ? { leadingIcon } : {}),
+      ...(trailingActions !== undefined ? { trailingActions } : {}),
+      ...(showDivider !== undefined ? { showDivider } : {}),
+      ...(value !== undefined ? { value } : {}),
+      ...(defaultValue !== undefined ? { defaultValue } : {}),
+      ...(onChange !== undefined ? { onChange } : {}),
+      ...(onSubmit !== undefined ? { onSubmit } : {}),
+      ...(placeholder !== undefined ? { placeholder } : {}),
+      headerClassName,
+      backButtonClassName,
+      clearButtonClassName,
+      inputClassName,
+      trailingActionsClassName,
+      dividerClassName,
+      contentClassName,
+    };
+
+    // Docked renders inline — no portal, no scroll-lock, no contain trap.
+    // This lets the container sit in normal document flow and be positioned
+    // by its parent wrapper (e.g. centered in the Storybook canvas).
+    if (layout === "docked") {
+      return <SearchViewPanel ref={forwardedRef} {...panelProps} />;
+    }
+
+    // Fullscreen renders in a portal over the page with scroll-lock + focus trap.
+    return createPortal(<SearchViewPanel ref={forwardedRef} {...panelProps} />, document.body);
   }
 );
 
@@ -248,18 +259,21 @@ interface SearchViewPanelProps {
   leadingIcon?: React.ReactNode;
   trailingActions?: React.ReactNode[];
   showDivider?: boolean;
+  /** Controls scroll-lock and focus containment — see SearchViewHeadless. */
+  layout: "fullscreen" | "docked";
   // Slot class names from the styled layer
   headerClassName?: string | undefined;
   backButtonClassName?: string | undefined;
   clearButtonClassName?: string | undefined;
   inputClassName?: string | undefined;
+  trailingActionsClassName?: string | undefined;
   dividerClassName?: string | undefined;
   contentClassName?: string | undefined;
 }
 
 /**
- * Inner panel for the search view. Separated to allow hooks
- * (`usePreventScroll`, `useOverlay`) which must be called unconditionally.
+ * Inner panel for the search view. Separated so that hooks that must be called
+ * unconditionally (`usePreventScroll`, `useOverlay`) always run.
  * @internal
  */
 const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
@@ -277,10 +291,12 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
       leadingIcon,
       trailingActions,
       showDivider,
+      layout,
       headerClassName,
       backButtonClassName,
       clearButtonClassName,
       inputClassName,
+      trailingActionsClassName,
       dividerClassName,
       contentClassName,
     },
@@ -290,7 +306,10 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
     const inputRef = useRef<HTMLInputElement>(null);
     const ref = (forwardedRef ?? panelRef) as React.RefObject<HTMLDivElement>;
 
-    usePreventScroll();
+    const isFullscreen = layout === "fullscreen";
+
+    // Scroll-lock only when the view covers the whole page (fullscreen portal).
+    usePreventScroll({ isDisabled: !isFullscreen });
 
     const { overlayProps } = useOverlay(
       {
@@ -329,7 +348,6 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
       onClose();
     }, [onClose]);
 
-    // MD3 SVG back arrow — replaces the former literal "←" glyph
     const defaultBackButton = (
       <button
         type="button"
@@ -342,8 +360,7 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
       </button>
     );
 
-    // MD3 SVG close icon — replaces the former literal "✕" glyph
-    // Visible only when input has a value (controlled by state.value)
+    // Clear button only rendered when the input has a value
     const clearButton = state.value ? (
       <button
         {...clearBtnDomProps}
@@ -358,13 +375,16 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
     ) : null;
 
     return (
-      <FocusScope contain restoreFocus autoFocus>
+      // Focus containment only for fullscreen — docked uses restoreFocus + autoFocus only
+      // so tabbing can naturally leave the widget.
+      <FocusScope contain={isFullscreen} restoreFocus autoFocus>
         <div {...overlayProps} ref={ref} role="search" aria-label={ariaLabel} className={className}>
           <div data-slot="header" className={headerClassName}>
-            {/* Leading icon: custom override or default MD3 back arrow */}
+            {/* Leading: custom override or default back arrow */}
             {leadingIcon ?? defaultBackButton}
 
-            {/* Search input */}
+            {/* Search input — receives inputClassName with flex-1, outline-none, and
+                the webkit search-cancel hide rule to suppress the native "×" button */}
             <input
               {...inputProps}
               ref={inputRef}
@@ -373,17 +393,13 @@ const SearchViewPanel = forwardRef<HTMLDivElement, SearchViewPanelProps>(
               className={inputClassName}
             />
 
-            {/* Clear button */}
+            {/* MD3 clear button (Close SVG) — only when input has content */}
             {clearButton}
 
-            {/* Trailing actions (view-state only) */}
+            {/* Trailing actions */}
             {trailingActions && trailingActions.length > 0 && (
-              <span data-slot="trailing-actions">
-                {trailingActions.map((action, index) => (
-                  <span key={index} data-slot="trailing-action">
-                    {action}
-                  </span>
-                ))}
+              <span data-slot="trailing-actions" className={trailingActionsClassName}>
+                {trailingActions}
               </span>
             )}
           </div>

--- a/packages/react/src/components/Search/SearchView.tsx
+++ b/packages/react/src/components/Search/SearchView.tsx
@@ -2,15 +2,24 @@
 
 import { forwardRef } from "react";
 import { SearchViewHeadless } from "./SearchHeadless";
-import { searchViewVariants } from "./Search.variants";
+import {
+  searchViewVariants,
+  searchViewHeaderVariants,
+  searchViewBackButtonVariants,
+  searchViewClearButtonVariants,
+  searchViewTrailingActionVariants,
+  searchViewInputVariants,
+  searchViewDividerVariants,
+  searchViewContentVariants,
+} from "./Search.variants";
 import { cn } from "../../utils/cn";
 import type { SearchViewProps } from "./Search.types";
 
 /**
  * Material Design 3 Search View Component (Layer 3: Styled)
  *
- * The expanded/focused search experience with input and results.
- * Displayed in a portal over page content.
+ * The expanded/focused search experience rendered in a portal over page content.
+ * Uses per-slot CVAs for all styling — no descendant-selector blobs.
  *
  * Anatomy:
  *   Header: [Back arrow] [Input] [Clear button] [Optional trailing actions]
@@ -19,9 +28,10 @@ import type { SearchViewProps } from "./Search.types";
  *
  * Features:
  * - Portal rendering with focus trap and scroll lock (via headless)
- * - Compound variants for 4 style+layout combinations
- * - Animate on mount with `animate-md-scale-in`
- * - Clear button visible only when input has value
+ * - Compound variants for all 4 style × layout combinations
+ * - Docked layout: animate-md-scale-in on mount
+ * - Fullscreen layout: animate-md-fade-in on mount
+ * - Clear button visible only when input has value (controlled by headless)
  * - aria-live region for autosuggest announcements
  *
  * @example
@@ -60,17 +70,41 @@ export const SearchView = forwardRef<HTMLDivElement, SearchViewProps>(
   ) => {
     const resolvedShowDivider = showDivider ?? searchStyle === "divided";
 
+    // Enter motion: docked uses scale-in (feels contained/popover-like),
+    // fullscreen uses fade-in (covers the screen, no scale distortion).
+    const enterMotionClass = layout === "docked" ? "animate-md-scale-in" : "animate-md-fade-in";
+
+    // ── Slot class strings resolved from CVAs ────────────────────────────────
+    const containerClass = cn(
+      searchViewVariants({ style: searchStyle, layout }),
+      enterMotionClass,
+      className
+    );
+
+    const headerClass = cn(searchViewHeaderVariants({ style: searchStyle, layout }));
+
+    const backButtonClass = cn(searchViewBackButtonVariants());
+
+    const clearButtonClass = cn(searchViewClearButtonVariants());
+
+    const trailingActionClass = cn(searchViewTrailingActionVariants());
+
+    const inputClass = cn(searchViewInputVariants());
+
+    const dividerClass = cn(searchViewDividerVariants());
+
+    const contentClass = cn(searchViewContentVariants());
+
+    // ── Styled leading icon ──────────────────────────────────────────────────
     const styledLeadingIcon = leadingIcon ? (
       <span className="text-on-surface flex size-12 shrink-0 items-center justify-center">
         {leadingIcon}
       </span>
     ) : undefined;
 
+    // ── Styled trailing actions ───────────────────────────────────────────────
     const styledTrailingActions = trailingActions?.map((action, index) => (
-      <span
-        key={index}
-        className="text-on-surface-variant flex size-12 shrink-0 items-center justify-center"
-      >
+      <span key={index} className={trailingActionClass}>
         {action}
       </span>
     ));
@@ -89,13 +123,14 @@ export const SearchView = forwardRef<HTMLDivElement, SearchViewProps>(
         {...(styledLeadingIcon !== undefined ? { leadingIcon: styledLeadingIcon } : {})}
         {...(styledTrailingActions !== undefined ? { trailingActions: styledTrailingActions } : {})}
         showDivider={resolvedShowDivider}
-        className={cn(
-          searchViewVariants({ style: searchStyle, layout }),
-          "animate-md-scale-in",
-          getHeaderClasses(searchStyle, layout),
-          slotClasses,
-          className
-        )}
+        // ── Slot class names passed to headless for direct application ────────
+        className={containerClass}
+        headerClassName={headerClass}
+        backButtonClassName={backButtonClass}
+        clearButtonClassName={clearButtonClass}
+        inputClassName={inputClass}
+        dividerClassName={dividerClass}
+        contentClassName={contentClass}
       >
         {children}
       </SearchViewHeadless>
@@ -104,53 +139,3 @@ export const SearchView = forwardRef<HTMLDivElement, SearchViewProps>(
 );
 
 SearchView.displayName = "SearchView";
-
-/**
- * Static slot styling applied via descendant selectors on the container.
- * Targets data-slot attributes rendered by SearchViewHeadless.
- */
-const slotClasses = cn(
-  // Input styling
-  "[&_input]:flex-1 [&_input]:bg-transparent [&_input]:outline-none",
-  "[&_input]:text-body-large [&_input]:text-on-surface",
-  "[&_input]:placeholder:text-on-surface-variant",
-  // Divider
-  "[&>[data-slot=divider]]:border-outline",
-  // Content area
-  "[&>[data-slot=content]]:flex-1 [&>[data-slot=content]]:overflow-y-auto",
-  // Clear button
-  "[&_[data-slot=clear-button]]:size-12 [&_[data-slot=clear-button]]:flex",
-  "[&_[data-slot=clear-button]]:items-center [&_[data-slot=clear-button]]:justify-center",
-  "[&_[data-slot=clear-button]]:text-on-surface-variant",
-  "[&_[data-slot=clear-button]]:transition-opacity [&_[data-slot=clear-button]]:duration-short4",
-  "[&_[data-slot=clear-button]]:ease-standard",
-  // Back button
-  "[&_[data-slot=back-button]]:size-12 [&_[data-slot=back-button]]:flex",
-  "[&_[data-slot=back-button]]:items-center [&_[data-slot=back-button]]:justify-center",
-  "[&_[data-slot=back-button]]:text-on-surface"
-);
-
-/**
- * Resolves header height and padding based on style + layout combination.
- * Contained: 56dp height, 12dp (px-3) side padding.
- * Divided + fullscreen: 72dp height, 16dp (px-4) side padding.
- * Divided + docked (or any docked): 56dp height.
- */
-function getHeaderClasses(style: "contained" | "divided", layout: "fullscreen" | "docked"): string {
-  const base =
-    "[&>[data-slot=header]]:flex [&>[data-slot=header]]:items-center [&>[data-slot=header]]:w-full [&>[data-slot=header]]:bg-surface-container-high [&>[data-slot=header]]:gap-1";
-
-  if (layout === "docked") {
-    return cn(
-      base,
-      "[&>[data-slot=header]]:h-14",
-      style === "contained" ? "[&>[data-slot=header]]:px-3" : "[&>[data-slot=header]]:px-4"
-    );
-  }
-
-  if (style === "contained") {
-    return cn(base, "[&>[data-slot=header]]:h-14 [&>[data-slot=header]]:px-3");
-  }
-
-  return cn(base, "[&>[data-slot=header]]:h-[72px] [&>[data-slot=header]]:px-4");
-}

--- a/packages/react/src/components/Search/SearchView.tsx
+++ b/packages/react/src/components/Search/SearchView.tsx
@@ -8,6 +8,7 @@ import {
   searchViewBackButtonVariants,
   searchViewClearButtonVariants,
   searchViewTrailingActionVariants,
+  searchViewTrailingActionsVariants,
   searchViewInputVariants,
   searchViewDividerVariants,
   searchViewContentVariants,
@@ -88,6 +89,7 @@ export const SearchView = forwardRef<HTMLDivElement, SearchViewProps>(
     const clearButtonClass = cn(searchViewClearButtonVariants());
 
     const trailingActionClass = cn(searchViewTrailingActionVariants());
+    const trailingActionsGroupClass = cn(searchViewTrailingActionsVariants());
 
     const inputClass = cn(searchViewInputVariants());
 
@@ -114,6 +116,7 @@ export const SearchView = forwardRef<HTMLDivElement, SearchViewProps>(
         ref={ref}
         isOpen={isOpen}
         onClose={onClose}
+        layout={layout}
         {...(value !== undefined ? { value } : {})}
         {...(defaultValue !== undefined ? { defaultValue } : {})}
         {...(onChange !== undefined ? { onChange } : {})}
@@ -129,6 +132,7 @@ export const SearchView = forwardRef<HTMLDivElement, SearchViewProps>(
         backButtonClassName={backButtonClass}
         clearButtonClassName={clearButtonClass}
         inputClassName={inputClass}
+        trailingActionsClassName={trailingActionsGroupClass}
         dividerClassName={dividerClass}
         contentClassName={contentClass}
       >

--- a/packages/react/src/components/Search/index.ts
+++ b/packages/react/src/components/Search/index.ts
@@ -6,8 +6,28 @@ export { Search } from "./Search";
 // Layer 2 — Headless
 export { SearchBarHeadless, SearchViewHeadless } from "./SearchHeadless";
 
-// CVA
-export { searchBarVariants, searchViewVariants, searchViewHeaderVariants } from "./Search.variants";
+// CVA — bar slots
+export {
+  searchBarRootVariants,
+  searchBarStateLayerVariants,
+  searchBarFocusRingVariants,
+  searchBarLeadingIconVariants,
+  searchBarTrailingActionVariants,
+  searchBarAvatarVariants,
+  searchBarInputVariants,
+} from "./Search.variants";
+
+// CVA — view slots
+export {
+  searchViewVariants,
+  searchViewHeaderVariants,
+  searchViewBackButtonVariants,
+  searchViewClearButtonVariants,
+  searchViewTrailingActionVariants,
+  searchViewInputVariants,
+  searchViewDividerVariants,
+  searchViewContentVariants,
+} from "./Search.variants";
 
 // Types
 export type {

--- a/packages/react/src/components/Search/index.ts
+++ b/packages/react/src/components/Search/index.ts
@@ -13,6 +13,7 @@ export {
   searchBarFocusRingVariants,
   searchBarLeadingIconVariants,
   searchBarTrailingActionVariants,
+  searchBarTrailingActionsVariants,
   searchBarAvatarVariants,
   searchBarInputVariants,
 } from "./Search.variants";
@@ -24,6 +25,7 @@ export {
   searchViewBackButtonVariants,
   searchViewClearButtonVariants,
   searchViewTrailingActionVariants,
+  searchViewTrailingActionsVariants,
   searchViewInputVariants,
   searchViewDividerVariants,
   searchViewContentVariants,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -318,6 +318,7 @@ export {
   searchBarFocusRingVariants,
   searchBarLeadingIconVariants,
   searchBarTrailingActionVariants,
+  searchBarTrailingActionsVariants,
   searchBarAvatarVariants,
   searchBarInputVariants,
   // View slot CVAs
@@ -326,6 +327,7 @@ export {
   searchViewBackButtonVariants,
   searchViewClearButtonVariants,
   searchViewTrailingActionVariants,
+  searchViewTrailingActionsVariants,
   searchViewInputVariants,
   searchViewDividerVariants,
   searchViewContentVariants,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -312,9 +312,23 @@ export {
   SearchView,
   SearchBarHeadless,
   SearchViewHeadless,
-  searchBarVariants,
+  // Bar slot CVAs
+  searchBarRootVariants,
+  searchBarStateLayerVariants,
+  searchBarFocusRingVariants,
+  searchBarLeadingIconVariants,
+  searchBarTrailingActionVariants,
+  searchBarAvatarVariants,
+  searchBarInputVariants,
+  // View slot CVAs
   searchViewVariants,
   searchViewHeaderVariants,
+  searchViewBackButtonVariants,
+  searchViewClearButtonVariants,
+  searchViewTrailingActionVariants,
+  searchViewInputVariants,
+  searchViewDividerVariants,
+  searchViewContentVariants,
 } from "./components/Search";
 export type {
   SearchStyle,


### PR DESCRIPTION
## Summary

- Rebuilds `Search.variants.ts` into per-slot CVAs (14 slots across bar and view); removes forbidden interaction-state CVA variants (`focused`, `disabled`, `noActions`) — all states now driven by `data-*` attributes via `group-data-[x]/search` Tailwind selectors
- Refactors `SearchBar.tsx` to use React Aria `useHover` + `useFocusRing({ within: true })` + `getInteractionDataAttributes`; renders the focus ring as a sibling span outside `overflow-hidden` (matching Button/Switch); M3 Expressive pane-margin transition (24dp → 12dp on focus) uses `duration-expressive-fast-spatial ease-expressive-fast-spatial`, guarded by `useReducedMotion`
- Refactors `SearchView.tsx` to apply per-slot CVAs directly, replacing the `getHeaderClasses()` helper and `[&>[data-slot=...]]` descendant-selector blobs; enter motion is layout-aware: docked → `animate-md-scale-in`, fullscreen → `animate-md-fade-in`
- Replaces literal `←` / `✕` glyphs in `SearchHeadless.tsx` with proper inline MD3 SVG icons (24×24, `currentColor`, `aria-hidden`)
- Updates `SearchViewHeadless` to accept per-slot `className` props for direct application on each slot element
- Updates tests to assert on the correct slot elements and `data-*`-driven class names

## Test plan

- [ ] `pnpm typecheck` — passes (0 errors)
- [ ] `pnpm lint` — passes (0 errors)
- [ ] `pnpm test` — 2102/2102 pass
- [ ] Visually verify in Storybook: SearchBar states (hover/focus/pressed), pane-margin animation, SearchView contained+fullscreen fade-in, contained+docked scale-in, divided divider