### PR TITLE
refactor(snackbar): slot-based md3 variants vs states architecture with spring motion

### DIFF
--- a/.changeset/snackbar-md3-expressive.md
+++ b/.changeset/snackbar-md3-expressive.md
@@ -1,5 +1,5 @@
 ---
-"@tinybigui/react": patch
+"@tinybigui/react": minor
 ---
 
 **Snackbar**: MD3 slot-based architecture refactor — visual and motion corrections

--- a/.changeset/snackbar-md3-expressive.md
+++ b/.changeset/snackbar-md3-expressive.md
@@ -1,0 +1,27 @@
+---
+"@tinybigui/react": patch
+---
+
+**Snackbar**: MD3 slot-based architecture refactor — visual and motion corrections
+
+**State-layer color fixes (MD3 spec compliance on inverse surface)**
+
+- Action button: replaced shared `Button` (state layer `bg-primary`) with a dedicated `SnackbarActionButton` slot using `bg-inverse-primary` state layer — the MD3-correct color for the inverse-surface container
+- Close icon button: replaced shared `IconButton` (state layer `bg-on-surface-variant`) with a dedicated `SnackbarCloseButton` slot using `bg-inverse-on-surface` state layer — the MD3-correct color
+
+**Close button sizing fix**
+
+- Close button was `size="medium"` (56dp), taller than the 48dp snackbar, causing overflow. Now 32dp (`size-8`) — fits within 48dp with 8dp margin on each side.
+
+**Motion migration to spring-standard tokens**
+
+- Enter/exit animation changed from legacy scale/zoom (`ease-emphasized-decelerate` + `duration-medium1`) to position-aware slide + fade using `duration-spring-standard-default-effects` (200ms enter) and `duration-spring-standard-fast-effects` (150ms exit)
+- Bottom positions slide up from below; top positions slide down from above
+- `prefers-reduced-motion`: translate suppressed — fade-only with no spatial motion
+
+**Other fixes**
+
+- `supportingText`: removed non-spec `opacity-80` reduction; now full `text-inverse-on-surface`
+- Two-line density: `min-h-[4.25rem]` (68dp) + `items-start` for two-line; `min-h-12` (48dp) + `items-center` for single-line
+
+**New exports** (action + close slot CVAs): `snackbarActionVariants`, `snackbarActionStateLayerVariants`, `snackbarActionFocusRingVariants`, `snackbarCloseVariants`, `snackbarCloseStateLayerVariants`, `snackbarCloseFocusRingVariants`, `snackbarCloseIconVariants` and their `VariantProps` types.

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
 
 ## ⚙️ Development Status
 
-> **Latest Release: v0.19.0** (2026-06-10)
+> **Latest Release: v0.20.0** (2026-06-10)
 >
-> **29 MD3 components** shipped across buttons, forms, navigation, feedback, and data display — all published to npm with **2,117 tests** passing.
+> **29 MD3 components** shipped across buttons, forms, navigation, feedback, and data display — all published to npm with **2,121 tests** passing.
 >
 > Watch this repository to follow our progress!
 
@@ -94,7 +94,7 @@ This is a monorepo containing multiple packages:
 
 | Package                                  | Description                   | Version | Status   |
 | ---------------------------------------- | ----------------------------- | ------- | -------- |
-| [`@tinybigui/react`](./packages/react)   | React components              | 0.19.0  | Released |
+| [`@tinybigui/react`](./packages/react)   | React components              | 0.20.0  | Released |
 | [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | 0.13.0  | Released |
 
 ---
@@ -143,7 +143,7 @@ This is a monorepo containing multiple packages:
 ### Phase 3: Feedback ✅
 
 - [x] Dialog — basic and fullscreen variants (v0.3.0)
-- [x] Snackbar — provider, stacking, imperative API (v0.3.0)
+- [x] Snackbar — MD3 slot-based architecture, inverse-surface state layers, spring motion, dedicated action/close slots (v0.20.0)
 - [x] Menu — dropdown, context menu, submenus (v0.3.0)
 - [x] Progress — MD3 expressive slot architecture, colorful tokens, gap, wavy shape, thick track (v0.16.0)
 - [x] BottomSheet — MD3 expressive handle refactor, variants-vs-states architecture (v0.11.0)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,9 +4,9 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 
 ## Current Status
 
-**Current Version:** v0.19.0 (released 2026-06-10)  
-**Next Release:** v0.20.0  
-**Status:** 29 components published to NPM; 2,117 tests passing
+**Current Version:** v0.20.0 (released 2026-06-10)  
+**Next Release:** v0.21.0  
+**Status:** 29 components published to NPM; 2,121 tests passing
 
 ## Release Timeline
 
@@ -36,6 +36,7 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 | v0.17.0 | —       | Radio MD3 expressive refactor — variants-vs-states architecture, slot CVAs, spring motion, `isInvalid` forwarding fix in RadioGroup                              | Released 2026-06-10 |
 | v0.18.0 | —       | Search MD3 expressive refactor — variants-vs-states architecture, per-slot CVAs, React Aria hover/focus, layout-aware enter motion, MD3 SVG icons                | Released 2026-06-10 |
 | v0.19.0 | —       | Slider MD3 expressive refactor — variants-vs-states architecture, spring motion, absolute track positioning, range/vertical layout fixes, vertical handle sizing | Released 2026-06-10 |
+| v0.20.0 | —       | Snackbar MD3 expressive refactor — slot-based architecture, inverse-surface state layers, spring motion, dedicated action/close slots, two-line density fix      | Released 2026-06-10 |
 | v1.0.0  | Stable  | API frozen, documentation site, migration guides                                                                                                                 | Planned             |
 
 ## Completed Work
@@ -101,7 +102,7 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 - [x] Tailwind CSS v4 integration with MD3 tokens
 - [x] React Aria accessibility primitives
 - [x] CVA variant management with variants-vs-states architecture
-- [x] Vitest + React Testing Library (2,117 tests)
+- [x] Vitest + React Testing Library (2,121 tests)
 - [x] Storybook 10 documentation
 - [x] ESLint + Prettier configuration
 - [x] Husky + Commitlint for commit standards

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,7 +12,7 @@ A modern, accessible React component library implementing Google's Material Desi
 
 ## ✅ Status
 
-> **Latest Release: v0.19.0** (2026-06-10)
+> **Latest Release: v0.20.0** (2026-06-10)
 >
 > **29 MD3 components** published to npm with full TypeScript support and WCAG 2.1 AA accessibility.
 >
@@ -159,14 +159,14 @@ See [THEMING.md](./THEMING.md) for the full customization guide.
 
 ### Phase 3: Feedback ✅
 
-| Component     | Status | Description                                                                 |
-| ------------- | ------ | --------------------------------------------------------------------------- |
-| `Dialog`      | ✅     | Basic and fullscreen modal dialogs                                          |
-| `Snackbar`    | ✅     | Provider, stacking, imperative API                                          |
-| `Menu`        | ✅     | Dropdown, context menu, submenus                                            |
-| `Progress`    | ✅     | MD3 expressive slot CVA, colorful tokens, wavy shape, thick track (v0.16.0) |
-| `BottomSheet` | ✅     | MD3 expressive handle, variants-vs-states architecture (v0.11.0)            |
-| `Tooltip`     | ✅     | Plain and rich tooltip with positioning                                     |
+| Component     | Status | Description                                                                        |
+| ------------- | ------ | ---------------------------------------------------------------------------------- |
+| `Dialog`      | ✅     | Basic and fullscreen modal dialogs                                                 |
+| `Snackbar`    | ✅     | MD3 slot-based architecture, inverse-surface state layers, spring motion (v0.20.0) |
+| `Menu`        | ✅     | Dropdown, context menu, submenus                                                   |
+| `Progress`    | ✅     | MD3 expressive slot CVA, colorful tokens, wavy shape, thick track (v0.16.0)        |
+| `BottomSheet` | ✅     | MD3 expressive handle, variants-vs-states architecture (v0.11.0)                   |
+| `Tooltip`     | ✅     | Plain and rich tooltip with positioning                                            |
 
 ### Phase 4: Data Display ✅
 

--- a/packages/react/src/components/Snackbar/Snackbar.stories.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.stories.tsx
@@ -41,7 +41,10 @@ import type { SnackbarPosition } from "./Snackbar.types";
  * - Elevation: level 3 → `shadow-elevation-3`
  * - Width: 288dp min, 568dp max, centered `bottom-4` by default
  * - Auto-dismiss: 4000ms default, pauses on hover and focus
- * - Motion: entry slide 250ms standard-decelerate / exit fade 200ms standard-accelerate
+ * - Motion: position-aware slide + fade, spring-standard effects tokens
+ *   (enter 200ms / exit 150ms, no overshoot — `prefers-reduced-motion` respected)
+ * - Action state layer: `inverse-primary` (MD3-correct on inverse surface)
+ * - Close state layer: `inverse-on-surface` (MD3-correct on inverse surface)
  */
 const meta: Meta<typeof Snackbar> = {
   title: "Components/Snackbar",
@@ -452,6 +455,62 @@ export const StackedSnackbars: Story = {
       description: {
         story:
           "Multiple Snackbars stack vertically with 8dp spacing between them. Each item enters and exits independently. Bottom positions stack upward; top positions stack downward. Click all three buttons quickly to see the full stack.",
+      },
+    },
+  },
+};
+
+// ─── States (action + close slot interaction on inverse surface) ──────────────
+
+/**
+ * Demonstrates the MD3-correct interactive states for the action button and
+ * close icon button on the inverse-surface container.
+ *
+ * **Action button** (`inverse-primary` state layer):
+ * - Hover: `opacity-8` on `bg-inverse-primary`
+ * - Focus-visible: `opacity-10` on `bg-inverse-primary`
+ * - Pressed: `opacity-10` on `bg-inverse-primary`
+ *
+ * **Close icon button** (`inverse-on-surface` state layer):
+ * - Container: 32dp (size-8) — fits within the 48dp snackbar
+ * - Hover: `opacity-8` on `bg-inverse-on-surface`
+ * - Focus-visible: `opacity-10` on `bg-inverse-on-surface`
+ * - Pressed: `opacity-10` on `bg-inverse-on-surface`
+ *
+ * Both use spring-standard-fast-effects (150ms, no overshoot) for state transitions.
+ * Focus rings use the inverse-color tokens for visibility on dark/inverse surfaces.
+ *
+ * Click "Show States Snackbar" to open a persistent Snackbar with both
+ * interactive elements — hover, focus, and press each to observe the state layer.
+ */
+const StatesDemo = (): JSX.Element => {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button
+        variant="filled"
+        onPress={() =>
+          showSnackbar({
+            message: "Photo deleted",
+            action: { label: "Undo", onAction: () => undefined },
+            showClose: true,
+            duration: 0,
+          })
+        }
+      >
+        Show States Snackbar
+      </Button>
+    </div>
+  );
+};
+
+export const States: Story = {
+  render: () => <StatesDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Opens a persistent Snackbar (duration: 0) with both the action button and close icon visible. Hover, Tab-focus, and press each interactive element to verify MD3-correct state-layer colors on the inverse surface: `inverse-primary` for the action, `inverse-on-surface` for the close icon. The close button is 32dp (size-8), fitting within the 48dp container.",
       },
     },
   },

--- a/packages/react/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.test.tsx
@@ -126,6 +126,41 @@ describe("Snackbar", () => {
       expect(container).toHaveClass("my-custom-class");
     });
 
+    test("action button state layer uses bg-inverse-primary (MD3 correct on inverse surface)", () => {
+      renderSnackbar({
+        message: "File deleted",
+        action: { label: "Undo", onAction: vi.fn() },
+      });
+      const actionBtn = screen.getByRole("button", { name: "Undo" });
+      // The state layer span is the first aria-hidden span inside the button
+      const stateLayer = actionBtn.querySelector("[aria-hidden='true']");
+      expect(stateLayer?.className).toContain("bg-inverse-primary");
+    });
+
+    test("close button state layer uses bg-inverse-on-surface (MD3 correct on inverse surface)", () => {
+      renderSnackbar({ message: "File deleted", showClose: true });
+      const closeBtn = screen.getByRole("button", { name: /close/i });
+      const stateLayer = closeBtn.querySelector("[aria-hidden='true']");
+      expect(stateLayer?.className).toContain("bg-inverse-on-surface");
+    });
+
+    test("close button is 32dp (size-8) — fits within 48dp snackbar", () => {
+      renderSnackbar({ message: "File deleted", showClose: true });
+      const closeBtn = screen.getByRole("button", { name: /close/i });
+      // Verify the close button is size-8 (32dp), not size-14 (56dp which overflows)
+      expect(closeBtn).toHaveClass("size-8");
+    });
+
+    test("supporting text renders without opacity reduction (full inverse-on-surface)", () => {
+      const { container } = renderSnackbar({
+        message: "Connection lost",
+        supportingText: "Please check your network",
+      });
+      const supportingText = container.querySelector(".mt-1");
+      // Supporting text slot must NOT have opacity-80 (non-spec opacity reduction)
+      expect(supportingText?.className).not.toContain("opacity-80");
+    });
+
     test("forwards ref to container element", () => {
       const ref = { current: null };
       render(
@@ -466,16 +501,19 @@ describe("Snackbar", () => {
   // ---------------------------------------------------------------------------
 
   describe("Animation states", () => {
-    test("container starts with entering animation class", () => {
+    test("container has slide+fade transition classes", () => {
       renderSnackbar({ message: "Hello" });
       const el = screen.getByRole("status");
+      // Base container carries the combined transition property
       expect(el.className).toMatch(/transition/);
     });
 
-    test("container applies opacity class for visibility", () => {
+    test("container starts in entering state (opacity-0 + translate offset)", () => {
       renderSnackbar({ message: "Hello" });
       const el = screen.getByRole("status");
-      expect(el.className).toMatch(/opacity/);
+      // Entering state: opacity-0 and translate-y-3 (bottom positions slide from below)
+      expect(el.className).toMatch(/opacity-0/);
+      expect(el.className).toMatch(/translate-y-3/);
     });
   });
 
@@ -556,21 +594,24 @@ describe("Snackbar", () => {
       expect(container.className).toMatch(/right-4/);
     });
 
-    test("bottom positions enter with scale-75 and origin-bottom (zoom-in from bottom)", () => {
+    test("bottom positions enter with translate-y-3 and opacity-0 (slide from below)", () => {
       renderSnackbar({ message: "Hello", position: "bottom-center" });
       const el = screen.getByRole("status");
-      // In entering state (before the zero-delay setTimeout fires), the snackbar
-      // starts at scale-75 + opacity-0, anchored at origin-bottom for the zoom.
-      expect(el.className).toMatch(/scale-75/);
-      expect(el.className).toMatch(/origin-bottom/);
+      // In entering state (before the double rAF fires), the snackbar starts
+      // offset downward (translate-y-3) and transparent — the slide-up entry
+      // begins from this position.
+      expect(el.className).toMatch(/translate-y-3/);
+      expect(el.className).toMatch(/opacity-0/);
     });
 
-    test("top positions enter with scale-75 and origin-top (zoom-in from top)", () => {
+    test("top positions enter with -translate-y-3 and opacity-0 (slide from above)", () => {
       renderSnackbar({ message: "Hello", position: "top-center" });
       const el = screen.getByRole("status");
-      // In entering state with "down" direction, scale anchors at origin-top.
-      expect(el.className).toMatch(/scale-75/);
-      expect(el.className).toMatch(/origin-top/);
+      // In entering state with "down" direction, the snackbar starts offset
+      // upward (-translate-y-3) and transparent — the slide-down entry begins
+      // from this position.
+      expect(el.className).toMatch(/-translate-y-3/);
+      expect(el.className).toMatch(/opacity-0/);
     });
   });
 

--- a/packages/react/src/components/Snackbar/Snackbar.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { forwardRef } from "react";
-import { Button } from "../Button";
-import { IconButton } from "../IconButton";
+import { forwardRef, useRef } from "react";
+import { useButton, useHover, useFocusRing, mergeProps } from "react-aria";
 import { cn } from "../../utils/cn";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
+import { useRipple } from "../../hooks/useRipple";
+import { useReducedMotion } from "../../hooks/useReducedMotion";
 import { SnackbarHeadless } from "./SnackbarHeadless";
 import {
   snackbarAnimationVariants,
@@ -12,11 +14,18 @@ import {
   snackbarMessageVariants,
   snackbarSupportingTextVariants,
   snackbarActionVariants,
+  snackbarActionStateLayerVariants,
+  snackbarActionFocusRingVariants,
   snackbarCloseVariants,
+  snackbarCloseStateLayerVariants,
+  snackbarCloseFocusRingVariants,
+  snackbarCloseIconVariants,
   getEnterDirection,
 } from "./Snackbar.variants";
 import type { SnackbarAnimationState } from "./SnackbarHeadless";
 import type { SnackbarPosition, SnackbarProps } from "./Snackbar.types";
+
+// ─── Close icon ───────────────────────────────────────────────────────────────
 
 /**
  * Close icon SVG (24dp, MD3 standard close symbol).
@@ -37,19 +46,133 @@ function CloseIcon(): JSX.Element {
   );
 }
 
+// ─── SnackbarActionButton (internal) ─────────────────────────────────────────
+
+/**
+ * Internal action button for the MD3 Snackbar.
+ *
+ * Implements the slot-based "Variants vs States" architecture:
+ * - React Aria `useButton` + `useHover` + `useFocusRing` for behavior
+ * - `getInteractionDataAttributes` → `group-data-[x]/snackbar-action` selectors
+ * - State-layer `bg-inverse-primary` — MD3-correct for the inverse-surface container
+ * - Focus ring `outline-inverse-primary` — visible on inverse-surface
+ *
+ * NOT exported — use the styled `Snackbar` component or `SnackbarHeadless` with
+ * a custom render function for custom action implementations.
+ */
+interface SnackbarActionButtonProps {
+  /** Visible label text. Also used as the accessible button name. */
+  label: string;
+  /** Callback fired when the action is pressed. */
+  onAction: () => void;
+}
+
+function SnackbarActionButton({ label, onAction }: SnackbarActionButtonProps): JSX.Element {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  const { buttonProps, isPressed } = useButton({ onPress: onAction }, ref);
+  const { isHovered, hoverProps } = useHover({});
+  const { isFocusVisible, focusProps } = useFocusRing();
+  const { onMouseDown, ripples } = useRipple();
+
+  return (
+    <button
+      type="button"
+      {...mergeProps(buttonProps, hoverProps, focusProps, { onMouseDown })}
+      ref={ref}
+      className={cn(snackbarActionVariants(), "group/snackbar-action")}
+      {...getInteractionDataAttributes({ isHovered, isFocusVisible, isPressed })}
+    >
+      {/* Ripple feedback */}
+      {ripples}
+
+      {/* State layer — bg-inverse-primary per MD3 Snackbar spec */}
+      <span className={snackbarActionStateLayerVariants()} aria-hidden="true" />
+
+      {/* Focus ring — extends 3px outside; root has no overflow-hidden */}
+      <span className={snackbarActionFocusRingVariants()} aria-hidden="true" />
+
+      {/* Label text — z-10 keeps it above state layer and ripple */}
+      <span className="relative z-10">{label}</span>
+    </button>
+  );
+}
+
+// ─── SnackbarCloseButton (internal) ──────────────────────────────────────────
+
+/**
+ * Internal close icon button for the MD3 Snackbar.
+ *
+ * Implements the slot-based "Variants vs States" architecture:
+ * - React Aria `useButton` + `useHover` + `useFocusRing` for behavior
+ * - `getInteractionDataAttributes` → `group-data-[x]/snackbar-close` selectors
+ * - Container: 32dp (size-8) — fits within the 48dp snackbar with 8dp margin
+ * - State-layer `bg-inverse-on-surface` — MD3-correct for the inverse-surface container
+ *
+ * NOT exported — use the styled `Snackbar` component's `showClose` prop.
+ */
+interface SnackbarCloseButtonProps {
+  /** Callback fired when the close button is pressed. */
+  onPress: () => void;
+}
+
+function SnackbarCloseButton({ onPress }: SnackbarCloseButtonProps): JSX.Element {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  const { buttonProps, isPressed } = useButton({ onPress, "aria-label": "Close" }, ref);
+  const { isHovered, hoverProps } = useHover({});
+  const { isFocusVisible, focusProps } = useFocusRing();
+  const { onMouseDown, ripples } = useRipple();
+
+  return (
+    <button
+      type="button"
+      {...mergeProps(buttonProps, hoverProps, focusProps, { onMouseDown })}
+      ref={ref}
+      className={cn(snackbarCloseVariants(), "group/snackbar-close")}
+      {...getInteractionDataAttributes({ isHovered, isFocusVisible, isPressed })}
+    >
+      {/* Ripple feedback */}
+      {ripples}
+
+      {/* State layer — bg-inverse-on-surface per MD3 Snackbar spec */}
+      <span className={snackbarCloseStateLayerVariants()} aria-hidden="true" />
+
+      {/* Focus ring — extends 3px outside; root has no overflow-hidden */}
+      <span className={snackbarCloseFocusRingVariants()} aria-hidden="true" />
+
+      {/* Icon — 24dp per MD3, z-10 keeps it above state layer */}
+      <span className={snackbarCloseIconVariants()} aria-hidden="true">
+        <CloseIcon />
+      </span>
+    </button>
+  );
+}
+
+// ─── Snackbar (Layer 3: MD3 Styled) ──────────────────────────────────────────
+
 /**
  * `Snackbar` — Layer 3 MD3 Styled Component.
  *
  * Renders one of four MD3 Snackbar content configurations:
  * 1. Single-line message only
  * 2. Two-line message + `supportingText`
- * 3. Single-line with text `action` button (styled `Button variant="text"` with
- *    `inverse-primary` color per MD3 spec)
+ * 3. Single-line with text `action` button (styled with `inverse-primary` per MD3 spec)
  * 4. Single-line with close icon (or combined with action)
  *
  * Uses `SnackbarHeadless` for all behavioral concerns (ARIA live region,
  * auto-dismiss timer with pause/resume, animation state machine) and CVA
  * variants for MD3-compliant visual styling.
+ *
+ * **Motion**: Position-aware slide + fade using spring-standard effects tokens.
+ * Automatically respects `prefers-reduced-motion` (fade-only when reduced motion
+ * is preferred — no translate offset).
+ *
+ * **State layers**: Dedicated slot components (`SnackbarActionButton`,
+ * `SnackbarCloseButton`) replace the shared `Button`/`IconButton` components.
+ * This ensures the state-layer colors are MD3-correct on an `inverse-surface`:
+ * - Action button state layer: `bg-inverse-primary`
+ * - Close button state layer: `bg-inverse-on-surface`
  *
  * For typical app usage, render inside `SnackbarProvider` and trigger via
  * the `useSnackbar` hook. For declarative/test usage, it can be rendered
@@ -82,9 +205,8 @@ export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(function Snack
   ref
 ) {
   const isTwoLine = Boolean(supportingText);
+  const reducedMotion = useReducedMotion();
 
-  // Base structural classes only — positioning is handled by the stack container
-  // in SnackbarProvider. pointer-events-auto is included in snackbarBaseVariants.
   const baseClassName = cn(snackbarBaseVariants({ twoLine: isTwoLine }), className);
 
   return (
@@ -99,9 +221,18 @@ export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(function Snack
       position={position}
       {...(onClose !== undefined && { onClose })}
       className={baseClassName}
-      getAnimationClassName={(state: SnackbarAnimationState, pos: SnackbarPosition) =>
-        snackbarAnimationVariants({ animationState: state, enterDirection: getEnterDirection(pos) })
-      }
+      getAnimationClassName={(state: SnackbarAnimationState, pos: SnackbarPosition) => {
+        // Reduced motion: fade-only — no translate offset
+        if (reducedMotion) {
+          return state === "visible"
+            ? "opacity-100 duration-spring-standard-default-effects ease-spring-standard-default-effects"
+            : "opacity-0";
+        }
+        return snackbarAnimationVariants({
+          animationState: state,
+          enterDirection: getEnterDirection(pos),
+        });
+      }}
     >
       {({ onClose: triggerClose }) => (
         <>
@@ -113,32 +244,11 @@ export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(function Snack
             )}
           </div>
 
-          {/* Action button — MD3: text variant with inverse-primary color */}
-          {action && (
-            <span className={snackbarActionVariants()}>
-              <Button
-                variant="text"
-                onPress={action.onAction}
-                className="text-inverse-primary hover:text-inverse-primary px-3"
-              >
-                {action.label}
-              </Button>
-            </span>
-          )}
+          {/* Action button — MD3: inverse-primary label + state layer */}
+          {action && <SnackbarActionButton label={action.label} onAction={action.onAction} />}
 
-          {/* Close icon button — MD3: standard icon button with inverse-on-surface */}
-          {showClose && (
-            <span className={snackbarCloseVariants()}>
-              <IconButton
-                variant="standard"
-                aria-label="Close"
-                onPress={triggerClose}
-                className="text-inverse-on-surface hover:text-inverse-on-surface"
-              >
-                <CloseIcon />
-              </IconButton>
-            </span>
-          )}
+          {/* Close icon button — MD3: inverse-on-surface icon + state layer, 32dp */}
+          {showClose && <SnackbarCloseButton onPress={triggerClose} />}
         </>
       )}
     </SnackbarHeadless>

--- a/packages/react/src/components/Snackbar/Snackbar.types.ts
+++ b/packages/react/src/components/Snackbar/Snackbar.types.ts
@@ -36,10 +36,19 @@ export type SnackbarSeverity = "default" | "error";
 /**
  * Internal animation state machine for the Snackbar.
  *
- * - `entering` → zoom-in start: scale-75 + opacity-0 (no duration, paints before transition)
- * - `visible`  → scale-100 + opacity-100 (medium1 / standard-decelerate = 250ms)
- * - `exiting`  → scale-75 + opacity-0 (short4 / standard-accelerate = 200ms)
+ * - `entering` → initial paint: opacity-0 + directional translate offset (no duration)
+ * - `visible`  → slide in + fade in: translate-y-0 + opacity-100
+ *                (spring-standard-default-effects = 200ms, no overshoot)
+ * - `exiting`  → slide out + fade out: offset + opacity-0
+ *                (spring-standard-fast-effects = 150ms)
  * - `exited`   → removed from DOM / stack updated
+ *
+ * The translate direction is position-aware:
+ *   bottom positions → slide up from below (translate-y-3 → translate-y-0)
+ *   top positions    → slide down from above (-translate-y-3 → translate-y-0)
+ *
+ * When `prefers-reduced-motion` is active, the translate offset is suppressed
+ * and only opacity transitions (fade-only).
  */
 export type SnackbarAnimationState = "entering" | "visible" | "exiting" | "exited";
 

--- a/packages/react/src/components/Snackbar/Snackbar.variants.ts
+++ b/packages/react/src/components/Snackbar/Snackbar.variants.ts
@@ -3,20 +3,29 @@ import { cva, type VariantProps } from "class-variance-authority";
 /**
  * Material Design 3 Snackbar Variants (CVA)
  *
- * Type-safe variant management using Tailwind CSS classes mapped to MD3 tokens.
+ * Architecture: Variants vs States
+ * ─────────────────────────────────
+ * - CVA holds design-time choices only (twoLine density, animationState, position).
+ * - Dedicated slot CVAs for the action button and close button replace the old
+ *   shared `Button`/`IconButton` usage, giving MD3-correct state-layer colors
+ *   on the inverse surface:
+ *     • Action button  → state-layer  bg-inverse-primary
+ *     • Close button   → state-layer  bg-inverse-on-surface
+ * - All interaction states on action/close slots are driven by data-* attributes
+ *   via group-data-[x]/snackbar-action and group-data-[x]/snackbar-close selectors.
  *
  * MD3 Specifications:
- * - Surface color: inverse-surface
- * - Text color: inverse-on-surface
- * - Shape: extra-small (4dp) → rounded-xs
- * - Elevation: level-3 → shadow-elevation-3
- * - Min width: 288dp → min-w-72
- * - Max width: 568dp → max-w-snackbar-max
- * - Default position: fixed bottom-4, horizontally centered
- * - Message text: body-medium
- * - Action text: label-large, inverse-primary color
- * - Entry motion: medium1 (250ms) + ease-emphasized-decelerate (zoom in)
- * - Exit motion:  short4 (200ms) + ease-standard-accelerate (fade out)
+ * - Surface color    : inverse-surface
+ * - Text color       : inverse-on-surface
+ * - Shape            : extra-small (4dp) → rounded-xs
+ * - Elevation        : level-3 → shadow-elevation-3
+ * - Width            : 288dp min (min-w-72) / 568dp max (max-w-snackbar-max)
+ * - Single-line height: 48dp (min-h-12)
+ * - Two-line height  : 68dp (min-h-[4.25rem])
+ * - Action text      : label-large, inverse-primary
+ * - Close icon       : 24dp (size-6), inverse-on-surface
+ * - Entry motion     : slide + fade in, spring-standard-default-effects (200ms)
+ * - Exit motion      : slide + fade out, spring-standard-fast-effects (150ms)
  */
 
 // ─── Stack container (fixed viewport anchor, per-position group) ──────────────
@@ -58,12 +67,15 @@ export const snackbarStackContainerVariants = cva(
 
 export type SnackbarStackContainerVariants = VariantProps<typeof snackbarStackContainerVariants>;
 
-// ─── Base container (surface, shape, layout — no positioning) ─────────────────
+// ─── Base container (surface, shape, density — no positioning) ────────────────
 
 /**
- * Snackbar base container variants — structural, surface, and layout classes.
- * Positioning is handled by the stack container (`snackbarStackContainerVariants`)
- * so individual snackbars only carry surface/shape/layout concerns.
+ * Snackbar base container variants — structural, surface, and density classes.
+ * Positioning is handled by the stack container (`snackbarStackContainerVariants`).
+ *
+ * `twoLine` drives two distinct density profiles:
+ *   false — 48dp min-height, content vertically centered (MD3 single-line)
+ *   true  — 68dp min-height, content top-aligned (MD3 two-line)
  */
 export const snackbarBaseVariants = cva(
   [
@@ -71,7 +83,6 @@ export const snackbarBaseVariants = cva(
     "min-w-72",
     "max-w-snackbar-max",
     "w-max",
-    "min-h-12",
 
     // Restore pointer events so hover/focus timer pause works
     "pointer-events-auto",
@@ -87,27 +98,29 @@ export const snackbarBaseVariants = cva(
 
     // Layout
     "flex",
-    "items-center",
     "gap-x-1",
-    "pl-4 pr-2",
+    "pl-4",
 
-    // Typography
+    // Typography base (inherited by message/supporting-text slots)
     "text-body-medium",
     "text-inverse-on-surface",
 
-    // Transition (properties used by both entry and exit)
+    // Slide + fade transition — spring-standard effects tokens (no overshoot).
+    // The translate offset is small (12px), so using the effects token pair for
+    // BOTH opacity AND transform is safe: no visible overshoot at this scale.
     "transition-[opacity,transform]",
     "will-change-[opacity,transform]",
   ],
   {
     variants: {
       /**
-       * Whether the Snackbar has supporting text (two-line layout).
-       * Adjusts vertical padding to MD3 spec for two-line configuration.
+       * Two-line density mode.
+       *   false — 48dp, items centered (single-line message)
+       *   true  — 68dp, items top-aligned (message + supporting text)
        */
       twoLine: {
-        true: "py-1",
-        false: "py-1",
+        false: ["min-h-12", "items-center", "pr-1"],
+        true: ["min-h-[4.25rem]", "items-start", "pr-1"],
       },
     },
     defaultVariants: {
@@ -118,14 +131,14 @@ export const snackbarBaseVariants = cva(
 
 export type SnackbarBaseVariants = VariantProps<typeof snackbarBaseVariants>;
 
-// ─── Position variants ────────────────────────────────────────────────────────
+// ─── Position variants (standalone / headless usage) ─────────────────────────
 
 /**
  * Snackbar screen position variants.
  *
- * These classes are now applied to the **stack container** rather than
- * individual snackbars. Kept as a separate export so standalone (non-provider)
- * usage of `SnackbarHeadless` can still apply position classes directly.
+ * Applied to the **stack container** in `SnackbarProvider`. Kept as a separate
+ * export so standalone (non-provider) `SnackbarHeadless` usage can apply
+ * position classes directly.
  *
  * MD3 default is `bottom-center`.
  */
@@ -150,40 +163,112 @@ export type SnackbarPositionVariants = VariantProps<typeof snackbarPositionVaria
 // ─── Animation state classes ──────────────────────────────────────────────────
 
 /**
- * Snackbar animation state variants.
- * Applied by `SnackbarHeadless` based on its internal animation state machine.
+ * Position-aware slide + fade animation variants.
  *
- * The `enterDirection` sets the transform-origin for the scale animation so the
- * snackbar appears to grow from the correct viewport edge:
- * - `up`   (bottom positions): `origin-bottom` — scales up from the bottom edge
- * - `down` (top positions):    `origin-top`    — scales up from the top edge
+ * Replaces the legacy scale/zoom approach with MD3-compliant slide + fade
+ * using spring-standard effects tokens (no overshoot on opacity or the small
+ * translate offset).
  *
- * MD3 motion spec (Emphasized easing set — appropriate for high-attention UI entries):
- * - `entering`: initial mount state — scaled down (75%) + transparent (no duration)
- * - `visible`:  scale-100 + opacity-100 (medium1 / emphasized-decelerate = 250ms) — zoom in
- * - `exiting`:  scale-75 + opacity-0 (short4 / standard-accelerate = 200ms) — zoom out
- * - `exited`:   fully transparent (removed from DOM by provider)
+ * Enter direction:
+ *   up   (bottom positions) → element starts below viewport edge, slides up
+ *   down (top positions)    → element starts above viewport edge, slides down
  *
- * `ease-emphasized-decelerate` (cubic-bezier(0.05, 0.7, 0.1, 1)) is used for entry
- * instead of `ease-standard-decelerate` (cubic-bezier(0, 0, 0, 1)) because the
- * standard-decelerate curve has an infinite initial velocity — it snaps to ~50%
- * progress in the first few milliseconds, making the zoom feel abrupt. The
- * emphasized-decelerate curve has a finite (but high) initial velocity that
- * produces a visible, smooth movement from scale-75 to scale-100.
+ * Animation flow:
+ *   entering → initial paint (opacity-0 + directional translate, no duration)
+ *   visible  → slide in + fade in (spring-standard-default-effects = 200ms)
+ *   exiting  → slide out + fade out (spring-standard-fast-effects = 150ms)
+ *   exited   → hold final position (removed from DOM by provider)
+ *
+ * compoundVariants express (animationState × enterDirection) pairs — both are
+ * derived runtime values, and full explicit compounds are the only reliable way
+ * to set direction-specific translate without Tailwind class-order conflicts.
  */
 export const snackbarAnimationVariants = cva("", {
   variants: {
     animationState: {
-      entering: ["opacity-0", "scale-75"],
-      visible: ["scale-100", "opacity-100", "duration-medium1", "ease-emphasized-decelerate"],
-      exiting: ["scale-75", "opacity-0", "duration-short4", "ease-standard-accelerate"],
-      exited: ["scale-75", "opacity-0", "duration-short4", "ease-standard-accelerate"],
+      entering: [],
+      visible: [],
+      exiting: [],
+      exited: [],
     },
     enterDirection: {
-      up: ["origin-bottom"],
-      down: ["origin-top"],
+      up: [],
+      down: [],
     },
   },
+  compoundVariants: [
+    // ── entering ──────────────────────────────────────────────────────────────
+    // No transition duration — instant jump to offset state before first paint.
+    {
+      animationState: "entering",
+      enterDirection: "up",
+      className: ["opacity-0", "translate-y-3"],
+    },
+    {
+      animationState: "entering",
+      enterDirection: "down",
+      className: ["opacity-0", "-translate-y-3"],
+    },
+
+    // ── visible ───────────────────────────────────────────────────────────────
+    // spring-standard default effects = 200ms, no overshoot.
+    {
+      animationState: "visible",
+      enterDirection: "up",
+      className: [
+        "opacity-100",
+        "translate-y-0",
+        "duration-spring-standard-default-effects",
+        "ease-spring-standard-default-effects",
+      ],
+    },
+    {
+      animationState: "visible",
+      enterDirection: "down",
+      className: [
+        "opacity-100",
+        "translate-y-0",
+        "duration-spring-standard-default-effects",
+        "ease-spring-standard-default-effects",
+      ],
+    },
+
+    // ── exiting ───────────────────────────────────────────────────────────────
+    // spring-standard fast effects = 150ms (quicker exit).
+    {
+      animationState: "exiting",
+      enterDirection: "up",
+      className: [
+        "opacity-0",
+        "translate-y-3",
+        "duration-spring-standard-fast-effects",
+        "ease-spring-standard-fast-effects",
+      ],
+    },
+    {
+      animationState: "exiting",
+      enterDirection: "down",
+      className: [
+        "opacity-0",
+        "-translate-y-3",
+        "duration-spring-standard-fast-effects",
+        "ease-spring-standard-fast-effects",
+      ],
+    },
+
+    // ── exited ────────────────────────────────────────────────────────────────
+    // Hold final position — element is removed from DOM shortly after.
+    {
+      animationState: "exited",
+      enterDirection: "up",
+      className: ["opacity-0", "translate-y-3"],
+    },
+    {
+      animationState: "exited",
+      enterDirection: "down",
+      className: ["opacity-0", "-translate-y-3"],
+    },
+  ],
   defaultVariants: {
     animationState: "entering",
     enterDirection: "up",
@@ -194,49 +279,149 @@ export type SnackbarAnimationVariants = VariantProps<typeof snackbarAnimationVar
 
 /**
  * Combined container variants (base + position + animation) for convenience.
- * The headless layer uses `snackbarAnimationVariants` directly; this export
- * is kept for consumers who want the full combined class string without the
+ * Used by consumers who want the full combined class string without the
  * render-prop pattern (e.g. standalone headless usage outside the provider).
+ *
+ * The main rendering path uses `snackbarBaseVariants` + `snackbarAnimationVariants`
+ * separately for better separation of concerns.
  */
-export const snackbarContainerVariants = cva([...snackbarBaseVariants()], {
-  variants: {
-    animationState: {
-      entering: ["opacity-0", "scale-75"],
-      visible: ["scale-100", "opacity-100", "duration-medium1", "ease-emphasized-decelerate"],
-      exiting: ["scale-75", "opacity-0", "duration-short4", "ease-standard-accelerate"],
-      exited: ["scale-75", "opacity-0", "duration-short4", "ease-standard-accelerate"],
+export const snackbarContainerVariants = cva(
+  [
+    "min-w-72",
+    "max-w-snackbar-max",
+    "w-max",
+    "pointer-events-auto",
+    "bg-inverse-surface",
+    "rounded-xs",
+    "shadow-elevation-3",
+    "flex",
+    "gap-x-1",
+    "pl-4",
+    "text-body-medium",
+    "text-inverse-on-surface",
+    "transition-[opacity,transform]",
+    "will-change-[opacity,transform]",
+  ],
+  {
+    variants: {
+      twoLine: {
+        false: ["min-h-12", "items-center", "pr-1"],
+        true: ["min-h-[4.25rem]", "items-start", "pr-1"],
+      },
+      animationState: {
+        entering: [],
+        visible: [],
+        exiting: [],
+        exited: [],
+      },
+      enterDirection: {
+        up: [],
+        down: [],
+      },
+      position: {
+        "bottom-center": ["bottom-4", "left-1/2", "-translate-x-1/2"],
+        "bottom-left": ["bottom-4", "left-4"],
+        "bottom-right": ["bottom-4", "right-4"],
+        "top-center": ["top-4", "left-1/2", "-translate-x-1/2"],
+        "top-left": ["top-4", "left-4"],
+        "top-right": ["top-4", "right-4"],
+      },
     },
-    enterDirection: {
-      up: ["origin-bottom"],
-      down: ["origin-top"],
+    compoundVariants: [
+      {
+        animationState: "entering",
+        enterDirection: "up",
+        className: ["opacity-0", "translate-y-3"],
+      },
+      {
+        animationState: "entering",
+        enterDirection: "down",
+        className: ["opacity-0", "-translate-y-3"],
+      },
+      {
+        animationState: "visible",
+        enterDirection: "up",
+        className: [
+          "opacity-100",
+          "translate-y-0",
+          "duration-spring-standard-default-effects",
+          "ease-spring-standard-default-effects",
+        ],
+      },
+      {
+        animationState: "visible",
+        enterDirection: "down",
+        className: [
+          "opacity-100",
+          "translate-y-0",
+          "duration-spring-standard-default-effects",
+          "ease-spring-standard-default-effects",
+        ],
+      },
+      {
+        animationState: "exiting",
+        enterDirection: "up",
+        className: [
+          "opacity-0",
+          "translate-y-3",
+          "duration-spring-standard-fast-effects",
+          "ease-spring-standard-fast-effects",
+        ],
+      },
+      {
+        animationState: "exiting",
+        enterDirection: "down",
+        className: [
+          "opacity-0",
+          "-translate-y-3",
+          "duration-spring-standard-fast-effects",
+          "ease-spring-standard-fast-effects",
+        ],
+      },
+      {
+        animationState: "exited",
+        enterDirection: "up",
+        className: ["opacity-0", "translate-y-3"],
+      },
+      {
+        animationState: "exited",
+        enterDirection: "down",
+        className: ["opacity-0", "-translate-y-3"],
+      },
+    ],
+    defaultVariants: {
+      animationState: "entering",
+      enterDirection: "up",
+      position: "bottom-center",
+      twoLine: false,
     },
-    position: {
-      "bottom-center": ["bottom-4", "left-1/2", "-translate-x-1/2"],
-      "bottom-left": ["bottom-4", "left-4"],
-      "bottom-right": ["bottom-4", "right-4"],
-      "top-center": ["top-4", "left-1/2", "-translate-x-1/2"],
-      "top-left": ["top-4", "left-4"],
-      "top-right": ["top-4", "right-4"],
-    },
-    twoLine: {
-      true: "py-1",
-      false: "py-1",
-    },
-  },
-  defaultVariants: {
-    animationState: "entering",
-    enterDirection: "up",
-    position: "bottom-center",
-    twoLine: false,
-  },
-});
+  }
+);
 
 export type SnackbarContainerVariants = VariantProps<typeof snackbarContainerVariants>;
+
+// ─── Content column ───────────────────────────────────────────────────────────
+
+/**
+ * Inner content column (message + optional supporting text).
+ *
+ * `py-3` (12dp) provides vertical breathing room:
+ *   Single-line: 12px + 20px text + 12px = 44px, centered in 48dp by parent
+ *   Two-line:    12px + 44px content + 12px = 68dp = exactly min-h-[4.25rem]
+ */
+export const snackbarContentVariants = cva([
+  "flex",
+  "flex-col",
+  "flex-1",
+  "min-w-0",
+  "py-3",
+  "pr-2",
+]);
 
 // ─── Message ─────────────────────────────────────────────────────────────────
 
 /**
- * Message text variants.
+ * Primary message text slot.
  * MD3: body-medium, inverse-on-surface color.
  */
 export const snackbarMessageVariants = cva([
@@ -248,45 +433,23 @@ export const snackbarMessageVariants = cva([
 // ─── Supporting text ─────────────────────────────────────────────────────────
 
 /**
- * Supporting text variants (two-line configuration).
- * Same color role as message text per MD3 spec.
+ * Supporting text slot (two-line configuration).
+ * MD3: body-medium, full inverse-on-surface color (no opacity reduction).
  */
 export const snackbarSupportingTextVariants = cva([
   "text-body-medium",
   "text-inverse-on-surface",
-  "opacity-80",
+  "mt-1",
 ]);
-
-// ─── Action button wrapper ────────────────────────────────────────────────────
-
-/**
- * Wrapper applied around the action `Button` to override its color to
- * `inverse-primary` as required by MD3 Snackbar spec.
- */
-export const snackbarActionVariants = cva(["shrink-0", "text-inverse-primary"]);
-
-// ─── Close icon button wrapper ────────────────────────────────────────────────
-
-/**
- * Wrapper applied around the close `IconButton` to use `inverse-on-surface`
- * as required by MD3 Snackbar spec.
- */
-export const snackbarCloseVariants = cva(["shrink-0", "text-inverse-on-surface"]);
-
-// ─── Text+action layout ───────────────────────────────────────────────────────
-
-/**
- * Inner content column (message + optional supporting text).
- */
-export const snackbarContentVariants = cva(["flex", "flex-col", "flex-1", "min-w-0 py-2 pr-2"]);
 
 // ─── Initial hidden state ─────────────────────────────────────────────────────
 
 /**
  * Classes applied before the enter animation begins (component just mounted).
- * Scaled down and transparent — the zoom-in entry starts from this state.
+ * Transparent — the slide-in entry starts from this state.
+ * The translate offset is applied via `snackbarAnimationVariants` entering state.
  */
-export const snackbarInitialVariants = cva(["scale-75", "opacity-0"]);
+export const snackbarInitialVariants = cva(["opacity-0"]);
 
 // ─── Position → direction helper ─────────────────────────────────────────────
 
@@ -297,3 +460,158 @@ export const snackbarInitialVariants = cva(["scale-75", "opacity-0"]);
 export function getEnterDirection(position: string): "up" | "down" {
   return position.startsWith("top") ? "down" : "up";
 }
+
+// ─── ACTION BUTTON — dedicated slot CVAs ─────────────────────────────────────
+//
+// Replaces the reused shared `Button` component whose state-layer color
+// (`bg-primary`) is wrong on an inverse-surface container. The dedicated slot
+// uses `bg-inverse-primary` for both label and state-layer per MD3 spec.
+//
+// Group scope: group/snackbar-action
+
+/**
+ * Action button root.
+ *
+ * MD3: text button style on inverse-surface.
+ * - Container: 36dp height (h-9), 12dp horizontal padding (px-3)
+ * - Shape: full rounded (rounded-full)
+ * - Color: inverse-primary label
+ * - No overflow-hidden on root so focus-ring span (inset-[-3px]) is not clipped.
+ *   State-layer has its own overflow-hidden to clip ripple children.
+ */
+export const snackbarActionVariants = cva([
+  // Layout
+  "relative inline-flex items-center justify-center shrink-0",
+  "h-9 px-3",
+  "rounded-full cursor-pointer select-none",
+
+  // Typography (MD3 text button: label-large)
+  "text-label-large",
+  "text-inverse-primary",
+
+  // Effects transition (color)
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+
+  // Disabled
+  "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+  "data-[disabled]:text-on-surface/38",
+]);
+
+/**
+ * Action button state layer.
+ * MD3: state-layer color = inverse-primary (matches the label color role).
+ * Opacities: hover 8% | focus-visible 10% | pressed 10% (doubled wins over hover).
+ */
+export const snackbarActionStateLayerVariants = cva([
+  "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+  "bg-inverse-primary",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Hover: 8%
+  "group-data-[hovered]/snackbar-action:opacity-8",
+  // Focus: 10%
+  "group-data-[focus-visible]/snackbar-action:opacity-10",
+  // Pressed: 10%, doubled selector wins over hover
+  "group-data-[pressed]/snackbar-action:group-data-[pressed]/snackbar-action:opacity-10",
+  // No state layer when disabled
+  "group-data-[disabled]/snackbar-action:hidden",
+]);
+
+/**
+ * Action button focus ring.
+ * Extends 3px outside the button boundary (inset-[-3px]).
+ * Requires NO overflow-hidden on the root button.
+ */
+export const snackbarActionFocusRingVariants = cva([
+  "pointer-events-none absolute inset-[-3px] rounded-full",
+  "outline outline-2 outline-offset-0 outline-inverse-primary",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/snackbar-action:opacity-100",
+]);
+
+// ─── CLOSE BUTTON — dedicated slot CVAs ──────────────────────────────────────
+//
+// Replaces the reused shared `IconButton` which was `size="medium"` (56dp),
+// overflowing the 48dp snackbar. The dedicated slot is 32dp (size-8) and uses
+// `bg-inverse-on-surface` for the state-layer per MD3 spec.
+//
+// Group scope: group/snackbar-close
+
+/**
+ * Close button root.
+ *
+ * MD3: standard icon button style on inverse-surface.
+ * - Container: 32dp (size-8) — fits within 48dp snackbar with 8dp margin each side
+ * - Shape: rounded-full
+ * - Color: inverse-on-surface icon
+ * - No overflow-hidden on root so focus-ring span (inset-[-3px]) is not clipped.
+ */
+export const snackbarCloseVariants = cva([
+  // Layout
+  "relative inline-flex items-center justify-center shrink-0",
+  "size-8",
+  "rounded-full cursor-pointer select-none",
+
+  // Color
+  "text-inverse-on-surface",
+
+  // Effects transition (color)
+  "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+
+  // Disabled
+  "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+  "data-[disabled]:text-on-surface/38",
+]);
+
+/**
+ * Close button state layer.
+ * MD3: state-layer color = inverse-on-surface (matches the icon color role).
+ * Opacities: hover 8% | focus-visible 10% | pressed 10% (doubled wins over hover).
+ */
+export const snackbarCloseStateLayerVariants = cva([
+  "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+  "bg-inverse-on-surface",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  // Hover: 8%
+  "group-data-[hovered]/snackbar-close:opacity-8",
+  // Focus: 10%
+  "group-data-[focus-visible]/snackbar-close:opacity-10",
+  // Pressed: 10%, doubled selector wins over hover
+  "group-data-[pressed]/snackbar-close:group-data-[pressed]/snackbar-close:opacity-10",
+  // No state layer when disabled
+  "group-data-[disabled]/snackbar-close:hidden",
+]);
+
+/**
+ * Close button focus ring.
+ * Extends 3px outside the button boundary (inset-[-3px]).
+ * Requires NO overflow-hidden on the root button.
+ */
+export const snackbarCloseFocusRingVariants = cva([
+  "pointer-events-none absolute inset-[-3px] rounded-full",
+  "outline outline-2 outline-offset-0 outline-inverse-on-surface",
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/snackbar-close:opacity-100",
+]);
+
+/**
+ * Close button icon wrapper.
+ * MD3: 24dp icon inside a 32dp touch target.
+ */
+export const snackbarCloseIconVariants = cva([
+  "relative z-10 inline-flex shrink-0 items-center justify-center",
+  "size-6",
+]);
+
+// ─── Exported types ───────────────────────────────────────────────────────────
+
+export type SnackbarActionVariants = VariantProps<typeof snackbarActionVariants>;
+export type SnackbarActionStateLayerVariants = VariantProps<
+  typeof snackbarActionStateLayerVariants
+>;
+export type SnackbarActionFocusRingVariants = VariantProps<typeof snackbarActionFocusRingVariants>;
+export type SnackbarCloseVariants = VariantProps<typeof snackbarCloseVariants>;
+export type SnackbarCloseStateLayerVariants = VariantProps<typeof snackbarCloseStateLayerVariants>;
+export type SnackbarCloseFocusRingVariants = VariantProps<typeof snackbarCloseFocusRingVariants>;
+export type SnackbarCloseIconVariants = VariantProps<typeof snackbarCloseIconVariants>;

--- a/packages/react/src/components/Snackbar/index.ts
+++ b/packages/react/src/components/Snackbar/index.ts
@@ -8,24 +8,45 @@ export type { SnackbarAnimationState } from "./SnackbarHeadless";
 // Provider + Hook (required for imperative queue API)
 export { SnackbarProvider, SnackbarContext, useSnackbar } from "./SnackbarProvider";
 
-// CVA Variants
+// CVA Variants — base + animation
 export {
   snackbarStackContainerVariants,
   snackbarBaseVariants,
   snackbarAnimationVariants,
   snackbarPositionVariants,
   snackbarContainerVariants,
+  snackbarContentVariants,
   snackbarMessageVariants,
   snackbarSupportingTextVariants,
-  snackbarActionVariants,
-  snackbarCloseVariants,
-  snackbarContentVariants,
+  snackbarInitialVariants,
   getEnterDirection,
   type SnackbarStackContainerVariants,
   type SnackbarBaseVariants,
   type SnackbarAnimationVariants,
   type SnackbarPositionVariants,
   type SnackbarContainerVariants,
+} from "./Snackbar.variants";
+
+// CVA Variants — action button slots
+export {
+  snackbarActionVariants,
+  snackbarActionStateLayerVariants,
+  snackbarActionFocusRingVariants,
+  type SnackbarActionVariants,
+  type SnackbarActionStateLayerVariants,
+  type SnackbarActionFocusRingVariants,
+} from "./Snackbar.variants";
+
+// CVA Variants — close button slots
+export {
+  snackbarCloseVariants,
+  snackbarCloseStateLayerVariants,
+  snackbarCloseFocusRingVariants,
+  snackbarCloseIconVariants,
+  type SnackbarCloseVariants,
+  type SnackbarCloseStateLayerVariants,
+  type SnackbarCloseFocusRingVariants,
+  type SnackbarCloseIconVariants,
 } from "./Snackbar.variants";
 
 // Types


### PR DESCRIPTION
## Summary

- **State-layer color fixes**: replaced shared `Button`/`IconButton` (wrong state-layer colors on inverse-surface) with dedicated `SnackbarActionButton` (`bg-inverse-primary` state layer) and `SnackbarCloseButton` (`bg-inverse-on-surface` state layer) slot components using React Aria + `getInteractionDataAttributes`
- **Close button sizing**: was 56dp (`size="medium"`) overflowing the 48dp snackbar; now 32dp (`size-8`) with 8dp clearance
- **Spring motion**: migrated from legacy scale/zoom (`ease-emphasized-decelerate`) to position-aware slide + fade using `duration-spring-standard-default-effects` (200ms enter) / `duration-spring-standard-fast-effects` (150ms exit); `useReducedMotion` guard for fade-only reduced-motion mode
- **Token/density fixes**: removed non-spec `opacity-80` from `supportingText`; meaningful two-line density (68dp + `items-start` vs 48dp + `items-center`)
- **New CVA exports**: action + close slot variants with `VariantProps` types

## Files changed

- `Snackbar.variants.ts` — new slot CVAs (action/close root, stateLayer, focusRing, icon); slide+fade animation variants with compoundVariants
- `Snackbar.tsx` — `SnackbarActionButton` + `SnackbarCloseButton` internal components; `useReducedMotion` guard
- `Snackbar.types.ts` — updated motion JSDoc
- `index.ts` — new slot variant exports
- `Snackbar.test.tsx` — updated motion assertions (translate/opacity vs scale/origin); added state-layer color + sizing assertions
- `Snackbar.stories.tsx` — updated motion docs; new `States` story

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 2121/2121 passing (60 Snackbar tests)
- [ ] Storybook visual check — `pnpm dev:storybook`: single-line, two-line, action/close states on inverse surface, all 6 position slide directions, reduced-motion fade-only