### PR TITLE
refactor(slider): md3 expressive architecture + spring motion

### DIFF
--- a/.changeset/slider-md3-expressive-refactor.md
+++ b/.changeset/slider-md3-expressive-refactor.md
@@ -2,9 +2,9 @@
 "@tinybigui/react": minor
 ---
 
-**Slider: MD3 Expressive architecture refactor with spring motion**
+**Slider: MD3 Expressive architecture refactor with spring motion, range/vertical layout fixes, and vertical orientation improvements**
 
-The Slider component has been fully migrated to the "Variants-vs-States" architecture used by Button and Switch, and all motion tokens have been updated to the MD3 spring system.
+The Slider component has been fully migrated to the "Variants-vs-States" architecture used by Button and Switch, all motion tokens have been updated to the MD3 spring system, range/vertical track alignment has been corrected to absolute positioning, and the vertical orientation now renders correctly at all sizes.
 
 **Architecture changes (no API breakage)**
 
@@ -24,6 +24,19 @@ The Slider component has been fully migrated to the "Variants-vs-States" archite
 **Value indicator change (user-visible)**
 
 The value indicator is now always rendered in the DOM when `showValueIndicator=true` (previously only rendered when the thumb was pressed). Visibility is CSS-driven via `group-data-[pressed]/slider-thumb:opacity-100 scale-100`. `aria-hidden="true"` is set permanently since the accessible value is in the React Aria `<output>` element.
+
+The value indicator motion has also been corrected for Tailwind CSS v4: `scale-*` utilities now use the CSS `scale` property (not `transform`), so the transition list uses `transition-[scale,opacity]` instead of `transition-[transform,opacity]`.
+
+**Track layout fixes (range & vertical)**
+
+- All active and inactive track segments are now `position: absolute` within the track region, aligned to the same percentage coordinate space as React Aria's thumb positions. This fixes the range slider fill not meeting handles at extreme values.
+- The MD3 6dp thumb-track gap is implemented as a symmetric 3px inset on each side of the thumb.
+- The vertical slider track region now uses `flex-1 min-h-0` instead of `h-full`, reliably filling its flex container regardless of nesting depth. At `value=0`, the active track collapses to zero height (no longer half-filled).
+
+**Vertical orientation improvements**
+
+- The vertical handle bar now has an explicit per-size width (xsmall/small: 44px, medium: 52px, large: 68px, xlarge: 108px) matching the track region width, per MD3 §10.9 transposed dimensions. The handle bar was previously sized to `w-full` which collapsed to zero width when the RA thumb had no explicit width.
+- Both `standard` and `centered` variants now render correctly in vertical orientation.
 
 **New `SliderHeadless` props**
 

--- a/.changeset/slider-md3-expressive-refactor.md
+++ b/.changeset/slider-md3-expressive-refactor.md
@@ -1,0 +1,35 @@
+---
+"@tinybigui/react": minor
+---
+
+**Slider: MD3 Expressive architecture refactor with spring motion**
+
+The Slider component has been fully migrated to the "Variants-vs-States" architecture used by Button and Switch, and all motion tokens have been updated to the MD3 spring system.
+
+**Architecture changes (no API breakage)**
+
+- Interaction states (hover, pressed/dragging, disabled, focus-visible) are now driven by React Aria's `isDragging`, `isHovered`, and `isFocusVisible` hooks via `getInteractionDataAttributes`, emitting `data-*` presence attributes on the RA thumb element (`group/slider-thumb`). All visual state changes — handle width, state-layer opacity, value-indicator visibility — are now handled entirely by `group-data-[x]/slider-thumb:*` CSS selectors.
+- The manual `thumbStates` React state and `onPointerEnter/Leave/Down/Up` handlers have been removed. React Aria is the single source of truth for interaction state.
+- The visual handle, state layer, and value indicator are now rendered **inside** the React Aria thumb element (which is absolutely positioned at the value percentage), via a `renderThumbContent` render prop on `SliderHeadless`.
+- Disabled track/stop colors are driven by `group-data-[disabled]/slider:*` selectors from the root `group/slider` scope.
+
+**Motion token changes (user-visible)**
+
+| Element                           | Before                                                                                  | After                                                                     |
+| --------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Handle width (4dp → 2dp on press) | `duration-short2 ease-standard`                                                         | `duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial` |
+| State layer opacity               | `duration-short1 ease-standard`                                                         | `duration-spring-standard-fast-effects ease-spring-standard-fast-effects` |
+| Value indicator (enter/exit)      | `duration-short3 ease-standard-decelerate` / `duration-short2 ease-standard-accelerate` | `duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial` |
+
+**Value indicator change (user-visible)**
+
+The value indicator is now always rendered in the DOM when `showValueIndicator=true` (previously only rendered when the thumb was pressed). Visibility is CSS-driven via `group-data-[pressed]/slider-thumb:opacity-100 scale-100`. `aria-hidden="true"` is set permanently since the accessible value is in the React Aria `<output>` element.
+
+**New `SliderHeadless` props**
+
+- `renderThumbContent?: (state: SliderThumbRenderState) => React.ReactNode` — render prop for injecting visual thumb content inside the RA thumb element.
+- `onThumbDraggingChange?: (index: number, isDragging: boolean) => void` — callback for tracking per-thumb drag state.
+
+**Deprecations (no removal)**
+
+`SliderThumbState` and `SliderRenderState` are marked `@deprecated`. They remain exported and unchanged for backwards compatibility.

--- a/packages/react/src/components/Slider/Slider.stories.tsx
+++ b/packages/react/src/components/Slider/Slider.stories.tsx
@@ -368,7 +368,80 @@ export const VerticalOrientation: Story = {
   },
 };
 
-// ─── 10. Disabled State ───────────────────────────────────────────────────────
+// ─── 10. Vertical Centered ────────────────────────────────────────────────────
+
+/**
+ * Centered variant in vertical orientation.
+ * Fill grows from the zero-point outward — up for positive values, down for negative.
+ * Demonstrates standard and centered side-by-side for visual comparison.
+ */
+export const VerticalCentered: Story = {
+  render: function VerticalCenteredRender() {
+    return (
+      <div className="flex h-[300px] items-end gap-8">
+        <div className="flex h-full flex-col items-center gap-2">
+          <span className="text-label-small text-on-surface-variant">Std</span>
+          <Slider
+            label="Volume"
+            defaultValue={[65]}
+            orientation="vertical"
+            size="small"
+            showValueIndicator
+          />
+        </div>
+        <div className="flex h-full flex-col items-center gap-2">
+          <span className="text-label-small text-on-surface-variant">+</span>
+          <Slider
+            variant="centered"
+            label="Treble"
+            defaultValue={[30]}
+            minValue={-50}
+            maxValue={50}
+            orientation="vertical"
+            size="small"
+            showValueIndicator
+          />
+        </div>
+        <div className="flex h-full flex-col items-center gap-2">
+          <span className="text-label-small text-on-surface-variant">−</span>
+          <Slider
+            variant="centered"
+            label="Bass"
+            defaultValue={[-20]}
+            minValue={-50}
+            maxValue={50}
+            orientation="vertical"
+            size="small"
+            showValueIndicator
+          />
+        </div>
+        <div className="flex h-full flex-col items-center gap-2">
+          <span className="text-label-small text-on-surface-variant">0</span>
+          <Slider
+            variant="centered"
+            label="Balance"
+            defaultValue={[0]}
+            minValue={-50}
+            maxValue={50}
+            orientation="vertical"
+            size="small"
+            showValueIndicator
+          />
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Centered variant in vertical orientation — fill extends from the zero midpoint toward the handle. Positive values fill upward, negative values fill downward. At value 0 the active track collapses to nothing.",
+      },
+    },
+  },
+};
+
+// ─── 11. Disabled State ───────────────────────────────────────────────────────
 
 /**
  * All three variants in disabled state. Disabled color treatment: active track
@@ -410,7 +483,7 @@ export const DisabledState: Story = {
   },
 };
 
-// ─── 11. Controlled ───────────────────────────────────────────────────────────
+// ─── 12. Controlled ───────────────────────────────────────────────────────────
 
 /**
  * Controlled slider with external state management. The current value is
@@ -461,7 +534,7 @@ export const Controlled: Story = {
   },
 };
 
-// ─── 12. Range With Custom Labels ─────────────────────────────────────────────
+// ─── 13. Range With Custom Labels ─────────────────────────────────────────────
 
 /**
  * Range slider with custom `thumbLabels` for accessible screen-reader
@@ -490,7 +563,7 @@ export const RangeWithCustomLabels: Story = {
   },
 };
 
-// ─── 13. All Variants Comparison ──────────────────────────────────────────────
+// ─── 14. All Variants Comparison ──────────────────────────────────────────────
 
 /**
  * Side-by-side comparison of all three variants at the same Small size,
@@ -544,7 +617,7 @@ export const AllVariantsComparison: Story = {
   },
 };
 
-// ─── 14. Sizes With Icon ──────────────────────────────────────────────────────
+// ─── 15. Sizes With Icon ──────────────────────────────────────────────────────
 
 /**
  * Medium, Large, and XLarge sizes with an inset brightness icon. The icon
@@ -585,7 +658,7 @@ export const SizesWithIcon: Story = {
   },
 };
 
-// ─── 15. Vertical Sizes ───────────────────────────────────────────────────────
+// ─── 16. Vertical Sizes ───────────────────────────────────────────────────────
 
 /**
  * All five sizes in vertical orientation for visual comparison.

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -780,32 +780,32 @@ describe("Slider — styled layer", () => {
     expect(handle).toHaveClass("rounded-[2px]");
   });
 
-  // 62. xsmall size: container has h-[44px]
+  // 62. xsmall size: track region has h-[44px]
   test("Slider xsmall size: container has h-[44px]", () => {
-    render(<Slider size="xsmall" label="Vol" defaultValue={[50]} />);
-    const group = screen.getByRole("group");
-    expect(group).toHaveClass("h-[44px]");
+    const { container } = render(<Slider size="xsmall" label="Vol" defaultValue={[50]} />);
+    const track = container.querySelector("[data-track]")!;
+    expect(track).toHaveClass("h-[44px]");
   });
 
-  // 63. medium size: container has h-[52px]
+  // 63. medium size: track region has h-[52px]
   test("Slider medium size: container has h-[52px]", () => {
-    render(<Slider size="medium" label="Vol" defaultValue={[50]} />);
-    const group = screen.getByRole("group");
-    expect(group).toHaveClass("h-[52px]");
+    const { container } = render(<Slider size="medium" label="Vol" defaultValue={[50]} />);
+    const track = container.querySelector("[data-track]")!;
+    expect(track).toHaveClass("h-[52px]");
   });
 
-  // 64. large size: container has h-[68px]
+  // 64. large size: track region has h-[68px]
   test("Slider large size: container has h-[68px]", () => {
-    render(<Slider size="large" label="Vol" defaultValue={[50]} />);
-    const group = screen.getByRole("group");
-    expect(group).toHaveClass("h-[68px]");
+    const { container } = render(<Slider size="large" label="Vol" defaultValue={[50]} />);
+    const track = container.querySelector("[data-track]")!;
+    expect(track).toHaveClass("h-[68px]");
   });
 
-  // 65. xlarge size: container has h-[108px]
+  // 65. xlarge size: track region has h-[108px]
   test("Slider xlarge size: container has h-[108px]", () => {
-    render(<Slider size="xlarge" label="Vol" defaultValue={[50]} />);
-    const group = screen.getByRole("group");
-    expect(group).toHaveClass("h-[108px]");
+    const { container } = render(<Slider size="xlarge" label="Vol" defaultValue={[50]} />);
+    const track = container.querySelector("[data-track]")!;
+    expect(track).toHaveClass("h-[108px]");
   });
 
   // 66. xsmall active track has h-[16px]
@@ -829,12 +829,14 @@ describe("Slider — styled layer", () => {
     expect(activeTrack).toHaveClass("h-[96px]");
   });
 
-  // 69. Track layout has gap-[6px] class (thumbTrackGapSize: 6dp between tracks)
-  test("Slider track layout has gap-[6px] class", () => {
+  // 69. Track layout is absolute/inset-0/pointer-events-none (absolute-fill container)
+  test("Slider track layout is absolute inset-0 pointer-events-none", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} />);
     const trackLayout = container.querySelector('[data-slot="track-layout"]');
     expect(trackLayout).toBeInTheDocument();
-    expect(trackLayout).toHaveClass("gap-[6px]");
+    expect(trackLayout).toHaveClass("absolute");
+    expect(trackLayout).toHaveClass("inset-0");
+    expect(trackLayout).toHaveClass("pointer-events-none");
   });
 
   // 70. Disabled: active track has group-data-driven disabled classes
@@ -1026,11 +1028,12 @@ describe("Slider — stop indicators and value indicator", () => {
 // ---------------------------------------------------------------------------
 
 describe("Slider — vertical orientation", () => {
-  // 91. Track layout has flex-col-reverse in vertical orientation
-  test("vertical orientation: track layout has flex-col-reverse class", () => {
+  // 91. Track layout is absolute (absolute-fill container, orientation-agnostic)
+  test("vertical orientation: track layout is absolute", () => {
     const { container } = render(<Slider label="Vol" orientation="vertical" defaultValue={[50]} />);
     const trackLayout = container.querySelector('[data-slot="track-layout"]');
-    expect(trackLayout).toHaveClass("flex-col-reverse");
+    expect(trackLayout).toHaveClass("absolute");
+    expect(trackLayout).not.toHaveClass("flex-1");
   });
 
   // 92. Container has data-orientation="vertical"
@@ -1080,12 +1083,13 @@ describe("Slider — vertical orientation", () => {
     expect(group).toHaveClass("w-[52px]");
   });
 
-  // 97. Handle dimensions are swapped in vertical
-  test("vertical orientation: handle has h-[4px] and w-full", () => {
+  // 97. Handle dimensions are swapped in vertical — width is explicitly sized per MD3 §10.9
+  test("vertical orientation: handle has h-[4px] and w-[44px] for xsmall (no w-full)", () => {
     const { container } = render(<Slider label="Vol" orientation="vertical" defaultValue={[50]} />);
     const handle = container.querySelector('[data-slot="handle"]');
     expect(handle).toHaveClass("h-[4px]");
-    expect(handle).toHaveClass("w-full");
+    expect(handle).toHaveClass("w-[44px]");
+    expect(handle).not.toHaveClass("w-full");
   });
 });
 
@@ -1204,11 +1208,11 @@ describe("Slider — motion and animation", () => {
     mockUseReducedMotion.mockReturnValue(false);
   });
 
-  // 109. active track has transition-[flex-basis] class
-  test("active track has transition-[flex-basis] class", () => {
+  // 109. active track has transition-[left,width,right] class (horizontal spring)
+  test("active track has transition-[left,width,right] class", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} />);
     const activeTrack = container.querySelector('[data-slot="active-track"]');
-    expect(activeTrack).toHaveClass("transition-[flex-basis]");
+    expect(activeTrack).toHaveClass("transition-[left,width,right]");
   });
 
   // 110. active track has duration-spring-standard-fast-spatial class
@@ -1260,11 +1264,11 @@ describe("Slider — motion and animation", () => {
     expect(stateLayer).toHaveClass("duration-spring-standard-fast-effects");
   });
 
-  // 117. value indicator has transition-[transform,opacity] class
-  test("value indicator has transition-[transform,opacity] class", () => {
+  // 117. value indicator has transition-[scale,opacity] class (Tailwind v4: scale is its own property)
+  test("value indicator has transition-[scale,opacity] class", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
     const tooltip = container.querySelector('[role="tooltip"]');
-    expect(tooltip).toHaveClass("transition-[transform,opacity]");
+    expect(tooltip).toHaveClass("transition-[scale,opacity]");
   });
 
   // 118. value indicator has duration-spring-standard-fast-spatial class (spatial spring)
@@ -1302,7 +1306,7 @@ describe("Slider — motion and animation", () => {
     mockUseReducedMotion.mockReturnValue(true);
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
     const tooltip = container.querySelector('[role="tooltip"]');
-    expect(tooltip).not.toHaveClass("transition-[transform,opacity]");
+    expect(tooltip).not.toHaveClass("transition-[scale,opacity]");
   });
 
   // 123. drag state: active track suppresses spring transition
@@ -1577,5 +1581,99 @@ describe("Slider — stories", () => {
     const input = container.querySelector('input[type="range"]');
     expect(group).toHaveAttribute("data-disabled");
     expect(input).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slider — regression tests (absolute track layout)
+// ---------------------------------------------------------------------------
+
+describe("Slider — absolute track layout regression", () => {
+  // R1. Vertical at value=0: active track is absolute, has no flex-1
+  test("vertical value=0: active track is absolute and has no flex-1", () => {
+    const { container } = render(<Slider label="Vol" orientation="vertical" defaultValue={[0]} />);
+    const activeTrack = container.querySelector('[data-slot="active-track"]');
+    expect(activeTrack).toHaveClass("absolute");
+    expect(activeTrack).not.toHaveClass("flex-1");
+  });
+
+  // R2. Range at defaultValue=[0, 50]: renders all three segments without throwing
+  test("range at [0, 50] renders all three track segments", () => {
+    const { container } = render(<Slider variant="range" label="Range" defaultValue={[0, 50]} />);
+    expect(container.querySelector('[data-slot="inactive-track-left"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="active-track"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="inactive-track-right"]')).toBeInTheDocument();
+  });
+
+  // R3. Range at defaultValue=[50, 100]: renders all three segments without throwing
+  test("range at [50, 100] renders all three track segments", () => {
+    const { container } = render(<Slider variant="range" label="Range" defaultValue={[50, 100]} />);
+    expect(container.querySelector('[data-slot="inactive-track-left"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="active-track"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="inactive-track-right"]')).toBeInTheDocument();
+  });
+
+  // R4. Active track is absolute (not flex-shrink-0 / flex-1)
+  test("horizontal active track is absolute", () => {
+    const { container } = render(<Slider label="Vol" defaultValue={[50]} />);
+    const activeTrack = container.querySelector('[data-slot="active-track"]');
+    expect(activeTrack).toHaveClass("absolute");
+    expect(activeTrack).not.toHaveClass("flex-shrink-0");
+    expect(activeTrack).not.toHaveClass("flex-1");
+  });
+
+  // R5. Inactive track is absolute (not flex-1)
+  test("horizontal inactive track is absolute", () => {
+    const { container } = render(<Slider label="Vol" defaultValue={[50]} />);
+    const inactiveTrack = container.querySelector('[data-slot="inactive-track"]');
+    expect(inactiveTrack).toHaveClass("absolute");
+    expect(inactiveTrack).not.toHaveClass("flex-1");
+  });
+
+  // R6. Vertical track region uses flex-1 (not h-full) so it fills the flex container
+  test("vertical track region has flex-1 and not h-full", () => {
+    const { container } = render(<Slider label="Vol" orientation="vertical" defaultValue={[50]} />);
+    const track = container.querySelector("[data-track]");
+    expect(track).toHaveClass("flex-1");
+    expect(track).not.toHaveClass("h-full");
+  });
+
+  // R7. Vertical handle width scales per size (medium = 52px, xlarge = 108px)
+  test("vertical handle width is w-[52px] for medium size", () => {
+    const { container } = render(
+      <Slider label="Vol" orientation="vertical" size="medium" defaultValue={[50]} />
+    );
+    const handle = container.querySelector('[data-slot="handle"]');
+    expect(handle).toHaveClass("w-[52px]");
+    expect(handle).not.toHaveClass("w-full");
+  });
+
+  test("vertical handle width is w-[108px] for xlarge size", () => {
+    const { container } = render(
+      <Slider label="Vol" orientation="vertical" size="xlarge" defaultValue={[50]} />
+    );
+    const handle = container.querySelector('[data-slot="handle"]');
+    expect(handle).toHaveClass("w-[108px]");
+    expect(handle).not.toHaveClass("w-full");
+  });
+
+  // R8. Vertical centered variant renders all three track segments (active + 2 inactive)
+  test("vertical centered renders active track and two inactive segments", () => {
+    const { container } = render(
+      <Slider
+        label="Balance"
+        variant="centered"
+        orientation="vertical"
+        minValue={-50}
+        maxValue={50}
+        defaultValue={[20]}
+      />
+    );
+    const activeTrack = container.querySelector('[data-slot="active-track"]');
+    const inactiveTracks = container.querySelectorAll(
+      '[data-slot="inactive-track-left"], [data-slot="inactive-track-right"]'
+    );
+    expect(activeTrack).toBeInTheDocument();
+    expect(inactiveTracks).toHaveLength(2);
   });
 });

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -829,7 +829,7 @@ describe("Slider — styled layer", () => {
     expect(activeTrack).toHaveClass("h-[96px]");
   });
 
-  // 69. Track layout has gap-[6px] class
+  // 69. Track layout has gap-[6px] class (thumbTrackGapSize: 6dp between tracks)
   test("Slider track layout has gap-[6px] class", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} />);
     const trackLayout = container.querySelector('[data-slot="track-layout"]');
@@ -837,27 +837,27 @@ describe("Slider — styled layer", () => {
     expect(trackLayout).toHaveClass("gap-[6px]");
   });
 
-  // 70. Disabled: active track has bg-on-surface and opacity-38
-  test("Slider disabled: active track has bg-on-surface and opacity-38", () => {
+  // 70. Disabled: active track has group-data-driven disabled classes
+  test("Slider disabled: active track has group-data disabled classes", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} isDisabled />);
     const activeTrack = container.querySelector('[data-slot="active-track"]');
-    expect(activeTrack).toHaveClass("bg-on-surface");
-    expect(activeTrack).toHaveClass("opacity-38");
+    expect(activeTrack).toHaveClass("group-data-[disabled]/slider:bg-on-surface");
+    expect(activeTrack).toHaveClass("group-data-[disabled]/slider:opacity-38");
   });
 
-  // 71. Disabled: inactive track has bg-on-surface/10
-  test("Slider disabled: inactive track has bg-on-surface/10", () => {
+  // 71. Disabled: inactive track has group-data-driven disabled class
+  test("Slider disabled: inactive track has group-data disabled class", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} isDisabled />);
     const inactiveTrack = container.querySelector('[data-slot="inactive-track"]');
-    expect(inactiveTrack).toHaveClass("bg-on-surface/10");
+    expect(inactiveTrack).toHaveClass("group-data-[disabled]/slider:bg-on-surface/10");
   });
 
-  // 72. Disabled: handle has bg-on-surface and opacity-38
-  test("Slider disabled: handle has bg-on-surface and opacity-38", () => {
+  // 72. Disabled: handle has group-data-driven disabled classes
+  test("Slider disabled: handle has group-data disabled classes", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} isDisabled />);
     const handle = container.querySelector('[data-slot="handle"]');
-    expect(handle).toHaveClass("bg-on-surface");
-    expect(handle).toHaveClass("opacity-38");
+    expect(handle).toHaveClass("group-data-[disabled]/slider-thumb:bg-on-surface");
+    expect(handle).toHaveClass("group-data-[disabled]/slider-thumb:opacity-38");
   });
 
   // 73. index.ts exports Slider, SliderHeadless, and all variants
@@ -947,21 +947,24 @@ describe("Slider — stop indicators and value indicator", () => {
     expect(tooltip).not.toBeInTheDocument();
   });
 
-  // 82. value indicator appears when thumb is pressed and showValueIndicator is true
-  test("value indicator appears when thumb is pressed and showValueIndicator is true", () => {
+  // 82. value indicator: pressing slider-thumb sets data-pressed attribute
+  // (CSS group-data-[pressed]/slider-thumb selector then reveals the indicator)
+  test("value indicator: pressing slider-thumb sets data-pressed when showValueIndicator is true", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
+    const thumbEl = container.querySelector('[data-slot="slider-thumb"]')!;
+    expect(thumbEl).toBeInTheDocument();
+    (thumbEl as HTMLElement).setPointerCapture = vi.fn();
+    (thumbEl as HTMLElement).releasePointerCapture = vi.fn();
+    fireEvent.pointerDown(thumbEl, { pointerId: 1, isPrimary: true, button: 0, buttons: 1 });
+    expect(thumbEl).toHaveAttribute("data-pressed");
+    // Indicator is always in DOM when showValueIndicator=true
     const tooltip = container.querySelector('[role="tooltip"]');
-    expect(tooltip).not.toHaveClass("opacity-0");
-    expect(tooltip).not.toHaveClass("scale-0");
+    expect(tooltip).toBeInTheDocument();
   });
 
   // 83. value indicator has bg-inverse-surface class
   test("value indicator has bg-inverse-surface class", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
     const tooltip = container.querySelector('[role="tooltip"]');
     expect(tooltip).toHaveClass("bg-inverse-surface");
   });
@@ -969,8 +972,6 @@ describe("Slider — stop indicators and value indicator", () => {
   // 84. value indicator has rounded-full class (pill shape)
   test("value indicator has rounded-full class (pill shape)", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
     const tooltip = container.querySelector('[role="tooltip"]');
     expect(tooltip).toHaveClass("rounded-full");
   });
@@ -978,8 +979,6 @@ describe("Slider — stop indicators and value indicator", () => {
   // 85. value indicator text has text-inverse-on-surface class
   test("value indicator text has text-inverse-on-surface class", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
     const textSpan = container.querySelector('[role="tooltip"] span');
     expect(textSpan).toHaveClass("text-inverse-on-surface");
   });
@@ -987,8 +986,6 @@ describe("Slider — stop indicators and value indicator", () => {
   // 86. value indicator text has text-label-large class
   test("value indicator text has text-label-large class", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
     const textSpan = container.querySelector('[role="tooltip"] span');
     expect(textSpan).toHaveClass("text-label-large");
   });
@@ -998,8 +995,6 @@ describe("Slider — stop indicators and value indicator", () => {
     const { container } = render(
       <Slider label="Vol" showValueIndicator formatValue={(v) => `$${v}`} defaultValue={[50]} />
     );
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
     const tooltip = container.querySelector('[role="tooltip"]');
     expect(tooltip).toHaveTextContent("$50");
   });
@@ -1007,8 +1002,6 @@ describe("Slider — stop indicators and value indicator", () => {
   // 88. value indicator has min-w-[48px] class
   test("value indicator has min-w-[48px] class", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
     const tooltip = container.querySelector('[role="tooltip"]');
     expect(tooltip).toHaveClass("min-w-[48px]");
   });
@@ -1239,18 +1232,18 @@ describe("Slider — motion and animation", () => {
     expect(handle).toHaveClass("transition-[width]");
   });
 
-  // 113. handle has duration-short2 class
-  test("handle has duration-short2 class", () => {
+  // 113. handle has duration-spring-standard-fast-spatial class (MD3 spring system)
+  test("handle has duration-spring-standard-fast-spatial class", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} />);
     const handle = container.querySelector('[data-slot="handle"]');
-    expect(handle).toHaveClass("duration-short2");
+    expect(handle).toHaveClass("duration-spring-standard-fast-spatial");
   });
 
-  // 114. handle has ease-standard class for width transition
-  test("handle has ease-standard class for width transition", () => {
+  // 114. handle has ease-spring-standard-fast-spatial class (MD3 spring system)
+  test("handle has ease-spring-standard-fast-spatial class for width transition", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} />);
     const handle = container.querySelector('[data-slot="handle"]');
-    expect(handle).toHaveClass("ease-standard");
+    expect(handle).toHaveClass("ease-spring-standard-fast-spatial");
   });
 
   // 115. state layer has transition-opacity class
@@ -1260,11 +1253,11 @@ describe("Slider — motion and animation", () => {
     expect(stateLayer).toHaveClass("transition-opacity");
   });
 
-  // 116. state layer has duration-short1 class
-  test("state layer has duration-short1 class", () => {
+  // 116. state layer has duration-spring-standard-fast-effects class (MD3 spring effects)
+  test("state layer has duration-spring-standard-fast-effects class", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} />);
     const stateLayer = container.querySelector('[data-slot="state-layer"]');
-    expect(stateLayer).toHaveClass("duration-short1");
+    expect(stateLayer).toHaveClass("duration-spring-standard-fast-effects");
   });
 
   // 117. value indicator has transition-[transform,opacity] class
@@ -1274,25 +1267,18 @@ describe("Slider — motion and animation", () => {
     expect(tooltip).toHaveClass("transition-[transform,opacity]");
   });
 
-  // 118. value indicator entry: has duration-short3 and ease-standard-decelerate
-  test("value indicator entry: has duration-short3 and ease-standard-decelerate", () => {
+  // 118. value indicator has duration-spring-standard-fast-spatial class (spatial spring)
+  test("value indicator has duration-spring-standard-fast-spatial class", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
     const tooltip = container.querySelector('[role="tooltip"]');
-    expect(tooltip).toHaveClass("duration-short3");
-    expect(tooltip).toHaveClass("ease-standard-decelerate");
+    expect(tooltip).toHaveClass("duration-spring-standard-fast-spatial");
   });
 
-  // 119. value indicator exit: has duration-short2 and ease-standard-accelerate
-  test("value indicator exit: has duration-short2 and ease-standard-accelerate", () => {
+  // 119. value indicator has ease-spring-standard-fast-spatial class (spatial spring)
+  test("value indicator has ease-spring-standard-fast-spatial class", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
-    fireEvent.pointerUp(handle);
     const tooltip = container.querySelector('[role="tooltip"]');
-    expect(tooltip).toHaveClass("duration-short2");
-    expect(tooltip).toHaveClass("ease-standard-accelerate");
+    expect(tooltip).toHaveClass("ease-spring-standard-fast-spatial");
   });
 
   // 120. reduced motion: no transition classes on active track
@@ -1311,21 +1297,22 @@ describe("Slider — motion and animation", () => {
     expect(handle).not.toHaveClass("transition-[width]");
   });
 
-  // 122. reduced motion: value indicator appears instantly (no scale transition)
-  test("reduced motion: value indicator appears instantly (no scale transition)", () => {
+  // 122. reduced motion: value indicator has no transition class (appears instantly)
+  test("reduced motion: value indicator has no transition class", () => {
     mockUseReducedMotion.mockReturnValue(true);
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
     const tooltip = container.querySelector('[role="tooltip"]');
     expect(tooltip).not.toHaveClass("transition-[transform,opacity]");
   });
 
-  // 123. drag state: active track suppresses transition (transition-none)
+  // 123. drag state: active track suppresses spring transition
+  // Triggered by pressing the slider-thumb (the RA-positioned interactive element)
   test("drag state: active track suppresses spring transition", () => {
     const { container } = render(<Slider label="Vol" defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
+    const thumbEl = container.querySelector('[data-slot="slider-thumb"]')!;
+    (thumbEl as HTMLElement).setPointerCapture = vi.fn();
+    (thumbEl as HTMLElement).releasePointerCapture = vi.fn();
+    fireEvent.pointerDown(thumbEl, { pointerId: 1, isPrimary: true, button: 0, buttons: 1 });
     const activeTrack = container.querySelector('[data-slot="active-track"]');
     expect(activeTrack).not.toHaveClass("transition-[flex-basis]");
   });
@@ -1502,11 +1489,11 @@ describe("Slider — accessibility", () => {
   // 138. value indicator is not announced to screen reader
   test("value indicator is not announced to screen reader", () => {
     const { container } = render(<Slider label="Vol" showValueIndicator defaultValue={[50]} />);
-    const handle = container.querySelector('[data-slot="handle"]')!;
-    fireEvent.pointerDown(handle);
+    // Indicator is always in DOM when showValueIndicator=true (CSS-driven visibility)
     const indicator = container.querySelector('[data-slot="value-indicator"]');
     expect(indicator).not.toBeNull();
-    // role="tooltip" is a non-live landmark — not a live region; or aria-hidden when collapsed
+    // role="tooltip" is a non-live landmark; aria-hidden="true" permanently since
+    // accessible value is in the <output> element managed by React Aria
     const hasTooltipRole = indicator?.getAttribute("role") === "tooltip";
     const isAriaHidden = indicator?.getAttribute("aria-hidden") === "true";
     expect(hasTooltipRole || isAriaHidden).toBe(true);

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -9,6 +9,7 @@ import { SliderStops } from "./SliderStops";
 import { SliderValueIndicator } from "./SliderValueIndicator";
 import {
   sliderContainerVariants,
+  sliderTrackRegionVariants,
   sliderActiveTrackVariants,
   sliderInactiveTrackVariants,
   sliderHandleVariants,
@@ -32,6 +33,46 @@ function resolveDefaultValue(
   if (variant === "range") return [25, 75];
   if (variant === "centered") return [0];
   return [minValue];
+}
+
+/**
+ * MD3 thumb-track gap: 6dp total, split symmetrically as 3px per side.
+ * Applied as an offset from the thumb's percentage position.
+ */
+const GAP_PX = 3;
+
+/**
+ * Build inline CSS position styles for an absolutely-positioned track segment.
+ *
+ * All segments share the same `position: absolute` coordinate space as the
+ * React Aria thumbs (`left: pct%` / `bottom: pct%`), so fills always align
+ * with handle positions regardless of value, variant, or orientation.
+ *
+ * Horizontal segments span along the X axis; vertical along Y (bottom = 0).
+ */
+function segmentStyle(
+  orientation: "horizontal" | "vertical",
+  opts: {
+    /** Start edge as a percentage of the track length. `null` = track start (0). */
+    start: number | null;
+    /** End edge as a percentage of the track length. `null` = track end (100). */
+    end: number | null;
+    /** Px offset added to the start edge (gap inset from a thumb). */
+    startGap?: number;
+    /** Px offset subtracted from the end edge (gap inset from a thumb). */
+    endGap?: number;
+  }
+): React.CSSProperties {
+  const { start, end, startGap = 0, endGap = 0 } = opts;
+
+  const startVal = start !== null ? `calc(${start}% + ${startGap}px)` : `${startGap}px`;
+  const endVal = end !== null ? `calc(${100 - end}% + ${endGap}px)` : `${endGap}px`;
+
+  if (orientation === "horizontal") {
+    return { left: startVal, right: endVal };
+  }
+  // Vertical: start = bottom edge, end = top edge (fills upward from 0)
+  return { bottom: startVal, top: endVal };
 }
 
 // ─── Slider ───────────────────────────────────────────────────────────────────
@@ -129,12 +170,16 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
 
     // ── Motion classes ─────────────────────────────────────────────────────────
 
-    // MD3 spring system: Track fill — spring-standard-fast-spatial.
+    // MD3 spring system: Track segment position/size — spring-standard-fast-spatial.
     // Suppressed during drag (follows pointer immediately) and reduced motion.
+    // Horizontal segments animate left+width; vertical animate top+bottom+height.
+    const springTokens = "duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial";
     const trackTransition =
       reducedMotion || anyThumbDragging
         ? ""
-        : "transition-[flex-basis] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial";
+        : orientation === "vertical"
+          ? `transition-[top,bottom,height] ${springTokens}`
+          : `transition-[left,width,right] ${springTokens}`;
 
     // MD3 spring system: Handle width change (4dp → 2dp on press) — spatial spring.
     // Suppressed for reduced motion; applied by the renderThumbContent closure.
@@ -159,6 +204,19 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
     const renderThumbContent = useCallback(
       ({ value: thumbValue }: SliderThumbRenderState): React.ReactNode => (
         <>
+          {/* Transparent hit-area enlarged beyond the 4dp visual handle so
+              dragging is comfortable. aria-hidden so it is invisible to AT. */}
+          <div
+            aria-hidden="true"
+            className={cn(
+              "absolute",
+              "left-1/2",
+              "top-1/2",
+              "-translate-x-1/2",
+              "-translate-y-1/2",
+              orientation === "vertical" ? "h-[20px] w-full" : "h-full w-[20px]"
+            )}
+          />
           {/* Visual handle — narrows from 4dp to 2dp on press via group-data */}
           <div
             data-slot="handle"
@@ -184,11 +242,11 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
 
       return (
         <>
-          {/* Active track — width/height driven by current value percentage */}
+          {/* Active track — spans from track start to 3px before the handle */}
           <div
             data-slot="active-track"
             className={cn(sliderActiveTrackVariants({ size, orientation }), trackTransition)}
-            style={{ flexBasis: `${pct}%` }}
+            style={segmentStyle(orientation, { start: null, end: pct, endGap: GAP_PX })}
           >
             {showIcon && (
               <span
@@ -199,10 +257,11 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
               </span>
             )}
           </div>
-          {/* Inactive track — fills remaining flex space */}
+          {/* Inactive track — spans from 3px after the handle to track end */}
           <div
             data-slot="inactive-track"
             className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
+            style={segmentStyle(orientation, { start: pct, startGap: GAP_PX, end: null })}
           >
             {showStops && (
               <span
@@ -222,15 +281,11 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
 
       return (
         <>
-          {/* Left inactive track */}
+          {/* Left inactive track — track start to 3px before left handle */}
           <div
             data-slot="inactive-track-left"
-            className={cn(
-              sliderInactiveTrackVariants({ size, orientation }),
-              "flex-shrink-0",
-              trackTransition
-            )}
-            style={{ flexBasis: `${leftPct}%` }}
+            className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
+            style={segmentStyle(orientation, { start: null, end: leftPct, endGap: GAP_PX })}
           >
             {showStops && (
               <span
@@ -239,20 +294,26 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
               />
             )}
           </div>
-          {/* Active track — area between the two handles */}
+          {/* Active track — 3px after left handle to 3px before right handle */}
           <div
             data-slot="active-track"
             className={cn(
               sliderActiveTrackVariants({ size, orientation }),
-              "rounded-[2px]", // Both ends near handles: 2dp (MD3 §10.2)
+              "rounded-[2px]", // Both ends near handles: 2dp inner (MD3 §10.2)
               trackTransition
             )}
-            style={{ flexBasis: `${rightPct - leftPct}%` }}
+            style={segmentStyle(orientation, {
+              start: leftPct,
+              startGap: GAP_PX,
+              end: rightPct,
+              endGap: GAP_PX,
+            })}
           />
-          {/* Right inactive track */}
+          {/* Right inactive track — 3px after right handle to track end */}
           <div
             data-slot="inactive-track-right"
             className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
+            style={segmentStyle(orientation, { start: rightPct, startGap: GAP_PX, end: null })}
           >
             {showStops && (
               <span
@@ -273,61 +334,57 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
 
       if (thumbPct >= zeroPct) {
         // Positive direction: inactive-left | active | inactive-right
-        const activePct = thumbPct - zeroPct;
         return (
           <>
+            {/* Left inactive — track start to zero point (no gap at center) */}
             <div
               data-slot="inactive-track-left"
-              className={cn(
-                sliderInactiveTrackVariants({ size, orientation }),
-                "flex-shrink-0",
-                trackTransition
-              )}
-              style={{ flexBasis: `${zeroPct}%` }}
+              className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
+              style={segmentStyle(orientation, { start: null, end: zeroPct })}
             />
+            {/* Active — zero point to 3px before handle */}
             <div
               data-slot="active-track"
-              className={cn(
-                sliderActiveTrackVariants({ size, orientation }),
-                "flex-shrink-0",
-                trackTransition
-              )}
-              style={{ flexBasis: `${activePct}%` }}
+              className={cn(sliderActiveTrackVariants({ size, orientation }), trackTransition)}
+              style={segmentStyle(orientation, {
+                start: zeroPct,
+                end: thumbPct,
+                endGap: GAP_PX,
+              })}
             />
+            {/* Right inactive — 3px after handle to track end */}
             <div
               data-slot="inactive-track-right"
               className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
-              style={{ flexBasis: `${100 - zeroPct - activePct}%` }}
+              style={segmentStyle(orientation, { start: thumbPct, startGap: GAP_PX, end: null })}
             />
           </>
         );
       } else {
         // Negative direction: inactive-left | active | inactive-right
-        const activePct = zeroPct - thumbPct;
         return (
           <>
+            {/* Left inactive — track start to 3px before handle */}
             <div
               data-slot="inactive-track-left"
-              className={cn(
-                sliderInactiveTrackVariants({ size, orientation }),
-                "flex-shrink-0",
-                trackTransition
-              )}
-              style={{ flexBasis: `${thumbPct}%` }}
+              className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
+              style={segmentStyle(orientation, { start: null, end: thumbPct, endGap: GAP_PX })}
             />
+            {/* Active — 3px after handle to zero point (no gap at center) */}
             <div
               data-slot="active-track"
-              className={cn(
-                sliderActiveTrackVariants({ size, orientation }),
-                "flex-shrink-0",
-                trackTransition
-              )}
-              style={{ flexBasis: `${activePct}%` }}
+              className={cn(sliderActiveTrackVariants({ size, orientation }), trackTransition)}
+              style={segmentStyle(orientation, {
+                start: thumbPct,
+                startGap: GAP_PX,
+                end: zeroPct,
+              })}
             />
+            {/* Right inactive — zero point to track end */}
             <div
               data-slot="inactive-track-right"
               className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
-              style={{ flexBasis: `${100 - zeroPct}%` }}
+              style={segmentStyle(orientation, { start: zeroPct, end: null })}
             />
           </>
         );
@@ -354,8 +411,9 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
         renderThumbContent={renderThumbContent}
         onThumbDraggingChange={handleThumbDraggingChange}
         className={cn(sliderContainerVariants({ size, orientation }), className)}
+        trackClassName={sliderTrackRegionVariants({ size, orientation })}
       >
-        <div data-slot="track-layout" className={cn(sliderTrackLayoutVariants({ orientation }))}>
+        <div data-slot="track-layout" className={cn(sliderTrackLayoutVariants())}>
           {isRange
             ? renderRangeTrack()
             : isCentered

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -17,7 +17,7 @@ import {
   sliderTrackStopVariants,
   sliderInsetIconVariants,
 } from "./Slider.variants";
-import type { SliderProps, SliderThumbState } from "./Slider.types";
+import type { SliderProps, SliderThumbRenderState } from "./Slider.types";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -39,15 +39,31 @@ function resolveDefaultValue(
 /**
  * Material Design 3 Slider Component (Layer 3: Styled)
  *
- * Wraps SliderHeadless with CVA styling for all five MD3 Expressive sizes.
- * Renders the visual track layout (active track → handle → inactive track) as
- * children inside the headless track element.
+ * Wraps `SliderHeadless` with CVA styling for all five MD3 Expressive sizes.
+ * Renders the visual track layout (active/inactive tracks) as children inside
+ * the headless track element. The visual handle, state layer, and value indicator
+ * are rendered as children of the React Aria thumb element via `renderThumbContent`,
+ * which positions them exactly at the value percentage.
  *
+ * **Architecture (Variants-vs-States)**
+ * - Interaction states (hover, pressed/dragging, disabled, focus) are driven by
+ *   React Aria hooks → `getInteractionDataAttributes` → `data-*` on the RA thumb
+ *   (`group/slider-thumb`) → `group-data-[x]/slider-thumb:*` CSS selectors.
+ * - No manual pointer state machine — React Aria's `isDragging`, `isHovered`,
+ *   and `isFocusVisible` are the single source of truth.
+ * - Disabled track/stop colors use `group-data-[disabled]/slider:*` selectors
+ *   from the root `group/slider` scope.
+ *
+ * **Geometry (documented inline-style exception)**
  * Track widths are driven by runtime values and use inline `flexBasis` styles —
  * a documented exception for geometry that cannot be expressed as design tokens.
  *
- * Motion: MD3 Appendix E token pairings applied; JS-driven animations are
- * guarded with `useReducedMotion()`.
+ * **Motion**
+ * - Track fill: spring-standard-fast-spatial (suppressed during drag + reduced motion)
+ * - Handle width: spring-standard-fast-spatial (suppressed for reduced motion)
+ * - State layer opacity: spring-standard-fast-effects (always present; CSS media
+ *   query handles `prefers-reduced-motion` for CSS-driven changes)
+ * - Value indicator: spring-standard-fast-spatial (suppressed for reduced motion)
  *
  * @example
  * ```tsx
@@ -102,32 +118,29 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
       [value, onChange]
     );
 
-    // Thumb interaction states — tracked for state layer opacity
-    const thumbCount = variant === "range" ? 2 : 1;
-    const [thumbStates, setThumbStates] = useState<SliderThumbState[]>(() =>
-      Array<SliderThumbState>(thumbCount).fill("enabled")
-    );
+    // Track whether any thumb is actively dragging so we can suppress the
+    // flex-basis spring transition during pointer drag (immediate feedback).
+    // Driven by onThumbDraggingChange callback from SliderHeadless.
+    const [anyThumbDragging, setAnyThumbDragging] = useState(false);
 
-    // Pointer-pressed on any thumb means the user is actively dragging.
-    // During drag: track fill suppresses transition for immediate pointer response.
-    const isDragging = thumbStates.some((s) => s === "pressed");
+    const handleThumbDraggingChange = useCallback((_index: number, isDragging: boolean) => {
+      setAnyThumbDragging(isDragging);
+    }, []);
 
-    // MD3 Appendix E: Track fill — spring-standard-fast-spatial (spatial, standard, fast).
-    // Suppressed during drag (follows pointer immediately) and when reduced motion is preferred.
+    // ── Motion classes ─────────────────────────────────────────────────────────
+
+    // MD3 spring system: Track fill — spring-standard-fast-spatial.
+    // Suppressed during drag (follows pointer immediately) and reduced motion.
     const trackTransition =
-      reducedMotion || isDragging
+      reducedMotion || anyThumbDragging
         ? ""
         : "transition-[flex-basis] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial";
 
-    // MD3 Appendix E: Handle width change — standard, fast (duration-short2 + ease-standard).
-    // Spatial property (width), guarded by reduced motion.
-    const handleMotion = reducedMotion ? "" : "transition-[width] duration-short2 ease-standard";
-
-    // MD3 Appendix E: State layer opacity — effects, standard, fast (duration-short1 + ease-standard).
-    // Effects property (opacity), guarded by reduced motion.
-    const stateLayerMotion = reducedMotion
+    // MD3 spring system: Handle width change (4dp → 2dp on press) — spatial spring.
+    // Suppressed for reduced motion; applied by the renderThumbContent closure.
+    const handleMotion = reducedMotion
       ? ""
-      : "transition-opacity duration-short1 ease-standard";
+      : "transition-[width] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial";
 
     const isRange = variant === "range";
     const isCentered = variant === "centered";
@@ -139,88 +152,57 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
       variant === "standard" &&
       (size === "medium" || size === "large" || size === "xlarge");
 
+    // ── Thumb content render prop ──────────────────────────────────────────────
+    // Renders the visual handle, state layer, and value indicator INSIDE the
+    // React Aria thumb element (absolutely positioned at the value percentage).
+    // All interaction styling is driven by group-data-[x]/slider-thumb selectors.
+    const renderThumbContent = useCallback(
+      ({ value: thumbValue }: SliderThumbRenderState): React.ReactNode => (
+        <>
+          {/* Visual handle — narrows from 4dp to 2dp on press via group-data */}
+          <div
+            data-slot="handle"
+            className={cn(sliderHandleVariants({ size, orientation }), handleMotion)}
+          />
+          {/* State layer — opacity driven by group-data hover/focus/pressed */}
+          <div data-slot="state-layer" className={cn(sliderHandleStateLayerVariants())} />
+          {/* Value indicator — always in DOM; CSS shows/hides via group-data-[pressed] */}
+          {showValueIndicator && (
+            <SliderValueIndicator
+              value={thumbValue}
+              {...(formatValue !== undefined ? { formatValue } : {})}
+            />
+          )}
+        </>
+      ),
+      [size, orientation, showValueIndicator, formatValue, handleMotion]
+    );
+
     // ── Standard track render ──────────────────────────────────────────────────
     const renderStandardTrack = (): React.JSX.Element => {
       const pct = clampPercent(currentValues[0] ?? minValue, minValue, maxValue);
-      const thumb0State: SliderThumbState = isDisabled ? "disabled" : (thumbStates[0] ?? "enabled");
 
       return (
         <>
           {/* Active track — width/height driven by current value percentage */}
           <div
             data-slot="active-track"
-            className={cn(
-              sliderActiveTrackVariants({ size, disabled: isDisabled, orientation }),
-              trackTransition
-            )}
+            className={cn(sliderActiveTrackVariants({ size, orientation }), trackTransition)}
             style={{ flexBasis: `${pct}%` }}
           >
             {showIcon && (
               <span
                 data-slot="inset-icon"
-                className={cn(
-                  sliderInsetIconVariants({
-                    size,
-                    orientation,
-                  })
-                )}
+                className={cn(sliderInsetIconVariants({ size, orientation }))}
               >
                 {icon}
               </span>
             )}
           </div>
-          {/* Visual handle — decorative; keyboard/pointer behaviour is in SliderThumbInternal.
-               stopPropagation prevents pointer events from bubbling to the React Aria track
-               which would trigger a position calculation (NaN in JSDOM / no-layout envs). */}
-          <div
-            data-slot="handle"
-            className={cn(
-              sliderHandleVariants({
-                size,
-                disabled: isDisabled,
-                pressed: thumb0State === "pressed",
-                orientation,
-              }),
-              handleMotion
-            )}
-            onPointerEnter={() => {
-              if (!isDisabled) setThumbStates(["hovered"]);
-            }}
-            onPointerLeave={() => {
-              if (!isDisabled) setThumbStates(["enabled"]);
-            }}
-            onPointerDown={(e) => {
-              e.stopPropagation();
-              if (!isDisabled) setThumbStates(["pressed"]);
-            }}
-            onPointerUp={(e) => {
-              e.stopPropagation();
-              if (!isDisabled) setThumbStates(["enabled"]);
-            }}
-          >
-            <div
-              data-slot="state-layer"
-              className={cn(
-                sliderHandleStateLayerVariants({ state: thumb0State }),
-                stateLayerMotion
-              )}
-            />
-            {showValueIndicator && (
-              <SliderValueIndicator
-                value={currentValues[0] ?? minValue}
-                isVisible={thumb0State === "pressed"}
-                {...(formatValue !== undefined ? { formatValue } : {})}
-              />
-            )}
-          </div>
           {/* Inactive track — fills remaining flex space */}
           <div
             data-slot="inactive-track"
-            className={cn(
-              sliderInactiveTrackVariants({ size, disabled: isDisabled, orientation }),
-              trackTransition
-            )}
-            style={{ flexBasis: `${100 - pct}%` }}
+            className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
           >
             {showStops && (
               <span
@@ -237,13 +219,6 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
     const renderRangeTrack = (): React.JSX.Element => {
       const leftPct = clampPercent(currentValues[0] ?? minValue, minValue, maxValue);
       const rightPct = clampPercent(currentValues[1] ?? maxValue, minValue, maxValue);
-      const thumb0State: SliderThumbState = isDisabled ? "disabled" : (thumbStates[0] ?? "enabled");
-      const thumb1State: SliderThumbState = isDisabled ? "disabled" : (thumbStates[1] ?? "enabled");
-
-      const setThumb0 = (next: SliderThumbState): void =>
-        setThumbStates((s) => [next, s[1] ?? "enabled"] as SliderThumbState[]);
-      const setThumb1 = (next: SliderThumbState): void =>
-        setThumbStates((s) => [s[0] ?? "enabled", next] as SliderThumbState[]);
 
       return (
         <>
@@ -251,7 +226,8 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
           <div
             data-slot="inactive-track-left"
             className={cn(
-              sliderInactiveTrackVariants({ size, disabled: isDisabled, orientation }),
+              sliderInactiveTrackVariants({ size, orientation }),
+              "flex-shrink-0",
               trackTransition
             )}
             style={{ flexBasis: `${leftPct}%` }}
@@ -263,110 +239,20 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
               />
             )}
           </div>
-          {/* Left handle */}
-          <div
-            data-slot="handle"
-            data-index="0"
-            className={cn(
-              sliderHandleVariants({
-                size,
-                disabled: isDisabled,
-                pressed: thumb0State === "pressed",
-                orientation,
-              }),
-              handleMotion
-            )}
-            onPointerEnter={() => {
-              if (!isDisabled) setThumb0("hovered");
-            }}
-            onPointerLeave={() => {
-              if (!isDisabled) setThumb0("enabled");
-            }}
-            onPointerDown={(e) => {
-              e.stopPropagation();
-              if (!isDisabled) setThumb0("pressed");
-            }}
-            onPointerUp={(e) => {
-              e.stopPropagation();
-              if (!isDisabled) setThumb0("enabled");
-            }}
-          >
-            <div
-              data-slot="state-layer"
-              className={cn(
-                sliderHandleStateLayerVariants({ state: thumb0State }),
-                stateLayerMotion
-              )}
-            />
-            {showValueIndicator && (
-              <SliderValueIndicator
-                value={currentValues[0] ?? minValue}
-                isVisible={thumb0State === "pressed"}
-                {...(formatValue !== undefined ? { formatValue } : {})}
-              />
-            )}
-          </div>
           {/* Active track — area between the two handles */}
           <div
             data-slot="active-track"
             className={cn(
-              sliderActiveTrackVariants({ size, disabled: isDisabled, orientation }),
+              sliderActiveTrackVariants({ size, orientation }),
               "rounded-[2px]", // Both ends near handles: 2dp (MD3 §10.2)
               trackTransition
             )}
             style={{ flexBasis: `${rightPct - leftPct}%` }}
           />
-          {/* Right handle */}
-          <div
-            data-slot="handle"
-            data-index="1"
-            className={cn(
-              sliderHandleVariants({
-                size,
-                disabled: isDisabled,
-                pressed: thumb1State === "pressed",
-                orientation,
-              }),
-              handleMotion
-            )}
-            onPointerEnter={() => {
-              if (!isDisabled) setThumb1("hovered");
-            }}
-            onPointerLeave={() => {
-              if (!isDisabled) setThumb1("enabled");
-            }}
-            onPointerDown={(e) => {
-              e.stopPropagation();
-              if (!isDisabled) setThumb1("pressed");
-            }}
-            onPointerUp={(e) => {
-              e.stopPropagation();
-              if (!isDisabled) setThumb1("enabled");
-            }}
-          >
-            <div
-              data-slot="state-layer"
-              className={cn(
-                sliderHandleStateLayerVariants({ state: thumb1State }),
-                stateLayerMotion
-              )}
-            />
-            {showValueIndicator && (
-              <SliderValueIndicator
-                value={currentValues[1] ?? maxValue}
-                isVisible={thumb1State === "pressed"}
-                {...(formatValue !== undefined ? { formatValue } : {})}
-              />
-            )}
-          </div>
           {/* Right inactive track */}
           <div
             data-slot="inactive-track-right"
-            className={cn(
-              sliderInactiveTrackVariants({ size, disabled: isDisabled, orientation }),
-              trackTransition
-            )}
-            style={{ flexBasis: `${100 - rightPct}%` }}
+            className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
           >
             {showStops && (
               <span
@@ -385,90 +271,46 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
       const zeroPct =
         minValue >= 0 ? 0 : maxValue <= 0 ? 100 : ((0 - minValue) / (maxValue - minValue)) * 100;
 
-      const thumb0State: SliderThumbState = isDisabled ? "disabled" : (thumbStates[0] ?? "enabled");
-
-      const handleEl = (
-        <div
-          data-slot="handle"
-          className={cn(
-            sliderHandleVariants({
-              size,
-              disabled: isDisabled,
-              pressed: thumb0State === "pressed",
-              orientation,
-            }),
-            handleMotion
-          )}
-          onPointerEnter={() => {
-            if (!isDisabled) setThumbStates(["hovered"]);
-          }}
-          onPointerLeave={() => {
-            if (!isDisabled) setThumbStates(["enabled"]);
-          }}
-          onPointerDown={(e) => {
-            e.stopPropagation();
-            if (!isDisabled) setThumbStates(["pressed"]);
-          }}
-          onPointerUp={(e) => {
-            e.stopPropagation();
-            if (!isDisabled) setThumbStates(["enabled"]);
-          }}
-        >
-          <div
-            data-slot="state-layer"
-            className={cn(sliderHandleStateLayerVariants({ state: thumb0State }), stateLayerMotion)}
-          />
-          {showValueIndicator && (
-            <SliderValueIndicator
-              value={currentValues[0] ?? minValue}
-              isVisible={thumb0State === "pressed"}
-              {...(formatValue !== undefined ? { formatValue } : {})}
-            />
-          )}
-        </div>
-      );
-
       if (thumbPct >= zeroPct) {
-        // Positive direction: inactive-left | handle | active | inactive-right
+        // Positive direction: inactive-left | active | inactive-right
         const activePct = thumbPct - zeroPct;
         return (
           <>
             <div
               data-slot="inactive-track-left"
               className={cn(
-                sliderInactiveTrackVariants({ size, disabled: isDisabled, orientation }),
+                sliderInactiveTrackVariants({ size, orientation }),
+                "flex-shrink-0",
                 trackTransition
               )}
               style={{ flexBasis: `${zeroPct}%` }}
             />
-            {handleEl}
             <div
               data-slot="active-track"
               className={cn(
-                sliderActiveTrackVariants({ size, disabled: isDisabled, orientation }),
+                sliderActiveTrackVariants({ size, orientation }),
+                "flex-shrink-0",
                 trackTransition
               )}
               style={{ flexBasis: `${activePct}%` }}
             />
             <div
               data-slot="inactive-track-right"
-              className={cn(
-                sliderInactiveTrackVariants({ size, disabled: isDisabled, orientation }),
-                trackTransition
-              )}
+              className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
               style={{ flexBasis: `${100 - zeroPct - activePct}%` }}
             />
           </>
         );
       } else {
-        // Negative direction: inactive-left | active | handle | inactive-right
+        // Negative direction: inactive-left | active | inactive-right
         const activePct = zeroPct - thumbPct;
         return (
           <>
             <div
               data-slot="inactive-track-left"
               className={cn(
-                sliderInactiveTrackVariants({ size, disabled: isDisabled, orientation }),
+                sliderInactiveTrackVariants({ size, orientation }),
+                "flex-shrink-0",
                 trackTransition
               )}
               style={{ flexBasis: `${thumbPct}%` }}
@@ -476,18 +318,15 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
             <div
               data-slot="active-track"
               className={cn(
-                sliderActiveTrackVariants({ size, disabled: isDisabled, orientation }),
+                sliderActiveTrackVariants({ size, orientation }),
+                "flex-shrink-0",
                 trackTransition
               )}
               style={{ flexBasis: `${activePct}%` }}
             />
-            {handleEl}
             <div
               data-slot="inactive-track-right"
-              className={cn(
-                sliderInactiveTrackVariants({ size, disabled: isDisabled, orientation }),
-                trackTransition
-              )}
+              className={cn(sliderInactiveTrackVariants({ size, orientation }), trackTransition)}
               style={{ flexBasis: `${100 - zeroPct}%` }}
             />
           </>
@@ -512,10 +351,9 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
         {...(value !== undefined ? { value } : {})}
         {...(defaultValue !== undefined ? { defaultValue } : {})}
         {...(onChangeEnd !== undefined ? { onChangeEnd } : {})}
-        className={cn(
-          sliderContainerVariants({ size, disabled: isDisabled, orientation }),
-          className
-        )}
+        renderThumbContent={renderThumbContent}
+        onThumbDraggingChange={handleThumbDraggingChange}
+        className={cn(sliderContainerVariants({ size, orientation }), className)}
       >
         <div data-slot="track-layout" className={cn(sliderTrackLayoutVariants({ orientation }))}>
           {isRange
@@ -530,7 +368,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
               step={step}
               values={currentValues}
               variant={variant}
-              isDisabled={isDisabled}
+              size={size}
             />
           )}
         </div>

--- a/packages/react/src/components/Slider/Slider.types.ts
+++ b/packages/react/src/components/Slider/Slider.types.ts
@@ -205,6 +205,14 @@ export interface SliderHeadlessProps {
   children?: React.ReactNode;
 
   /**
+   * CSS classes applied to the `data-track` region element.
+   * The styled layer uses this to carry the size-based height/width and
+   * `touch-none` on the element React Aria measures for pointer math.
+   * When omitted, the track region defaults to `relative w-full`.
+   */
+  trackClassName?: string;
+
+  /**
    * Render prop called for each thumb to produce visual thumb content
    * (handle, state layer, value indicator). Receives the thumb's current
    * render state. When provided, visual content is rendered inside the

--- a/packages/react/src/components/Slider/Slider.types.ts
+++ b/packages/react/src/components/Slider/Slider.types.ts
@@ -56,6 +56,29 @@ export type SliderOrientation = "horizontal" | "vertical";
  */
 export type SliderRangeThumbLabels = [string, string];
 
+// ─── SliderThumbRenderState ───────────────────────────────────────────────────
+
+/**
+ * Render state provided to `renderThumbContent` for each thumb slot.
+ *
+ * The styled layer (`Slider`) uses this to render the visual handle,
+ * state layer, and value indicator inside the React Aria thumb element.
+ */
+export interface SliderThumbRenderState {
+  /** Zero-based index of this thumb (0 for single-thumb, 0 or 1 for range). */
+  index: number;
+  /** Current numeric value of this thumb (from React Stately state). */
+  value: number;
+  /** Whether this thumb is currently being dragged (pointer down). */
+  isDragging: boolean;
+  /** Whether keyboard focus ring is visible on this thumb. */
+  isFocusVisible: boolean;
+  /** Whether pointer is hovering over this thumb. */
+  isHovered: boolean;
+  /** Whether the slider is disabled. */
+  isDisabled: boolean;
+}
+
 // ─── SliderHeadlessProps ──────────────────────────────────────────────────────
 
 /**
@@ -176,10 +199,28 @@ export interface SliderHeadlessProps {
   isDisabled?: boolean;
 
   /**
-   * Content (children) rendered inside the slider container.
-   * Used by the styled layer to inject track, handle, stops, etc.
+   * Content (children) rendered inside the slider track element.
+   * Used by the styled layer to inject track layout.
    */
   children?: React.ReactNode;
+
+  /**
+   * Render prop called for each thumb to produce visual thumb content
+   * (handle, state layer, value indicator). Receives the thumb's current
+   * render state. When provided, visual content is rendered inside the
+   * React Aria thumb element (which is absolutely positioned at the value %).
+   *
+   * Used by the styled `Slider` layer; advanced users of `SliderHeadless`
+   * may supply custom thumb visuals.
+   */
+  renderThumbContent?: (state: SliderThumbRenderState) => React.ReactNode;
+
+  /**
+   * Called when any thumb's dragging state changes.
+   * Receives the thumb index and a boolean indicating whether it is dragging.
+   * Used by the styled layer to suppress track animation during pointer drag.
+   */
+  onThumbDraggingChange?: (index: number, isDragging: boolean) => void;
 
   /**
    * Additional CSS classes applied to the slider root element.
@@ -286,7 +327,10 @@ export interface SliderThumbProps {
  * />
  * ```
  */
-export interface SliderProps extends Omit<SliderHeadlessProps, "children"> {
+export interface SliderProps extends Omit<
+  SliderHeadlessProps,
+  "children" | "renderThumbContent" | "onThumbDraggingChange"
+> {
   /**
    * MD3 Expressive size preset.
    * Controls track height, handle height, corner radius, and icon size.
@@ -320,11 +364,15 @@ export interface SliderProps extends Omit<SliderHeadlessProps, "children"> {
   className?: string;
 }
 
-// ─── Internal State Types ─────────────────────────────────────────────────────
+// ─── Internal State Types (kept for public API compatibility) ─────────────────
 
 /**
  * Interactive state of a slider thumb.
- * Used internally by the styled layer for state-dependent styling.
+ *
+ * @deprecated The styled Slider now drives interaction states via React Aria
+ *   hooks + `data-*` attributes (group-data-[x]/slider-thumb selectors) instead
+ *   of a manual state machine. This type is retained only for backwards
+ *   compatibility with existing usages of `SliderHeadlessProps`.
  *
  * @internal
  */
@@ -332,6 +380,10 @@ export type SliderThumbState = "enabled" | "hovered" | "pressed" | "disabled";
 
 /**
  * Render state passed to internal sub-components for conditional styling.
+ *
+ * @deprecated The styled Slider now uses `SliderThumbRenderState` (per-thumb
+ *   render state) provided by the `renderThumbContent` render prop. This type
+ *   is retained only for backwards compatibility.
  *
  * @internal
  */

--- a/packages/react/src/components/Slider/Slider.variants.ts
+++ b/packages/react/src/components/Slider/Slider.variants.ts
@@ -1,312 +1,78 @@
-import { cva, type VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
+
+// ─── Container ────────────────────────────────────────────────────────────────
 
 /**
- * CVA variants for the Slider container (root element — the `role="group"` div).
+ * Slider root container variants.
  *
- * MD3 spec §4.2: Container height equals handle height for each size.
- * MD3 spec §4.1, §10.9: In vertical orientation, container width = handle height (dimensions transposed).
- * Applied via className on SliderHeadless so the groupProps div receives these classes.
+ * The root element carries:
+ * - `group/slider` — scope for track/stop disabled-state selectors
+ *   (`group-data-[disabled]/slider:*`)
  */
 export const sliderContainerVariants = cva(
-  [
-    "relative",
-    "flex",
-    "items-center",
-    "w-full",
-    "touch-none", // NOTE: measurement-derived value from MD3 spec; permitted exception — prevents browser scroll on drag
-    "select-none",
-  ],
+  ["group/slider", "flex", "items-center", "w-full", "relative", "select-none"],
   {
     variants: {
+      orientation: {
+        horizontal: "flex-row",
+        vertical: "flex-col w-auto",
+      },
       size: {
-        // NOTE: measurement-derived values from MD3 spec §4.2; permitted exception
         xsmall: "h-[44px]",
         small: "h-[44px]",
         medium: "h-[52px]",
         large: "h-[68px]",
         xlarge: "h-[108px]",
       },
-      orientation: {
-        // Horizontal: w-full already in base; flex-row is default flex direction
-        horizontal: "",
-        // Vertical: transposed — container height fills parent, width = handle height (per size)
-        // flex-col stacks label → track → output vertically
-        // NOTE: h-full requires a parent with defined height; w-[...] set via compound variants
-        vertical: "h-full flex-col",
-      },
-      disabled: {
-        true: "cursor-not-allowed pointer-events-none",
-        false: "cursor-pointer",
-      },
     },
     compoundVariants: [
-      // Vertical: container WIDTH = handle height (MD3 §10.9 — dimensions transposed)
-      // Overrides w-full from base via tailwind-merge in cn()
-      // NOTE: measurement-derived values from MD3 spec §4.2; permitted exception
-      { orientation: "vertical", size: "xsmall", className: "w-[44px]" },
-      { orientation: "vertical", size: "small", className: "w-[44px]" },
-      { orientation: "vertical", size: "medium", className: "w-[52px]" },
-      { orientation: "vertical", size: "large", className: "w-[68px]" },
-      { orientation: "vertical", size: "xlarge", className: "w-[108px]" },
-    ],
-    defaultVariants: {
-      size: "xsmall",
-      orientation: "horizontal",
-      disabled: false,
-    },
-  }
-);
-
-/**
- * CVA for the active track (filled portion).
- *
- * MD3 spec §6, §8.1, §10.2: `bg-primary`, size-dependent outer corners, 2dp inner corners.
- * Inner corner (near handle) is always 2dp regardless of size.
- * MD3 spec §10.9: In vertical orientation, track thickness becomes width (not height).
- * Transition: flex-basis spatial spring (md3-motion spring-standard-fast-spatial).
- */
-export const sliderActiveTrackVariants = cva(
-  ["bg-primary", "flex-shrink-0", "overflow-hidden", "relative"],
-  {
-    variants: {
-      size: {
-        // NOTE: measurement-derived values from MD3 spec §4.2, §6 Corner tokens; permitted exception
-        // Corner classes are in compound variants to avoid conflicts with vertical orientation corners
-        xsmall: "h-[16px] rounded-l-[16px] rounded-r-[2px]", // corner.large outer (16dp), 2dp inner
-        small: "h-[16px] rounded-l-[16px] rounded-r-[2px]",
-        medium: "h-[40px] rounded-l-[12px] rounded-r-[2px]", // corner.medium outer (12dp), 2dp inner
-        large: "h-[56px] rounded-l-[16px] rounded-r-[2px]", // corner.large outer (16dp), 2dp inner
-        xlarge: "h-[96px] rounded-l-[28px] rounded-r-[2px]", // corner.extra-large outer (28dp), 2dp inner
-      },
-      orientation: {
-        horizontal: "",
-        // Vertical: track thickness is now width; flex-basis (inline style) controls height.
-        // h-[...] from size variant is overridden by flex-basis in a flex-col container.
-        // Individual corner classes (rounded-tl/tr/bl/br) override the horizontal rounded-l/r
-        // via tailwind-merge conflict resolution in cn().
-        vertical: "",
-      },
-      disabled: {
-        true: "bg-on-surface opacity-38",
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Vertical: width = track thickness, corners transposed (bottom = outer, top = inner near handle)
-      // Using individual corner utilities so tailwind-merge correctly resolves conflicts with
-      // the horizontal rounded-l/rounded-r classes from size variants.
-      // NOTE: measurement-derived values from MD3 spec §4.2, §6 Corner tokens; permitted exception
       {
         orientation: "vertical",
         size: "xsmall",
-        className: "w-[16px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[16px] rounded-br-[16px]",
+        class: "h-full w-[44px]",
       },
       {
         orientation: "vertical",
         size: "small",
-        className: "w-[16px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[16px] rounded-br-[16px]",
+        class: "h-full w-[44px]",
       },
       {
         orientation: "vertical",
         size: "medium",
-        className: "w-[40px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[12px] rounded-br-[12px]",
+        class: "h-full w-[52px]",
       },
       {
         orientation: "vertical",
         size: "large",
-        className: "w-[56px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[16px] rounded-br-[16px]",
+        class: "h-full w-[68px]",
       },
       {
         orientation: "vertical",
         size: "xlarge",
-        className: "w-[96px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[28px] rounded-br-[28px]",
+        class: "h-full w-[108px]",
       },
     ],
     defaultVariants: {
-      size: "xsmall",
       orientation: "horizontal",
-      disabled: false,
-    },
-  }
-);
-
-/**
- * CVA for the inactive track (unfilled portion).
- *
- * MD3 spec §6, §8.1, §10.2: `bg-secondary-container`, 2dp inner corners, size-dependent outer corners.
- * MD3 spec §10.9: In vertical orientation, track thickness becomes width (not height).
- * Disabled: `bg-on-surface` at 10% opacity via Tailwind alpha modifier.
- */
-export const sliderInactiveTrackVariants = cva(
-  ["bg-secondary-container", "flex-1", "overflow-hidden", "relative"],
-  {
-    variants: {
-      size: {
-        // NOTE: measurement-derived values from MD3 spec §4.2, §6 Corner tokens; permitted exception
-        xsmall: "h-[16px] rounded-l-[2px] rounded-r-[16px]",
-        small: "h-[16px] rounded-l-[2px] rounded-r-[16px]",
-        medium: "h-[40px] rounded-l-[2px] rounded-r-[12px]",
-        large: "h-[56px] rounded-l-[2px] rounded-r-[16px]",
-        xlarge: "h-[96px] rounded-l-[2px] rounded-r-[28px]",
-      },
-      orientation: {
-        horizontal: "",
-        // Vertical: track thickness is width; flex-1 controls height growth.
-        // Individual corner classes override horizontal rounded-l/r via tailwind-merge.
-        vertical: "",
-      },
-      disabled: {
-        true: "bg-on-surface/10", // MD3 §8.2: 10% opacity via background alpha
-        false: "",
-      },
-    },
-    compoundVariants: [
-      // Vertical: width = track thickness, corners transposed (top = outer, bottom = inner near handle)
-      // NOTE: measurement-derived values from MD3 spec §4.2, §6 Corner tokens; permitted exception
-      {
-        orientation: "vertical",
-        size: "xsmall",
-        className: "w-[16px] rounded-tl-[16px] rounded-tr-[16px] rounded-bl-[2px] rounded-br-[2px]",
-      },
-      {
-        orientation: "vertical",
-        size: "small",
-        className: "w-[16px] rounded-tl-[16px] rounded-tr-[16px] rounded-bl-[2px] rounded-br-[2px]",
-      },
-      {
-        orientation: "vertical",
-        size: "medium",
-        className: "w-[40px] rounded-tl-[12px] rounded-tr-[12px] rounded-bl-[2px] rounded-br-[2px]",
-      },
-      {
-        orientation: "vertical",
-        size: "large",
-        className: "w-[56px] rounded-tl-[16px] rounded-tr-[16px] rounded-bl-[2px] rounded-br-[2px]",
-      },
-      {
-        orientation: "vertical",
-        size: "xlarge",
-        className: "w-[96px] rounded-tl-[28px] rounded-tr-[28px] rounded-bl-[2px] rounded-br-[2px]",
-      },
-    ],
-    defaultVariants: {
       size: "xsmall",
-      orientation: "horizontal",
-      disabled: false,
     },
   }
 );
 
-/**
- * CVA for the handle/thumb element.
- *
- * MD3 spec §6, §9, §10.3: 4dp wide, full container height, 2dp border-radius.
- * MD3 spec §10.9: In vertical orientation, width and height are transposed —
- *   handle becomes 4dp tall (main axis) × full width (cross axis).
- * Width narrows to 2dp on press (md3 spec §9.3).
- * Motion: transition-[width] with duration-short2 + ease-standard applied conditionally
- * in Slider.tsx based on useReducedMotion() guard (MD3 Appendix E).
- */
-export const sliderHandleVariants = cva(
-  [
-    "bg-primary",
-    "rounded-[2px]", // NOTE: measurement-derived value from MD3 spec §10.3 (2dp handle border-radius); permitted exception
-    "flex-shrink-0",
-    "relative",
-    "z-10",
-    "outline-none",
-    // Motion classes applied conditionally in Slider.tsx via useReducedMotion guard
-  ],
-  {
-    variants: {
-      size: {
-        // NOTE: measurement-derived values from MD3 spec §4.2, §10.3; permitted exception
-        xsmall: "w-[4px] h-[44px]",
-        small: "w-[4px] h-[44px]",
-        medium: "w-[4px] h-[52px]",
-        large: "w-[4px] h-[68px]",
-        xlarge: "w-[4px] h-[108px]",
-      },
-      orientation: {
-        horizontal: "",
-        // Vertical: dimensions transposed. h-[4px] overrides size-variant h-[...] via tailwind-merge;
-        // w-full overrides size-variant w-[4px] via tailwind-merge (both in cn() call at styled layer).
-        // NOTE: measurement-derived value from MD3 spec §10.3 (4dp handle width); permitted exception
-        vertical: "h-[4px] w-full",
-      },
-      pressed: {
-        true: "w-[2px]", // NOTE: measurement-derived value from MD3 spec §10.3 (2dp pressed width); permitted exception
-        false: "",
-      },
-      disabled: {
-        true: "bg-on-surface opacity-38",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      size: "xsmall",
-      orientation: "horizontal",
-      pressed: false,
-      disabled: false,
-    },
-  }
-);
+// ─── Track Layout ─────────────────────────────────────────────────────────────
 
 /**
- * CVA for the handle's state layer overlay.
+ * Inner flex container that holds the active and inactive track segments.
  *
- * MD3 spec §8.3: Inset overlay within the handle.
- * - Hover: on-primary at 8% opacity
- * - Focus/Pressed: on-primary at 10% opacity
- * Motion: transition-opacity with duration-short1 + ease-standard applied conditionally
- * in Slider.tsx based on useReducedMotion() guard (MD3 Appendix E).
- */
-export const sliderHandleStateLayerVariants = cva(
-  [
-    "absolute",
-    "inset-0",
-    "rounded-[4px]", // NOTE: measurement-derived value from MD3 spec §10.3 (4dp state layer border-radius); permitted exception
-    "bg-on-primary",
-    "pointer-events-none",
-    // Motion classes applied conditionally in Slider.tsx via useReducedMotion guard
-  ],
-  {
-    variants: {
-      state: {
-        enabled: "opacity-0",
-        hovered: "opacity-8", // MD3 §8.3: 8% hover
-        pressed: "opacity-10", // MD3 §8.3: 10% pressed
-        focused: "opacity-10", // MD3 §8.3: 10% focus
-        disabled: "opacity-0",
-      },
-    },
-    defaultVariants: {
-      state: "enabled",
-    },
-  }
-);
-
-/**
- * CVA for the track layout container (holds active track + handle + inactive track).
- *
- * MD3 spec §7, §10.2: Flex row with 6dp gap between handle and track segments.
- * The 6dp gap is the `thumbTrackGapSize` token from MD3 spec.
- * MD3 spec §10.9: Vertical orientation uses flex-col-reverse for bottom-to-top fill.
- * `relative` is required so the absolute stops overlay is positioned within.
+ * The 6dp gap (MD3 `thumbTrackGapSize`) is preserved here as `gap-[6px]`
+ * between the active and inactive track flex items.
  */
 export const sliderTrackLayoutVariants = cva(
-  [
-    "relative",
-    "flex",
-    "items-center",
-    "gap-[6px]", // NOTE: measurement-derived value from MD3 spec §2, §6 (thumbTrackGapSize: 6dp); permitted exception
-  ],
+  ["relative", "flex", "items-center", "gap-[6px]", "w-full", "h-full"],
   {
     variants: {
       orientation: {
-        // Horizontal: full width, left-to-right fill
-        horizontal: "flex-row w-full",
-        // Vertical: full height, bottom-to-top fill (flex-col-reverse places active track at bottom)
+        horizontal: "flex-row",
         vertical: "flex-col-reverse h-full",
       },
     },
@@ -316,13 +82,253 @@ export const sliderTrackLayoutVariants = cva(
   }
 );
 
+// ─── Active Track ─────────────────────────────────────────────────────────────
+
 /**
- * CVA for the stops overlay container.
+ * The filled (active) portion of the slider track.
  *
- * An absolute overlay positioned within the track layout, spanning its full area.
- * Dots are distributed with justify-between.
- * Padding from track edges: 4dp.
- * MD3 spec §5.2, §10.5.
+ * **Color**: `bg-primary`
+ * **Disabled**: driven by `group-data-[disabled]/slider:*` — no CVA disabled variant.
+ * **Transition**: `flex-basis` spring (spatial) when not dragging/reduced-motion.
+ */
+export const sliderActiveTrackVariants = cva(
+  [
+    // Color
+    "bg-primary",
+    // Disabled — driven by root group/slider data-disabled attr
+    "group-data-[disabled]/slider:bg-on-surface",
+    "group-data-[disabled]/slider:opacity-38",
+    // Layout
+    "flex-shrink-0",
+    "overflow-hidden",
+    "relative",
+  ],
+  {
+    variants: {
+      size: {
+        xsmall: "h-[16px] rounded-[8px]",
+        small: "h-[16px] rounded-[8px]",
+        medium: "h-[40px] rounded-[20px]",
+        large: "h-[56px] rounded-[28px]",
+        xlarge: "h-[96px] rounded-[48px]",
+      },
+      orientation: {
+        horizontal: "",
+        vertical: "w-full flex-1",
+      },
+    },
+    defaultVariants: {
+      size: "xsmall",
+      orientation: "horizontal",
+    },
+  }
+);
+
+// ─── Inactive Track ───────────────────────────────────────────────────────────
+
+/**
+ * The unfilled (inactive) portion of the slider track.
+ *
+ * **Color**: `bg-secondary-container`
+ * **Disabled**: driven by `group-data-[disabled]/slider:*` — no CVA disabled variant.
+ */
+export const sliderInactiveTrackVariants = cva(
+  [
+    // Color
+    "bg-secondary-container",
+    // Disabled — driven by root group/slider data-disabled attr
+    "group-data-[disabled]/slider:bg-on-surface/10",
+    // Layout
+    "flex-1",
+    "overflow-hidden",
+    "relative",
+  ],
+  {
+    variants: {
+      size: {
+        xsmall: "h-[16px] rounded-[8px]",
+        small: "h-[16px] rounded-[8px]",
+        medium: "h-[40px] rounded-[20px]",
+        large: "h-[56px] rounded-[28px]",
+        xlarge: "h-[96px] rounded-[48px]",
+      },
+      orientation: {
+        horizontal: "",
+        vertical: "w-full h-auto",
+      },
+    },
+    defaultVariants: {
+      size: "xsmall",
+      orientation: "horizontal",
+    },
+  }
+);
+
+// ─── Handle ───────────────────────────────────────────────────────────────────
+
+/**
+ * Visual handle (thumb indicator) element inside the React Aria thumb container.
+ *
+ * **Architecture**: This element lives inside the `group/slider-thumb` scope (the
+ * RA-positioned thumb div). All interaction states are driven by
+ * `group-data-[x]/slider-thumb:*` selectors — no CVA interaction-state variants.
+ *
+ * **Pressed width**: `group-data-[pressed]/slider-thumb:w-[2px]` (4dp → 2dp, MD3 spec)
+ * **Motion**: `transition-[width]` with spring-standard-fast-spatial tokens.
+ *   Applied conditionally in `Slider.tsx` (suppressed for `useReducedMotion()`).
+ */
+export const sliderHandleVariants = cva(
+  [
+    // Color
+    "bg-primary",
+    // Disabled — driven by thumb group/slider-thumb data-disabled attr
+    "group-data-[disabled]/slider-thumb:bg-on-surface",
+    "group-data-[disabled]/slider-thumb:opacity-38",
+    // Pressed width (MD3: 4dp → 2dp on press, spatial spring)
+    "group-data-[pressed]/slider-thumb:w-[2px]",
+    // Shape
+    "rounded-[2px]",
+    // Layout
+    "flex-shrink-0",
+    "pointer-events-none",
+  ],
+  {
+    variants: {
+      size: {
+        xsmall: "w-[4px] h-[44px]",
+        small: "w-[4px] h-[44px]",
+        medium: "w-[4px] h-[52px]",
+        large: "w-[4px] h-[68px]",
+        xlarge: "w-[4px] h-[108px]",
+      },
+      orientation: {
+        horizontal: "",
+        vertical: "h-[4px] w-full",
+      },
+    },
+    compoundVariants: [
+      // Vertical: override to height-based narrowing
+      {
+        orientation: "vertical",
+        class: "group-data-[pressed]/slider-thumb:h-[2px]",
+      },
+    ],
+    defaultVariants: {
+      size: "xsmall",
+      orientation: "horizontal",
+    },
+  }
+);
+
+// ─── State Layer ──────────────────────────────────────────────────────────────
+
+/**
+ * State layer overlay on the handle (hover ripple).
+ *
+ * **Architecture**: Lives inside `group/slider-thumb`; opacity driven entirely
+ * by `group-data-[x]/slider-thumb:opacity-*` selectors — no CVA state variant.
+ *
+ * State-layer opacities per MD3 spec:
+ * - hover:   8%   (`opacity-8`)
+ * - focused: 10%  (`opacity-10`)
+ * - pressed: 10%  (`opacity-10`)
+ * - dragged: 16%  (`opacity-16`) — note: drag = pressed in RA isDragging → data-pressed
+ *
+ * **Motion**: `transition-opacity` with spring-standard-fast-effects tokens.
+ *   Always present; `@media prefers-reduced-motion` suppresses the transition at
+ *   the CSS level.
+ */
+export const sliderHandleStateLayerVariants = cva([
+  // Color
+  "bg-primary",
+  // Positioning — covers the handle
+  "absolute",
+  "inset-0",
+  "rounded-[2px]",
+  // Interaction: hidden by default
+  "opacity-0",
+  "pointer-events-none",
+  // State opacities — driven by group/slider-thumb data attrs
+  "group-data-[hovered]/slider-thumb:opacity-8",
+  "group-data-[focus-visible]/slider-thumb:opacity-10",
+  "group-data-[pressed]/slider-thumb:opacity-10",
+  // Disabled: hide state layer (no interaction feedback)
+  "group-data-[disabled]/slider-thumb:hidden",
+  // Motion: effects spring (opacity transition only)
+  "transition-opacity",
+  "duration-spring-standard-fast-effects",
+  "ease-spring-standard-fast-effects",
+]);
+
+// ─── Value Indicator ──────────────────────────────────────────────────────────
+
+/**
+ * Floating pill label above the handle showing the current value.
+ *
+ * **Architecture**: Always rendered in DOM when `showValueIndicator=true`.
+ * Visibility is driven by `group-data-[pressed]/slider-thumb:*` CSS selectors;
+ * hidden by default via `opacity-0 scale-0`, revealed on press.
+ *
+ * **Motion**: `transition-[transform,opacity]` with spring-standard-fast-spatial
+ *   tokens (dominant animation is scale/transform — spatial personality).
+ *   Applied conditionally in `SliderValueIndicator.tsx` (suppressed for
+ *   `useReducedMotion()`).
+ */
+export const sliderValueIndicatorVariants = cva([
+  // Positioning: float above handle center
+  "absolute",
+  "left-1/2",
+  "-translate-x-1/2",
+  "bottom-[calc(100%+4px)]",
+  // Shape & color
+  "bg-inverse-surface",
+  "rounded-full",
+  "px-[12px]",
+  "py-[6px]",
+  "min-w-[48px]",
+  "text-center",
+  // Hidden by default; revealed when thumb group has data-pressed
+  "opacity-0",
+  "scale-0",
+  "group-data-[pressed]/slider-thumb:opacity-100",
+  "group-data-[pressed]/slider-thumb:scale-100",
+  // Prevent interaction (value display only)
+  "pointer-events-none",
+  // Z-index above track overlays
+  "z-10",
+  // Will-change hint for browser compositing
+  "will-change-[transform,opacity]",
+]);
+
+// ─── Stop Dots ────────────────────────────────────────────────────────────────
+
+/**
+ * Individual stop indicator dot for discrete sliders.
+ */
+export const sliderStopDotVariants = cva(["rounded-full", "flex-shrink-0", "pointer-events-none"], {
+  variants: {
+    region: {
+      active: "bg-on-primary",
+      inactive: "bg-on-secondary-container",
+    },
+    size: {
+      xsmall: "w-[4px] h-[4px]",
+      small: "w-[4px] h-[4px]",
+      medium: "w-[6px] h-[6px]",
+      large: "w-[6px] h-[6px]",
+      xlarge: "w-[8px] h-[8px]",
+    },
+  },
+  defaultVariants: {
+    region: "inactive",
+    size: "xsmall",
+  },
+});
+
+// ─── Stops Container ──────────────────────────────────────────────────────────
+
+/**
+ * Absolute overlay container for discrete stop indicator dots.
  */
 export const sliderStopsContainerVariants = cva([
   "absolute",
@@ -330,66 +336,30 @@ export const sliderStopsContainerVariants = cva([
   "flex",
   "items-center",
   "justify-between",
-  "px-[4px]", // NOTE: measurement-derived value from MD3 spec §10.5 (stopPadding: 4dp); permitted exception
+  "px-[4px]",
   "pointer-events-none",
-  "z-0",
+  "z-10",
 ]);
 
-/**
- * CVA for individual stop indicator dots.
- *
- * MD3 spec §5.2, §10.5: 4dp circular dots, color depends on whether dot is on
- * active or inactive track.
- */
-export const sliderStopDotVariants = cva(
-  [
-    "rounded-full",
-    "flex-shrink-0",
-    "w-[4px]", // NOTE: measurement-derived value from MD3 spec §10.5 (stopIndicatorSize: 4dp); permitted exception
-    "h-[4px]",
-  ],
-  {
-    variants: {
-      /**
-       * Whether this dot is positioned on the active track portion.
-       * Determines the dot color per MD3 spec §5.2.
-       */
-      onActiveTrack: {
-        true: "bg-on-primary", // Light dots on primary background
-        false: "bg-on-secondary-container", // Dark dots on secondary-container background
-      },
-      disabled: {
-        true: "opacity-38",
-        false: "",
-      },
-    },
-    defaultVariants: {
-      onActiveTrack: false,
-      disabled: false,
-    },
-  }
-);
+// ─── Track Stop (end cap) ─────────────────────────────────────────────────────
 
 /**
- * CVA for end track stops (4dp dots at track endpoints).
- *
- * MD3 spec §10.6: positioned 4dp from track edge, vertically centered.
+ * Absolute-positioned stop indicator at the start or end of a track segment.
+ * Used for the terminal positions in range and standard sliders.
  */
 export const sliderTrackStopVariants = cva(
   [
     "absolute",
-    "top-1/2",
-    "-translate-y-1/2",
-    "w-[4px]", // NOTE: measurement-derived value from MD3 spec §10.6 (trackStopDiameter: 4dp); permitted exception
-    "h-[4px]",
     "rounded-full",
     "bg-on-secondary-container",
     "pointer-events-none",
+    "w-[4px]",
+    "h-[4px]",
   ],
   {
     variants: {
       position: {
-        start: "left-[4px]", // NOTE: measurement-derived (trackStopOffset: 4dp); permitted exception
+        start: "left-[4px]",
         end: "right-[4px]",
       },
     },
@@ -399,89 +369,34 @@ export const sliderTrackStopVariants = cva(
   }
 );
 
-/**
- * CVA for the value indicator (floating pill label above the handle).
- *
- * MD3 spec §5.3, §10.4:
- * - Shape: pill (border-radius 1000dp = rounded-full)
- * - Background: inverse-surface
- * - Min-width: 48dp
- * - Padding: 16dp horizontal, 12dp vertical
- * - Position: centered above handle via absolute + left-1/2 + -translate-x-1/2
- * - Only visible during Pressed state; hidden with opacity-0 + scale-0
- * Motion: standard fast effects (small component, utility tooltip).
- */
-export const sliderValueIndicatorVariants = cva(
-  [
-    "absolute",
-    "left-1/2",
-    "-translate-x-1/2",
-    "bottom-[calc(100%+4px)]", // NOTE: measurement-derived (4dp gap above handle); permitted exception
-    "bg-inverse-surface",
-    "rounded-full", // pill shape (1000dp radius)
-    "px-[16px]", // NOTE: measurement-derived (valueIndicatorPaddingH: 16dp); permitted exception
-    "py-[12px]", // NOTE: measurement-derived (valueIndicatorPaddingV: 12dp); permitted exception
-    "min-w-[48px]", // NOTE: measurement-derived (valueIndicatorWidth: 48dp); permitted exception
-    "flex",
-    "items-center",
-    "justify-center",
-    "pointer-events-none",
-    "z-20",
-    // Motion classes (transition-[transform,opacity] with directional easing) applied
-    // conditionally in SliderValueIndicator.tsx via useReducedMotion guard.
-  ],
-  {
-    variants: {
-      visible: {
-        true: "opacity-100 scale-100",
-        false: "opacity-0 scale-0",
-      },
-    },
-    defaultVariants: {
-      visible: false,
-    },
-  }
-);
+// ─── Value Indicator Text ─────────────────────────────────────────────────────
 
 /**
- * CVA for value indicator text content.
- *
- * MD3 spec §5.3: Label Large typography — 14px, weight 500, line-height 20px, tracking 0.1px.
- * Color: inverse-on-surface.
+ * Text span inside the value indicator pill.
  */
 export const sliderValueIndicatorTextVariants = cva([
   "text-inverse-on-surface",
-  "text-label-large", // MD3 Label Large typescale token
+  "text-label-large",
+  "select-none",
   "whitespace-nowrap",
-  "text-center",
 ]);
 
+// ─── Inset Icon ───────────────────────────────────────────────────────────────
+
 /**
- * CVA for the inset icon element rendered inside the active track.
- *
- * MD3 spec §5.1, §10.7:
- * - Only available for Medium, Large, XLarge sizes (Standard variant only)
- * - Positioned absolutely inside the active track
- * - Horizontal: 8dp from left edge, vertically centered
- * - Vertical: 8dp from bottom edge, horizontally centered
- * - Icon sizes: 24×24dp (Medium, Large), 32×32dp (XLarge)
- * - Color: on-primary (icon sits on primary-colored active track)
+ * Icon rendered inside the active track (medium/large/xlarge sizes only).
  */
 export const sliderInsetIconVariants = cva(
   ["absolute", "text-on-primary", "pointer-events-none", "flex", "items-center", "justify-center"],
   {
     variants: {
       size: {
-        // NOTE: measurement-derived values from MD3 spec §10.7 (icon sizes); permitted exception
         medium: "w-[24px] h-[24px]",
         large: "w-[24px] h-[24px]",
         xlarge: "w-[32px] h-[32px]",
       },
       orientation: {
-        // Horizontal: 8dp from active track left edge, vertically centered
-        // NOTE: measurement-derived value from MD3 spec §10.7 (iconOffset: 8dp); permitted exception
         horizontal: "left-[8px] top-1/2 -translate-y-1/2",
-        // Vertical: 8dp from active track bottom edge (outer end), horizontally centered
         vertical: "bottom-[8px] left-1/2 -translate-x-1/2",
       },
     },
@@ -491,17 +406,3 @@ export const sliderInsetIconVariants = cva(
     },
   }
 );
-
-// ─── Variant Prop Types ────────────────────────────────────────────────────────
-
-export type SliderContainerVariants = VariantProps<typeof sliderContainerVariants>;
-export type SliderActiveTrackVariants = VariantProps<typeof sliderActiveTrackVariants>;
-export type SliderInactiveTrackVariants = VariantProps<typeof sliderInactiveTrackVariants>;
-export type SliderHandleVariants = VariantProps<typeof sliderHandleVariants>;
-export type SliderHandleStateLayerVariants = VariantProps<typeof sliderHandleStateLayerVariants>;
-export type SliderTrackLayoutVariants = VariantProps<typeof sliderTrackLayoutVariants>;
-export type SliderStopsContainerVariants = VariantProps<typeof sliderStopsContainerVariants>;
-export type SliderStopDotVariants = VariantProps<typeof sliderStopDotVariants>;
-export type SliderTrackStopVariants = VariantProps<typeof sliderTrackStopVariants>;
-export type SliderValueIndicatorVariants = VariantProps<typeof sliderValueIndicatorVariants>;
-export type SliderInsetIconVariants = VariantProps<typeof sliderInsetIconVariants>;

--- a/packages/react/src/components/Slider/Slider.variants.ts
+++ b/packages/react/src/components/Slider/Slider.variants.ts
@@ -8,79 +8,121 @@ import { cva } from "class-variance-authority";
  * The root element carries:
  * - `group/slider` — scope for track/stop disabled-state selectors
  *   (`group-data-[disabled]/slider:*`)
+ *
+ * Horizontal layout: CSS grid with label (col 1) + output (col 2) in the first
+ * row, and the full-width track region spanning both columns in the second row.
+ * This matches the canonical React Aria / MD3 layout and prevents the track
+ * from collapsing when label + output are inline siblings.
+ *
+ * Vertical layout: flex-col so label is above the track.
+ * The size-based HEIGHT lives on the track region, not here (the container is
+ * auto-height in horizontal so it wraps the grid rows naturally).
  */
-export const sliderContainerVariants = cva(
-  ["group/slider", "flex", "items-center", "w-full", "relative", "select-none"],
-  {
-    variants: {
-      orientation: {
-        horizontal: "flex-row",
-        vertical: "flex-col w-auto",
-      },
-      size: {
-        xsmall: "h-[44px]",
-        small: "h-[44px]",
-        medium: "h-[52px]",
-        large: "h-[68px]",
-        xlarge: "h-[108px]",
-      },
+export const sliderContainerVariants = cva(["group/slider", "relative", "select-none"], {
+  variants: {
+    orientation: {
+      // Grid: 1fr for label, auto for output value; gap-x for label↔output spacing
+      horizontal: "grid grid-cols-[1fr_auto] items-center gap-x-2 w-full",
+      // Flex column: label → track → output stacked; width = handle height (per size)
+      vertical: "flex flex-col items-center h-full",
     },
-    compoundVariants: [
-      {
-        orientation: "vertical",
-        size: "xsmall",
-        class: "h-full w-[44px]",
-      },
-      {
-        orientation: "vertical",
-        size: "small",
-        class: "h-full w-[44px]",
-      },
-      {
-        orientation: "vertical",
-        size: "medium",
-        class: "h-full w-[52px]",
-      },
-      {
-        orientation: "vertical",
-        size: "large",
-        class: "h-full w-[68px]",
-      },
-      {
-        orientation: "vertical",
-        size: "xlarge",
-        class: "h-full w-[108px]",
-      },
-    ],
-    defaultVariants: {
-      orientation: "horizontal",
-      size: "xsmall",
+    size: {
+      // Vertical orientation: container width = handle height (dimensions transposed)
+      // Applied only for vertical via compoundVariants below
+      // NOTE: measurement-derived values from MD3 spec §4.2; permitted exception
+      xsmall: "",
+      small: "",
+      medium: "",
+      large: "",
+      xlarge: "",
     },
-  }
-);
+  },
+  compoundVariants: [
+    // Vertical: container WIDTH = handle height (MD3 §10.9 — dimensions transposed)
+    // NOTE: measurement-derived values from MD3 spec §4.2; permitted exception
+    { orientation: "vertical", size: "xsmall", class: "w-[44px]" },
+    { orientation: "vertical", size: "small", class: "w-[44px]" },
+    { orientation: "vertical", size: "medium", class: "w-[52px]" },
+    { orientation: "vertical", size: "large", class: "w-[68px]" },
+    { orientation: "vertical", size: "xlarge", class: "w-[108px]" },
+  ],
+  defaultVariants: {
+    orientation: "horizontal",
+    size: "xsmall",
+  },
+});
+
+// ─── Track Region ─────────────────────────────────────────────────────────────
+
+/**
+ * The track region element (`data-track`).
+ *
+ * This is the element that React Aria measures for pointer math. It must have
+ * a defined width (horizontal) or height (vertical) and be `position: relative`
+ * so the absolutely-positioned RA thumb children resolve correctly.
+ *
+ * In horizontal grid layout it spans both columns (`col-span-2`) and carries
+ * the size HEIGHT that was previously on the container. In vertical layout it
+ * fills the full parent height and carries the size WIDTH.
+ *
+ * NOTE: measurement-derived size values from MD3 spec §4.2; permitted exception.
+ */
+export const sliderTrackRegionVariants = cva(["relative", "touch-none"], {
+  variants: {
+    orientation: {
+      horizontal: "col-span-2 w-full",
+      // flex-1 fills the vertical container reliably; h-full collapses when the
+      // container itself is a flex item without an explicit pixel height (CSS spec).
+      // min-h-0 allows the flex child to shrink below its natural size if needed.
+      vertical: "flex-1 min-h-0",
+    },
+    size: {
+      // Horizontal: size controls track region HEIGHT (= handle height)
+      // Vertical: size controls track region WIDTH (= handle height, dimensions transposed)
+      // Applied as compound variants below to avoid cross-orientation conflicts
+      xsmall: "",
+      small: "",
+      medium: "",
+      large: "",
+      xlarge: "",
+    },
+  },
+  compoundVariants: [
+    // Horizontal: height = handle height per MD3 §4.2
+    { orientation: "horizontal", size: "xsmall", class: "h-[44px]" },
+    { orientation: "horizontal", size: "small", class: "h-[44px]" },
+    { orientation: "horizontal", size: "medium", class: "h-[52px]" },
+    { orientation: "horizontal", size: "large", class: "h-[68px]" },
+    { orientation: "horizontal", size: "xlarge", class: "h-[108px]" },
+    // Vertical: width = handle height (transposed per MD3 §10.9)
+    { orientation: "vertical", size: "xsmall", class: "w-[44px]" },
+    { orientation: "vertical", size: "small", class: "w-[44px]" },
+    { orientation: "vertical", size: "medium", class: "w-[52px]" },
+    { orientation: "vertical", size: "large", class: "w-[68px]" },
+    { orientation: "vertical", size: "xlarge", class: "w-[108px]" },
+  ],
+  defaultVariants: {
+    orientation: "horizontal",
+    size: "xsmall",
+  },
+});
 
 // ─── Track Layout ─────────────────────────────────────────────────────────────
 
 /**
- * Inner flex container that holds the active and inactive track segments.
+ * Absolute-fill container that holds the active and inactive track segments.
  *
- * The 6dp gap (MD3 `thumbTrackGapSize`) is preserved here as `gap-[6px]`
- * between the active and inactive track flex items.
+ * Segments are `position: absolute` children sharing the same percentage
+ * coordinate space as the React Aria thumbs, so fills always align with
+ * handle positions regardless of value or orientation.
+ *
+ * The MD3 6dp thumb-track gap (`thumbTrackGapSize`) is applied as a symmetric
+ * 3px offset on each side of the thumb in the parent's inline position styles.
+ *
+ * `pointer-events-none` lets React Aria's track click-to-seek events
+ * reach the `data-track` region without interference.
  */
-export const sliderTrackLayoutVariants = cva(
-  ["relative", "flex", "items-center", "gap-[6px]", "w-full", "h-full"],
-  {
-    variants: {
-      orientation: {
-        horizontal: "flex-row",
-        vertical: "flex-col-reverse h-full",
-      },
-    },
-    defaultVariants: {
-      orientation: "horizontal",
-    },
-  }
-);
+export const sliderTrackLayoutVariants = cva(["absolute", "inset-0", "pointer-events-none"]);
 
 // ─── Active Track ─────────────────────────────────────────────────────────────
 
@@ -90,6 +132,9 @@ export const sliderTrackLayoutVariants = cva(
  * **Color**: `bg-primary`
  * **Disabled**: driven by `group-data-[disabled]/slider:*` — no CVA disabled variant.
  * **Transition**: `flex-basis` spring (spatial) when not dragging/reduced-motion.
+ *
+ * MD3 §6, §10.2: outer corner = size corner token, inner corner (near handle) = 2dp.
+ * NOTE: measurement-derived corner values from MD3 spec §6; permitted exception.
  */
 export const sliderActiveTrackVariants = cva(
   [
@@ -98,25 +143,57 @@ export const sliderActiveTrackVariants = cva(
     // Disabled — driven by root group/slider data-disabled attr
     "group-data-[disabled]/slider:bg-on-surface",
     "group-data-[disabled]/slider:opacity-38",
-    // Layout
-    "flex-shrink-0",
+    // Layout — absolute fill within the track region
+    "absolute",
     "overflow-hidden",
-    "relative",
   ],
   {
     variants: {
       size: {
-        xsmall: "h-[16px] rounded-[8px]",
-        small: "h-[16px] rounded-[8px]",
-        medium: "h-[40px] rounded-[20px]",
-        large: "h-[56px] rounded-[28px]",
-        xlarge: "h-[96px] rounded-[48px]",
+        // Horizontal: left (start) = outer corner, right (near handle) = 2dp inner
+        // NOTE: measurement-derived values from MD3 spec §4.2, §6; permitted exception
+        xsmall: "h-[16px] rounded-l-[16px] rounded-r-[2px]",
+        small: "h-[16px] rounded-l-[16px] rounded-r-[2px]",
+        medium: "h-[40px] rounded-l-[12px] rounded-r-[2px]",
+        large: "h-[56px] rounded-l-[16px] rounded-r-[2px]",
+        xlarge: "h-[96px] rounded-l-[28px] rounded-r-[2px]",
       },
       orientation: {
-        horizontal: "",
-        vertical: "w-full flex-1",
+        // Horizontal: center vertically within track region
+        horizontal: "top-1/2 -translate-y-1/2",
+        // Vertical: center horizontally; length controlled by inline top/height styles
+        vertical: "left-1/2 -translate-x-1/2",
       },
     },
+    compoundVariants: [
+      // Vertical: width = track thickness; bottom = outer corner, top = 2dp inner (near handle)
+      // NOTE: measurement-derived values from MD3 spec §4.2, §6; permitted exception
+      {
+        orientation: "vertical",
+        size: "xsmall",
+        class: "w-[16px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[16px] rounded-br-[16px]",
+      },
+      {
+        orientation: "vertical",
+        size: "small",
+        class: "w-[16px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[16px] rounded-br-[16px]",
+      },
+      {
+        orientation: "vertical",
+        size: "medium",
+        class: "w-[40px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[12px] rounded-br-[12px]",
+      },
+      {
+        orientation: "vertical",
+        size: "large",
+        class: "w-[56px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[16px] rounded-br-[16px]",
+      },
+      {
+        orientation: "vertical",
+        size: "xlarge",
+        class: "w-[96px] rounded-tl-[2px] rounded-tr-[2px] rounded-bl-[28px] rounded-br-[28px]",
+      },
+    ],
     defaultVariants: {
       size: "xsmall",
       orientation: "horizontal",
@@ -131,6 +208,9 @@ export const sliderActiveTrackVariants = cva(
  *
  * **Color**: `bg-secondary-container`
  * **Disabled**: driven by `group-data-[disabled]/slider:*` — no CVA disabled variant.
+ *
+ * MD3 §6, §10.2: inner corner (near handle) = 2dp, outer corner = size corner token.
+ * NOTE: measurement-derived corner values from MD3 spec §6; permitted exception.
  */
 export const sliderInactiveTrackVariants = cva(
   [
@@ -138,25 +218,57 @@ export const sliderInactiveTrackVariants = cva(
     "bg-secondary-container",
     // Disabled — driven by root group/slider data-disabled attr
     "group-data-[disabled]/slider:bg-on-surface/10",
-    // Layout
-    "flex-1",
+    // Layout — absolute fill within the track region
+    "absolute",
     "overflow-hidden",
-    "relative",
   ],
   {
     variants: {
       size: {
-        xsmall: "h-[16px] rounded-[8px]",
-        small: "h-[16px] rounded-[8px]",
-        medium: "h-[40px] rounded-[20px]",
-        large: "h-[56px] rounded-[28px]",
-        xlarge: "h-[96px] rounded-[48px]",
+        // Horizontal: left (near handle) = 2dp inner, right (end) = outer corner
+        // NOTE: measurement-derived values from MD3 spec §4.2, §6; permitted exception
+        xsmall: "h-[16px] rounded-l-[2px] rounded-r-[16px]",
+        small: "h-[16px] rounded-l-[2px] rounded-r-[16px]",
+        medium: "h-[40px] rounded-l-[2px] rounded-r-[12px]",
+        large: "h-[56px] rounded-l-[2px] rounded-r-[16px]",
+        xlarge: "h-[96px] rounded-l-[2px] rounded-r-[28px]",
       },
       orientation: {
-        horizontal: "",
-        vertical: "w-full h-auto",
+        // Horizontal: center vertically within track region
+        horizontal: "top-1/2 -translate-y-1/2",
+        // Vertical: center horizontally; length controlled by inline top/height styles
+        vertical: "left-1/2 -translate-x-1/2",
       },
     },
+    compoundVariants: [
+      // Vertical: width = track thickness; top = outer corner, bottom = 2dp inner (near handle)
+      // NOTE: measurement-derived values from MD3 spec §4.2, §6; permitted exception
+      {
+        orientation: "vertical",
+        size: "xsmall",
+        class: "w-[16px] rounded-tl-[16px] rounded-tr-[16px] rounded-bl-[2px] rounded-br-[2px]",
+      },
+      {
+        orientation: "vertical",
+        size: "small",
+        class: "w-[16px] rounded-tl-[16px] rounded-tr-[16px] rounded-bl-[2px] rounded-br-[2px]",
+      },
+      {
+        orientation: "vertical",
+        size: "medium",
+        class: "w-[40px] rounded-tl-[12px] rounded-tr-[12px] rounded-bl-[2px] rounded-br-[2px]",
+      },
+      {
+        orientation: "vertical",
+        size: "large",
+        class: "w-[56px] rounded-tl-[16px] rounded-tr-[16px] rounded-bl-[2px] rounded-br-[2px]",
+      },
+      {
+        orientation: "vertical",
+        size: "xlarge",
+        class: "w-[96px] rounded-tl-[28px] rounded-tr-[28px] rounded-bl-[2px] rounded-br-[2px]",
+      },
+    ],
     defaultVariants: {
       size: "xsmall",
       orientation: "horizontal",
@@ -203,15 +315,26 @@ export const sliderHandleVariants = cva(
       },
       orientation: {
         horizontal: "",
-        vertical: "h-[4px] w-full",
+        // Vertical: handle is a thin horizontal bar. h-[4px] overrides the base
+        // h-[44px..108px]. Width is explicitly set per size below so the RA thumb
+        // (which is shrink-to-fit) assumes the correct measured width — this also
+        // fixes the hit-area (w-full) and state-layer (inset-0) widths.
+        vertical: "h-[4px]",
       },
     },
     compoundVariants: [
-      // Vertical: override to height-based narrowing
+      // Vertical: override to height-based narrowing on press
       {
         orientation: "vertical",
         class: "group-data-[pressed]/slider-thumb:h-[2px]",
       },
+      // Vertical per-size widths (transposed handle length = track region width per MD3 §10.9)
+      // NOTE: measurement-derived values from MD3 spec §4.2; permitted exception
+      { orientation: "vertical", size: "xsmall", class: "w-[44px]" },
+      { orientation: "vertical", size: "small", class: "w-[44px]" },
+      { orientation: "vertical", size: "medium", class: "w-[52px]" },
+      { orientation: "vertical", size: "large", class: "w-[68px]" },
+      { orientation: "vertical", size: "xlarge", class: "w-[108px]" },
     ],
     defaultVariants: {
       size: "xsmall",
@@ -296,8 +419,9 @@ export const sliderValueIndicatorVariants = cva([
   "pointer-events-none",
   // Z-index above track overlays
   "z-10",
-  // Will-change hint for browser compositing
-  "will-change-[transform,opacity]",
+  // In Tailwind v4, scale-* maps to the CSS `scale` property (not `transform`),
+  // so we must list `scale` here — not `transform` — to animate the reveal.
+  "will-change-[scale,opacity]",
 ]);
 
 // ─── Stop Dots ────────────────────────────────────────────────────────────────

--- a/packages/react/src/components/Slider/SliderHeadless.tsx
+++ b/packages/react/src/components/Slider/SliderHeadless.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { forwardRef, useMemo, useRef } from "react";
+import { forwardRef, useEffect, useMemo, useRef } from "react";
 import type React from "react";
-import { mergeProps, useFocusRing, useSlider, useSliderThumb, VisuallyHidden } from "react-aria";
+import {
+  mergeProps,
+  useFocusRing,
+  useHover,
+  useSlider,
+  useSliderThumb,
+  VisuallyHidden,
+} from "react-aria";
 import { useSliderState } from "react-stately";
 import type { SliderState } from "react-stately";
 import { cn } from "../../utils/cn";
-import type { SliderHeadlessProps } from "./Slider.types";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
+import type { SliderHeadlessProps, SliderThumbRenderState } from "./Slider.types";
 
 // ─── Centered Variant Utilities ───────────────────────────────────────────────
 
@@ -38,10 +46,13 @@ interface SliderThumbInternalProps {
   state: SliderState;
   trackRef: React.RefObject<HTMLDivElement>;
   isDisabled: boolean;
+  orientation: "horizontal" | "vertical";
   formatValue?: (value: number) => string;
   "aria-label"?: string;
   className?: string;
   "data-direction"?: "negative" | "positive" | "zero";
+  renderContent?: (state: SliderThumbRenderState) => React.ReactNode;
+  onDraggingChange?: (isDragging: boolean) => void;
 }
 
 function SliderThumbInternal({
@@ -49,9 +60,12 @@ function SliderThumbInternal({
   state,
   trackRef,
   isDisabled,
+  orientation,
   formatValue,
   className,
   "data-direction": dataDirection,
+  renderContent,
+  onDraggingChange,
   ...ariaProps
 }: SliderThumbInternalProps): React.JSX.Element {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -68,23 +82,69 @@ function SliderThumbInternal({
   );
 
   const { isFocusVisible, focusProps } = useFocusRing();
+  const { isHovered, hoverProps } = useHover({ isDisabled });
+
+  // Notify parent when dragging state changes so Slider.tsx can suppress
+  // the track flex-basis transition during active drag (matches Switch/Button pattern).
+  useEffect(() => {
+    onDraggingChange?.(isDragging);
+  }, [isDragging, onDraggingChange]);
 
   // Override aria-valuetext with the custom formatter when provided.
   // React Stately v3.7 does not support getValueLabel; we patch the attribute directly.
   const currentValue = state.getThumbValue(index);
   const ariaValueText = formatValue ? formatValue(currentValue) : undefined;
 
+  // Absolute positioning: place the thumb (and its visual content) exactly
+  // at the value's percentage position on the track.
+  // Horizontal: left edge at `pct%`, centered via translate(-50%, -50%)
+  // Vertical:   bottom edge at `pct%`, centered via translate(-50%, 50%)
+  const thumbPercent = state.getThumbPercent(index);
+  const positionStyle: React.CSSProperties =
+    orientation === "horizontal"
+      ? {
+          position: "absolute",
+          left: `${thumbPercent * 100}%`,
+          top: "50%",
+          transform: "translate(-50%, -50%)",
+          zIndex: 10,
+        }
+      : {
+          position: "absolute",
+          bottom: `${thumbPercent * 100}%`,
+          left: "50%",
+          transform: "translate(-50%, 50%)",
+          zIndex: 10,
+        };
+
+  const renderState: SliderThumbRenderState = {
+    index,
+    value: currentValue,
+    isDragging,
+    isFocusVisible,
+    isHovered,
+    isDisabled,
+  };
+
   return (
     <div
-      {...thumbProps}
+      {...mergeProps(thumbProps, hoverProps, { style: positionStyle })}
+      data-slot="slider-thumb"
       data-dragging={isDragging || undefined}
       data-focused={isFocused || undefined}
-      data-focus-visible={isFocusVisible || undefined}
-      data-disabled={isDisabled || undefined}
       {...(dataDirection !== undefined ? { "data-direction": dataDirection } : {})}
+      {...getInteractionDataAttributes({
+        isHovered,
+        isFocusVisible,
+        isPressed: isDragging,
+        isDisabled,
+      })}
       className={cn(
+        // Group scope: interaction selectors on children target this element
+        "group/slider-thumb",
+        // Accessibility: remove default outline (custom focus ring via data-[focus-visible])
         "outline-none",
-        // Focus ring visible only on keyboard focus — matches project pattern (md3-design.mdc §Accessibility)
+        // Focus ring visible only on keyboard focus — matches project pattern
         "data-[focus-visible]:ring-3",
         "data-[focus-visible]:ring-secondary",
         "data-[focus-visible]:ring-offset-2",
@@ -98,6 +158,7 @@ function SliderThumbInternal({
           {...(ariaValueText !== undefined ? { "aria-valuetext": ariaValueText } : {})}
         />
       </VisuallyHidden>
+      {renderContent?.(renderState)}
     </div>
   );
 }
@@ -120,6 +181,8 @@ function SliderThumbInternal({
  * - Discrete stepping support
  * - Live value announcements via <output>
  * - data-* attributes for styled layer targeting
+ * - `group/slider-thumb` scope on each thumb for group-data CSS selectors
+ * - `renderThumbContent` render prop for injecting visual content inside RA thumb
  *
  * @example
  * ```tsx
@@ -154,6 +217,8 @@ export const SliderHeadless = forwardRef<HTMLDivElement, SliderHeadlessProps>(
       className,
       style,
       children,
+      renderThumbContent,
+      onThumbDraggingChange,
       ...ariaProps
     } = props;
 
@@ -236,6 +301,10 @@ export const SliderHeadless = forwardRef<HTMLDivElement, SliderHeadlessProps>(
           data-orientation={orientation}
           data-track
           {...(zeroPercent !== undefined ? { "data-zero-percent": zeroPercent } : {})}
+          // `relative` is required so the absolutely-positioned RA thumbs
+          // (which carry all visual content in the new arch) are positioned
+          // relative to this element.
+          className={cn("relative", orientation === "vertical" && "h-full w-full")}
         >
           {children}
           <SliderThumbInternal
@@ -243,9 +312,14 @@ export const SliderHeadless = forwardRef<HTMLDivElement, SliderHeadlessProps>(
             state={state}
             trackRef={trackRef}
             isDisabled={isDisabled}
+            orientation={orientation}
             {...(formatValue !== undefined ? { formatValue } : {})}
             {...(thumb0Label !== undefined ? { "aria-label": thumb0Label } : {})}
             {...(direction !== undefined ? { "data-direction": direction } : {})}
+            {...(renderThumbContent !== undefined ? { renderContent: renderThumbContent } : {})}
+            {...(onThumbDraggingChange !== undefined
+              ? { onDraggingChange: (d) => onThumbDraggingChange(0, d) }
+              : {})}
           />
           {isRange && (
             <SliderThumbInternal
@@ -253,8 +327,13 @@ export const SliderHeadless = forwardRef<HTMLDivElement, SliderHeadlessProps>(
               state={state}
               trackRef={trackRef}
               isDisabled={isDisabled}
+              orientation={orientation}
               {...(formatValue !== undefined ? { formatValue } : {})}
               aria-label={thumbLabels?.[1] ?? "Maximum"}
+              {...(renderThumbContent !== undefined ? { renderContent: renderThumbContent } : {})}
+              {...(onThumbDraggingChange !== undefined
+                ? { onDraggingChange: (d) => onThumbDraggingChange(1, d) }
+                : {})}
             />
           )}
         </div>

--- a/packages/react/src/components/Slider/SliderHeadless.tsx
+++ b/packages/react/src/components/Slider/SliderHeadless.tsx
@@ -217,6 +217,7 @@ export const SliderHeadless = forwardRef<HTMLDivElement, SliderHeadlessProps>(
       className,
       style,
       children,
+      trackClassName,
       renderThumbContent,
       onThumbDraggingChange,
       ...ariaProps
@@ -294,7 +295,26 @@ export const SliderHeadless = forwardRef<HTMLDivElement, SliderHeadlessProps>(
         data-variant={variant}
         {...(zeroPercent !== undefined ? { "data-zero-percent": zeroPercent } : {})}
       >
-        {label && <label {...labelProps}>{label}</label>}
+        {label && (
+          <label {...labelProps} className={cn(orientation === "vertical" && "sr-only")}>
+            {label}
+          </label>
+        )}
+        <output
+          {...outputProps}
+          className={cn(
+            orientation === "horizontal" && "justify-self-end",
+            orientation === "vertical" && "sr-only"
+          )}
+        >
+          {isRange
+            ? formatValue
+              ? `${formatValue(state.getThumbValue(0))} \u2013 ${formatValue(state.getThumbValue(1))}`
+              : `${state.getThumbValueLabel(0)} \u2013 ${state.getThumbValueLabel(1)}`
+            : formatValue
+              ? formatValue(state.getThumbValue(0))
+              : state.getThumbValueLabel(0)}
+        </output>
         <div
           {...trackProps}
           ref={trackRef}
@@ -304,7 +324,10 @@ export const SliderHeadless = forwardRef<HTMLDivElement, SliderHeadlessProps>(
           // `relative` is required so the absolutely-positioned RA thumbs
           // (which carry all visual content in the new arch) are positioned
           // relative to this element.
-          className={cn("relative", orientation === "vertical" && "h-full w-full")}
+          className={cn(
+            trackClassName ?? "relative w-full",
+            orientation === "vertical" && !trackClassName && "h-full"
+          )}
         >
           {children}
           <SliderThumbInternal
@@ -337,15 +360,6 @@ export const SliderHeadless = forwardRef<HTMLDivElement, SliderHeadlessProps>(
             />
           )}
         </div>
-        <output {...outputProps}>
-          {isRange
-            ? formatValue
-              ? `${formatValue(state.getThumbValue(0))} \u2013 ${formatValue(state.getThumbValue(1))}`
-              : `${state.getThumbValueLabel(0)} \u2013 ${state.getThumbValueLabel(1)}`
-            : formatValue
-              ? formatValue(state.getThumbValue(0))
-              : state.getThumbValueLabel(0)}
-        </output>
       </div>
     );
   }

--- a/packages/react/src/components/Slider/SliderStops.tsx
+++ b/packages/react/src/components/Slider/SliderStops.tsx
@@ -3,7 +3,7 @@
 import type React from "react";
 import { cn } from "../../utils/cn";
 import { sliderStopsContainerVariants, sliderStopDotVariants } from "./Slider.variants";
-import type { SliderVariant } from "./Slider.types";
+import type { SliderSize, SliderVariant } from "./Slider.types";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -62,9 +62,10 @@ interface SliderStopsProps {
    */
   variant: SliderVariant;
   /**
-   * Whether the slider is disabled (renders dots at 38% opacity).
+   * Size of the slider (controls dot dimensions).
+   * @default 'xsmall'
    */
-  isDisabled: boolean;
+  size?: SliderSize;
   /**
    * Additional CSS classes for the stops container.
    */
@@ -80,6 +81,9 @@ interface SliderStopsProps {
  * colored `on-primary` on the active track and `on-secondary-container` on
  * the inactive track. Padding of 4dp from track edges.
  *
+ * Disabled dot styling is driven by `group-data-[disabled]/slider:` CSS
+ * selectors on the root slider container — no explicit `isDisabled` prop needed.
+ *
  * This is a purely decorative sub-component. All accessibility information
  * is carried by the underlying `<input type="range">` via React Aria.
  *
@@ -91,7 +95,7 @@ interface SliderStopsProps {
  *   step={10}
  *   values={[50]}
  *   variant="standard"
- *   isDisabled={false}
+ *   size="xsmall"
  * />
  * ```
  */
@@ -101,7 +105,7 @@ export function SliderStops({
   step,
   values,
   variant,
-  isDisabled,
+  size = "xsmall",
   className,
 }: SliderStopsProps): React.JSX.Element {
   const stopCount = Math.floor((maxValue - minValue) / step) + 1;
@@ -120,7 +124,10 @@ export function SliderStops({
             key={i}
             data-slot="stop-dot"
             className={cn(
-              sliderStopDotVariants({ onActiveTrack: isOnActive, disabled: isDisabled })
+              sliderStopDotVariants({
+                region: isOnActive ? "active" : "inactive",
+                size,
+              })
             )}
           />
         );

--- a/packages/react/src/components/Slider/SliderValueIndicator.tsx
+++ b/packages/react/src/components/Slider/SliderValueIndicator.tsx
@@ -13,12 +13,6 @@ interface SliderValueIndicatorProps {
    */
   value: number;
   /**
-   * Whether the indicator is currently visible (thumb in Pressed state).
-   * When false the pill is rendered but hidden via `opacity-0 scale-0`.
-   * @default false
-   */
-  isVisible: boolean;
-  /**
    * Optional formatter for the displayed value string.
    * @default (v) => `${Math.round(v)}`
    * @example (v) => `$${v}`
@@ -41,56 +35,46 @@ interface SliderValueIndicatorProps {
  * - Text: `inverse-on-surface`, Label Large typography
  * - Min-width: 48dp, padding 16dp horizontal / 12dp vertical
  * - Positioned absolutely above the thumb; centered horizontally
- * - Visible only during Pressed state; hidden otherwise (`opacity-0 scale-0`)
- * - Transition: spring standard fast effects (MD3 motion §9.3)
+ * - Visible only during Pressed state; CSS-driven via
+ *   `group-data-[pressed]/slider-thumb:opacity-100 scale-100`
  *
- * Rendered as a child of the handle element (which is `position: relative`).
- * The `role="tooltip"` marks it as decorative — accessible value is in the
- * underlying `<input type="range">` managed by React Aria.
+ * Rendered as a child of the RA thumb element (`group/slider-thumb`).
+ * The element is always present in the DOM when `showValueIndicator=true`.
+ * Visibility is driven by `group-data-[pressed]/slider-thumb` CSS selectors
+ * (no JS state required). `aria-hidden="true"` permanently since the accessible
+ * value is in the `<output>` element managed by React Aria.
+ *
+ * **Motion**: MD3 spring standard fast spatial tokens for transform/opacity.
+ *   Suppressed via `useReducedMotion()` for prefers-reduced-motion.
  *
  * @example
  * ```tsx
- * <SliderValueIndicator
- *   value={50}
- *   isVisible={isPressed}
- *   formatValue={(v) => `$${v}`}
- * />
+ * // Inside renderThumbContent — always rendered when showValueIndicator=true
+ * <SliderValueIndicator value={50} formatValue={(v) => `$${v}`} />
  * ```
  */
 export function SliderValueIndicator({
   value,
-  isVisible,
   formatValue,
   className,
 }: SliderValueIndicatorProps): React.JSX.Element {
   const displayValue = formatValue ? formatValue(value) : `${Math.round(value)}`;
   const reducedMotion = useReducedMotion();
 
-  // MD3 Appendix E: Value indicator uses directional legacy easing for enter/exit —
-  // enter (scale in): ease-standard-decelerate + duration-short3 (150ms)
-  // exit  (scale out): ease-standard-accelerate + duration-short2 (100ms)
-  // The -translate-x-1/2 from CVA is inherited as part of the transform; scale is
-  // added via the visible/false variant (scale-100 / scale-0).
-  // When reduced motion is preferred, all transitions are suppressed for instant state change.
+  // MD3 spring system: transform/opacity transition for entry/exit.
+  // Scale (transform) uses spatial spring; opacity is coupled to the same
+  // spring for a single unified animation.
+  // Suppressed entirely when prefers-reduced-motion is active.
   const transitionClasses = reducedMotion
     ? ""
-    : cn(
-        "transition-[transform,opacity]",
-        isVisible
-          ? "duration-short3 ease-standard-decelerate"
-          : "duration-short2 ease-standard-accelerate"
-      );
+    : "transition-[transform,opacity] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial";
 
   return (
     <div
       data-slot="value-indicator"
-      className={cn(
-        sliderValueIndicatorVariants({ visible: isVisible }),
-        transitionClasses,
-        className
-      )}
+      className={cn(sliderValueIndicatorVariants(), transitionClasses, className)}
       role="tooltip"
-      aria-hidden={!isVisible}
+      aria-hidden="true"
     >
       <span className={sliderValueIndicatorTextVariants()}>{displayValue}</span>
     </div>

--- a/packages/react/src/components/Slider/SliderValueIndicator.tsx
+++ b/packages/react/src/components/Slider/SliderValueIndicator.tsx
@@ -62,12 +62,12 @@ export function SliderValueIndicator({
   const reducedMotion = useReducedMotion();
 
   // MD3 spring system: transform/opacity transition for entry/exit.
-  // Scale (transform) uses spatial spring; opacity is coupled to the same
-  // spring for a single unified animation.
+  // In Tailwind v4, scale-* uses the CSS `scale` property (not `transform`),
+  // so the transition list must include `scale` instead of `transform`.
   // Suppressed entirely when prefers-reduced-motion is active.
   const transitionClasses = reducedMotion
     ? ""
-    : "transition-[transform,opacity] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial";
+    : "transition-[scale,opacity] duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial";
 
   return (
     <div

--- a/packages/react/src/components/Slider/index.ts
+++ b/packages/react/src/components/Slider/index.ts
@@ -32,6 +32,7 @@ export type {
   SliderHeadlessProps,
   SliderThumbProps,
   SliderProps,
+  SliderThumbRenderState,
   SliderThumbState,
   SliderRenderState,
   SliderRangeThumbLabels,

--- a/packages/react/src/components/Slider/index.ts
+++ b/packages/react/src/components/Slider/index.ts
@@ -11,6 +11,7 @@ export { SliderValueIndicator } from "./SliderValueIndicator";
 // CVA Variants
 export {
   sliderContainerVariants,
+  sliderTrackRegionVariants,
   sliderActiveTrackVariants,
   sliderInactiveTrackVariants,
   sliderHandleVariants,


### PR DESCRIPTION
## Summary

- Migrates `Slider` from a manual pointer state machine to the "Variants-vs-States" architecture used by `Button` and `Switch`: React Aria's `isDragging`/`isHovered`/`isFocusVisible` hooks feed `getInteractionDataAttributes`, which emits `data-*` presence attributes on the RA thumb (`group/slider-thumb`). All interaction styling is then driven by `group-data-[x]/slider-thumb:*` CSS selectors — no more CVA `pressed`/`disabled` variant keys.
- Replaces legacy motion tokens (`duration-short2 ease-standard`, `duration-short1`) with the MD3 spring system (`spring-standard-fast-spatial` for handle width + track fill, `spring-standard-fast-effects` for state layer opacity, `spring-standard-fast-spatial` for value indicator scale/opacity).
- The visual handle, state layer, and value indicator are rendered **inside** the React Aria thumb element (via `renderThumbContent` render prop on `SliderHeadless`) so they are positioned exactly at the value percentage by RA — no separate invisible + visible thumb duality.
- Value indicator is always in the DOM when `showValueIndicator=true`; CSS controls visibility. `SliderThumbState` and `SliderRenderState` are marked `@deprecated` but remain exported.

## Test plan

- [x] 157/157 Slider tests pass (`pnpm --filter @tinybigui/react test -- Slider`)
- [x] TypeScript typecheck passes (`pnpm --filter @tinybigui/react typecheck`)
- [x] ESLint passes workspace-wide (`pnpm lint`)
- [ ] Storybook visual pass across all 5 sizes × standard/range/centered × horizontal/vertical, disabled, stops, value indicator, reduced-motion (manual verification)