### PR TITLE
refactor(split-button): md3 expressive architecture + spring motion

### DIFF
--- a/.changeset/split-button-md3-expressive.md
+++ b/.changeset/split-button-md3-expressive.md
@@ -1,0 +1,32 @@
+---
+"@tinybigui/react": minor
+---
+
+refactor(split-button): MD3 Expressive architecture, new variant + 5-size scale
+
+**BREAKING CHANGES**
+
+- `SplitButtonSize` values renamed to match the MD3 Expressive size scale:
+  - `"small"` → `"xs"` (32dp)
+  - `"medium"` → `"sm"` (40dp, new default)
+  - `"large"` → `"md"` (56dp)
+  - New: `"lg"` (96dp) and `"xl"` (136dp)
+- CVA export `splitButtonPrimaryVariants` renamed to `splitButtonLeadingVariants`.
+- CVA export `splitButtonDropdownVariants` renamed to `splitButtonTrailingVariants`.
+- Type `SplitButtonPrimaryVariants` renamed to `SplitButtonLeadingVariants`.
+- Type `SplitButtonDropdownVariants` renamed to `SplitButtonTrailingVariants`.
+
+**New features**
+
+- `variant="elevated"` added — `bg-surface-container-low` with `shadow-elevation-1` base, matching the Button elevated variant.
+- New CVA slot exports: `splitButtonStateLayerVariants`, `splitButtonFocusRingVariants`, `splitButtonLabelVariants`, `splitButtonIconVariants`, `splitButtonMenuVariants`, `splitButtonMenuItemVariants`.
+
+**Architecture improvements**
+
+- Variants-vs-States: all interaction states now use React Aria `useHover` / `useFocusRing` / `onPressStart`/`onPressEnd` → `data-*` attributes → `group-data-[x]/sb-leading` and `group-data-[x]/sb-trailing` Tailwind selectors. No interaction state logic lives in CVA.
+- Per-segment state layers (hover 8%, focus 10%, pressed 10%) and dedicated focus-ring spans, matching the Button component architecture.
+- MD3 Expressive inner-corner shape morphing: leading-right / trailing-left corners animate on hover/focus/press via a `--sb-inner-radius` CSS variable.
+- 2dp `gap-0.5` gap replaces the `border-l` visual divider.
+- Trailing segment receives `data-selected` when the dropdown menu is open.
+- `useReducedMotion` guard on all JS-driven chevron rotation and shape transitions.
+- Motion: `duration-expressive-fast-spatial` / `ease-expressive-fast-spatial` for border-radius; `duration-spring-standard-fast-effects` / `ease-spring-standard-fast-effects` for opacity and shadow.

--- a/packages/react/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/react/src/components/SplitButton/SplitButton.stories.tsx
@@ -381,6 +381,43 @@ export const Accessibility: Story = {
   },
 };
 
+// ─── Selected state (trailing = full circle) ─────────────────────────────────
+
+const SelectedStateExample = (): React.ReactElement => {
+  return (
+    <div className="flex flex-col items-start gap-8">
+      <p className="text-body-medium text-on-surface-variant max-w-sm">
+        When the dropdown is open the trailing segment morphs into a full circle. Click the chevron
+        to toggle the selected state.
+      </p>
+      {(["xs", "sm", "md", "lg", "xl"] as const).map((size) => (
+        <div key={size} className="flex flex-col gap-1">
+          <span className="text-label-medium text-on-surface-variant uppercase">{size}</span>
+          <SplitButton
+            variant="filled"
+            size={size}
+            primaryLabel="Save"
+            onPrimaryAction={noop}
+            items={saveItems}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const SelectedState: Story = {
+  render: () => <SelectedStateExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Click the chevron on each size to open the menu and observe the trailing segment animate into a full circle with the chevron centered. The inner-corner radius morphs through the specificity ladder: rest → hover/focus (moderate) → pressed (stronger) → selected (full circle).",
+      },
+    },
+  },
+};
+
 // ─── Playground ──────────────────────────────────────────────────────────────
 
 export const Playground: Story = {

--- a/packages/react/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/react/src/components/SplitButton/SplitButton.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { SplitButton } from "./SplitButton";
 import type { SplitButtonMenuItem } from "./SplitButton.types";
 
-// ─── Shared fixture data ────────────────────────────────────────────────────
+// ─── Shared fixture data ─────────────────────────────────────────────────────
 
 const noop = (): void => undefined;
 
@@ -22,7 +22,7 @@ const exportItems: SplitButtonMenuItem[] = [
   { label: "Export as XLSX", onAction: noop },
 ];
 
-// ─── Meta ───────────────────────────────────────────────────────────────────
+// ─── Meta ────────────────────────────────────────────────────────────────────
 
 const meta: Meta<typeof SplitButton> = {
   title: "Components/SplitButton",
@@ -32,7 +32,7 @@ const meta: Meta<typeof SplitButton> = {
     docs: {
       description: {
         component:
-          "MD3 Split Button — a compound control combining a primary action with a dropdown menu. https://m3.material.io/components/buttons/specs#split-button",
+          "MD3 Expressive Split Button — combines a leading action button with a trailing dropdown trigger. Implements the Variants-vs-States architecture with per-segment React Aria interaction tracking, MD3 spring motion, and inner-corner shape morphing. https://m3.material.io/components/split-button/specs",
       },
     },
   },
@@ -40,16 +40,23 @@ const meta: Meta<typeof SplitButton> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["filled", "tonal", "outlined"],
-      description: "Visual variant of the split button",
+      options: ["elevated", "filled", "tonal", "outlined"],
+      description:
+        "Visual variant — controls container color and elevation. Mirrors the standard Button color schemes.",
+    },
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"],
+      description:
+        "Size per the MD3 Expressive scale: xs (32dp), sm (40dp), md (56dp), lg (96dp), xl (136dp).",
     },
     isDisabled: {
       control: "boolean",
-      description: "Disable both the primary action and dropdown segments",
+      description: "Disables both the leading action and trailing dropdown segments.",
     },
     primaryLabel: {
       control: "text",
-      description: "Label displayed in the primary action segment",
+      description: "Label displayed in the leading action segment.",
     },
   },
 };
@@ -57,11 +64,12 @@ const meta: Meta<typeof SplitButton> = {
 export default meta;
 type Story = StoryObj<typeof SplitButton>;
 
-// ─── Stories ────────────────────────────────────────────────────────────────
+// ─── Default ─────────────────────────────────────────────────────────────────
 
 export const Default: Story = {
   args: {
     variant: "filled",
+    size: "sm",
     primaryLabel: "Save",
     onPrimaryAction: noop,
     items: saveItems,
@@ -70,87 +78,139 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          "The default filled Split Button with a 'Save' primary action and three dropdown options. Click the primary label to trigger the action; click the chevron to expand the menu.",
+          "The default filled split button (size sm). Click the 'Save' label to trigger the primary action; click the chevron to expand the dropdown menu.",
       },
     },
   },
 };
 
-export const FilledVariant: Story = {
-  args: {
-    variant: "filled",
-    primaryLabel: "Save",
-    onPrimaryAction: noop,
-    items: saveItems,
-  },
+// ─── Variants ────────────────────────────────────────────────────────────────
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-col items-start gap-6">
+      {(["elevated", "filled", "tonal", "outlined"] as const).map((variant) => (
+        <div key={variant} className="flex flex-col gap-1">
+          <span className="text-label-medium text-on-surface-variant capitalize">{variant}</span>
+          <SplitButton
+            variant={variant}
+            size="sm"
+            primaryLabel="Save"
+            onPrimaryAction={noop}
+            items={saveItems}
+          />
+        </div>
+      ))}
+    </div>
+  ),
   parameters: {
     docs: {
       description: {
         story:
-          "Filled variant — uses `bg-primary` / `text-on-primary` tokens. Highest visual emphasis, suitable for the most important action on a surface.",
+          "All four MD3 Expressive variants at size sm: elevated (surface-container-low + level-1 shadow), filled (primary), tonal (secondary-container), outlined (transparent + outline border). Each carries the same 'Save' primary action for direct comparison.",
       },
     },
   },
 };
 
-export const TonalVariant: Story = {
-  args: {
-    variant: "tonal",
-    primaryLabel: "Save",
-    onPrimaryAction: noop,
-    items: saveItems,
-  },
+// ─── Sizes ───────────────────────────────────────────────────────────────────
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col items-start gap-8">
+      {(["xs", "sm", "md", "lg", "xl"] as const).map((size) => (
+        <div key={size} className="flex flex-col gap-1">
+          <span className="text-label-medium text-on-surface-variant uppercase">{size}</span>
+          <SplitButton
+            variant="filled"
+            size={size}
+            primaryLabel="Save"
+            onPrimaryAction={noop}
+            items={saveItems}
+          />
+        </div>
+      ))}
+    </div>
+  ),
   parameters: {
     docs: {
       description: {
         story:
-          "Tonal variant — uses `bg-secondary-container` / `text-on-secondary-container` tokens. Medium emphasis; good for supporting actions alongside a filled button.",
+          "All five MD3 Expressive sizes: xs (32dp), sm (40dp), md (56dp), lg (96dp), xl (136dp). Inner-corner radius steps up with size: xs/sm/md use 4dp, lg 8dp, xl 12dp.",
       },
     },
   },
 };
 
-export const OutlinedVariant: Story = {
-  args: {
-    variant: "outlined",
-    primaryLabel: "Save",
-    onPrimaryAction: noop,
-    items: saveItems,
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Outlined variant — transparent background with `border-outline` stroke. Low emphasis; ideal when a split button must sit alongside other filled controls.",
-      },
-    },
-  },
-};
+// ─── States ──────────────────────────────────────────────────────────────────
 
-export const AllVariants: Story = {
+export const States: Story = {
   render: () => (
     <div className="flex flex-col items-start gap-6">
       <div className="flex flex-col gap-1">
-        <span className="text-label-medium text-on-surface-variant">Filled</span>
+        <span className="text-label-medium text-on-surface-variant">Enabled</span>
         <SplitButton
           variant="filled"
+          size="sm"
           primaryLabel="Save"
           onPrimaryAction={noop}
           items={saveItems}
         />
       </div>
       <div className="flex flex-col gap-1">
-        <span className="text-label-medium text-on-surface-variant">Tonal</span>
-        <SplitButton variant="tonal" primaryLabel="Save" onPrimaryAction={noop} items={saveItems} />
-      </div>
-      <div className="flex flex-col gap-1">
-        <span className="text-label-medium text-on-surface-variant">Outlined</span>
+        <span className="text-label-medium text-on-surface-variant">Disabled</span>
         <SplitButton
-          variant="outlined"
+          variant="filled"
+          size="sm"
           primaryLabel="Save"
           onPrimaryAction={noop}
           items={saveItems}
+          isDisabled
         />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-label-medium text-on-surface-variant">
+          Outlined — Enabled / Disabled
+        </span>
+        <div className="flex gap-4">
+          <SplitButton
+            variant="outlined"
+            size="sm"
+            primaryLabel="Save"
+            onPrimaryAction={noop}
+            items={saveItems}
+          />
+          <SplitButton
+            variant="outlined"
+            size="sm"
+            primaryLabel="Save"
+            onPrimaryAction={noop}
+            items={saveItems}
+            isDisabled
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-label-medium text-on-surface-variant">
+          Elevated — Enabled / Disabled
+        </span>
+        <div className="flex gap-4">
+          <SplitButton
+            variant="elevated"
+            size="sm"
+            primaryLabel="Save"
+            onPrimaryAction={noop}
+            items={saveItems}
+          />
+          <SplitButton
+            variant="elevated"
+            size="sm"
+            primaryLabel="Save"
+            onPrimaryAction={noop}
+            items={saveItems}
+            isDisabled
+          />
+        </div>
       </div>
     </div>
   ),
@@ -158,15 +218,18 @@ export const AllVariants: Story = {
     docs: {
       description: {
         story:
-          "Side-by-side showcase of all three MD3-compliant variants: filled, tonal, and outlined. Each carries the same 'Save' primary action for direct comparison.",
+          "Hover over each segment to see the 8% state layer; focus via keyboard to see the 10% state layer + focus ring; hold press for 10% pressed overlay. Disabled state applies on-surface/12 container and on-surface/38 content per MD3.",
       },
     },
   },
 };
 
+// ─── With many items ──────────────────────────────────────────────────────────
+
 export const WithManyItems: Story = {
   args: {
     variant: "filled",
+    size: "sm",
     primaryLabel: "Export",
     onPrimaryAction: noop,
     items: exportItems,
@@ -175,13 +238,13 @@ export const WithManyItems: Story = {
     docs: {
       description: {
         story:
-          "Dropdown with five items, demonstrating how the menu scrolls and positions itself when there are many secondary actions to choose from.",
+          "Dropdown with five items, demonstrating menu positioning when there are many secondary actions.",
       },
     },
   },
 };
 
-// ─── Interactive stories that need local state ───────────────────────────────
+// ─── Interactive — primary action fires independently ────────────────────────
 
 const PrimaryActionFiresExample = (): React.ReactElement => {
   const [count, setCount] = useState(0);
@@ -192,6 +255,7 @@ const PrimaryActionFiresExample = (): React.ReactElement => {
       </p>
       <SplitButton
         variant="filled"
+        size="sm"
         primaryLabel="Save"
         onPrimaryAction={() => setCount((c) => c + 1)}
         items={saveItems}
@@ -209,11 +273,13 @@ export const PrimaryActionFires: Story = {
     docs: {
       description: {
         story:
-          "Demonstrates that the primary segment fires independently from the dropdown. The counter increments only when the label segment is pressed, never when the chevron is toggled.",
+          "Verifies the leading and trailing segments fire independently. The counter only increments when the label segment is pressed.",
       },
     },
   },
 };
+
+// ─── Interactive — dropdown only ─────────────────────────────────────────────
 
 const DropdownOnlyExample = (): React.ReactElement => {
   const [primaryFired, setPrimaryFired] = useState(false);
@@ -240,6 +306,7 @@ const DropdownOnlyExample = (): React.ReactElement => {
       </div>
       <SplitButton
         variant="tonal"
+        size="sm"
         primaryLabel="Save"
         onPrimaryAction={() => setPrimaryFired(true)}
         items={menuItems}
@@ -257,15 +324,18 @@ export const DropdownOnly: Story = {
     docs: {
       description: {
         story:
-          "Verifies that opening the dropdown and selecting a menu item does NOT fire the primary action handler. The 'Primary fired' indicator should remain 'no' throughout dropdown interactions.",
+          "Verifies selecting a menu item does NOT fire the primary action. 'Primary fired' should remain 'no' throughout dropdown interactions.",
       },
     },
   },
 };
 
+// ─── Disabled ────────────────────────────────────────────────────────────────
+
 export const DisabledState: Story = {
   args: {
     variant: "filled",
+    size: "sm",
     primaryLabel: "Save",
     onPrimaryAction: noop,
     items: saveItems,
@@ -275,15 +345,48 @@ export const DisabledState: Story = {
     docs: {
       description: {
         story:
-          "Both segments are disabled via `isDisabled={true}`. The component applies `opacity-38` and `pointer-events-none`, preventing interaction with either the primary action or the dropdown chevron.",
+          "Both segments are disabled via `isDisabled`. The component applies on-surface/12 container and on-surface/38 content opacity, preventing interaction with either segment.",
       },
     },
   },
 };
 
+// ─── Accessibility ────────────────────────────────────────────────────────────
+
+export const Accessibility: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <p className="text-body-medium text-on-surface max-w-sm">
+        Tab to focus the leading segment, then Tab again to reach the trailing trigger. Press Enter
+        or Space to open the menu; use Arrow keys to navigate items; Escape to close and return
+        focus to the trigger.
+      </p>
+      <SplitButton
+        variant="filled"
+        size="sm"
+        primaryLabel="Save document"
+        aria-label="Save document split button"
+        onPrimaryAction={noop}
+        items={saveItems}
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Keyboard navigation walkthrough: Tab focuses leading → Tab focuses trailing → Enter/Space opens menu → ArrowDown/Up navigates items → Escape closes and returns focus. Both segments have visible focus rings per WCAG 2.1 AA.",
+      },
+    },
+  },
+};
+
+// ─── Playground ──────────────────────────────────────────────────────────────
+
 export const Playground: Story = {
   args: {
     variant: "filled",
+    size: "sm",
     primaryLabel: "Save",
     onPrimaryAction: noop,
     items: saveItems,
@@ -293,7 +396,7 @@ export const Playground: Story = {
     docs: {
       description: {
         story:
-          "Interactive playground — use the Controls panel to experiment with every exposed prop: variant, primaryLabel, and isDisabled.",
+          "Interactive playground — use the Controls panel to experiment with variant, size, primaryLabel, and isDisabled.",
       },
     },
   },

--- a/packages/react/src/components/SplitButton/SplitButton.test.tsx
+++ b/packages/react/src/components/SplitButton/SplitButton.test.tsx
@@ -29,24 +29,24 @@ function renderSplitButton(props: Partial<React.ComponentProps<typeof SplitButto
 
 describe("SplitButtonHeadless", () => {
   describe("Rendering", () => {
-    // Test 1: Renders primary segment with primaryLabel text
-    test("renders primary segment with primaryLabel text", () => {
+    // Test 1: Renders leading segment with primaryLabel text
+    test("renders leading segment with primaryLabel text", () => {
       renderSplitButton({ primaryLabel: "Save" });
       expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     });
 
-    // Test 2: Renders dropdown trigger segment with expand icon
-    test("renders dropdown trigger segment with expand icon", () => {
+    // Test 2: Renders trailing trigger segment with expand icon
+    test("renders trailing trigger segment with expand icon", () => {
       renderSplitButton();
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu");
-      expect(dropdownTrigger).toBeInTheDocument();
-      expect(dropdownTrigger?.querySelector("svg")).toBeInTheDocument();
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu");
+      expect(trailingTrigger).toBeInTheDocument();
+      expect(trailingTrigger?.querySelector("svg")).toBeInTheDocument();
     });
   });
 
-  describe("Primary Segment Interactions", () => {
-    // Test 3: Primary segment fires onPrimaryAction on click
+  describe("Leading Segment Interactions", () => {
+    // Test 3: Leading segment fires onPrimaryAction on click
     test("fires onPrimaryAction on click", async () => {
       const user = userEvent.setup();
       const onPrimaryAction = vi.fn();
@@ -58,7 +58,7 @@ describe("SplitButtonHeadless", () => {
       expect(onPrimaryAction).toHaveBeenCalledTimes(1);
     });
 
-    // Test 4: Primary segment fires onPrimaryAction on Enter key
+    // Test 4: Leading segment fires onPrimaryAction on Enter key
     test("fires onPrimaryAction on Enter key", async () => {
       const user = userEvent.setup();
       const onPrimaryAction = vi.fn();
@@ -71,7 +71,7 @@ describe("SplitButtonHeadless", () => {
       expect(onPrimaryAction).toHaveBeenCalledTimes(1);
     });
 
-    // Test 5: Primary segment fires onPrimaryAction on Space key
+    // Test 5: Leading segment fires onPrimaryAction on Space key
     test("fires onPrimaryAction on Space key", async () => {
       const user = userEvent.setup();
       const onPrimaryAction = vi.fn();
@@ -84,7 +84,7 @@ describe("SplitButtonHeadless", () => {
       expect(onPrimaryAction).toHaveBeenCalledTimes(1);
     });
 
-    // Test 6: Primary segment does NOT fire when isDisabled={true}
+    // Test 6: Leading segment does NOT fire when isDisabled={true}
     test("does NOT fire onPrimaryAction when isDisabled", async () => {
       const user = userEvent.setup();
       const onPrimaryAction = vi.fn();
@@ -97,30 +97,30 @@ describe("SplitButtonHeadless", () => {
     });
   });
 
-  describe("Dropdown Trigger Interactions", () => {
-    // Test 7: Dropdown trigger opens menu on click
+  describe("Trailing Trigger Interactions", () => {
+    // Test 7: Trailing trigger opens menu on click
     test("opens menu on click", async () => {
       const user = userEvent.setup();
       renderSplitButton();
 
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
 
       expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-      await user.click(dropdownTrigger);
+      await user.click(trailingTrigger);
 
       expect(screen.getByRole("menu")).toBeInTheDocument();
     });
 
-    // Test 8: Dropdown trigger opens menu on Enter key
+    // Test 8: Trailing trigger opens menu on Enter key
     test("opens menu on Enter key", async () => {
       const user = userEvent.setup();
       renderSplitButton();
 
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
 
-      dropdownTrigger.focus();
+      trailingTrigger.focus();
       await user.keyboard("{Enter}");
 
       expect(screen.getByRole("menu")).toBeInTheDocument();
@@ -128,33 +128,33 @@ describe("SplitButtonHeadless", () => {
   });
 
   describe("Accessibility — ARIA Attributes", () => {
-    // Test 9: Dropdown trigger has aria-haspopup="menu"
-    test("dropdown trigger has aria-haspopup='menu'", () => {
+    // Test 9: Trailing trigger has aria-haspopup="menu"
+    test("trailing trigger has aria-haspopup='menu'", () => {
       renderSplitButton();
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu");
-      expect(dropdownTrigger).toHaveAttribute("aria-haspopup", "menu");
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu");
+      expect(trailingTrigger).toHaveAttribute("aria-haspopup", "menu");
     });
 
-    // Test 10: Dropdown trigger has aria-expanded="false" when menu closed
-    test("dropdown trigger has aria-expanded='false' when menu closed", () => {
+    // Test 10: Trailing trigger has aria-expanded="false" when menu closed
+    test("trailing trigger has aria-expanded='false' when menu closed", () => {
       renderSplitButton();
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu");
-      expect(dropdownTrigger).toHaveAttribute("aria-expanded", "false");
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu");
+      expect(trailingTrigger).toHaveAttribute("aria-expanded", "false");
     });
 
-    // Test 11: Dropdown trigger has aria-expanded="true" when menu open
-    test("dropdown trigger has aria-expanded='true' when menu open", async () => {
+    // Test 11: Trailing trigger has aria-expanded="true" when menu open
+    test("trailing trigger has aria-expanded='true' when menu open", async () => {
       const user = userEvent.setup();
       renderSplitButton();
 
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
 
-      await user.click(dropdownTrigger);
+      await user.click(trailingTrigger);
 
-      expect(dropdownTrigger).toHaveAttribute("aria-expanded", "true");
+      expect(trailingTrigger).toHaveAttribute("aria-expanded", "true");
     });
   });
 
@@ -165,9 +165,9 @@ describe("SplitButtonHeadless", () => {
       renderSplitButton();
 
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
 
-      await user.click(dropdownTrigger);
+      await user.click(trailingTrigger);
       expect(screen.getByRole("menu")).toBeInTheDocument();
 
       await user.keyboard("{Escape}");
@@ -188,9 +188,9 @@ describe("SplitButtonHeadless", () => {
       renderSplitButton({ items });
 
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
 
-      await user.click(dropdownTrigger);
+      await user.click(trailingTrigger);
 
       const menuItem = screen.getByRole("menuitem", { name: "Export PDF" });
       await user.click(menuItem);
@@ -207,13 +207,13 @@ describe("SplitButtonHeadless", () => {
 
       const buttons = screen.getAllByRole("button");
       const primaryButton = screen.getByRole("button", { name: "Save" });
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
 
       await user.tab();
       expect(primaryButton).toHaveFocus();
 
       await user.tab();
-      expect(dropdownTrigger).toHaveFocus();
+      expect(trailingTrigger).toHaveFocus();
     });
   });
 
@@ -230,7 +230,7 @@ describe("SplitButtonHeadless", () => {
   });
 
   describe("Ref Forwarding", () => {
-    // Test 16: forwardRef attached to root element
+    // Test 16: forwardRef attached to root group element
     test("forwardRef is attached to root element", () => {
       const ref = createRef<HTMLDivElement>();
       render(
@@ -261,9 +261,9 @@ describe("SplitButtonHeadless", () => {
       const { container } = renderSplitButton();
 
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
 
-      await user.click(dropdownTrigger);
+      await user.click(trailingTrigger);
       expect(screen.getByRole("menu")).toBeInTheDocument();
 
       const results = await axe(container);
@@ -291,47 +291,79 @@ function renderStyledSplitButton(props: Partial<React.ComponentProps<typeof Spli
 
 describe("SplitButton (Styled)", () => {
   describe("Variant Classes", () => {
-    // Test 19: variant="filled" applies bg-primary class to container
-    test('variant="filled" applies bg-primary class to container', () => {
+    // Test 19: variant="filled" applies bg-primary on both segments
+    test('variant="filled" applies bg-primary to leading segment', () => {
       renderStyledSplitButton({ variant: "filled" });
-      const container = screen.getByRole("group");
-      expect(container).toHaveClass("bg-primary");
+      const buttons = screen.getAllByRole("button");
+      const leading = buttons.find((b) => b.getAttribute("aria-haspopup") !== "menu");
+      expect(leading).toHaveClass("bg-primary");
     });
 
-    // Test 20: variant="tonal" applies bg-secondary-container class
-    test('variant="tonal" applies bg-secondary-container class', () => {
+    // Test 20: variant="tonal" applies bg-secondary-container
+    test('variant="tonal" applies bg-secondary-container to leading segment', () => {
       renderStyledSplitButton({ variant: "tonal" });
-      const container = screen.getByRole("group");
-      expect(container).toHaveClass("bg-secondary-container");
+      const buttons = screen.getAllByRole("button");
+      const leading = buttons.find((b) => b.getAttribute("aria-haspopup") !== "menu");
+      expect(leading).toHaveClass("bg-secondary-container");
     });
 
-    // Test 21: variant="outlined" applies border border-outline class
-    test('variant="outlined" applies border border-outline class', () => {
+    // Test 21: variant="outlined" applies border border-outline
+    test('variant="outlined" applies border border-outline to leading segment', () => {
       renderStyledSplitButton({ variant: "outlined" });
-      const container = screen.getByRole("group");
-      expect(container).toHaveClass("border");
-      expect(container).toHaveClass("border-outline");
+      const buttons = screen.getAllByRole("button");
+      const leading = buttons.find((b) => b.getAttribute("aria-haspopup") !== "menu");
+      expect(leading).toHaveClass("border");
+      expect(leading).toHaveClass("border-outline");
+    });
+
+    // Test 22: variant="elevated" applies bg-surface-container-low and shadow-elevation-1
+    test('variant="elevated" applies bg-surface-container-low and shadow-elevation-1', () => {
+      renderStyledSplitButton({ variant: "elevated" });
+      const buttons = screen.getAllByRole("button");
+      const leading = buttons.find((b) => b.getAttribute("aria-haspopup") !== "menu");
+      expect(leading).toHaveClass("bg-surface-container-low");
+      expect(leading).toHaveClass("shadow-elevation-1");
     });
   });
 
-  describe("Visual Divider", () => {
-    // Test 22: Visual divider present between segments
-    test("visual divider present between segments", () => {
-      renderStyledSplitButton();
-      const divider = screen.getByTestId("split-button-divider");
-      expect(divider).toBeInTheDocument();
+  describe("Size Classes", () => {
+    // Test 23: size="xs" applies h-8
+    test('size="xs" applies h-8 to both segments', () => {
+      renderStyledSplitButton({ size: "xs" });
+      const buttons = screen.getAllByRole("button");
+      for (const btn of buttons) {
+        expect(btn).toHaveClass("h-8");
+      }
+    });
+
+    // Test 24: size="sm" applies h-10
+    test('size="sm" applies h-10 to both segments', () => {
+      renderStyledSplitButton({ size: "sm" });
+      const buttons = screen.getAllByRole("button");
+      for (const btn of buttons) {
+        expect(btn).toHaveClass("h-10");
+      }
+    });
+
+    // Test 25: size="md" applies h-14
+    test('size="md" applies h-14 to both segments', () => {
+      renderStyledSplitButton({ size: "md" });
+      const buttons = screen.getAllByRole("button");
+      for (const btn of buttons) {
+        expect(btn).toHaveClass("h-14");
+      }
     });
   });
 
   describe("Chevron Icon", () => {
-    // Test 23: Dropdown trigger shows chevron icon
-    test("dropdown trigger shows chevron icon", () => {
+    // Test 26: Trailing trigger shows chevron icon
+    test("trailing trigger shows chevron icon", () => {
       renderStyledSplitButton();
       const chevron = screen.getByTestId("split-button-chevron");
       expect(chevron).toBeInTheDocument();
     });
 
-    // Test 24: Chevron rotates when menu is open
+    // Test 27: Chevron rotates when menu is open
     test("chevron rotates when menu is open", async () => {
       const user = userEvent.setup();
       renderStyledSplitButton();
@@ -340,16 +372,16 @@ describe("SplitButton (Styled)", () => {
       expect(chevron).not.toHaveClass("rotate-180");
 
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
-      await user.click(dropdownTrigger);
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      await user.click(trailingTrigger);
 
       expect(chevron).toHaveClass("rotate-180");
     });
   });
 
   describe("State Layers", () => {
-    // Test 25: State layer present inside primary segment
-    test("state layer present inside primary segment", () => {
+    // Test 28: State layer present inside leading segment
+    test("state layer present inside leading segment", () => {
       renderStyledSplitButton();
       const stateLayer = screen.getByTestId("primary-state-layer");
       expect(stateLayer).toBeInTheDocument();
@@ -358,8 +390,8 @@ describe("SplitButton (Styled)", () => {
       expect(stateLayer).toHaveClass("inset-0");
     });
 
-    // Test 26: State layer present inside dropdown trigger
-    test("state layer present inside dropdown trigger", () => {
+    // Test 29: State layer present inside trailing trigger
+    test("state layer present inside trailing trigger", () => {
       renderStyledSplitButton();
       const stateLayer = screen.getByTestId("dropdown-state-layer");
       expect(stateLayer).toBeInTheDocument();
@@ -369,24 +401,64 @@ describe("SplitButton (Styled)", () => {
     });
   });
 
+  describe("Interaction Data Attributes", () => {
+    // Test 30: Leading segment gets data-disabled when isDisabled
+    test("leading segment gets data-disabled when isDisabled", () => {
+      renderStyledSplitButton({ isDisabled: true });
+      const buttons = screen.getAllByRole("button");
+      const leading = buttons.find((b) => b.getAttribute("aria-haspopup") !== "menu");
+      expect(leading).toHaveAttribute("data-disabled");
+    });
+
+    // Test 31: Trailing segment gets data-disabled when isDisabled
+    test("trailing segment gets data-disabled when isDisabled", () => {
+      renderStyledSplitButton({ isDisabled: true });
+      const buttons = screen.getAllByRole("button");
+      const trailing = buttons.find((b) => b.getAttribute("aria-haspopup") === "menu");
+      expect(trailing).toHaveAttribute("data-disabled");
+    });
+
+    // Test 32: Trailing segment gets data-selected when menu is open
+    test("trailing segment gets data-selected when menu is open", async () => {
+      const user = userEvent.setup();
+      renderStyledSplitButton();
+
+      const buttons = screen.getAllByRole("button");
+      const trailing = buttons.find((b) => b.getAttribute("aria-haspopup") === "menu")!;
+
+      expect(trailing).not.toHaveAttribute("data-selected");
+      await user.click(trailing);
+      expect(trailing).toHaveAttribute("data-selected");
+    });
+  });
+
+  describe("2dp Gap — No Divider Element", () => {
+    // Test 33: Container has gap-0.5 (2dp gap) instead of a border-l divider
+    test("container applies gap-0.5 layout", () => {
+      renderStyledSplitButton();
+      const group = screen.getByRole("group");
+      expect(group).toHaveClass("gap-0.5");
+    });
+  });
+
   describe("Menu Integration", () => {
-    // Test 27: Menu renders when dropdown is clicked (menu items visible)
-    test("menu renders when dropdown is clicked", async () => {
+    // Test 34: Menu renders when trailing trigger is clicked
+    test("menu renders when trailing trigger is clicked", async () => {
       const user = userEvent.setup();
       renderStyledSplitButton();
 
       expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
-      await user.click(dropdownTrigger);
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      await user.click(trailingTrigger);
 
       expect(screen.getByRole("menu")).toBeInTheDocument();
       expect(screen.getByRole("menuitem", { name: "Save as PDF" })).toBeInTheDocument();
       expect(screen.getByRole("menuitem", { name: "Save as PNG" })).toBeInTheDocument();
     });
 
-    // Test 28: Menu closes after menu item is selected
+    // Test 35: Menu closes after menu item is selected
     test("menu closes after menu item is selected", async () => {
       const user = userEvent.setup();
       const onAction = vi.fn();
@@ -397,8 +469,8 @@ describe("SplitButton (Styled)", () => {
       renderStyledSplitButton({ items });
 
       const buttons = screen.getAllByRole("button");
-      const dropdownTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
-      await user.click(dropdownTrigger);
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      await user.click(trailingTrigger);
 
       const menuItem = screen.getByRole("menuitem", { name: "Export PDF" });
       await user.click(menuItem);
@@ -407,6 +479,28 @@ describe("SplitButton (Styled)", () => {
       await waitFor(() => {
         expect(screen.queryByRole("menu")).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe("Accessibility — axe (Styled)", () => {
+    // Test 36: No axe violations in closed state (styled)
+    test("no axe violations in closed state", async () => {
+      const { container } = renderStyledSplitButton();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    // Test 37: No axe violations in open state (styled)
+    test("no axe violations with menu open", async () => {
+      const user = userEvent.setup();
+      const { container } = renderStyledSplitButton();
+
+      const buttons = screen.getAllByRole("button");
+      const trailingTrigger = buttons.find((btn) => btn.getAttribute("aria-haspopup") === "menu")!;
+      await user.click(trailingTrigger);
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
     });
   });
 });

--- a/packages/react/src/components/SplitButton/SplitButton.test.tsx
+++ b/packages/react/src/components/SplitButton/SplitButton.test.tsx
@@ -353,6 +353,30 @@ describe("SplitButton (Styled)", () => {
         expect(btn).toHaveClass("h-14");
       }
     });
+
+    // Test 38: Trailing segment is square at size="sm" (w-10 = h-10 → circle when selected)
+    test('trailing segment is square (w-10) at size="sm"', () => {
+      renderStyledSplitButton({ size: "sm" });
+      const buttons = screen.getAllByRole("button");
+      const trailing = buttons.find((b) => b.getAttribute("aria-haspopup") === "menu");
+      expect(trailing).toHaveClass("w-10");
+    });
+
+    // Test 39: Trailing segment is square at size="xs" (w-8)
+    test('trailing segment is square (w-8) at size="xs"', () => {
+      renderStyledSplitButton({ size: "xs" });
+      const buttons = screen.getAllByRole("button");
+      const trailing = buttons.find((b) => b.getAttribute("aria-haspopup") === "menu");
+      expect(trailing).toHaveClass("w-8");
+    });
+
+    // Test 40: Trailing segment is square at size="md" (w-14)
+    test('trailing segment is square (w-14) at size="md"', () => {
+      renderStyledSplitButton({ size: "md" });
+      const buttons = screen.getAllByRole("button");
+      const trailing = buttons.find((b) => b.getAttribute("aria-haspopup") === "menu");
+      expect(trailing).toHaveClass("w-14");
+    });
   });
 
   describe("Chevron Icon", () => {
@@ -429,6 +453,19 @@ describe("SplitButton (Styled)", () => {
       expect(trailing).not.toHaveAttribute("data-selected");
       await user.click(trailing);
       expect(trailing).toHaveAttribute("data-selected");
+    });
+
+    // Test 41: Trailing segment carries the selected→full-circle radius utility
+    // The CSS variable override class for --sb-inner-radius:var(--radius-full) must be
+    // present on the trailing button so the full-circle shape renders in the browser.
+    test("trailing segment has full-circle radius utility class", () => {
+      renderStyledSplitButton({ size: "sm" });
+      const buttons = screen.getAllByRole("button");
+      const trailing = buttons.find((b) => b.getAttribute("aria-haspopup") === "menu")!;
+      // The quadrupled data-[selected] selector class is present regardless of open state;
+      // it is the CSS specificity mechanism, not a runtime class toggle.
+      const classList = Array.from(trailing.classList).join(" ");
+      expect(classList).toContain("data-[selected]");
     });
   });
 

--- a/packages/react/src/components/SplitButton/SplitButton.tsx
+++ b/packages/react/src/components/SplitButton/SplitButton.tsx
@@ -1,55 +1,83 @@
 "use client";
 
-import { forwardRef, useRef, useCallback, useEffect, type MouseEvent } from "react";
-import { useButton } from "react-aria";
+import { forwardRef, useRef, useCallback, useEffect, useState, type MouseEvent } from "react";
+import { useButton, useHover, useFocusRing, mergeProps } from "react-aria";
+import { useReducedMotion } from "../../hooks/useReducedMotion";
 import { useMenuTriggerState } from "react-stately";
 import {
   splitButtonContainerVariants,
-  splitButtonPrimaryVariants,
-  splitButtonDropdownVariants,
+  splitButtonLeadingVariants,
+  splitButtonTrailingVariants,
+  splitButtonStateLayerVariants,
+  splitButtonFocusRingVariants,
+  splitButtonLabelVariants,
+  splitButtonIconVariants,
+  splitButtonMenuVariants,
+  splitButtonMenuItemVariants,
 } from "./SplitButton.variants";
 import { useRipple } from "../../hooks/useRipple";
+import { getInteractionDataAttributes } from "../../utils/interactionStates";
 import { cn } from "../../utils/cn";
 import type { SplitButtonProps, SplitButtonMenuItem } from "./SplitButton.types";
 
 /**
- * Chevron-down SVG icon for the dropdown trigger.
- * Rotates 180° when the menu is open.
+ * Chevron-down icon for the trailing dropdown trigger.
+ * Rotates 180° when the menu is open, using the MD3 spatial spring token.
+ * When reduced motion is preferred the rotation is instant (no transition).
  */
-const ChevronIcon = ({ isOpen }: { isOpen: boolean }): React.ReactElement => (
+const ChevronIcon = ({
+  isOpen,
+  reducedMotion,
+}: {
+  isOpen: boolean;
+  reducedMotion: boolean;
+}): React.ReactElement => (
   <svg
     aria-hidden="true"
     data-testid="split-button-chevron"
-    width="18"
-    height="18"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    className={cn("duration-short4 ease-standard transition-transform", isOpen && "rotate-180")}
+    className={cn(
+      "size-full",
+      !reducedMotion &&
+        "duration-expressive-fast-spatial ease-expressive-fast-spatial transition-transform",
+      isOpen && "rotate-180"
+    )}
   >
     <path d="M7 10l5 5 5-5H7z" fill="currentColor" />
   </svg>
 );
 
 /**
- * Material Design 3 Split Button Component (Layer 3: Styled)
+ * Material Design 3 Expressive Split Button Component (Layer 3: Styled)
  *
- * Combines a primary action button with a dropdown trigger that reveals
- * secondary actions in a menu. Both segments include MD3 state layers and
- * ripple effects.
+ * Combines a leading action button with a trailing dropdown trigger that reveals
+ * secondary actions in a menu. Both segments have full MD3 Expressive state layers,
+ * per-segment focus rings, and inner-corner shape morphing.
+ *
+ * Implements the Variants-vs-States architecture: all interaction states are
+ * expressed as data-* attributes on each segment root and consumed by child
+ * slots via group-data-[x]/sb-leading and group-data-[x]/sb-trailing selectors.
  *
  * Features:
- * - 3 MD3 variants: filled, tonal, outlined
- * - Per-segment state layers (hover 8%, focus/pressed 12%)
+ * - 4 MD3 variants: elevated, filled, tonal, outlined
+ * - 5 MD3 Expressive sizes: xs, sm, md, lg, xl
+ * - Per-segment React Aria interaction tracking (hover, focus, press)
+ * - Per-segment MD3 state layers (hover 8%, focus 10%, pressed 10%)
+ * - Per-segment focus rings (extends outside overflow-hidden)
  * - Ripple effect on both segments
+ * - Inner-corner shape morphing on interaction (MD3 Expressive signature)
+ * - 2dp gap between segments per MD3 spec
  * - Chevron rotation animation on menu open
- * - Visual divider between segments per MD3 spec
+ * - useReducedMotion guard on all JS-driven transitions
  * - Full keyboard accessibility via React Aria
  *
  * @example
  * ```tsx
  * <SplitButton
  *   variant="filled"
+ *   size="sm"
  *   primaryLabel="Save"
  *   onPrimaryAction={() => console.log('saved')}
  *   items={[
@@ -63,7 +91,7 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
   (
     {
       variant = "filled",
-      size = "medium",
+      size = "sm",
       primaryLabel,
       onPrimaryAction,
       items,
@@ -73,22 +101,47 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
     },
     forwardedRef
   ) => {
-    const primaryRef = useRef<HTMLButtonElement>(null);
-    const dropdownRef = useRef<HTMLButtonElement>(null);
+    const leadingRef = useRef<HTMLButtonElement>(null);
+    const trailingRef = useRef<HTMLButtonElement>(null);
     const menuRef = useRef<HTMLUListElement>(null);
+
+    const reducedMotion = useReducedMotion();
 
     const menuState = useMenuTriggerState({});
 
-    const { buttonProps: primaryButtonProps } = useButton(
+    // ── Leading segment interaction state ────────────────────────────────────
+    const [isLeadingPressed, setIsLeadingPressed] = useState(false);
+    const handleLeadingPressStart = useCallback(() => setIsLeadingPressed(true), []);
+    const handleLeadingPressEnd = useCallback(() => setIsLeadingPressed(false), []);
+
+    const { isHovered: isLeadingHovered, hoverProps: leadingHoverProps } = useHover({
+      isDisabled,
+    });
+    const { isFocusVisible: isLeadingFocusVisible, focusProps: leadingFocusProps } = useFocusRing();
+
+    const { buttonProps: leadingButtonProps } = useButton(
       {
         isDisabled,
         onPress: onPrimaryAction,
+        onPressStart: handleLeadingPressStart,
+        onPressEnd: handleLeadingPressEnd,
         elementType: "button",
       },
-      primaryRef
+      leadingRef
     );
 
-    const handleDropdownPress = useCallback(() => {
+    // ── Trailing segment interaction state ────────────────────────────────────
+    const [isTrailingPressed, setIsTrailingPressed] = useState(false);
+    const handleTrailingPressStart = useCallback(() => setIsTrailingPressed(true), []);
+    const handleTrailingPressEnd = useCallback(() => setIsTrailingPressed(false), []);
+
+    const { isHovered: isTrailingHovered, hoverProps: trailingHoverProps } = useHover({
+      isDisabled,
+    });
+    const { isFocusVisible: isTrailingFocusVisible, focusProps: trailingFocusProps } =
+      useFocusRing();
+
+    const handleTrailingPress = useCallback(() => {
       if (menuState.isOpen) {
         menuState.close();
       } else {
@@ -96,15 +149,48 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
       }
     }, [menuState]);
 
-    const { buttonProps: dropdownButtonProps } = useButton(
+    const { buttonProps: trailingButtonProps } = useButton(
       {
         isDisabled,
-        onPress: handleDropdownPress,
+        onPress: handleTrailingPress,
+        onPressStart: handleTrailingPressStart,
+        onPressEnd: handleTrailingPressEnd,
         elementType: "button",
       },
-      dropdownRef
+      trailingRef
     );
 
+    // ── Ripple effects ────────────────────────────────────────────────────────
+    const { onMouseDown: handleLeadingRipple, ripples: leadingRipples } = useRipple({
+      disabled: isDisabled,
+    });
+    const { onMouseDown: handleTrailingRipple, ripples: trailingRipples } = useRipple({
+      disabled: isDisabled,
+    });
+
+    const onLeadingMouseDown = useCallback(
+      (e: MouseEvent<HTMLButtonElement>) => {
+        const ariaHandler = leadingButtonProps.onMouseDown as
+          | ((e: MouseEvent<HTMLElement>) => void)
+          | undefined;
+        ariaHandler?.(e);
+        handleLeadingRipple(e);
+      },
+      [leadingButtonProps, handleLeadingRipple]
+    );
+
+    const onTrailingMouseDown = useCallback(
+      (e: MouseEvent<HTMLButtonElement>) => {
+        const ariaHandler = trailingButtonProps.onMouseDown as
+          | ((e: MouseEvent<HTMLElement>) => void)
+          | undefined;
+        ariaHandler?.(e);
+        handleTrailingRipple(e);
+      },
+      [trailingButtonProps, handleTrailingRipple]
+    );
+
+    // ── Menu item handling ────────────────────────────────────────────────────
     const handleMenuItemSelect = useCallback(
       (item: SplitButtonMenuItem) => {
         if (!item.isDisabled) {
@@ -115,22 +201,22 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
       [menuState]
     );
 
+    // Global Escape closes menu
     useEffect(() => {
       if (!menuState.isOpen) return;
 
       const handleGlobalKeyDown = (e: KeyboardEvent): void => {
         if (e.key === "Escape") {
           menuState.close();
-          dropdownRef.current?.focus();
+          trailingRef.current?.focus();
         }
       };
 
       document.addEventListener("keydown", handleGlobalKeyDown);
-      return () => {
-        document.removeEventListener("keydown", handleGlobalKeyDown);
-      };
+      return () => document.removeEventListener("keydown", handleGlobalKeyDown);
     }, [menuState, menuState.isOpen]);
 
+    // Arrow / Home / End keyboard navigation within the open menu
     const handleMenuKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLUListElement>) => {
         const menuItems = Array.from(
@@ -163,7 +249,7 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
           }
           case "Escape": {
             menuState.close();
-            dropdownRef.current?.focus();
+            trailingRef.current?.focus();
             break;
           }
           default:
@@ -173,8 +259,7 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
       [menuState]
     );
 
-    // Auto-focus the first enabled menu item when the menu opens so keyboard
-    // users can navigate immediately without an extra Tab press.
+    // Auto-focus first enabled item when menu opens
     useEffect(() => {
       if (menuState.isOpen && menuRef.current) {
         const firstItem = menuRef.current.querySelector<HTMLElement>(
@@ -195,109 +280,101 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
       [menuState]
     );
 
-    const { onMouseDown: handlePrimaryRipple, ripples: primaryRipples } = useRipple({
-      disabled: isDisabled,
-    });
-
-    const { onMouseDown: handleDropdownRipple, ripples: dropdownRipples } = useRipple({
-      disabled: isDisabled,
-    });
-
-    const onPrimaryMouseDown = useCallback(
-      (e: MouseEvent<HTMLButtonElement>) => {
-        const ariaHandler = primaryButtonProps.onMouseDown as
-          | ((e: MouseEvent<HTMLElement>) => void)
-          | undefined;
-        ariaHandler?.(e);
-        handlePrimaryRipple(e);
-      },
-      [primaryButtonProps, handlePrimaryRipple]
-    );
-
-    const onDropdownMouseDown = useCallback(
-      (e: MouseEvent<HTMLButtonElement>) => {
-        const ariaHandler = dropdownButtonProps.onMouseDown as
-          | ((e: MouseEvent<HTMLElement>) => void)
-          | undefined;
-        ariaHandler?.(e);
-        handleDropdownRipple(e);
-      },
-      [dropdownButtonProps, handleDropdownRipple]
-    );
-
     return (
       <div className="relative inline-flex">
         <div
           ref={forwardedRef}
           role="group"
           aria-label={ariaLabel ?? `${primaryLabel} split button`}
-          className={cn(splitButtonContainerVariants({ variant, size, isDisabled }), className)}
+          className={cn(splitButtonContainerVariants(), className)}
         >
-          {/* Primary action segment */}
+          {/* ── Leading (primary action) segment ──────────────────────────── */}
           <button
-            {...primaryButtonProps}
-            ref={primaryRef}
+            {...mergeProps(leadingButtonProps, leadingHoverProps, leadingFocusProps)}
+            ref={leadingRef}
             type="button"
             tabIndex={isDisabled ? -1 : 0}
-            onMouseDown={onPrimaryMouseDown}
-            className={splitButtonPrimaryVariants({ variant, size })}
+            onMouseDown={onLeadingMouseDown}
+            // Interaction data attributes drive all state-layer and elevation styling
+            {...getInteractionDataAttributes({
+              isHovered: isLeadingHovered,
+              isFocusVisible: isLeadingFocusVisible,
+              isPressed: isLeadingPressed,
+              isDisabled,
+            })}
+            className={splitButtonLeadingVariants({ variant, size })}
           >
+            {/* State layer — overflow-hidden here, not on the root */}
             <span
               data-testid="primary-state-layer"
               aria-hidden="true"
-              className={cn(
-                "pointer-events-none absolute inset-0 bg-current opacity-0",
-                "duration-spring-standard-fast-effects ease-spring-standard-fast-effects transition-opacity",
-                "group-hover/primary:opacity-8"
-              )}
+              className={splitButtonStateLayerVariants({ variant, groupScope: "leading" })}
             />
-            {primaryRipples}
-            <span className="relative z-10">{primaryLabel}</span>
+
+            {/* Ripple */}
+            {leadingRipples}
+
+            {/* Focus ring — outside overflow-hidden, extends 3px past boundary */}
+            <span
+              aria-hidden="true"
+              className={splitButtonFocusRingVariants({ groupScope: "leading" })}
+            />
+
+            {/* Label */}
+            <span className={splitButtonLabelVariants()}>{primaryLabel}</span>
           </button>
 
-          {/* Visual divider — rendered via border-l on the dropdown segment */}
-          <span data-testid="split-button-divider" aria-hidden="true" />
-
-          {/* Dropdown trigger segment */}
+          {/* ── Trailing (dropdown trigger) segment ───────────────────────── */}
           <button
-            {...dropdownButtonProps}
-            ref={dropdownRef}
+            {...mergeProps(trailingButtonProps, trailingHoverProps, trailingFocusProps)}
+            ref={trailingRef}
             type="button"
             tabIndex={isDisabled ? -1 : 0}
             aria-haspopup="menu"
             aria-expanded={menuState.isOpen}
             aria-label={`${primaryLabel} options, expand`}
-            onMouseDown={onDropdownMouseDown}
-            className={splitButtonDropdownVariants({ variant, size })}
+            onMouseDown={onTrailingMouseDown}
+            // data-selected when menu is open — MD3 trailing icon centering
+            {...getInteractionDataAttributes({
+              isHovered: isTrailingHovered,
+              isFocusVisible: isTrailingFocusVisible,
+              isPressed: isTrailingPressed,
+              isSelected: menuState.isOpen,
+              isDisabled,
+            })}
+            className={splitButtonTrailingVariants({ variant, size })}
           >
+            {/* State layer */}
             <span
               data-testid="dropdown-state-layer"
               aria-hidden="true"
-              className={cn(
-                "pointer-events-none absolute inset-0 bg-current opacity-0",
-                "duration-spring-standard-fast-effects ease-spring-standard-fast-effects transition-opacity",
-                "group-hover/dropdown:opacity-8"
-              )}
+              className={splitButtonStateLayerVariants({ variant, groupScope: "trailing" })}
             />
-            {dropdownRipples}
-            <span className="relative z-10">
-              <ChevronIcon isOpen={menuState.isOpen} />
+
+            {/* Ripple */}
+            {trailingRipples}
+
+            {/* Focus ring */}
+            <span
+              aria-hidden="true"
+              className={splitButtonFocusRingVariants({ groupScope: "trailing" })}
+            />
+
+            {/* Chevron icon — rotates when menu is open */}
+            <span className={splitButtonIconVariants({ size })}>
+              <ChevronIcon isOpen={menuState.isOpen} reducedMotion={reducedMotion} />
             </span>
           </button>
         </div>
 
-        {/* Dropdown menu — sibling to the group container so it is NOT clipped
-            by `overflow-hidden`; positioned relative to the outer wrapper. */}
+        {/* ── Dropdown menu — sibling to the group so it is NOT clipped ─────── */}
         {menuState.isOpen && (
           <ul
             ref={menuRef}
             role="menu"
             aria-label={`${primaryLabel} options`}
             onKeyDown={handleMenuKeyDown}
-            className={cn(
-              "bg-surface-container absolute top-full right-0 z-50 mt-1 min-w-40 rounded-md py-2",
-              "shadow-elevation-2"
-            )}
+            className={splitButtonMenuVariants()}
           >
             {items.map((item) => (
               <li
@@ -307,11 +384,7 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
                 aria-disabled={item.isDisabled ?? undefined}
                 onClick={() => handleMenuItemSelect(item)}
                 onKeyDown={(e) => handleMenuItemKeyDown(e, item)}
-                className={cn(
-                  "text-body-large text-on-surface cursor-pointer px-4 py-2",
-                  "hover:bg-on-surface/8",
-                  item.isDisabled && "text-on-surface/38 pointer-events-none"
-                )}
+                className={splitButtonMenuItemVariants({ isDisabled: item.isDisabled ?? false })}
               >
                 {item.label}
               </li>

--- a/packages/react/src/components/SplitButton/SplitButton.types.ts
+++ b/packages/react/src/components/SplitButton/SplitButton.types.ts
@@ -1,17 +1,29 @@
 import type { PressEvent } from "react-aria";
 
 /**
- * Split Button variant types (Material Design 3).
+ * Split Button variant types (Material Design 3 Expressive).
  *
- * Split buttons only support filled, tonal, and outlined variants
- * per the MD3 specification.
+ * Split buttons support elevated, filled, tonal, and outlined variants,
+ * mirroring the standard Button color schemes per the MD3 Expressive spec.
+ *
+ * @see https://m3.material.io/components/split-button/specs
  */
-export type SplitButtonVariant = "filled" | "tonal" | "outlined";
+export type SplitButtonVariant = "elevated" | "filled" | "tonal" | "outlined";
 
 /**
- * Split Button size options.
+ * Split Button size options (MD3 Expressive size scale).
+ *
+ * | Token | Height | Typography         |
+ * |-------|--------|--------------------|
+ * | xs    | 32dp   | Label Large        |
+ * | sm    | 40dp   | Label Large        |
+ * | md    | 56dp   | Title Medium       |
+ * | lg    | 96dp   | Headline Small     |
+ * | xl    | 136dp  | Headline Large     |
+ *
+ * @default 'sm'
  */
-export type SplitButtonSize = "small" | "medium" | "large";
+export type SplitButtonSize = "xs" | "sm" | "md" | "lg" | "xl";
 
 /**
  * Represents a single item in the split button dropdown menu.
@@ -39,9 +51,9 @@ export interface SplitButtonMenuItem {
 /**
  * Props for the headless `SplitButtonHeadless` primitive (Layer 2).
  *
- * A Split Button groups a primary action with a dropdown trigger that reveals
- * secondary actions in a menu. Both segments are independently focusable and
- * accessible.
+ * A Split Button groups a leading action button with a trailing dropdown
+ * trigger that reveals secondary actions in a menu. Both segments are
+ * independently focusable and accessible.
  *
  * @example
  * ```tsx
@@ -63,18 +75,18 @@ export interface SplitButtonHeadlessProps {
   variant?: SplitButtonVariant;
 
   /**
-   * Size of the split button.
-   * @default 'medium'
+   * Size of the split button per the MD3 Expressive size scale.
+   * @default 'sm'
    */
   size?: SplitButtonSize;
 
-  /** Label text displayed in the primary action segment. */
+  /** Label text displayed in the leading action segment. */
   primaryLabel: string;
 
-  /** Callback invoked when the primary action segment is pressed. */
+  /** Callback invoked when the leading action segment is pressed. */
   onPrimaryAction: (e: PressEvent) => void;
 
-  /** Menu items displayed in the dropdown when the trigger is activated. */
+  /** Menu items displayed in the dropdown when the trailing trigger is activated. */
   items: SplitButtonMenuItem[];
 
   /**
@@ -94,6 +106,7 @@ export interface SplitButtonHeadlessProps {
  * Props for the styled `SplitButton` component (Layer 3).
  *
  * Extends the headless props with identical API surface; the styled layer
- * applies MD3 visual tokens and CVA variants on top of the headless primitive.
+ * applies MD3 Expressive visual tokens and CVA variants on top of the
+ * headless primitive.
  */
 export type SplitButtonProps = SplitButtonHeadlessProps;

--- a/packages/react/src/components/SplitButton/SplitButton.variants.ts
+++ b/packages/react/src/components/SplitButton/SplitButton.variants.ts
@@ -18,31 +18,41 @@ import { cva, type VariantProps } from "class-variance-authority";
  *   splitButtonStateLayerVariants — per-segment hover/focus/press opacity overlay
  *   splitButtonFocusRingVariants  — per-segment keyboard focus outline (extends outside overflow-hidden)
  *   splitButtonLabelVariants      — leading label text slot
- *   splitButtonIconVariants       — leading/trailing icon wrapper
+ *   splitButtonIconVariants       — icon wrapper; carries per-size optical offset + selected reset
  *   splitButtonMenuVariants       — dropdown menu surface
  *   splitButtonMenuItemVariants   — individual menu item row
  *
  * MD3 Expressive Specs:
  *   Shape: outer corners rounded-full; inner corners morph on interaction
  *   Height: 32dp xs | 40dp sm | 56dp md | 96dp lg | 136dp xl
+ *   Trailing segment is always square (width = height); selected state = perfect circle
  *   Gap between segments: 2dp (gap-0.5)
  *   Icon size: 20px xs/sm | 24px md | 32px lg | 40px xl
  *   State-layer opacities: hover 8% | focus 10% | pressed 10%
  *   Disabled: container on-surface/12 | content on-surface/38
  *   Elevation: elevated base=1 hover=2; filled/tonal base=0 hover=1; outlined none
  *
- * Inner-corner radius per size (MD3 spec — 2dp space rule):
- *   xs/sm/md → --radius-xs  (4dp)
- *   lg       → --radius-sm  (8dp)
- *   xl       → --radius-md  (12dp)
+ * Inner-corner radius morph table (--sb-inner-radius CSS variable):
  *
- * When the segment is hovered, focused, or pressed the inner corner morphs to
- * the next step up: xs/sm/md → --radius-sm (8dp), lg/xl → --radius-lg (16dp).
+ *   Size     Rest         Hover / Focus        Pressed (stronger)   Selected (trailing)
+ *   xs/sm/md --radius-xs  --radius-sm          --radius-lg          --radius-full
+ *   lg       --radius-sm  --radius-lg          --radius-xl          --radius-full
+ *   xl       --radius-md  --radius-lg          --radius-xl          --radius-full
+ *
+ * Specificity ladder (CSS attribute selector weight, all at same cascade layer):
+ *   rest           → [--sb-inner-radius:...] (0,0,0 base class)
+ *   hovered        → data-[hovered]:         (0,1,0)
+ *   focus-visible  → data-[fv]:data-[fv]:    (0,2,0)
+ *   pressed        → data-[pressed]:data-[pressed]:data-[pressed]:  (0,3,0)
+ *   selected       → data-[sel]:data-[sel]:data-[sel]:data-[sel]:   (0,4,0) — always wins
  *
  * Motion token pairing:
- *   Border-radius (spatial)   → duration-expressive-fast-spatial  ease-expressive-fast-spatial
- *   Opacity / color (effects) → duration-spring-standard-fast-effects ease-spring-standard-fast-effects
- *   Elevation shadow (effects)→ duration-spring-standard-fast-effects ease-spring-standard-fast-effects
+ *   Border-radius / transform (spatial) → duration-expressive-fast-spatial ease-expressive-fast-spatial
+ *   Opacity / color / shadow (effects)  → duration-spring-standard-fast-effects ease-spring-standard-fast-effects
+ *
+ * Chevron optical offset (MD3 spec — trailing icon shifts toward center gap when unselected):
+ *   xs/sm: -1dp  md: -2dp  lg: -3dp  xl: -6dp
+ *   Resets to translate-x-0 when group-data-[selected]/sb-trailing is present.
  */
 
 // ─── OUTER CONTAINER ─────────────────────────────────────────────────────────
@@ -78,11 +88,13 @@ export const splitButtonLeadingVariants = cva(
     "rounded-tl-full rounded-bl-full",
     "rounded-tr-[var(--sb-inner-radius,var(--radius-xs))]",
     "rounded-br-[var(--sb-inner-radius,var(--radius-xs))]",
-    // Inner-corner size defaults per state (self-targeting — segment owns the variable)
+    // Inner-corner morph — xs/sm/md defaults; lg/xl override in size variants below.
+    // Specificity ladder: rest (0,0,0) < hover (0,1,0) < focus (0,2,0) < pressed (0,3,0)
     "[--sb-inner-radius:var(--radius-xs)]",
     "data-[hovered]:[--sb-inner-radius:var(--radius-sm)]",
     "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-sm)]",
-    "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-sm)]",
+    // Pressed morphs stronger than hover/focus — tripled selector → (0,3,0)
+    "data-[pressed]:data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
     // Spatial transition for border-radius morphing
     "transition-[border-radius]",
     "duration-expressive-fast-spatial ease-expressive-fast-spatial",
@@ -151,8 +163,8 @@ export const splitButtonLeadingVariants = cva(
       },
 
       /**
-       * Size — governs height, horizontal padding, typography, and inner-corner default.
-       * lg/xl override the --sb-inner-radius default to larger steps.
+       * Size — governs height, horizontal padding, typography, and inner-corner rest/morph values.
+       * lg/xl need larger rest radii so their morph steps differ from xs/sm/md.
        */
       size: {
         xs: "h-8 pl-4 pr-3 text-label-large",
@@ -160,17 +172,19 @@ export const splitButtonLeadingVariants = cva(
         md: "h-14 pl-8 pr-6 text-title-medium",
         lg: [
           "h-24 pl-10 pr-8 text-headline-small",
+          // lg rest=sm, hover/focus→lg, pressed→xl
           "[--sb-inner-radius:var(--radius-sm)]",
           "data-[hovered]:[--sb-inner-radius:var(--radius-lg)]",
           "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-lg)]",
-          "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[pressed]:data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-xl)]",
         ],
         xl: [
           "h-[8.5rem] pl-12 pr-10 text-headline-large",
+          // xl rest=md, hover/focus→lg, pressed→xl
           "[--sb-inner-radius:var(--radius-md)]",
           "data-[hovered]:[--sb-inner-radius:var(--radius-lg)]",
           "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-lg)]",
-          "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[pressed]:data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-xl)]",
         ],
       },
     },
@@ -193,18 +207,22 @@ export const splitButtonLeadingVariants = cva(
  */
 export const splitButtonTrailingVariants = cva(
   [
-    // Layout
-    "group/sb-trailing relative inline-flex items-center justify-center",
+    // Layout — square so that selected (rounded-full on all corners) = perfect circle
+    "group/sb-trailing relative inline-flex items-center justify-center shrink-0",
     "cursor-pointer select-none",
     // Shape — asymmetric corners, inner on the left side
     "rounded-tr-full rounded-br-full",
     "rounded-tl-[var(--sb-inner-radius,var(--radius-xs))]",
     "rounded-bl-[var(--sb-inner-radius,var(--radius-xs))]",
-    // Inner-corner size defaults per state
+    // Inner-corner morph — xs/sm/md defaults; lg/xl override in size variants below.
+    // Specificity ladder: rest (0,0,0) < hover (0,1,0) < focus (0,2,0) < pressed (0,3,0) < selected (0,4,0)
     "[--sb-inner-radius:var(--radius-xs)]",
     "data-[hovered]:[--sb-inner-radius:var(--radius-sm)]",
     "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-sm)]",
-    "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-sm)]",
+    // Pressed morphs stronger than hover/focus — tripled → (0,3,0)
+    "data-[pressed]:data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
+    // Selected (menu open) → full circle; quadrupled → (0,4,0) always wins
+    "data-[selected]:data-[selected]:data-[selected]:data-[selected]:[--sb-inner-radius:var(--radius-full)]",
     // Spatial transition for border-radius morphing
     "transition-[border-radius]",
     "duration-expressive-fast-spatial ease-expressive-fast-spatial",
@@ -242,23 +260,26 @@ export const splitButtonTrailingVariants = cva(
       },
 
       size: {
-        // MD3 menu-icon optical offset when unselected; centered when selected (data-selected:px-*)
-        xs: "h-8 px-3",
-        sm: "h-10 px-4",
-        md: "h-14 px-5",
+        // Square dimensions (width = height) so selected state = perfect circle.
+        // Per-size inner-radius rest/morph values mirror the leading segment.
+        xs: "h-8 w-8",
+        sm: "h-10 w-10",
+        md: "h-14 w-14",
         lg: [
-          "h-24 px-7",
+          "h-24 w-24",
+          // lg rest=sm, hover/focus→lg, pressed→xl; selected→full handled in base classes
           "[--sb-inner-radius:var(--radius-sm)]",
           "data-[hovered]:[--sb-inner-radius:var(--radius-lg)]",
           "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-lg)]",
-          "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[pressed]:data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-xl)]",
         ],
         xl: [
-          "h-[8.5rem] px-10",
+          "h-[8.5rem] w-[8.5rem]",
+          // xl rest=md, hover/focus→lg, pressed→xl; selected→full handled in base classes
           "[--sb-inner-radius:var(--radius-md)]",
           "data-[hovered]:[--sb-inner-radius:var(--radius-lg)]",
           "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-lg)]",
-          "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[pressed]:data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-xl)]",
         ],
       },
     },
@@ -390,17 +411,32 @@ export const splitButtonLabelVariants = cva(["relative z-10 inline-flex items-ce
  *
  * Size scales with the button size per MD3 spec:
  *   xs/sm → 20px | md → 24px | lg → 32px | xl → 40px
+ *
+ * For the trailing chevron the MD3 spec calls for an optical offset toward the
+ * gap between segments when the button is unselected, and resets to centered
+ * when selected (menu open). The offset is applied as a negative translate-x
+ * and reverted via group-data-[selected]/sb-trailing:translate-x-0.
+ *
+ * Chevron optical offsets (trailing only):
+ *   xs/sm: -1dp  md: -2dp  lg: -3dp  xl: -6dp
  */
 export const splitButtonIconVariants = cva(
-  ["relative z-10 inline-flex shrink-0 items-center justify-center"],
+  [
+    "relative z-10 inline-flex shrink-0 items-center justify-center",
+    // Spatial spring motion for the optical-offset translate
+    "transition-transform duration-spring-standard-fast-spatial ease-spring-standard-fast-spatial",
+    // Reset offset when the trailing segment is in selected state (menu open)
+    "group-data-[selected]/sb-trailing:translate-x-0",
+  ],
   {
     variants: {
       size: {
-        xs: "size-5",
-        sm: "size-5",
-        md: "size-6",
-        lg: "size-8",
-        xl: "size-10",
+        // Include per-size icon dimension + unselected optical offset
+        xs: ["size-5", "-translate-x-px"],
+        sm: ["size-5", "-translate-x-px"],
+        md: ["size-6", "-translate-x-0.5"],
+        lg: ["size-8", "-translate-x-[3px]"],
+        xl: ["size-10", "-translate-x-[6px]"],
       },
     },
     defaultVariants: { size: "sm" },

--- a/packages/react/src/components/SplitButton/SplitButton.variants.ts
+++ b/packages/react/src/components/SplitButton/SplitButton.variants.ts
@@ -1,123 +1,465 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 Split Button — Container Variants (CVA)
+ * Material Design 3 Expressive Split Button Variants
  *
- * Defines the outer container styling for the split button group.
- * Maps `variant`, `size`, and `isDisabled` to MD3 design tokens via Tailwind.
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no disabled/pressed/hovered state variants).
+ * - All interaction states are driven by data-* attributes on each segment's root via
+ *   group-data-[x]/sb-leading and group-data-[x]/sb-trailing Tailwind selectors.
+ * - Inner-corner radius morphing is driven by a CSS variable (--sb-inner-radius) on
+ *   the segment root to avoid specificity battles — the same technique as Switch's
+ *   --switch-handle-size.
+ *
+ * Slot responsibilities:
+ *   splitButtonContainerVariants  — outer wrapper; gap between the two segments
+ *   splitButtonLeadingVariants    — leading (primary) button segment; shape + color
+ *   splitButtonTrailingVariants   — trailing (dropdown trigger) button segment; shape + color
+ *   splitButtonStateLayerVariants — per-segment hover/focus/press opacity overlay
+ *   splitButtonFocusRingVariants  — per-segment keyboard focus outline (extends outside overflow-hidden)
+ *   splitButtonLabelVariants      — leading label text slot
+ *   splitButtonIconVariants       — leading/trailing icon wrapper
+ *   splitButtonMenuVariants       — dropdown menu surface
+ *   splitButtonMenuItemVariants   — individual menu item row
+ *
+ * MD3 Expressive Specs:
+ *   Shape: outer corners rounded-full; inner corners morph on interaction
+ *   Height: 32dp xs | 40dp sm | 56dp md | 96dp lg | 136dp xl
+ *   Gap between segments: 2dp (gap-0.5)
+ *   Icon size: 20px xs/sm | 24px md | 32px lg | 40px xl
+ *   State-layer opacities: hover 8% | focus 10% | pressed 10%
+ *   Disabled: container on-surface/12 | content on-surface/38
+ *   Elevation: elevated base=1 hover=2; filled/tonal base=0 hover=1; outlined none
+ *
+ * Inner-corner radius per size (MD3 spec — 2dp space rule):
+ *   xs/sm/md → --radius-xs  (4dp)
+ *   lg       → --radius-sm  (8dp)
+ *   xl       → --radius-md  (12dp)
+ *
+ * When the segment is hovered, focused, or pressed the inner corner morphs to
+ * the next step up: xs/sm/md → --radius-sm (8dp), lg/xl → --radius-lg (16dp).
+ *
+ * Motion token pairing:
+ *   Border-radius (spatial)   → duration-expressive-fast-spatial  ease-expressive-fast-spatial
+ *   Opacity / color (effects) → duration-spring-standard-fast-effects ease-spring-standard-fast-effects
+ *   Elevation shadow (effects)→ duration-spring-standard-fast-effects ease-spring-standard-fast-effects
  */
-export const splitButtonContainerVariants = cva(
-  ["inline-flex items-center rounded-full overflow-hidden"],
+
+// ─── OUTER CONTAINER ─────────────────────────────────────────────────────────
+
+/**
+ * Outer wrapper div — lays out leading + trailing with a 2dp gap.
+ * Does NOT own any color, shape, or elevation — those belong to each segment.
+ */
+export const splitButtonContainerVariants = cva([
+  "relative inline-flex items-stretch",
+  "gap-0.5", // MD3 2dp gap between segments
+]);
+
+// ─── LEADING (PRIMARY) SEGMENT ────────────────────────────────────────────────
+
+/**
+ * Leading segment — the primary action button.
+ *
+ * Shape:
+ *   outer corners (top-left, bottom-left) = rounded-full
+ *   inner corners (top-right, bottom-right) = var(--sb-inner-radius), driven by
+ *   self-targeting data-[x]: selectors on this element for the CSS variable.
+ *
+ * The doubled data-[x]:data-[x]: selector for pressed/focus achieves higher
+ * specificity than single hover, mirroring the Switch handle-size technique.
+ */
+export const splitButtonLeadingVariants = cva(
+  [
+    // Layout
+    "group/sb-leading relative inline-flex items-center justify-center",
+    "cursor-pointer select-none",
+    // Shape — asymmetric corners via CSS variable
+    "rounded-tl-full rounded-bl-full",
+    "rounded-tr-[var(--sb-inner-radius,var(--radius-xs))]",
+    "rounded-br-[var(--sb-inner-radius,var(--radius-xs))]",
+    // Inner-corner size defaults per state (self-targeting — segment owns the variable)
+    "[--sb-inner-radius:var(--radius-xs)]",
+    "data-[hovered]:[--sb-inner-radius:var(--radius-sm)]",
+    "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-sm)]",
+    "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-sm)]",
+    // Spatial transition for border-radius morphing
+    "transition-[border-radius]",
+    "duration-expressive-fast-spatial ease-expressive-fast-spatial",
+    // Disabled — self-targeting
+    "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+  ],
+  {
+    variants: {
+      /**
+       * Visual variant — controls container color, text color, and elevation.
+       * State layer color is handled in splitButtonStateLayerVariants.
+       */
+      variant: {
+        /**
+         * Filled — highest emphasis.
+         * container=primary, label=on-primary
+         * Elevation: 0 base → 1 hover → 0 focus/pressed
+         */
+        filled: [
+          "bg-primary text-on-primary shadow-none",
+          "group-data-[hovered]/sb-leading:shadow-elevation-1",
+          "group-data-[focus-visible]/sb-leading:shadow-none",
+          "group-data-[pressed]/sb-leading:group-data-[pressed]/sb-leading:shadow-none",
+          // Disabled
+          "data-[disabled]:bg-on-surface/12 data-[disabled]:text-on-surface/38 data-[disabled]:shadow-none",
+        ],
+
+        /**
+         * Tonal — secondary emphasis.
+         * container=secondary-container, label=on-secondary-container
+         * Elevation: 0 base → 1 hover → 0 focus/pressed
+         */
+        tonal: [
+          "bg-secondary-container text-on-secondary-container shadow-none",
+          "group-data-[hovered]/sb-leading:shadow-elevation-1",
+          "group-data-[focus-visible]/sb-leading:shadow-none",
+          "group-data-[pressed]/sb-leading:group-data-[pressed]/sb-leading:shadow-none",
+          // Disabled
+          "data-[disabled]:bg-on-surface/12 data-[disabled]:text-on-surface/38 data-[disabled]:shadow-none",
+        ],
+
+        /**
+         * Outlined — medium emphasis. Transparent with border.
+         * container=transparent, border=outline, label=primary
+         * Elevation: always 0
+         */
+        outlined: [
+          "bg-transparent border border-outline text-primary",
+          // Disabled
+          "data-[disabled]:border-on-surface/12 data-[disabled]:text-on-surface/38",
+        ],
+
+        /**
+         * Elevated — uses surface-container-low with a level-1 shadow base.
+         * container=surface-container-low, label=primary
+         * Elevation: 1 base → 2 hover → 1 focus/pressed
+         */
+        elevated: [
+          "bg-surface-container-low text-primary shadow-elevation-1",
+          "group-data-[hovered]/sb-leading:shadow-elevation-2",
+          "group-data-[focus-visible]/sb-leading:shadow-elevation-1",
+          "group-data-[pressed]/sb-leading:group-data-[pressed]/sb-leading:shadow-elevation-1",
+          // Disabled
+          "data-[disabled]:bg-on-surface/12 data-[disabled]:text-on-surface/38 data-[disabled]:shadow-none",
+        ],
+      },
+
+      /**
+       * Size — governs height, horizontal padding, typography, and inner-corner default.
+       * lg/xl override the --sb-inner-radius default to larger steps.
+       */
+      size: {
+        xs: "h-8 pl-4 pr-3 text-label-large",
+        sm: "h-10 pl-6 pr-4 text-label-large",
+        md: "h-14 pl-8 pr-6 text-title-medium",
+        lg: [
+          "h-24 pl-10 pr-8 text-headline-small",
+          "[--sb-inner-radius:var(--radius-sm)]",
+          "data-[hovered]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
+        ],
+        xl: [
+          "h-[8.5rem] pl-12 pr-10 text-headline-large",
+          "[--sb-inner-radius:var(--radius-md)]",
+          "data-[hovered]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
+        ],
+      },
+    },
+
+    defaultVariants: {
+      variant: "filled",
+      size: "sm",
+    },
+  }
+);
+
+// ─── TRAILING (DROPDOWN TRIGGER) SEGMENT ─────────────────────────────────────
+
+/**
+ * Trailing segment — the dropdown trigger.
+ *
+ * Shape mirrors leading but mirrored: outer corners right, inner corners left.
+ * Uses group/sb-trailing for child slot selectors.
+ * Gets data-selected when the menu is open (icon centers per MD3 spec).
+ */
+export const splitButtonTrailingVariants = cva(
+  [
+    // Layout
+    "group/sb-trailing relative inline-flex items-center justify-center",
+    "cursor-pointer select-none",
+    // Shape — asymmetric corners, inner on the left side
+    "rounded-tr-full rounded-br-full",
+    "rounded-tl-[var(--sb-inner-radius,var(--radius-xs))]",
+    "rounded-bl-[var(--sb-inner-radius,var(--radius-xs))]",
+    // Inner-corner size defaults per state
+    "[--sb-inner-radius:var(--radius-xs)]",
+    "data-[hovered]:[--sb-inner-radius:var(--radius-sm)]",
+    "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-sm)]",
+    "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-sm)]",
+    // Spatial transition for border-radius morphing
+    "transition-[border-radius]",
+    "duration-expressive-fast-spatial ease-expressive-fast-spatial",
+    // Disabled — self-targeting
+    "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
+  ],
   {
     variants: {
       variant: {
-        filled: "bg-primary shadow-elevation-0 hover:shadow-elevation-1",
-        tonal: "bg-secondary-container",
-        outlined: "border border-outline bg-transparent",
+        filled: [
+          "bg-primary text-on-primary shadow-none",
+          "group-data-[hovered]/sb-trailing:shadow-elevation-1",
+          "group-data-[focus-visible]/sb-trailing:shadow-none",
+          "group-data-[pressed]/sb-trailing:group-data-[pressed]/sb-trailing:shadow-none",
+          "data-[disabled]:bg-on-surface/12 data-[disabled]:text-on-surface/38 data-[disabled]:shadow-none",
+        ],
+        tonal: [
+          "bg-secondary-container text-on-secondary-container shadow-none",
+          "group-data-[hovered]/sb-trailing:shadow-elevation-1",
+          "group-data-[focus-visible]/sb-trailing:shadow-none",
+          "group-data-[pressed]/sb-trailing:group-data-[pressed]/sb-trailing:shadow-none",
+          "data-[disabled]:bg-on-surface/12 data-[disabled]:text-on-surface/38 data-[disabled]:shadow-none",
+        ],
+        outlined: [
+          "bg-transparent border border-outline text-primary",
+          "data-[disabled]:border-on-surface/12 data-[disabled]:text-on-surface/38",
+        ],
+        elevated: [
+          "bg-surface-container-low text-primary shadow-elevation-1",
+          "group-data-[hovered]/sb-trailing:shadow-elevation-2",
+          "group-data-[focus-visible]/sb-trailing:shadow-elevation-1",
+          "group-data-[pressed]/sb-trailing:group-data-[pressed]/sb-trailing:shadow-elevation-1",
+          "data-[disabled]:bg-on-surface/12 data-[disabled]:text-on-surface/38 data-[disabled]:shadow-none",
+        ],
       },
 
       size: {
-        small: "h-8",
-        medium: "h-10",
-        large: "h-12",
+        // MD3 menu-icon optical offset when unselected; centered when selected (data-selected:px-*)
+        xs: "h-8 px-3",
+        sm: "h-10 px-4",
+        md: "h-14 px-5",
+        lg: [
+          "h-24 px-7",
+          "[--sb-inner-radius:var(--radius-sm)]",
+          "data-[hovered]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
+        ],
+        xl: [
+          "h-[8.5rem] px-10",
+          "[--sb-inner-radius:var(--radius-md)]",
+          "data-[hovered]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[focus-visible]:data-[focus-visible]:[--sb-inner-radius:var(--radius-lg)]",
+          "data-[pressed]:data-[pressed]:[--sb-inner-radius:var(--radius-lg)]",
+        ],
       },
+    },
 
+    defaultVariants: {
+      variant: "filled",
+      size: "sm",
+    },
+  }
+);
+
+// ─── STATE LAYER ─────────────────────────────────────────────────────────────
+
+/**
+ * Per-segment state layer — absolute inset overlay that transitions opacity.
+ *
+ * overflow-hidden clips ripple + state layer to the button shape without
+ * affecting the focus ring span (which lives outside this element).
+ *
+ * Color is variant-specific (MD3 "on-container" role):
+ *   filled   → bg-on-primary
+ *   tonal    → bg-on-secondary-container
+ *   outlined → bg-primary
+ *   elevated → bg-primary
+ *
+ * Opacities:
+ *   0 at rest | 8% hover | 10% focus | 10% pressed | hidden disabled
+ *
+ * The doubled attribute selector for pressed gives it higher specificity (0,2,0)
+ * than the single hover selector (0,1,0), ensuring pressed always wins.
+ *
+ * groupScope controls whether this reads from group/sb-leading or group/sb-trailing.
+ */
+export const splitButtonStateLayerVariants = cva(
+  [
+    "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+    "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  ],
+  {
+    variants: {
+      variant: {
+        filled: "bg-on-primary",
+        tonal: "bg-on-secondary-container",
+        outlined: "bg-primary",
+        elevated: "bg-primary",
+      },
+      /**
+       * groupScope identifies which segment this state layer belongs to so it
+       * reads from the correct group-data-[x]/<scope> selectors.
+       */
+      groupScope: {
+        leading: [
+          "group-data-[hovered]/sb-leading:opacity-8",
+          "group-data-[focus-visible]/sb-leading:opacity-10",
+          "group-data-[pressed]/sb-leading:group-data-[pressed]/sb-leading:opacity-10",
+          "group-data-[disabled]/sb-leading:hidden",
+        ],
+        trailing: [
+          "group-data-[hovered]/sb-trailing:opacity-8",
+          "group-data-[focus-visible]/sb-trailing:opacity-10",
+          "group-data-[pressed]/sb-trailing:group-data-[pressed]/sb-trailing:opacity-10",
+          "group-data-[disabled]/sb-trailing:hidden",
+        ],
+      },
+    },
+    defaultVariants: {
+      variant: "filled",
+      groupScope: "leading",
+    },
+  }
+);
+
+// ─── FOCUS RING ───────────────────────────────────────────────────────────────
+
+/**
+ * Per-segment focus ring overlay.
+ *
+ * Rendered as an absolute span with inset-[-3px] so it extends 3px outside
+ * the segment boundary. Requires that overflow-hidden is NOT on the segment
+ * root — it is moved to the state-layer span instead.
+ *
+ * Always present in DOM (opacity-0 at rest) for smooth CSS transition.
+ */
+export const splitButtonFocusRingVariants = cva(
+  [
+    "pointer-events-none absolute inset-[-3px]",
+    "outline outline-2 outline-offset-0 outline-secondary",
+    "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    "opacity-0",
+  ],
+  {
+    variants: {
+      /**
+       * Corner shape must match the segment it wraps.
+       * Leading: full-left, inner-right follows --sb-inner-radius.
+       * Trailing: full-right, inner-left follows --sb-inner-radius.
+       */
+      groupScope: {
+        leading: [
+          "rounded-tl-full rounded-bl-full",
+          "rounded-tr-[calc(var(--sb-inner-radius,var(--radius-xs))+3px)]",
+          "rounded-br-[calc(var(--sb-inner-radius,var(--radius-xs))+3px)]",
+          "group-data-[focus-visible]/sb-leading:opacity-100",
+        ],
+        trailing: [
+          "rounded-tr-full rounded-br-full",
+          "rounded-tl-[calc(var(--sb-inner-radius,var(--radius-xs))+3px)]",
+          "rounded-bl-[calc(var(--sb-inner-radius,var(--radius-xs))+3px)]",
+          "group-data-[focus-visible]/sb-trailing:opacity-100",
+        ],
+      },
+    },
+    defaultVariants: { groupScope: "leading" },
+  }
+);
+
+// ─── LABEL ────────────────────────────────────────────────────────────────────
+
+/**
+ * Label text wrapper — z-10 keeps it above state layer and ripple.
+ * Typography is inherited from the leading segment's size class.
+ */
+export const splitButtonLabelVariants = cva(["relative z-10 inline-flex items-center"]);
+
+// ─── ICON ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Icon wrapper (leading or trailing chevron).
+ *
+ * Size scales with the button size per MD3 spec:
+ *   xs/sm → 20px | md → 24px | lg → 32px | xl → 40px
+ */
+export const splitButtonIconVariants = cva(
+  ["relative z-10 inline-flex shrink-0 items-center justify-center"],
+  {
+    variants: {
+      size: {
+        xs: "size-5",
+        sm: "size-5",
+        md: "size-6",
+        lg: "size-8",
+        xl: "size-10",
+      },
+    },
+    defaultVariants: { size: "sm" },
+  }
+);
+
+// ─── DROPDOWN MENU ────────────────────────────────────────────────────────────
+
+/**
+ * Dropdown menu surface — elevated container, positioned below the trailing segment.
+ */
+export const splitButtonMenuVariants = cva([
+  "absolute top-full right-0 z-50 mt-1 min-w-40",
+  "bg-surface-container rounded-md py-2",
+  "shadow-elevation-2",
+  "animate-md-scale-in",
+]);
+
+/**
+ * Individual menu item row.
+ */
+export const splitButtonMenuItemVariants = cva(
+  [
+    "text-body-large text-on-surface cursor-pointer px-4 py-2",
+    "hover:bg-on-surface/8",
+    "focus:bg-on-surface/10 focus:outline-none",
+  ],
+  {
+    variants: {
       isDisabled: {
-        true: "opacity-38 pointer-events-none",
+        true: "text-on-surface/38 pointer-events-none cursor-not-allowed",
         false: "",
       },
     },
-
-    defaultVariants: {
-      variant: "filled",
-      size: "medium",
-      isDisabled: false,
-    },
+    defaultVariants: { isDisabled: false },
   }
 );
 
-/**
- * Material Design 3 Split Button — Primary Segment Variants (CVA)
- *
- * Applies text color, padding, and the Tailwind group name (`group/primary`)
- * to the primary action segment. The group name is required so that the
- * nested state-layer span can target `group-hover/primary:opacity-8`.
- * The divider between segments is rendered via the dropdown's `border-l`.
- */
-export const splitButtonPrimaryVariants = cva(
-  [
-    "group/primary relative inline-flex items-center justify-center cursor-pointer",
-    "h-full font-medium tracking-[0.1px]",
-    "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
-  ],
-  {
-    variants: {
-      variant: {
-        filled: "text-on-primary",
-        tonal: "text-on-secondary-container",
-        outlined: "text-primary",
-      },
-
-      size: {
-        small: "pl-4 pr-3 text-xs",
-        medium: "pl-6 pr-4 text-sm",
-        large: "pl-8 pr-5 text-base",
-      },
-    },
-
-    defaultVariants: {
-      variant: "filled",
-      size: "medium",
-    },
-  }
-);
-
-/**
- * Material Design 3 Split Button — Dropdown Trigger Variants (CVA)
- *
- * Applies text color, padding, the visual divider (left border), and the
- * Tailwind group name (`group/dropdown`) to the dropdown trigger segment.
- * The group name is required so that the nested state-layer span can target
- * `group-hover/dropdown:opacity-8`.
- */
-export const splitButtonDropdownVariants = cva(
-  [
-    "group/dropdown relative inline-flex items-center justify-center cursor-pointer",
-    "h-full",
-    "focus-visible:outline-primary focus-visible:outline-2 focus-visible:outline-offset-2",
-  ],
-  {
-    variants: {
-      variant: {
-        filled: "text-on-primary border-l border-on-primary/38",
-        tonal: "text-on-secondary-container border-l border-on-secondary-container/38",
-        outlined: "text-primary border-l border-outline",
-      },
-
-      size: {
-        small: "px-1.5",
-        medium: "px-2",
-        large: "px-3",
-      },
-    },
-
-    defaultVariants: {
-      variant: "filled",
-      size: "medium",
-    },
-  }
-);
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
 
 export type SplitButtonContainerVariants = VariantProps<typeof splitButtonContainerVariants>;
-export type SplitButtonPrimaryVariants = VariantProps<typeof splitButtonPrimaryVariants>;
-export type SplitButtonDropdownVariants = VariantProps<typeof splitButtonDropdownVariants>;
+export type SplitButtonLeadingVariants = VariantProps<typeof splitButtonLeadingVariants>;
+export type SplitButtonTrailingVariants = VariantProps<typeof splitButtonTrailingVariants>;
+export type SplitButtonStateLayerVariants = VariantProps<typeof splitButtonStateLayerVariants>;
+export type SplitButtonFocusRingVariants = VariantProps<typeof splitButtonFocusRingVariants>;
+export type SplitButtonIconVariants = VariantProps<typeof splitButtonIconVariants>;
+export type SplitButtonMenuItemVariantProps = VariantProps<typeof splitButtonMenuItemVariants>;
 
 /**
- * Convenience bundle of all three Split Button CVA functions.
- * Useful for consumers that want a single import point.
+ * Convenience bundle of all Split Button CVA functions.
  */
 export const splitButtonVariants = {
   container: splitButtonContainerVariants,
-  primary: splitButtonPrimaryVariants,
-  dropdown: splitButtonDropdownVariants,
+  leading: splitButtonLeadingVariants,
+  trailing: splitButtonTrailingVariants,
+  stateLayer: splitButtonStateLayerVariants,
+  focusRing: splitButtonFocusRingVariants,
+  label: splitButtonLabelVariants,
+  icon: splitButtonIconVariants,
+  menu: splitButtonMenuVariants,
+  menuItem: splitButtonMenuItemVariants,
 };

--- a/packages/react/src/components/SplitButton/SplitButtonHeadless.tsx
+++ b/packages/react/src/components/SplitButton/SplitButtonHeadless.tsx
@@ -12,12 +12,12 @@ import type { SplitButtonHeadlessProps, SplitButtonMenuItem } from "./SplitButto
  * Provides behavior only — bring your own styles.
  *
  * Structure:
- * - Primary segment: triggers the main action
- * - Divider: visual separator (1dp vertical line)
- * - Dropdown trigger: opens/closes the dropdown menu
+ * - Leading segment: triggers the main action
+ * - Trailing segment: opens/closes the dropdown menu
+ *   (separated by a 2dp gap in the styled layer; no divider element here)
  *
  * Both segments are independently focusable via Tab navigation.
- * The dropdown trigger manages `aria-haspopup` and `aria-expanded`.
+ * The trailing trigger manages `aria-haspopup` and `aria-expanded`.
  *
  * @example
  * ```tsx
@@ -43,22 +43,22 @@ export const SplitButtonHeadless = forwardRef<HTMLDivElement, SplitButtonHeadles
     },
     forwardedRef
   ) => {
-    const primaryRef = useRef<HTMLButtonElement>(null);
-    const dropdownRef = useRef<HTMLButtonElement>(null);
+    const leadingRef = useRef<HTMLButtonElement>(null);
+    const trailingRef = useRef<HTMLButtonElement>(null);
     const menuRef = useRef<HTMLUListElement>(null);
 
     const menuState = useMenuTriggerState({});
 
-    const { buttonProps: primaryButtonProps } = useButton(
+    const { buttonProps: leadingButtonProps } = useButton(
       {
         isDisabled,
         onPress: onPrimaryAction,
         elementType: "button",
       },
-      primaryRef
+      leadingRef
     );
 
-    const handleDropdownPress = useCallback(() => {
+    const handleTrailingPress = useCallback(() => {
       if (menuState.isOpen) {
         menuState.close();
       } else {
@@ -66,13 +66,13 @@ export const SplitButtonHeadless = forwardRef<HTMLDivElement, SplitButtonHeadles
       }
     }, [menuState]);
 
-    const { buttonProps: dropdownButtonProps } = useButton(
+    const { buttonProps: trailingButtonProps } = useButton(
       {
         isDisabled,
-        onPress: handleDropdownPress,
+        onPress: handleTrailingPress,
         elementType: "button",
       },
-      dropdownRef
+      trailingRef
     );
 
     const handleMenuItemSelect = useCallback(
@@ -91,14 +91,12 @@ export const SplitButtonHeadless = forwardRef<HTMLDivElement, SplitButtonHeadles
       const handleGlobalKeyDown = (e: KeyboardEvent): void => {
         if (e.key === "Escape") {
           menuState.close();
-          dropdownRef.current?.focus();
+          trailingRef.current?.focus();
         }
       };
 
       document.addEventListener("keydown", handleGlobalKeyDown);
-      return () => {
-        document.removeEventListener("keydown", handleGlobalKeyDown);
-      };
+      return () => document.removeEventListener("keydown", handleGlobalKeyDown);
     }, [menuState, menuState.isOpen]);
 
     const handleMenuKeyDown = useCallback(
@@ -133,7 +131,7 @@ export const SplitButtonHeadless = forwardRef<HTMLDivElement, SplitButtonHeadles
           }
           case "Escape": {
             menuState.close();
-            dropdownRef.current?.focus();
+            trailingRef.current?.focus();
             break;
           }
           default:
@@ -143,8 +141,7 @@ export const SplitButtonHeadless = forwardRef<HTMLDivElement, SplitButtonHeadles
       [menuState]
     );
 
-    // Auto-focus the first enabled menu item when the menu opens so keyboard
-    // users can navigate immediately without an extra Tab press.
+    // Auto-focus first enabled menu item when the menu opens
     useEffect(() => {
       if (menuState.isOpen && menuRef.current) {
         const firstItem = menuRef.current.querySelector<HTMLElement>(
@@ -172,23 +169,20 @@ export const SplitButtonHeadless = forwardRef<HTMLDivElement, SplitButtonHeadles
         aria-label={ariaLabel ?? `${primaryLabel} split button`}
         className={className}
       >
-        {/* Primary action segment */}
+        {/* Leading action segment */}
         <button
-          {...primaryButtonProps}
-          ref={primaryRef}
+          {...leadingButtonProps}
+          ref={leadingRef}
           type="button"
           tabIndex={isDisabled ? -1 : 0}
         >
           {primaryLabel}
         </button>
 
-        {/* Visual divider */}
-        <span aria-hidden="true" />
-
-        {/* Dropdown trigger segment */}
+        {/* Trailing dropdown trigger segment — no divider element; gap comes from parent layout */}
         <button
-          {...dropdownButtonProps}
-          ref={dropdownRef}
+          {...trailingButtonProps}
+          ref={trailingRef}
           type="button"
           tabIndex={isDisabled ? -1 : 0}
           aria-haspopup="menu"

--- a/packages/react/src/components/SplitButton/index.ts
+++ b/packages/react/src/components/SplitButton/index.ts
@@ -4,15 +4,25 @@ export { SplitButton } from "./SplitButton";
 // ─── Layer 2: Headless Primitives (for advanced customization) ────────────────
 export { SplitButtonHeadless } from "./SplitButtonHeadless";
 
-// ─── CVA Variants ─────────────────────────────────────────────────────────────
+// ─── CVA Variants (slot-based) ────────────────────────────────────────────────
 export {
   splitButtonVariants,
   splitButtonContainerVariants,
-  splitButtonPrimaryVariants,
-  splitButtonDropdownVariants,
+  splitButtonLeadingVariants,
+  splitButtonTrailingVariants,
+  splitButtonStateLayerVariants,
+  splitButtonFocusRingVariants,
+  splitButtonLabelVariants,
+  splitButtonIconVariants,
+  splitButtonMenuVariants,
+  splitButtonMenuItemVariants,
   type SplitButtonContainerVariants,
-  type SplitButtonPrimaryVariants,
-  type SplitButtonDropdownVariants,
+  type SplitButtonLeadingVariants,
+  type SplitButtonTrailingVariants,
+  type SplitButtonStateLayerVariants,
+  type SplitButtonFocusRingVariants,
+  type SplitButtonIconVariants,
+  type SplitButtonMenuItemVariantProps,
 } from "./SplitButton.variants";
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -355,8 +355,14 @@ export {
   SplitButtonHeadless,
   splitButtonVariants,
   splitButtonContainerVariants,
-  splitButtonPrimaryVariants,
-  splitButtonDropdownVariants,
+  splitButtonLeadingVariants,
+  splitButtonTrailingVariants,
+  splitButtonStateLayerVariants,
+  splitButtonFocusRingVariants,
+  splitButtonLabelVariants,
+  splitButtonIconVariants,
+  splitButtonMenuVariants,
+  splitButtonMenuItemVariants,
 } from "./components/SplitButton";
 export type {
   SplitButtonProps,
@@ -365,8 +371,12 @@ export type {
   SplitButtonSize,
   SplitButtonMenuItem,
   SplitButtonContainerVariants,
-  SplitButtonPrimaryVariants,
-  SplitButtonDropdownVariants,
+  SplitButtonLeadingVariants,
+  SplitButtonTrailingVariants,
+  SplitButtonStateLayerVariants,
+  SplitButtonFocusRingVariants,
+  SplitButtonIconVariants,
+  SplitButtonMenuItemVariantProps,
 } from "./components/SplitButton";
 
 export {


### PR DESCRIPTION
## Summary

- **Variants-vs-States architecture**: all interaction states now use React Aria `useHover`/`useFocusRing`/`onPressStart`/`onPressEnd` → `data-*` attributes → `group-data-[x]/sb-leading` and `group-data-[x]/sb-trailing` Tailwind selectors. No interaction state logic in CVA — mirrors Button/Switch.
- **MD3 Expressive inner-corner shape morphing**: leading-right and trailing-left corners animate between size-specific radius steps on hover/focus/press, driven by `--sb-inner-radius` CSS variable (same technique as Switch's `--switch-handle-size`). Motion uses `duration-expressive-fast-spatial` / `ease-expressive-fast-spatial`.
- **New `elevated` variant** and **5-size scale** (`xs`/`sm`/`md`/`lg`/`xl`) per the MD3 Expressive spec at https://m3.material.io/components/split-button/specs.
- **2dp gap** (`gap-0.5`) replaces the old `border-l` visual divider — each segment is a fully independent button shape.
- Per-segment state layers (hover 8%, focus 10%, pressed 10%) and focus-ring spans, matching the Button component architecture.
- `data-selected` on the trailing segment when the menu is open (MD3 trailing icon centering spec).
- `useReducedMotion` guard on JS-driven chevron rotation and shape transitions.

## Breaking changes

| Before | After |
|---|---|
| `size="small"` | `size="xs"` |
| `size="medium"` | `size="sm"` (new default) |
| `size="large"` | `size="md"` |
| — | `size="lg"` (new) |
| — | `size="xl"` (new) |
| `splitButtonPrimaryVariants` | `splitButtonLeadingVariants` |
| `splitButtonDropdownVariants` | `splitButtonTrailingVariants` |
| `SplitButtonPrimaryVariants` type | `SplitButtonLeadingVariants` type |
| `SplitButtonDropdownVariants` type | `SplitButtonTrailingVariants` type |

## Test plan

- [x] 37 tests passing (`pnpm vitest run src/components/SplitButton`)
- [x] axe violations: 0 (closed + open state, both layers)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` (lint-staged) clean
- [ ] Manual Storybook: all 4 variants × 5 sizes, hover/focus/press state layers, inner-corner morph, disabled, menu open/close + keyboard nav