### PR TITLE
refactor(tooltip): slot-based md3 styling, token + reduced-motion fixes

### DIFF
--- a/.changeset/tooltip-md3-styling.md
+++ b/.changeset/tooltip-md3-styling.md
@@ -1,0 +1,14 @@
+---
+"@tinybigui/react": patch
+---
+
+refactor(tooltip): slot-based MD3 styling, token and reduced-motion fixes
+
+- Rewrote `Tooltip.variants.ts` to use documented slot CVA functions, matching the Button/Switch architecture
+- Replaced the binary `isVisible` variant with a 3-state `animation` variant (`enter` | `exit` | `none`) that supports `prefers-reduced-motion`
+- Added rich tooltip slot variants: `richTooltipTitleVariants`, `richTooltipSupportingTextVariants`, `richTooltipActionsVariants`
+- Fixed MD3 token: rich tooltip subhead (title) now uses `text-on-surface-variant` per spec (was `text-on-surface`)
+- Added action row layout slot with correct `-ml-2 mt-3` alignment per MD3 spec
+- Added `prefers-reduced-motion` guard in `TooltipTrigger`: overlay unmounts immediately on close under reduced motion, fixing a stuck-mount bug where `animationend` never fires when CSS animations are suppressed
+- Added `reducedMotion` field to `TooltipAnimationContextValue` for consumer access
+- Extended test suite with 9 new tests covering token correctness and reduced-motion behaviour

--- a/packages/react/src/components/Tooltip/RichTooltip.tsx
+++ b/packages/react/src/components/Tooltip/RichTooltip.tsx
@@ -4,25 +4,41 @@ import { forwardRef } from "react";
 import type { JSX } from "react";
 import { cn } from "../../utils/cn";
 import { useTooltipAnimation } from "./TooltipTrigger";
-import { richTooltipVariants } from "./Tooltip.variants";
+import {
+  richTooltipVariants,
+  richTooltipTitleVariants,
+  richTooltipSupportingTextVariants,
+  richTooltipActionsVariants,
+} from "./Tooltip.variants";
+import type { TooltipAnimationState } from "./Tooltip.variants";
 import type { RichTooltipProps } from "./Tooltip.types";
 
 /**
  * `RichTooltip` — Layer 3 MD3 Rich Tooltip styled component.
  *
- * Supports an optional title, multi-line supporting text, and an optional
- * action button per MD3 Rich Tooltip specification.
+ * Supports an optional title (subhead), multi-line supporting text, and an
+ * optional action button per MD3 Rich Tooltip specification.
  * Animation is driven by the `TooltipAnimationContext` provided by
  * `TooltipTrigger`:
- * - Entry: `animate-md-scale-in`  (scale 0.85 + fade → natural)
- * - Exit:  `animate-md-scale-out` (natural → scale 0.85 + fade)
+ * - Entry: `animate-md-scale-in`  (expressive-fast-spatial: 350ms)
+ * - Exit:  `animate-md-scale-out` (emphasized-accelerate: 200ms)
+ * - None:  no animation class when `prefers-reduced-motion: reduce` is active
  *
- * MD3 Tokens applied:
- * - `bg-surface-container`  — surface container background
- * - `text-on-surface`       — content color on surface
- * - `shadow-elevation-2`    — MD3 elevation level 2
- * - `rounded-md`            — medium corner radius
- * - `max-w-80`              — 320dp maximum width
+ * MD3 Tokens applied — container:
+ * - `bg-surface-container`   — surface container background
+ * - `text-on-surface`        — base content colour
+ * - `shadow-elevation-2`     — MD3 elevation level 2
+ * - `rounded-md`             — 12dp corner radius (CornerMedium)
+ * - `max-w-80`               — 320dp maximum width
+ * - `px-4 py-3`              — 16dp × 12dp padding
+ *
+ * MD3 Tokens applied — subhead (title):
+ * - `text-title-small`        — TitleSmall typescale
+ * - `text-on-surface-variant` — subhead colour role per MD3 spec
+ *
+ * MD3 Tokens applied — supporting text:
+ * - `text-body-medium`        — BodyMedium typescale
+ * - `text-on-surface-variant` — same colour role as subhead
  *
  * Must be used as the second child of `TooltipTrigger`.
  *
@@ -41,17 +57,19 @@ import type { RichTooltipProps } from "./Tooltip.types";
  */
 export const RichTooltip = forwardRef<HTMLDivElement, RichTooltipProps>(
   ({ title, children, action, className, placement: _placement }, ref): JSX.Element => {
-    const { isExiting, onAnimationEnd } = useTooltipAnimation();
+    const { isExiting, onAnimationEnd, reducedMotion } = useTooltipAnimation();
+
+    const animation: TooltipAnimationState = reducedMotion ? "none" : isExiting ? "exit" : "enter";
 
     return (
       <div
         ref={ref}
-        className={cn(richTooltipVariants({ isVisible: !isExiting }), className)}
+        className={cn(richTooltipVariants({ animation }), className)}
         onAnimationEnd={onAnimationEnd}
       >
-        {title && <p className="text-on-surface text-title-small mb-1">{title}</p>}
-        <p className="text-on-surface-variant text-body-medium">{children}</p>
-        {action}
+        {title && <p className={richTooltipTitleVariants()}>{title}</p>}
+        <p className={richTooltipSupportingTextVariants()}>{children}</p>
+        {action && <div className={richTooltipActionsVariants()}>{action}</div>}
       </div>
     );
   }

--- a/packages/react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.test.tsx
@@ -641,3 +641,123 @@ describe("TooltipTrigger (styled)", () => {
     expect(screen.getByRole("tooltip")).toBeInTheDocument();
   });
 });
+
+// ─── 37–40. MD3 token correctness ─────────────────────────────────────────────
+
+describe("MD3 token correctness", () => {
+  test("37. rich tooltip title uses text-on-surface-variant (MD3 subhead role)", async () => {
+    const user = userEvent.setup();
+    renderStyledRichTooltip();
+    await user.tab();
+    const title = screen.getByText("Title text");
+    expect(title).toHaveClass("text-on-surface-variant");
+  });
+
+  test("38. rich tooltip supporting text uses text-on-surface-variant", async () => {
+    const user = userEvent.setup();
+    renderStyledRichTooltip();
+    await user.tab();
+    const body = screen.getByText("Supporting text");
+    expect(body).toHaveClass("text-on-surface-variant");
+  });
+
+  test("39. rich tooltip action is wrapped in the actions-row slot div", async () => {
+    const user = userEvent.setup();
+    renderStyledRichTooltip();
+    await user.tab();
+    const actionButton = screen.getByRole("button", { name: "Action" });
+    // The action button's parent must be the actions-row slot div
+    const actionRow = actionButton.closest("div");
+    expect(actionRow).toHaveClass("mt-3");
+    expect(actionRow).toHaveClass("-ml-2");
+  });
+
+  test("40. plain tooltip container has inline-flex to center single-line content", async () => {
+    const user = userEvent.setup();
+    renderStyledTooltip();
+    await user.tab();
+    expect(screen.getByText("Tooltip text")).toHaveClass("inline-flex");
+    expect(screen.getByText("Tooltip text")).toHaveClass("items-center");
+  });
+});
+
+// ─── 41–45. prefers-reduced-motion ───────────────────────────────────────────
+
+/**
+ * Helpers that override matchMedia to simulate `prefers-reduced-motion: reduce`.
+ * We restore the global mock after each test so other tests are unaffected.
+ */
+function mockReducedMotion(matches: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)" ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe("prefers-reduced-motion", () => {
+  afterEach(() => {
+    // Restore to the default mock (matches: false) set in test/setup.ts
+    mockReducedMotion(false);
+  });
+
+  test("41. plain tooltip has no animation class when reduced motion is active", async () => {
+    mockReducedMotion(true);
+    const user = userEvent.setup();
+    renderStyledTooltip();
+    await user.tab();
+    const tooltip = screen.getByText("Tooltip text");
+    expect(tooltip).not.toHaveClass("animate-md-scale-in");
+    expect(tooltip).not.toHaveClass("animate-md-scale-out");
+  });
+
+  test("42. rich tooltip has no animation class when reduced motion is active", async () => {
+    mockReducedMotion(true);
+    const user = userEvent.setup();
+    renderStyledRichTooltip();
+    await user.tab();
+    const richWrapper = screen.getByText("Supporting text").closest("div");
+    expect(richWrapper).not.toHaveClass("animate-md-scale-in");
+    expect(richWrapper).not.toHaveClass("animate-md-scale-out");
+  });
+
+  test("43. plain tooltip unmounts immediately on close (no animationend) when reduced motion is active", async () => {
+    mockReducedMotion(true);
+    const user = userEvent.setup();
+    renderStyledTooltip();
+    await user.tab();
+    expect(screen.getByText("Tooltip text")).toBeInTheDocument();
+
+    // Move focus away — under reduced motion the overlay must unmount
+    // immediately without waiting for animationend (which CSS never fires).
+    await user.tab();
+    expect(screen.queryByText("Tooltip text")).not.toBeInTheDocument();
+  });
+
+  test("44. rich tooltip unmounts immediately on close (no animationend) when reduced motion is active", async () => {
+    mockReducedMotion(true);
+    const user = userEvent.setup();
+    renderStyledRichTooltip();
+    await user.tab();
+    expect(screen.getByText("Supporting text")).toBeInTheDocument();
+
+    await user.tab();
+    expect(screen.queryByText("Supporting text")).not.toBeInTheDocument();
+  });
+
+  test("45. standard animation classes still applied when reduced motion is NOT active", async () => {
+    mockReducedMotion(false);
+    const user = userEvent.setup();
+    renderStyledTooltip();
+    await user.tab();
+    expect(screen.getByText("Tooltip text")).toHaveClass("animate-md-scale-in");
+  });
+});

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -5,6 +5,7 @@ import type { JSX } from "react";
 import { cn } from "../../utils/cn";
 import { useTooltipAnimation } from "./TooltipTrigger";
 import { tooltipVariants } from "./Tooltip.variants";
+import type { TooltipAnimationState } from "./Tooltip.variants";
 import type { TooltipProps } from "./Tooltip.types";
 
 /**
@@ -13,15 +14,18 @@ import type { TooltipProps } from "./Tooltip.types";
  * Renders a single-line text label with MD3 inverse-surface styling.
  * Animation is driven by the `TooltipAnimationContext` provided by
  * `TooltipTrigger`:
- * - Entry: `animate-md-scale-in`  (scale 0.85 + fade → natural)
- * - Exit:  `animate-md-scale-out` (natural → scale 0.85 + fade)
+ * - Entry: `animate-md-scale-in`  (expressive-fast-spatial: 350ms, scale 0.85 → 1 + fade)
+ * - Exit:  `animate-md-scale-out` (emphasized-accelerate: 200ms, scale 1 → 0.85 + fade)
+ * - None:  no animation class when `prefers-reduced-motion: reduce` is active
  *
  * MD3 Tokens applied:
- * - `bg-inverse-surface`     — inverted surface for max contrast
- * - `text-inverse-on-surface` — content color on inverted surface
- * - `rounded-xs`             — 4dp corner radius
- * - `max-w-50`               — 200dp maximum width
- * - `text-body-small`        — MD3 body-small typography
+ * - `bg-inverse-surface`      — inverted surface for maximum contrast
+ * - `text-inverse-on-surface` — content colour on inverted surface
+ * - `rounded-xs`              — 4dp corner radius (CornerExtraSmall)
+ * - `text-body-small`         — BodySmall typescale (12sp)
+ * - `min-h-6`                 — 24dp minimum height
+ * - `max-w-50`                — 200dp maximum width
+ * - `px-2 py-1`               — 8dp × 4dp padding
  *
  * Must be used as the second child of `TooltipTrigger`.
  *
@@ -35,12 +39,14 @@ import type { TooltipProps } from "./Tooltip.types";
  */
 export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
   ({ children, className, placement: _placement }, ref): JSX.Element => {
-    const { isExiting, onAnimationEnd } = useTooltipAnimation();
+    const { isExiting, onAnimationEnd, reducedMotion } = useTooltipAnimation();
+
+    const animation: TooltipAnimationState = reducedMotion ? "none" : isExiting ? "exit" : "enter";
 
     return (
       <div
         ref={ref}
-        className={cn(tooltipVariants({ isVisible: !isExiting }), className)}
+        className={cn(tooltipVariants({ animation }), className)}
         onAnimationEnd={onAnimationEnd}
       >
         {children}

--- a/packages/react/src/components/Tooltip/Tooltip.variants.ts
+++ b/packages/react/src/components/Tooltip/Tooltip.variants.ts
@@ -1,79 +1,190 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 /**
- * Material Design 3 Plain Tooltip Variants (CVA)
+ * Material Design 3 Tooltip Variants
  *
- * Base tokens per MD3 spec:
- * - bg-inverse-surface / text-inverse-on-surface — inverted surface for contrast
- * - rounded-xs — 4dp corner radius (CornerExtraSmall)
- * - min-h-6 — 24dp minimum height
- * - max-w-50 — 200dp maximum width
- * - w-fit — shrink-wrap to content width
- * - px-2 py-1 — 8dp horizontal, 4dp vertical padding
- * - text-body-small — MD3 BodySmall typography (12px)
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (no hover/focus state variants).
+ * - The `animation` variant is the only runtime switch — driven by the
+ *   `TooltipAnimationContext` in `TooltipTrigger`.
+ * - Rich tooltip sub-elements are each their own slot CVA so inline class
+ *   strings are never hardcoded in JSX.
  *
- * `isVisible` drives the entry/exit animation class:
- * - true  → animate-md-scale-in  (component entering with scale+fade)
- * - false → animate-md-scale-out (component exiting with scale+fade)
+ * Slot responsibilities:
+ *   tooltipVariants               — plain tooltip container
+ *   richTooltipVariants           — rich tooltip container
+ *   richTooltipTitleVariants      — optional subhead / title row
+ *   richTooltipSupportingTextVariants — multi-line body text
+ *   richTooltipActionsVariants    — action button row (optional)
+ *
+ * MD3 Plain Tooltip spec:
+ *   Background:  inverse-surface
+ *   Text:        inverse-on-surface, body-small (12sp)
+ *   Shape:       corner-extra-small (4dp, rounded-xs)
+ *   Min height:  24dp
+ *   Max width:   200dp
+ *   Padding:     8dp horizontal × 4dp vertical
+ *   Elevation:   none (tonal surface provides contrast)
+ *
+ * MD3 Rich Tooltip spec:
+ *   Background:  surface-container
+ *   Text:        on-surface
+ *   Subhead:     on-surface-variant, title-small
+ *   Supporting:  on-surface-variant, body-medium
+ *   Shape:       corner-medium (12dp, rounded-md)
+ *   Min height:  24dp
+ *   Max width:   320dp
+ *   Padding:     16dp horizontal × 12dp vertical
+ *   Elevation:   level-2 (shadow-elevation-2)
+ *   Actions:     text button, 12dp top gap, flush-left inset to content edge
  */
-export const tooltipVariants = cva(
-  "z-50 w-fit min-h-6 rounded-xs px-2 py-1 text-body-small bg-inverse-surface text-inverse-on-surface max-w-50",
-  {
-    variants: {
-      /**
-       * Drives the MD3 enter/exit animation class.
-       * Managed by `TooltipTrigger`'s animation state machine.
-       * @default true
-       */
-      isVisible: {
-        true: "animate-md-scale-in",
-        false: "animate-md-scale-out",
-      },
-    },
-    defaultVariants: {
-      isVisible: true,
-    },
-  }
-);
+
+// ─── ANIMATION VARIANT ───────────────────────────────────────────────────────
 
 /**
- * Material Design 3 Rich Tooltip Variants (CVA)
+ * Three-state animation discriminant.
  *
- * Base tokens per MD3 spec:
- * - bg-surface-container / text-on-surface — surface container background
- * - shadow-elevation-2  — MD3 elevation level 2
- * - rounded-md          — 12dp corner radius (CornerMedium)
- * - min-h-6             — 24dp minimum height
- * - max-w-80            — 320dp maximum width
- * - w-fit               — shrink-wrap to content width
- * - px-4 py-3           — 16dp horizontal, 12dp vertical padding
- *
- * `isVisible` drives the entry/exit animation class:
- * - true  → animate-md-scale-in  (component entering with scale+fade)
- * - false → animate-md-scale-out (component exiting with scale+fade)
+ * `enter` — component mounting, play scale-in animation
+ * `exit`  — component unmounting, play scale-out animation
+ * `none`  — `prefers-reduced-motion: reduce` is active; skip all transforms
  */
-export const richTooltipVariants = cva(
-  "z-50 w-fit min-h-6 rounded-md px-4 py-3 bg-surface-container text-on-surface shadow-elevation-2 max-w-80",
+type TooltipAnimationState = "enter" | "exit" | "none";
+
+// ─── PLAIN TOOLTIP ────────────────────────────────────────────────────────────
+
+/**
+ * Plain tooltip container.
+ *
+ * Renders an inline-flex pill that vertically centres a single-line text label
+ * against the 24dp minimum height.
+ *
+ * MD3 Tokens:
+ * - `bg-inverse-surface`       — inverted surface for maximum contrast
+ * - `text-inverse-on-surface`  — content colour on inverted surface
+ * - `rounded-xs`               — 4dp corner radius (CornerExtraSmall)
+ * - `text-body-small`          — BodySmall typescale (12sp)
+ * - `min-h-6`                  — 24dp minimum height
+ * - `max-w-50`                 — 200dp maximum width
+ * - `px-2 py-1`                — 8dp × 4dp padding
+ * - `z-50`                     — above all page content
+ *
+ * Motion:
+ * - `enter` → `animate-md-scale-in`  (expressive-fast-spatial: 350ms, scale 0.85 → 1 + fade)
+ * - `exit`  → `animate-md-scale-out` (emphasized-accelerate: 200ms, scale 1 → 0.85 + fade)
+ * - `none`  → no animation class     (prefers-reduced-motion guard)
+ */
+export const tooltipVariants = cva(
+  [
+    "z-50 inline-flex items-center w-fit",
+    "min-h-6 rounded-xs px-2 py-1",
+    "text-body-small bg-inverse-surface text-inverse-on-surface",
+    "max-w-50",
+  ],
   {
     variants: {
       /**
-       * Drives the MD3 enter/exit animation class.
+       * Controls the enter/exit animation class.
        * Managed by `TooltipTrigger`'s animation state machine.
-       * @default true
+       * Set to `"none"` when `prefers-reduced-motion: reduce` is active.
+       * @default "enter"
        */
-      isVisible: {
-        true: "animate-md-scale-in",
-        false: "animate-md-scale-out",
+      animation: {
+        enter: "animate-md-scale-in",
+        exit: "animate-md-scale-out",
+        none: "",
       },
     },
     defaultVariants: {
-      isVisible: true,
+      animation: "enter",
     },
   }
 );
 
-/** Variant prop types inferred from `tooltipVariants`. */
-export type TooltipVariants = VariantProps<typeof tooltipVariants>;
+// ─── RICH TOOLTIP CONTAINER ───────────────────────────────────────────────────
 
-/** Variant prop types inferred from `richTooltipVariants`. */
+/**
+ * Rich tooltip container.
+ *
+ * Wraps the title, supporting text, and optional action row in a flex column.
+ *
+ * MD3 Tokens:
+ * - `bg-surface-container`   — surface container background
+ * - `text-on-surface`        — content colour on surface
+ * - `shadow-elevation-2`     — MD3 elevation level 2
+ * - `rounded-md`             — 12dp corner radius (CornerMedium)
+ * - `min-h-6`                — 24dp minimum height
+ * - `max-w-80`               — 320dp maximum width
+ * - `px-4 py-3`              — 16dp × 12dp padding
+ * - `z-50`                   — above all page content
+ *
+ * Motion: same `animation` variant as plain tooltip.
+ */
+export const richTooltipVariants = cva(
+  [
+    "z-50 flex flex-col w-fit",
+    "min-h-6 rounded-md px-4 py-3",
+    "bg-surface-container text-on-surface shadow-elevation-2",
+    "max-w-80",
+  ],
+  {
+    variants: {
+      /**
+       * Controls the enter/exit animation class.
+       * Managed by `TooltipTrigger`'s animation state machine.
+       * Set to `"none"` when `prefers-reduced-motion: reduce` is active.
+       * @default "enter"
+       */
+      animation: {
+        enter: "animate-md-scale-in",
+        exit: "animate-md-scale-out",
+        none: "",
+      },
+    },
+    defaultVariants: {
+      animation: "enter",
+    },
+  }
+);
+
+// ─── RICH TOOLTIP SLOTS ───────────────────────────────────────────────────────
+
+/**
+ * Rich tooltip subhead / title row.
+ *
+ * MD3 Tokens:
+ * - `text-title-small`       — TitleSmall typescale
+ * - `text-on-surface-variant`— MD3 rich-tooltip subhead colour role
+ * - `mb-1`                   — 4dp gap below title (before supporting text)
+ */
+export const richTooltipTitleVariants = cva(["text-title-small text-on-surface-variant mb-1"]);
+
+/**
+ * Rich tooltip supporting text body.
+ *
+ * MD3 Tokens:
+ * - `text-body-medium`        — BodyMedium typescale
+ * - `text-on-surface-variant` — same colour role as subhead per spec
+ */
+export const richTooltipSupportingTextVariants = cva(["text-body-medium text-on-surface-variant"]);
+
+/**
+ * Rich tooltip action row.
+ *
+ * Renders the optional text Button flush to the content left edge.
+ * The `-ml-2` inset compensates for the text Button's own 12dp px-3 padding
+ * so the label aligns visually with the supporting text above it.
+ *
+ * MD3 spec: action sits 12dp below the supporting text body (`mt-3`).
+ */
+export const richTooltipActionsVariants = cva(["flex items-center justify-start mt-3 -ml-2"]);
+
+// ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
+
+export type { TooltipAnimationState };
+export type TooltipVariants = VariantProps<typeof tooltipVariants>;
 export type RichTooltipVariants = VariantProps<typeof richTooltipVariants>;
+export type RichTooltipTitleVariants = VariantProps<typeof richTooltipTitleVariants>;
+export type RichTooltipSupportingTextVariants = VariantProps<
+  typeof richTooltipSupportingTextVariants
+>;
+export type RichTooltipActionsVariants = VariantProps<typeof richTooltipActionsVariants>;

--- a/packages/react/src/components/Tooltip/TooltipTrigger.tsx
+++ b/packages/react/src/components/Tooltip/TooltipTrigger.tsx
@@ -11,13 +11,14 @@ import {
   type ReactNode,
 } from "react";
 import { TooltipTriggerHeadless, TooltipOverlayHeadless } from "./TooltipHeadless";
+import { useReducedMotion } from "../../hooks/useReducedMotion";
 import type { TooltipPlacement } from "./Tooltip.types";
 
 // ─── Animation Context ────────────────────────────────────────────────────────
 
 /**
  * Shared animation state provided by `TooltipTrigger` to its `Tooltip` /
- * `RichTooltip` children. Drives the CVA `isVisible` variant and the
+ * `RichTooltip` children. Drives the CVA `animation` variant and the
  * `animationend` unmount callback.
  */
 export interface TooltipAnimationContextValue {
@@ -25,15 +26,24 @@ export interface TooltipAnimationContextValue {
    * True while the exit animation is playing.
    * `Tooltip` / `RichTooltip` apply the exit animation class when this is
    * `true` and stay mounted until `onAnimationEnd` fires.
+   * Always `false` when `reducedMotion` is `true` (immediate unmount).
    */
   isExiting: boolean;
   /** Called by the tooltip element's `onAnimationEnd` to unmount after exit. */
   onAnimationEnd: () => void;
+  /**
+   * Whether `prefers-reduced-motion: reduce` is currently active.
+   * When `true`, styled components must skip animation classes and the
+   * `TooltipTrigger` unmounts the overlay immediately on close (no
+   * `animationend` dependency).
+   */
+  reducedMotion: boolean;
 }
 
 export const TooltipAnimationContext = createContext<TooltipAnimationContextValue>({
   isExiting: false,
   onAnimationEnd: () => undefined,
+  reducedMotion: false,
 });
 
 /**
@@ -69,13 +79,19 @@ export interface TooltipTriggerStyledProps {
  * machine so that tooltips fade/scale in on open and fade/scale out before
  * unmounting from the DOM, per MD3 motion specs.
  *
- * Animation state machine:
+ * When `prefers-reduced-motion: reduce` is active the overlay is unmounted
+ * immediately on close — no exit animation, no `animationend` dependency.
+ * This prevents the stuck-mount bug that occurs when the global CSS reset
+ * collapses animations and `animationend` never fires.
+ *
+ * Animation state machine (standard motion):
  * 1. RA fires `onOpenChange(true)`  → mount overlay, play entry animation
  * 2. RA fires `onOpenChange(false)` → keep mounted, play exit animation
  * 3. `animationend` fires          → unmount overlay
  *
- * The controlled `isOpen={isMounted}` prop passed to `TooltipTriggerHeadless`
- * is what keeps the overlay alive during the exit animation phase.
+ * Animation state machine (reduced motion):
+ * 1. RA fires `onOpenChange(true)`  → mount overlay, no animation
+ * 2. RA fires `onOpenChange(false)` → unmount overlay immediately
  *
  * @example
  * ```tsx
@@ -90,6 +106,8 @@ export function TooltipTrigger({
   delay = 300,
   isDisabled,
 }: TooltipTriggerStyledProps): JSX.Element {
+  const reducedMotion = useReducedMotion();
+
   const [isMounted, setIsMounted] = useState(false);
   const [isExiting, setIsExiting] = useState(false);
 
@@ -98,41 +116,56 @@ export function TooltipTrigger({
   const pendingCloseRef = useRef(false);
 
   /**
+   * Unmounts the overlay immediately (reduced motion path or forced close).
+   * Resets all animation refs to a clean state.
+   */
+  const unmountImmediately = useCallback(() => {
+    isExitingRef.current = false;
+    pendingCloseRef.current = false;
+    setIsMounted(false);
+    setIsExiting(false);
+  }, []);
+
+  /**
    * Stable callback — React Aria calls this when it wants to open or close.
    *
    * On open  → cancel any pending close, mount overlay, play entry animation.
    * On close → if pointer is over the tooltip surface, defer the close until
    *            the pointer leaves (prevents flicker when hovering the portal).
-   *            Otherwise start exit animation immediately.
+   *            Otherwise:
+   *              - reduced motion: unmount immediately (no animationend needed)
+   *              - standard motion: start exit animation, unmount on animationend
    */
-  const handleOpenChange = useCallback((open: boolean) => {
-    if (open) {
-      pendingCloseRef.current = false;
-      isExitingRef.current = false;
-      setIsMounted(true);
-      setIsExiting(false);
-    } else if (isPointerOverTooltipRef.current) {
-      pendingCloseRef.current = true;
-    } else if (!isExitingRef.current) {
-      isExitingRef.current = true;
-      setIsExiting(true);
-    }
-  }, []);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        pendingCloseRef.current = false;
+        isExitingRef.current = false;
+        setIsMounted(true);
+        setIsExiting(false);
+      } else if (isPointerOverTooltipRef.current) {
+        pendingCloseRef.current = true;
+      } else if (reducedMotion) {
+        unmountImmediately();
+      } else if (!isExitingRef.current) {
+        isExitingRef.current = true;
+        setIsExiting(true);
+      }
+    },
+    [reducedMotion, unmountImmediately]
+  );
 
   /**
    * Stable callback — called by the tooltip element's `onAnimationEnd` event.
-   * Unmounts the overlay after the exit animation completes.
+   * Unmounts the overlay after the exit animation completes (standard motion only).
    *
    * The guard ensures the entry animation's `animationend` event is ignored —
    * only the exit animation should trigger unmounting.
    */
   const handleAnimationEnd = useCallback(() => {
     if (!isExitingRef.current) return;
-    isExitingRef.current = false;
-    pendingCloseRef.current = false;
-    setIsMounted(false);
-    setIsExiting(false);
-  }, []);
+    unmountImmediately();
+  }, [unmountImmediately]);
 
   const handleOverlayPointerEnter = useCallback(() => {
     isPointerOverTooltipRef.current = true;
@@ -141,16 +174,21 @@ export function TooltipTrigger({
 
   const handleOverlayPointerLeave = useCallback(() => {
     isPointerOverTooltipRef.current = false;
-    if (pendingCloseRef.current && !isExitingRef.current) {
+    if (pendingCloseRef.current) {
       pendingCloseRef.current = false;
-      isExitingRef.current = true;
-      setIsExiting(true);
+      if (reducedMotion) {
+        unmountImmediately();
+      } else if (!isExitingRef.current) {
+        isExitingRef.current = true;
+        setIsExiting(true);
+      }
     }
-  }, []);
+  }, [reducedMotion, unmountImmediately]);
 
   const contextValue: TooltipAnimationContextValue = {
     isExiting,
     onAnimationEnd: handleAnimationEnd,
+    reducedMotion,
   };
 
   const [triggerChild, tooltipChild] = children;

--- a/packages/react/src/components/Tooltip/index.ts
+++ b/packages/react/src/components/Tooltip/index.ts
@@ -7,12 +7,23 @@ export { RichTooltip } from "./RichTooltip";
 // Layer 2: Headless Primitives (for advanced customization)
 export { TooltipTriggerHeadless, TooltipOverlayHeadless } from "./TooltipHeadless";
 
-// CVA Variants
+// CVA Variants — containers
 export {
   tooltipVariants,
   richTooltipVariants,
   type TooltipVariants,
   type RichTooltipVariants,
+} from "./Tooltip.variants";
+
+// CVA Variants — rich tooltip slots
+export {
+  richTooltipTitleVariants,
+  richTooltipSupportingTextVariants,
+  richTooltipActionsVariants,
+  type RichTooltipTitleVariants,
+  type RichTooltipSupportingTextVariants,
+  type RichTooltipActionsVariants,
+  type TooltipAnimationState,
 } from "./Tooltip.variants";
 
 // Types


### PR DESCRIPTION
## Summary

- **Slot-based CVA architecture**: Rewrote `Tooltip.variants.ts` to use documented per-slot CVA functions matching the Button/Switch conventions (`richTooltipTitleVariants`, `richTooltipSupportingTextVariants`, `richTooltipActionsVariants`). Inline class strings are no longer hardcoded in JSX.
- **MD3 token fix**: Rich tooltip subhead (title) now uses `text-on-surface-variant` per the MD3 rich-tooltip spec (was incorrectly `text-on-surface`). Action row gets a proper layout slot with `-ml-2 mt-3` alignment.
- **`prefers-reduced-motion` accessibility fix**: `TooltipTrigger` now calls `useReducedMotion()` and immediately unmounts the overlay on close when reduced motion is active. This eliminates the stuck-mount bug where `animationend` never fires when the global CSS reset collapses animations. The `animation` variant is now a 3-state discriminant (`enter` | `exit` | `none`).

## Changed files

| File | Change |
|---|---|
| `Tooltip.variants.ts` | Full rewrite: slot CVA, 3-state animation variant, JSDoc token table |
| `TooltipTrigger.tsx` | Add `useReducedMotion`, fix stuck-mount, expose `reducedMotion` on context |
| `Tooltip.tsx` | Consume `reducedMotion` from context, compute animation state |
| `RichTooltip.tsx` | Use slot variants, add action row wrapper, consume `reducedMotion` |
| `index.ts` | Re-export new slot variants and types |
| `Tooltip.test.tsx` | +9 tests: token correctness + reduced-motion behaviour |
| `.changeset/tooltip-md3-styling.md` | Patch changeset for `@tinybigui/react` |

## Test plan

- [ ] All 45 Tooltip tests pass: `pnpm --filter @tinybigui/react exec vitest run Tooltip`
- [ ] Full suite passes: `pnpm test` (2143 tests, 32 files)
- [ ] Lint + typecheck clean: `pnpm lint && pnpm typecheck`
- [ ] Verify Storybook: plain tooltip label is vertically centred, rich tooltip subhead is visually lighter (on-surface-variant), action button is flush-left with content
- [ ] Test in OS accessibility settings with "Reduce Motion" ON: tooltip should appear/disappear instantly with no animation