### PR TITLE
refactor(menu): align styling with slot architecture and md3 spec

### DIFF
--- a/.changeset/menu-md3-styling-refactor.md
+++ b/.changeset/menu-md3-styling-refactor.md
@@ -20,3 +20,15 @@ fix(menu): fire open/close motion on popover and inset expressive highlight
 - Update `menuItemStateLayerVariants` geometry to be menuStyle-aware: baseline `inset-0 rounded-[inherit]`, vertical `inset-1 rounded-lg`
 - Remove `data-[selected]:bg-*` from `menuItemVariants` root; background now lives exclusively on the highlight layer
 - Render highlight → state layer → ripple → content DOM order in `MenuItem.tsx`; ripple container geometry also respects menuStyle
+
+fix(menu): align expressive vertical menu gap and spacing to MD3 segmented spec
+
+- `menuContainerVariants` vertical: transparent background (was `bg-surface-container-low`) — the container is now a clear overlay; group surface color moves onto individual items
+- `menuItemVariants` vertical: each item carries its own group surface (`bg-surface-container-low` / `bg-tertiary-container` vibrant) and CSS sibling selectors on `[data-menu-gap]` produce segmented corner rounding (leading group 16/8dp, trailing group 8/16dp, middle group 8/8dp), matching the MD3 Expressive segmented-group model (`SegmentedMenuTokens`)
+- `MenuGap`: height reduced from `h-2` (8dp) to `h-0.5` (2dp) matching `SegmentedMenuTokens.SegmentedGap = 2dp`; `data-menu-gap` attribute added to enable CSS sibling selectors for segmented rounding on adjacent items
+- `MenuItem` vertical height map: default density 0 = `h-11` (44dp) instead of `h-12` (48dp), matching `SegmentedMenuTokens.Item = 44dp`; density steps -1/-2/-3 adjusted accordingly (h-10/h-9/h-8)
+- `menuItemIconVariants` vertical: icon size `h-5 w-5` (20dp) matching `SegmentedMenuTokens.ItemLeadingIconSize = 20dp`; baseline stays `h-6 w-6` (24dp)
+- `menuItemHighlightVariants` vertical: `inset-x-1 inset-y-0 rounded-md` (horizontal-only 4dp inset, 12dp CornerMedium per `ItemSelectedShape`) — replaces `inset-1 rounded-lg`; selection no longer spans full width but fills item height eliminating vertical detachment
+- `menuItemStateLayerVariants` vertical: geometry updated to match highlight layer: `inset-x-1 inset-y-0 rounded-md`
+- `menuDividerVariants`: `my-0.5 mx-3` (2dp vertical, 12dp horizontal inset) for consistency with gap and vertical layout
+- All changes are vertical-only; baseline menu visuals, public API, and props are unchanged

--- a/.changeset/menu-md3-styling-refactor.md
+++ b/.changeset/menu-md3-styling-refactor.md
@@ -1,0 +1,13 @@
+---
+"@tinybigui/react": patch
+---
+
+fix(menu): align Menu styling with component-variants.mdc slot architecture
+
+- Replace hardcoded `menu-enter`/`menu-exit` animations with `animate-md-scale-in`/`animate-md-scale-out` composite utilities (350ms expressive spring enter, 200ms emphasized-accelerate exit)
+- Remove `isDisabled`/`isSelected` CVA variant keys from `menuItemVariants`; interaction states are now driven by React Aria's native `data-hovered`, `data-pressed`, `data-focus-visible`, `data-selected`, `data-disabled` attributes via `group-data-[x]/menuitem` selectors
+- Add dedicated `menuItemStateLayerVariants` slot with hover 8% / focus+press 10% opacities using MD3 spring tokens (no more `before:` pseudo-element on the root)
+- Add `menuItemIconVariants` slot so leading/trailing icons recolor on selection in vertical/vibrant menus
+- Fix disabled treatment: per-slot `text-on-surface/38` instead of whole-item `opacity-38`
+- Update item typography: Body Large → Label Large per MD3 menu spec
+- Fix state-layer color transition to `duration-spring-standard-fast-effects ease-spring-standard-fast-effects`

--- a/.changeset/menu-md3-styling-refactor.md
+++ b/.changeset/menu-md3-styling-refactor.md
@@ -11,3 +11,12 @@ fix(menu): align Menu styling with component-variants.mdc slot architecture
 - Fix disabled treatment: per-slot `text-on-surface/38` instead of whole-item `opacity-38`
 - Update item typography: Body Large → Label Large per MD3 menu spec
 - Fix state-layer color transition to `duration-spring-standard-fast-effects ease-spring-standard-fast-effects`
+
+fix(menu): fire open/close motion on popover and inset expressive highlight
+
+- Add `menuPopoverVariants` CVA and apply to all three React Aria `<Popover>` elements (main trigger, submenu, context menu); RAC emits `data-entering`/`data-exiting`/`data-placement` on the Popover, not the inner RACMenu, so animation classes must live there
+- Strip dead `will-change`, `data-[entering]`, `data-[exiting]`, `origin-*`, and `motion-reduce:` classes from `menuContainerVariants` (those now belong exclusively to `menuPopoverVariants`)
+- Add `menuItemHighlightVariants` selected-background layer: `inset-0` (baseline) / `inset-1 rounded-lg` (vertical) — creates the inset, pill-shaped MD3 Expressive highlight matching the spec reference
+- Update `menuItemStateLayerVariants` geometry to be menuStyle-aware: baseline `inset-0 rounded-[inherit]`, vertical `inset-1 rounded-lg`
+- Remove `data-[selected]:bg-*` from `menuItemVariants` root; background now lives exclusively on the highlight layer
+- Render highlight → state layer → ripple → content DOM order in `MenuItem.tsx`; ripple container geometry also respects menuStyle

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -10,7 +10,11 @@ import { MenuGap } from "./MenuGap";
 import { SubmenuTrigger } from "./SubmenuTrigger";
 import { ContextMenuTrigger } from "./ContextMenuTrigger";
 import { HeadlessMenuTrigger } from "./MenuHeadless";
-import { menuContainerVariants, menuItemVariants } from "./Menu.variants";
+import {
+  menuContainerVariants,
+  menuItemVariants,
+  menuItemStateLayerVariants,
+} from "./Menu.variants";
 
 // ─── Test Icon Mocks ───────────────────────────────────────────────────────────
 
@@ -283,11 +287,11 @@ describe("MenuItem", () => {
       expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
     });
 
-    test("uses body-large typography for label text", async () => {
+    test("uses label-large typography for label text", async () => {
       renderBasicMenu();
       await openMenu();
       const item = screen.getByRole("menuitem", { name: "Cut" });
-      expect(item).toHaveClass("text-body-large");
+      expect(item).toHaveClass("text-label-large");
     });
 
     test("renders leading icon when provided", async () => {
@@ -447,6 +451,20 @@ describe("MenuItem", () => {
       );
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("custom-item");
+    });
+
+    test("item root carries group/menuitem scope class", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("group/menuitem");
+    });
+
+    test("item contains a state-layer span slot", async () => {
+      renderBasicMenu();
+      await openMenu();
+      const item = screen.getByRole("menuitem", { name: "Cut" });
+      const stateLayer = item.querySelector("span[aria-hidden='true']");
+      expect(stateLayer).toBeInTheDocument();
     });
   });
 
@@ -854,7 +872,9 @@ describe("Selection mode", () => {
     );
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
-    expect(selectedItem).toHaveClass("bg-surface-container-highest");
+    // RAC emits data-selected on the element; CVA applies data-[selected]:bg-surface-container-highest
+    expect(selectedItem).toHaveAttribute("data-selected");
+    expect(selectedItem).toHaveClass("data-[selected]:bg-surface-container-highest");
   });
 
   test("selected item in vertical standard has tertiary container background", async () => {
@@ -875,7 +895,8 @@ describe("Selection mode", () => {
     );
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
-    expect(selectedItem).toHaveClass("bg-tertiary-container");
+    expect(selectedItem).toHaveAttribute("data-selected");
+    expect(selectedItem).toHaveClass("data-[selected]:bg-tertiary-container");
   });
 
   test("selected item in vertical vibrant has tertiary background", async () => {
@@ -896,7 +917,8 @@ describe("Selection mode", () => {
     );
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
-    expect(selectedItem).toHaveClass("bg-tertiary");
+    expect(selectedItem).toHaveAttribute("data-selected");
+    expect(selectedItem).toHaveClass("data-[selected]:bg-tertiary");
   });
 
   test("checkmark appears on selected item when selectionMode is set and no leadingIcon", async () => {
@@ -1264,35 +1286,52 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("bg-tertiary-container");
   });
 
-  test("menuItemVariants: uses text-body-large", () => {
+  test("menuItemVariants: uses text-label-large", () => {
     const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "baseline" });
-    expect(cls).toContain("text-body-large");
+    expect(cls).toContain("text-label-large");
   });
 
-  test("menuItemVariants: baseline selected uses bg-surface-container-highest", () => {
+  test("menuItemVariants: baseline includes data-[selected] bg class for surface-container-highest", () => {
     const cls = menuItemVariants({
-      isSelected: true,
       colorScheme: "standard",
       menuStyle: "baseline",
     });
-    expect(cls).toContain("bg-surface-container-highest");
+    expect(cls).toContain("data-[selected]:bg-surface-container-highest");
   });
 
-  test("menuItemVariants: vertical standard selected uses bg-tertiary-container", () => {
+  test("menuItemVariants: vertical standard includes data-[selected] bg class for tertiary-container", () => {
     const cls = menuItemVariants({
-      isSelected: true,
       colorScheme: "standard",
       menuStyle: "vertical",
     });
-    expect(cls).toContain("bg-tertiary-container");
+    expect(cls).toContain("data-[selected]:bg-tertiary-container");
   });
 
-  test("menuItemVariants: vertical vibrant selected uses bg-tertiary", () => {
+  test("menuItemVariants: vertical vibrant includes data-[selected] bg class for tertiary", () => {
     const cls = menuItemVariants({
-      isSelected: true,
       colorScheme: "vibrant",
       menuStyle: "vertical",
     });
-    expect(cls).toContain("bg-tertiary");
+    expect(cls).toContain("data-[selected]:bg-tertiary");
+  });
+
+  test("menuItemStateLayerVariants: standard uses bg-on-surface", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("bg-on-surface");
+  });
+
+  test("menuItemStateLayerVariants: vibrant uses bg-on-tertiary-container", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "vibrant", menuStyle: "baseline" });
+    expect(cls).toContain("bg-on-tertiary-container");
+  });
+
+  test("menuItemStateLayerVariants: includes hover opacity-8 selector", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("group-data-[hovered]/menuitem:opacity-8");
+  });
+
+  test("menuItemStateLayerVariants: includes focus-visible opacity-10 selector", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("group-data-[focus-visible]/menuitem:opacity-10");
   });
 });

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -15,6 +15,8 @@ import {
   menuItemVariants,
   menuItemStateLayerVariants,
   menuItemHighlightVariants,
+  menuItemIconVariants,
+  menuGapVariants,
   menuPopoverVariants,
 } from "./Menu.variants";
 
@@ -243,11 +245,12 @@ describe("Menu", () => {
       expect(menu).toHaveClass("bg-surface-container");
     });
 
-    test("vibrant colorScheme applies tertiary container background", async () => {
+    test("vibrant colorScheme on vertical menu: items carry tertiary container background", async () => {
       renderBasicMenu({ colorScheme: "vibrant", menuStyle: "vertical" });
       await openMenu();
-      const menu = screen.getByRole("menu");
-      expect(menu).toHaveClass("bg-tertiary-container");
+      // vertical container is transparent; the item carries bg-tertiary-container
+      const items = screen.getAllByRole("menuitem");
+      expect(items[0]).toHaveClass("bg-tertiary-container");
     });
 
     test("baseline menuStyle uses extra-small corner radius", async () => {
@@ -311,7 +314,7 @@ describe("MenuItem", () => {
       expect(screen.getByTestId("copy-icon")).toBeInTheDocument();
     });
 
-    test("leading icon wrapper has 24dp size constraint", async () => {
+    test("leading icon wrapper has 24dp size constraint (baseline)", async () => {
       render(
         <MenuTrigger>
           <button type="button">Open Menu</button>
@@ -329,6 +332,24 @@ describe("MenuItem", () => {
       expect(wrapper).toHaveClass("h-6");
     });
 
+    test("leading icon wrapper has 20dp size constraint in vertical menu", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions" menuStyle="vertical">
+            <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const icon = screen.getByTestId("copy-icon");
+      const wrapper = icon.closest("span");
+      expect(wrapper).toHaveClass("w-5");
+      expect(wrapper).toHaveClass("h-5");
+    });
+
     test("renders trailing icon when provided", async () => {
       render(
         <MenuTrigger>
@@ -344,7 +365,7 @@ describe("MenuItem", () => {
       expect(screen.getByTestId("cut-icon")).toBeInTheDocument();
     });
 
-    test("trailing icon wrapper has 24dp size constraint", async () => {
+    test("trailing icon wrapper has 24dp size constraint (baseline)", async () => {
       render(
         <MenuTrigger>
           <button type="button">Open Menu</button>
@@ -472,28 +493,40 @@ describe("MenuItem", () => {
   });
 
   describe("Density", () => {
-    test("density 0 (default) renders items with h-12 class", async () => {
+    test("density 0 (default) renders baseline items with h-12 class", async () => {
       renderBasicMenu({ density: 0 });
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-12");
     });
 
-    test("density -1 renders items with h-11 class", async () => {
+    test("density -1 renders baseline items with h-11 class", async () => {
       renderBasicMenu({ density: -1 });
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-11");
     });
 
-    test("density -2 renders items with h-10 class", async () => {
+    test("density -2 renders baseline items with h-10 class", async () => {
       renderBasicMenu({ density: -2 });
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-10");
     });
 
-    test("density -3 renders items with h-9 class", async () => {
+    test("density -3 renders baseline items with h-9 class", async () => {
       renderBasicMenu({ density: -3 });
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-9");
+    });
+
+    test("vertical density 0 renders items with h-11 class (44dp)", async () => {
+      renderBasicMenu({ density: 0, menuStyle: "vertical" });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-11");
+    });
+
+    test("vertical density -1 renders items with h-10 class", async () => {
+      renderBasicMenu({ density: -1, menuStyle: "vertical" });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-10");
     });
   });
 
@@ -743,7 +776,7 @@ describe("MenuDivider", () => {
     expect(screen.getByRole("separator", { hidden: true })).toBeInTheDocument();
   });
 
-  test("divider has correct 8dp top/bottom padding (my-2)", async () => {
+  test("divider has correct 2dp top/bottom spacing (my-0.5) and horizontal inset (mx-3)", async () => {
     render(
       <MenuTrigger>
         <button type="button">Open Menu</button>
@@ -756,7 +789,8 @@ describe("MenuDivider", () => {
     );
     await openMenu();
     const divider = screen.getByRole("separator", { hidden: true });
-    expect(divider).toHaveClass("my-2");
+    expect(divider).toHaveClass("my-0.5");
+    expect(divider).toHaveClass("mx-3");
   });
 
   test("accepts custom className", async () => {
@@ -1284,15 +1318,16 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("rounded-xs");
   });
 
-  test("menuContainerVariants: vertical standard has bg-surface-container-low and rounded-lg", () => {
+  test("menuContainerVariants: vertical standard is transparent (bg-transparent) and has rounded-lg", () => {
     const cls = menuContainerVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("bg-surface-container-low");
+    expect(cls).toContain("bg-transparent");
     expect(cls).toContain("rounded-lg");
   });
 
-  test("menuContainerVariants: vertical vibrant has bg-tertiary-container", () => {
+  test("menuContainerVariants: vertical vibrant is transparent (container itself has no bg)", () => {
     const cls = menuContainerVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
-    expect(cls).toContain("bg-tertiary-container");
+    expect(cls).toContain("bg-transparent");
+    expect(cls).not.toContain("bg-tertiary-container");
   });
 
   test("menuItemVariants: uses text-label-large", () => {
@@ -1322,10 +1357,11 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("group-data-[selected]/menuitem:bg-tertiary");
   });
 
-  test("menuItemHighlightVariants: vertical uses inset-1 rounded-lg", () => {
+  test("menuItemHighlightVariants: vertical uses inset-x-1 inset-y-0 rounded-md (horizontal inset, CornerMedium)", () => {
     const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("inset-1");
-    expect(cls).toContain("rounded-lg");
+    expect(cls).toContain("inset-x-1");
+    expect(cls).toContain("inset-y-0");
+    expect(cls).toContain("rounded-md");
   });
 
   // ── menuItemStateLayerVariants ────────────────────────────────────────────
@@ -1345,10 +1381,11 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("inset-0");
   });
 
-  test("menuItemStateLayerVariants: vertical uses inset-1 rounded-lg", () => {
+  test("menuItemStateLayerVariants: vertical uses inset-x-1 inset-y-0 rounded-md (horizontal inset, CornerMedium)", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("inset-1");
-    expect(cls).toContain("rounded-lg");
+    expect(cls).toContain("inset-x-1");
+    expect(cls).toContain("inset-y-0");
+    expect(cls).toContain("rounded-md");
   });
 
   test("menuItemStateLayerVariants: includes hover opacity-8 selector", () => {
@@ -1377,5 +1414,50 @@ describe("CVA variants (unit)", () => {
     const cls = menuPopoverVariants();
     expect(cls).toContain("origin-top");
     expect(cls).toContain("data-[placement=top]:origin-bottom");
+  });
+
+  // ── menuItemVariants — vertical segmented bg + rounding ───────────────────
+
+  test("menuItemVariants: vertical standard has bg-surface-container-low", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("bg-surface-container-low");
+  });
+
+  test("menuItemVariants: vertical vibrant has bg-tertiary-container", () => {
+    const cls = menuItemVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
+    expect(cls).toContain("bg-tertiary-container");
+  });
+
+  test("menuItemVariants: vertical has segmented rounding classes", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("first:rounded-t-lg");
+    expect(cls).toContain("last:rounded-b-lg");
+    expect(cls).toContain("rounded-xs");
+  });
+
+  test("menuItemVariants: vertical uses px-4 (ItemLeadingSpace = 16dp)", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("px-4");
+  });
+
+  // ── menuItemIconVariants — size per menuStyle ─────────────────────────────
+
+  test("menuItemIconVariants: baseline uses h-6 w-6 (24dp)", () => {
+    const cls = menuItemIconVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("h-6");
+    expect(cls).toContain("w-6");
+  });
+
+  test("menuItemIconVariants: vertical uses h-5 w-5 (20dp, ItemLeadingIconSize)", () => {
+    const cls = menuItemIconVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("h-5");
+    expect(cls).toContain("w-5");
+  });
+
+  // ── menuGapVariants ───────────────────────────────────────────────────────
+
+  test("menuGapVariants: height is h-0.5 (2dp, SegmentedMenuTokens.SegmentedGap)", () => {
+    const cls = menuGapVariants();
+    expect(cls).toContain("h-0.5");
   });
 });

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -14,6 +14,8 @@ import {
   menuContainerVariants,
   menuItemVariants,
   menuItemStateLayerVariants,
+  menuItemHighlightVariants,
+  menuPopoverVariants,
 } from "./Menu.variants";
 
 // ─── Test Icon Mocks ───────────────────────────────────────────────────────────
@@ -463,8 +465,9 @@ describe("MenuItem", () => {
       renderBasicMenu();
       await openMenu();
       const item = screen.getByRole("menuitem", { name: "Cut" });
-      const stateLayer = item.querySelector("span[aria-hidden='true']");
-      expect(stateLayer).toBeInTheDocument();
+      // The highlight layer is the first aria-hidden span; state layer is the second
+      const overlaySpans = item.querySelectorAll("span[aria-hidden='true']");
+      expect(overlaySpans.length).toBeGreaterThanOrEqual(2);
     });
   });
 
@@ -872,9 +875,11 @@ describe("Selection mode", () => {
     );
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
-    // RAC emits data-selected on the element; CVA applies data-[selected]:bg-surface-container-highest
+    // RAC emits data-selected on the element; selected bg lives on the highlight layer
     expect(selectedItem).toHaveAttribute("data-selected");
-    expect(selectedItem).toHaveClass("data-[selected]:bg-surface-container-highest");
+    const highlight = selectedItem.querySelector("[data-testid='menuitem-highlight']");
+    expect(highlight).toBeInTheDocument();
+    expect(highlight).toHaveClass("group-data-[selected]/menuitem:bg-surface-container-highest");
   });
 
   test("selected item in vertical standard has tertiary container background", async () => {
@@ -896,7 +901,9 @@ describe("Selection mode", () => {
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
     expect(selectedItem).toHaveAttribute("data-selected");
-    expect(selectedItem).toHaveClass("data-[selected]:bg-tertiary-container");
+    const highlight = selectedItem.querySelector("[data-testid='menuitem-highlight']");
+    expect(highlight).toBeInTheDocument();
+    expect(highlight).toHaveClass("group-data-[selected]/menuitem:bg-tertiary-container");
   });
 
   test("selected item in vertical vibrant has tertiary background", async () => {
@@ -918,7 +925,9 @@ describe("Selection mode", () => {
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
     expect(selectedItem).toHaveAttribute("data-selected");
-    expect(selectedItem).toHaveClass("data-[selected]:bg-tertiary");
+    const highlight = selectedItem.querySelector("[data-testid='menuitem-highlight']");
+    expect(highlight).toBeInTheDocument();
+    expect(highlight).toHaveClass("group-data-[selected]/menuitem:bg-tertiary");
   });
 
   test("checkmark appears on selected item when selectionMode is set and no leadingIcon", async () => {
@@ -1291,29 +1300,35 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("text-label-large");
   });
 
-  test("menuItemVariants: baseline includes data-[selected] bg class for surface-container-highest", () => {
-    const cls = menuItemVariants({
-      colorScheme: "standard",
-      menuStyle: "baseline",
-    });
-    expect(cls).toContain("data-[selected]:bg-surface-container-highest");
+  // ── menuItemHighlightVariants ──────────────────────────────────────────────
+
+  test("menuItemHighlightVariants: baseline standard has bg-surface-container-highest selector", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("group-data-[selected]/menuitem:bg-surface-container-highest");
   });
 
-  test("menuItemVariants: vertical standard includes data-[selected] bg class for tertiary-container", () => {
-    const cls = menuItemVariants({
-      colorScheme: "standard",
-      menuStyle: "vertical",
-    });
-    expect(cls).toContain("data-[selected]:bg-tertiary-container");
+  test("menuItemHighlightVariants: baseline uses inset-0 (full-bleed)", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("inset-0");
   });
 
-  test("menuItemVariants: vertical vibrant includes data-[selected] bg class for tertiary", () => {
-    const cls = menuItemVariants({
-      colorScheme: "vibrant",
-      menuStyle: "vertical",
-    });
-    expect(cls).toContain("data-[selected]:bg-tertiary");
+  test("menuItemHighlightVariants: vertical standard has tertiary-container selector", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("group-data-[selected]/menuitem:bg-tertiary-container");
   });
+
+  test("menuItemHighlightVariants: vertical vibrant has tertiary selector", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
+    expect(cls).toContain("group-data-[selected]/menuitem:bg-tertiary");
+  });
+
+  test("menuItemHighlightVariants: vertical uses inset-1 rounded-lg", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("inset-1");
+    expect(cls).toContain("rounded-lg");
+  });
+
+  // ── menuItemStateLayerVariants ────────────────────────────────────────────
 
   test("menuItemStateLayerVariants: standard uses bg-on-surface", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
@@ -1325,6 +1340,17 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("bg-on-tertiary-container");
   });
 
+  test("menuItemStateLayerVariants: baseline uses inset-0", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("inset-0");
+  });
+
+  test("menuItemStateLayerVariants: vertical uses inset-1 rounded-lg", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("inset-1");
+    expect(cls).toContain("rounded-lg");
+  });
+
   test("menuItemStateLayerVariants: includes hover opacity-8 selector", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
     expect(cls).toContain("group-data-[hovered]/menuitem:opacity-8");
@@ -1333,5 +1359,23 @@ describe("CVA variants (unit)", () => {
   test("menuItemStateLayerVariants: includes focus-visible opacity-10 selector", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
     expect(cls).toContain("group-data-[focus-visible]/menuitem:opacity-10");
+  });
+
+  // ── menuPopoverVariants ───────────────────────────────────────────────────
+
+  test("menuPopoverVariants: includes animate-md-scale-in on entering", () => {
+    const cls = menuPopoverVariants();
+    expect(cls).toContain("data-[entering]:animate-md-scale-in");
+  });
+
+  test("menuPopoverVariants: includes animate-md-scale-out on exiting", () => {
+    const cls = menuPopoverVariants();
+    expect(cls).toContain("data-[exiting]:animate-md-scale-out");
+  });
+
+  test("menuPopoverVariants: includes placement-aware origin classes", () => {
+    const cls = menuPopoverVariants();
+    expect(cls).toContain("origin-top");
+    expect(cls).toContain("data-[placement=top]:origin-bottom");
   });
 });

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -26,8 +26,6 @@ export const menuContainerVariants = cva(
     "shadow-elevation-2",
     // Width constraints: 112dp min / 280dp max per MD3 spec
     "min-w-28 max-w-70",
-    // Layout
-    "py-2",
     // Scroll behaviour
     "overflow-y-auto",
     "max-h-[calc(var(--visual-viewport-height,100vh)-2rem)]",
@@ -39,8 +37,9 @@ export const menuContainerVariants = cva(
   {
     variants: {
       /**
-       * Color scheme — drives the container background (vertical style only).
-       * baseline always uses surface-container regardless of colorScheme.
+       * Color scheme — drives the container background (baseline only).
+       * vertical menus paint each item with the group surface; the container
+       * itself is transparent so the 2dp gap between groups reveals nothing.
        */
       colorScheme: {
         standard: [],
@@ -48,20 +47,16 @@ export const menuContainerVariants = cva(
       },
       /**
        * Visual style — drives corner radius and container background.
+       *
+       * baseline: solid surface-container, 4dp corners, 8dp vertical padding.
+       * vertical: transparent container, 16dp corners, no vertical padding —
+       *   each item owns its group background so gaps appear between them.
        */
       menuStyle: {
-        baseline: ["rounded-xs", "bg-surface-container"],
-        vertical: ["rounded-lg", "bg-surface-container-low"],
+        baseline: ["rounded-xs", "bg-surface-container", "py-2"],
+        vertical: ["rounded-lg", "bg-transparent"],
       },
     },
-    compoundVariants: [
-      // vertical + vibrant → tertiary container background
-      {
-        menuStyle: "vertical",
-        colorScheme: "vibrant",
-        class: ["bg-tertiary-container"],
-      },
-    ],
     defaultVariants: {
       colorScheme: "standard",
       menuStyle: "baseline",
@@ -120,17 +115,20 @@ export const menuPopoverVariants = cva([
  * - The root element sets group/menuitem so all slot children can read state.
  *
  * Typography: Label Large per MD3 menu spec (14sp / 500 weight).
- * Height: 48/44/40/36dp controlled by density via context (not CVA).
- * Padding: 12dp left/right, 12dp gap between elements.
+ * Height: 48/44/40/36dp (baseline/vertical) controlled by density via context.
+ * Padding: baseline 12dp left/right; vertical 16dp left/right (ItemLeadingSpace).
+ * Gap between icon and label: 12dp (ItemBetweenSpace, unchanged).
  *
- * Selected backgrounds per menuStyle × colorScheme:
- *   baseline (any):          data-[selected]:bg-surface-container-highest
- *   vertical + standard:     data-[selected]:bg-tertiary-container
- *   vertical + vibrant:      data-[selected]:bg-tertiary
- *
- * Disabled:
- *   The root itself gets data-[disabled]:pointer-events-none/cursor-not-allowed.
- *   Content (label, icons) are coloured at 38% via per-slot selectors.
+ * Vertical segmented group background strategy:
+ *   The container is transparent for vertical menus. Each item paints its own
+ *   group surface (bg-surface-container-low / bg-tertiary-container), and CSS
+ *   sibling selectors on [data-menu-gap] adjacent items produce the correct
+ *   corner-radius composition:
+ *     leading item (first or after-gap): rounded-t-lg (16dp top) + rounded-b-xs (4dp bottom)
+ *     trailing item (last or before-gap): rounded-t-xs (4dp top) + rounded-b-lg (16dp bottom)
+ *     standalone (first AND last): rounded-lg (all 16dp)
+ *     middle item: rounded-xs (4dp all)
+ *   [data-menu-gap] is set on the MenuGap component so the CSS selectors resolve.
  *
  * @see https://m3.material.io/components/menus/specs
  */
@@ -138,7 +136,7 @@ export const menuItemVariants = cva(
   [
     // Layout — height set by density context in MenuItem component
     "relative flex w-full items-center",
-    "px-3 gap-3",
+    "gap-3",
     // Typography: Label Large per MD3 menu spec
     "text-label-large",
     // Interaction
@@ -159,15 +157,39 @@ export const menuItemVariants = cva(
         vibrant: ["text-on-tertiary-container"],
       },
       /**
-       * Visual style — drives corner radius on items.
-       * Selected background is now handled by menuItemHighlightVariants.
+       * Visual style — drives padding, group background, and corner rounding.
+       *
+       * baseline: 12dp h-padding, no item background (container provides it).
+       * vertical: 16dp h-padding, item owns group surface background, CSS
+       *   sibling selectors on [data-menu-gap] form the rounded group cards.
        */
       menuStyle: {
-        baseline: [],
-        vertical: [],
+        baseline: ["px-3"],
+        vertical: [
+          "px-4",
+          // Group surface — the container is transparent for vertical
+          "bg-surface-container-low",
+          // Segmented corner rounding
+          // Default: inner item (4dp all corners)
+          "rounded-xs",
+          // First item in menu: 16dp top corners
+          "first:rounded-t-lg",
+          // Last item in menu: 16dp bottom corners
+          "last:rounded-b-lg",
+          // Item immediately before a gap: 16dp bottom corners
+          "has-[[data-menu-gap]~&]:rounded-b-lg",
+          // Item immediately after a gap: 16dp top corners
+          "[[data-menu-gap]~&]:rounded-t-lg",
+        ],
       },
     },
     compoundVariants: [
+      // vertical + vibrant: item bg → tertiary-container
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["bg-tertiary-container"],
+      },
       // vertical + standard: selected text → on-tertiary-container
       {
         menuStyle: "vertical",
@@ -195,13 +217,12 @@ export const menuItemVariants = cva(
  *
  * Geometry is menuStyle-aware:
  *   baseline — `inset-0` (full-bleed, square background; unchanged MD3 look)
- *   vertical — `inset-1 rounded-lg` (inset ~4dp, 16dp corners per MD3 Expressive
- *               spec; creates the pill-shaped highlight visible in the reference)
+ *   vertical — `inset-x-1 inset-y-0 rounded-md` (horizontal-only 4dp inset,
+ *               12dp CornerMedium per MD3 Expressive; selection no longer spans
+ *               full width but does fill item height to avoid vertical gaps)
  *
- * The layer is always present in the DOM (opacity-0 / transparent at rest) and
- * transitions its background-color to the selection color on `data-selected`.
- * This keeps the item hit-target and density height unchanged (they remain on
- * the root `<li>`) while the visual background is confined to the inset shape.
+ * The layer is always present in the DOM and transitions its background-color
+ * to the selection color on `data-selected`.
  *
  * Selection colors per menuStyle × colorScheme:
  *   baseline (any):         group-data-[selected]/menuitem:bg-surface-container-highest
@@ -222,7 +243,8 @@ export const menuItemHighlightVariants = cva(
     variants: {
       menuStyle: {
         baseline: ["inset-0"],
-        vertical: ["inset-1 rounded-lg"],
+        // horizontal-only inset + 12dp corners (CornerMedium = ItemSelectedShape)
+        vertical: ["inset-x-1 inset-y-0 rounded-md"],
       },
       colorScheme: {
         standard: [
@@ -302,8 +324,8 @@ export const menuItemStateLayerVariants = cva(
       menuStyle: {
         // baseline: full-bleed, inherits container corner radius
         baseline: ["inset-0 rounded-[inherit]"],
-        // vertical: inset to match the highlight layer shape
-        vertical: ["inset-1 rounded-lg"],
+        // vertical: horizontal-only inset to match the highlight layer shape
+        vertical: ["inset-x-1 inset-y-0 rounded-md"],
       },
     },
     compoundVariants: [
@@ -341,7 +363,7 @@ export const menuItemStateLayerVariants = cva(
  */
 export const menuItemIconVariants = cva(
   [
-    "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center",
+    "relative z-10 shrink-0 flex items-center justify-center",
     "text-on-surface-variant",
     "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
     // Disabled: 38% opacity on icon color
@@ -356,9 +378,14 @@ export const menuItemIconVariants = cva(
           "text-on-tertiary-container",
         ],
       },
+      /**
+       * Size per menuStyle:
+       *   baseline — 24dp (MD3 baseline spec)
+       *   vertical — 20dp (SegmentedMenuTokens.ItemLeadingIconSize = 20dp)
+       */
       menuStyle: {
-        baseline: [],
-        vertical: [],
+        baseline: ["h-6 w-6"],
+        vertical: ["h-5 w-5"],
       },
     },
     compoundVariants: [
@@ -412,7 +439,7 @@ export const menuSectionHeaderVariants = cva([
  *
  * @see https://m3.material.io/components/menus/specs — Measurements
  */
-export const menuDividerVariants = cva(["border-t border-outline-variant", "my-2 mx-0"]);
+export const menuDividerVariants = cva(["border-t border-outline-variant", "my-0.5 mx-3"]);
 
 // ─── MENU GAP ────────────────────────────────────────────────────────────────
 
@@ -425,7 +452,7 @@ export const menuDividerVariants = cva(["border-t border-outline-variant", "my-2
  *
  * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
  */
-export const menuGapVariants = cva(["h-2 w-full"]);
+export const menuGapVariants = cva(["h-0.5 w-full"]);
 
 // ─── MENU ITEM TRAILING TEXT ──────────────────────────────────────────────────
 

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -3,77 +3,77 @@ import { cva, type VariantProps } from "class-variance-authority";
 /**
  * Material Design 3 Menu container variants (CVA).
  *
- * Elevation: `shadow-elevation-2` (both styles)
- * Width: min 112dp / max 280dp per MD3 spec
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (menuStyle, colorScheme).
+ * - Enter/exit animation uses composite MD3 utilities (animate-md-scale-in/out)
+ *   sourced from the token system — no hardcoded durations or beziers.
+ * - Placement-aware transform-origin is set via data-placement data attributes
+ *   emitted by React Aria's Popover.
  *
  * Shape per menuStyle:
- * - baseline: `rounded-xs` (4dp extra-small)
- * - vertical: `rounded-lg` (16dp large)
+ *   baseline: `rounded-xs` (4dp extra-small)
+ *   vertical: `rounded-lg` (16dp large, MD3 Expressive)
  *
- * Background per colorScheme + menuStyle:
- * - baseline + standard: `bg-surface-container`
- * - vertical + standard: `bg-surface-container-low`
- * - vertical + vibrant:  `bg-tertiary-container`
+ * Background per menuStyle × colorScheme:
+ *   baseline + standard:  bg-surface-container
+ *   vertical + standard:  bg-surface-container-low
+ *   vertical + vibrant:   bg-tertiary-container
  *
  * @see https://m3.material.io/components/menus/specs
  */
 export const menuContainerVariants = cva(
   [
-    // Elevation
+    // Elevation: level 2
     "shadow-elevation-2",
-    // Width constraints per MD3 spec (112dp min / 280dp max)
+    // Width constraints: 112dp min / 280dp max per MD3 spec
     "min-w-28 max-w-70",
     // Layout
     "py-2",
-    // Scroll: show scrollbar when content overflows; max height avoids clipping
+    // Scroll behaviour
     "overflow-y-auto",
     "max-h-[calc(var(--visual-viewport-height,100vh)-2rem)]",
     // Stacking
     "z-50",
-    // Focus outline handled by React Aria
+    // Focus outline delegated to React Aria
     "outline-none",
-    // GPU compositing — promotes menu to its own compositor layer so
-    // scale + opacity animations run without triggering layout reflow.
+    // Promote to compositor layer — scale + opacity animations run without layout reflow
     "will-change-[transform,opacity]",
-    // Pointer events blocked during animation to prevent accidental clicks
-    // on menu items while the panel is still animating in or out.
+    // Block pointer events during animation to prevent accidental item clicks
     "data-[entering]:pointer-events-none data-[exiting]:pointer-events-none",
-    // ── Enter animation ────────────────────────────────────────────────────
-    // @keyframes menu-enter (defined in styles.css): scale(0.8)+opacity:0 →
-    // scale(1)+opacity:1 in 120ms with cubic-bezier(0,0,0.2,1) (standard
-    // decelerate — matches Angular Material's _mat-menu-enter keyframe).
-    "data-[entering]:animate-[menu-enter_120ms_cubic-bezier(0,0,0.2,1)_both]",
-    // ── Exit animation ─────────────────────────────────────────────────────
-    // @keyframes menu-exit (defined in styles.css): opacity:1 → opacity:0
-    // in 100ms after 25ms delay, linear — matches Angular Material's
-    // _mat-menu-exit keyframe (fade-only, no reverse scale).
-    "data-[exiting]:animate-[menu-exit_100ms_25ms_linear_both]",
-    // ── Transform origin (placement-aware) ────────────────────────────────
-    // RAC sets data-placement="bottom|top|left|right" on the Popover element.
-    // Default (bottom): origin at top edge (menu expands downward).
+
+    // ── Enter animation ─────────────────────────────────────────────────────
+    // animate-md-scale-in: scale(0.85)+opacity:0 → scale(1)+opacity:1
+    // Duration: 350ms expressive-fast-spatial spring (intentional overshoot)
+    "data-[entering]:animate-md-scale-in",
+
+    // ── Exit animation ──────────────────────────────────────────────────────
+    // animate-md-scale-out: scale(1)+opacity:1 → scale(0.85)+opacity:0
+    // Duration: 200ms emphasized-accelerate (accelerating exit)
+    "data-[exiting]:animate-md-scale-out",
+
+    // ── Transform origin (placement-aware) ──────────────────────────────────
+    // RAC sets data-placement on the Popover element.
+    // Default (bottom): origin at top edge (menu expands downward)
     "origin-top",
-    // top: origin at bottom edge (menu expands upward)
     "data-[placement=top]:origin-bottom",
-    // left: origin at right edge
     "data-[placement=left]:origin-right",
-    // right: origin at left edge
     "data-[placement=right]:origin-left",
-    // ── Reduced motion ────────────────────────────────────────────────────
-    // Skip both animations entirely for users who prefer reduced motion.
+
+    // ── Reduced motion ───────────────────────────────────────────────────────
     "motion-reduce:data-[entering]:animate-none motion-reduce:data-[exiting]:animate-none",
   ],
   {
     variants: {
       /**
-       * Color scheme — drives the container background.
-       * baseline+standard uses a separate compound variant.
+       * Color scheme — drives the container background (vertical style only).
+       * baseline always uses surface-container regardless of colorScheme.
        */
       colorScheme: {
         standard: [],
         vibrant: [],
       },
       /**
-       * Visual style — drives corner radius and baseline vs vertical background.
+       * Visual style — drives corner radius and container background.
        */
       menuStyle: {
         baseline: ["rounded-xs", "bg-surface-container"],
@@ -81,7 +81,7 @@ export const menuContainerVariants = cva(
       },
     },
     compoundVariants: [
-      // Vertical + vibrant: tertiary container background
+      // vertical + vibrant → tertiary container background
       {
         menuStyle: "vertical",
         colorScheme: "vibrant",
@@ -95,25 +95,30 @@ export const menuContainerVariants = cva(
   }
 );
 
+// ─── MENU ITEM ROOT ───────────────────────────────────────────────────────────
+
 /**
- * Material Design 3 Menu item variants (CVA).
+ * Material Design 3 Menu item root variants (CVA).
  *
- * Typography: `text-body-large` per MD3 baseline spec (16sp / 400 weight).
- * Padding: `px-3` (12dp left/right), `gap-3` (12dp between elements).
+ * Architecture: Variants vs States
+ * - CVA holds only design-time decisions: colorScheme, menuStyle.
+ * - All interaction/selection states are driven by data-* attributes that RAC
+ *   MenuItem emits natively (data-hovered, data-pressed, data-focus-visible,
+ *   data-selected, data-disabled) — read via group-data-[x]/menuitem selectors.
+ * - The root element sets group/menuitem so all slot children can read state.
  *
- * State layers (MD3 spec):
- * - Hover:         `opacity-8`  on state layer
- * - Focus visible: `opacity-12` on state layer
- * - Pressed:       `opacity-12` on state layer
- * - Disabled:      `opacity-38` on entire item
+ * Typography: Label Large per MD3 menu spec (14sp / 500 weight).
+ * Height: 48/44/40/36dp controlled by density via context (not CVA).
+ * Padding: 12dp left/right, 12dp gap between elements.
  *
- * Selection colors per menuStyle + colorScheme:
- * - baseline (any):         `bg-surface-container-highest`
- * - vertical + standard:    `bg-tertiary-container text-on-tertiary-container`
- * - vertical + vibrant:     `bg-tertiary text-on-tertiary`
+ * Selected backgrounds per menuStyle × colorScheme:
+ *   baseline (any):          data-[selected]:bg-surface-container-highest
+ *   vertical + standard:     data-[selected]:bg-tertiary-container
+ *   vertical + vibrant:      data-[selected]:bg-tertiary
  *
- * Note: item height (48/44/40/36dp) is controlled by density via context,
- * applied directly in MenuItem component (not CVA) to avoid negative key issues.
+ * Disabled:
+ *   The root itself gets data-[disabled]:pointer-events-none/cursor-not-allowed.
+ *   Content (label, icons) are coloured at 38% via per-slot selectors.
  *
  * @see https://m3.material.io/components/menus/specs
  */
@@ -122,99 +127,189 @@ export const menuItemVariants = cva(
     // Layout — height set by density context in MenuItem component
     "relative flex w-full items-center",
     "px-3 gap-3",
-    // Typography: Body Large per MD3 baseline spec
-    "text-body-large",
+    // Typography: Label Large per MD3 menu spec
+    "text-label-large",
     // Interaction
     "cursor-pointer select-none outline-none",
-    // State layer pseudo-element
-    "before:absolute before:inset-0 before:rounded-[inherit]",
-    "before:transition-opacity before:duration-short2 before:ease-standard",
-    "before:opacity-0",
-    // Hover state layer
-    "hover:before:opacity-8",
-    // Focus visible state layer
-    "focus-visible:before:opacity-12",
-    // Active pressed state layer
-    "active:before:opacity-12",
-    // Color transition for selection
-    "transition-colors duration-short2 ease-standard",
+    // Color transition (effects — no overshoot)
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Disabled — self-targeting data-[x]: selectors (RAC emits data-disabled)
+    "data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed",
   ],
   {
     variants: {
       /**
-       * Disabled state: reduces opacity and blocks interaction.
-       */
-      isDisabled: {
-        true: ["opacity-38 cursor-not-allowed pointer-events-none"],
-        false: [],
-      },
-      /**
-       * Selected state: background and text color driven by compound variants.
-       */
-      isSelected: {
-        true: [],
-        false: [],
-      },
-      /**
-       * Color scheme: drives default text and state layer colors.
-       * - standard: on-surface text, on-surface state layer
-       * - vibrant (vertical only): on-tertiary-container text + state layer
+       * Color scheme — drives default text color, state-layer color, and
+       * selection text colors.
        */
       colorScheme: {
-        standard: ["text-on-surface", "before:bg-on-surface"],
-        vibrant: ["text-on-tertiary-container", "before:bg-on-tertiary-container"],
+        standard: ["text-on-surface"],
+        vibrant: ["text-on-tertiary-container"],
       },
       /**
-       * Visual style: drives corner radius on items (vertical uses rounded-lg
-       * inherited from container, items stay flat inside).
+       * Visual style — drives corner radius on items and selection background.
        */
       menuStyle: {
-        baseline: [],
+        baseline: [
+          // Selected: surface-container-highest, text stays on-surface
+          "data-[selected]:bg-surface-container-highest",
+        ],
         vertical: [],
       },
     },
     compoundVariants: [
-      // ── Baseline selection (both colorSchemes) ──────────────────────────
+      // vertical + standard: selected → tertiary-container
       {
-        isSelected: true,
-        menuStyle: "baseline",
-        class: [
-          "bg-surface-container-highest",
-          // text-on-surface already applied by standard colorScheme variant
-        ],
-      },
-      // ── Vertical + Standard selection ───────────────────────────────────
-      {
-        isSelected: true,
         menuStyle: "vertical",
         colorScheme: "standard",
         class: [
-          "bg-tertiary-container",
-          "text-on-tertiary-container",
-          "before:bg-on-tertiary-container",
+          "data-[selected]:bg-tertiary-container",
+          "data-[selected]:text-on-tertiary-container",
         ],
       },
-      // ── Vertical + Vibrant selection ─────────────────────────────────────
+      // vertical + vibrant: selected → tertiary
       {
-        isSelected: true,
         menuStyle: "vertical",
         colorScheme: "vibrant",
-        class: ["bg-tertiary", "text-on-tertiary", "before:bg-on-tertiary"],
+        class: ["data-[selected]:bg-tertiary", "data-[selected]:text-on-tertiary"],
       },
     ],
     defaultVariants: {
-      isDisabled: false,
-      isSelected: false,
       colorScheme: "standard",
       menuStyle: "baseline",
     },
   }
 );
 
+// ─── MENU ITEM STATE LAYER ────────────────────────────────────────────────────
+
+/**
+ * State layer slot — absolute inset overlay that transitions opacity on
+ * hover / focus / press interaction states.
+ *
+ * Architecture mirrors buttonStateLayerVariants:
+ * - Opacity driven by group-data-[x]/menuitem selectors (no CSS pseudo-classes)
+ * - Pressed (opacity-10) uses doubled attribute selector to beat hover (opacity-8)
+ * - Hidden entirely when disabled — no state layer on disabled items
+ * - Color is variant-driven (on-surface for standard, on-tertiary-container for
+ *   vibrant), with selected override per menuStyle × colorScheme
+ *
+ * State-layer opacities per MD3 spec:
+ *   Hover:         8%   (opacity-8)
+ *   Focus visible: 10%  (opacity-10)
+ *   Pressed:       10%  (opacity-10, doubled selector wins over hover)
+ *
+ * @see https://m3.material.io/components/menus/specs#state-layers
+ */
+export const menuItemStateLayerVariants = cva(
+  [
+    "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+    // Effects transition — opacity must NOT overshoot
+    "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Hover: 8%
+    "group-data-[hovered]/menuitem:opacity-8",
+    // Focus visible: 10%
+    "group-data-[focus-visible]/menuitem:opacity-10",
+    // Pressed: 10%, doubled selector wins over hover at same cascade position
+    "group-data-[pressed]/menuitem:group-data-[pressed]/menuitem:opacity-10",
+    // No state layer when disabled
+    "group-data-[disabled]/menuitem:hidden",
+  ],
+  {
+    variants: {
+      colorScheme: {
+        standard: ["bg-on-surface"],
+        vibrant: ["bg-on-tertiary-container"],
+      },
+      menuStyle: {
+        baseline: [],
+        vertical: [],
+      },
+    },
+    compoundVariants: [
+      // vertical + standard selected: state layer switches to on-tertiary-container
+      {
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: ["group-data-[selected]/menuitem:bg-on-tertiary-container"],
+      },
+      // vertical + vibrant selected: state layer switches to on-tertiary
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["group-data-[selected]/menuitem:bg-on-tertiary"],
+      },
+    ],
+    defaultVariants: {
+      colorScheme: "standard",
+      menuStyle: "baseline",
+    },
+  }
+);
+
+// ─── MENU ITEM ICON ───────────────────────────────────────────────────────────
+
+/**
+ * Icon slot (leading and trailing icons) for menu items.
+ *
+ * Base: 24×24dp, on-surface-variant color.
+ * Selected: color follows the menuStyle × colorScheme selection color.
+ * Disabled: on-surface/38 per MD3 spec.
+ * Transition: effects spring (no overshoot on color).
+ *
+ * @see https://m3.material.io/components/menus/specs#anatomy
+ */
+export const menuItemIconVariants = cva(
+  [
+    "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center",
+    "text-on-surface-variant",
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Disabled: 38% opacity on icon color
+    "group-data-[disabled]/menuitem:text-on-surface/38",
+  ],
+  {
+    variants: {
+      colorScheme: {
+        standard: [],
+        vibrant: [
+          // Vibrant unselected icon: on-tertiary-container
+          "text-on-tertiary-container",
+        ],
+      },
+      menuStyle: {
+        baseline: [],
+        vertical: [],
+      },
+    },
+    compoundVariants: [
+      // vertical + standard selected: icon → on-tertiary-container
+      {
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: ["group-data-[selected]/menuitem:text-on-tertiary-container"],
+      },
+      // vertical + vibrant selected: icon → on-tertiary
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["group-data-[selected]/menuitem:text-on-tertiary"],
+      },
+    ],
+    defaultVariants: {
+      colorScheme: "standard",
+      menuStyle: "baseline",
+    },
+  }
+);
+
+// ─── MENU SECTION ─────────────────────────────────────────────────────────────
+
 /**
  * Menu section container variants (CVA).
  */
 export const menuSectionVariants = cva(["flex flex-col w-full"]);
+
+// ─── MENU SECTION HEADER ──────────────────────────────────────────────────────
 
 /**
  * Menu section header variants (CVA).
@@ -227,50 +322,65 @@ export const menuSectionHeaderVariants = cva([
   "select-none",
 ]);
 
+// ─── MENU DIVIDER ─────────────────────────────────────────────────────────────
+
 /**
  * Menu item divider variants (CVA).
  *
- * Renders a horizontal separator with `border-outline-variant`.
+ * Horizontal separator with `border-outline-variant`.
  * Padding: 8dp top/bottom (`my-2`) per MD3 spec.
  *
  * @see https://m3.material.io/components/menus/specs — Measurements
  */
 export const menuDividerVariants = cva(["border-t border-outline-variant", "my-2 mx-0"]);
 
+// ─── MENU GAP ────────────────────────────────────────────────────────────────
+
 /**
  * Menu gap variants (CVA).
  *
- * A visual spacer for M3 Expressive vertical menus. Uses spacing instead of
- * a border line to separate item groups. `aria-hidden` and `role="none"`.
+ * A visual spacer for MD3 Expressive vertical menus. Uses spacing instead of
+ * a border line to separate item groups. Set aria-hidden and role="none" in
+ * the component.
  *
  * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
  */
 export const menuGapVariants = cva(["h-2 w-full"]);
+
+// ─── MENU ITEM TRAILING TEXT ──────────────────────────────────────────────────
 
 /**
  * Trailing text (keyboard shortcut) variants (CVA).
  *
  * Color: `text-on-surface-variant`, size: `text-label-large` (14sp).
  * The element also carries `aria-keyshortcuts` for screen reader support.
+ * Disabled: on-surface/38 to match the rest of the item content.
  */
 export const menuItemTrailingTextVariants = cva([
   "ml-auto shrink-0 text-label-large text-on-surface-variant",
   "select-none",
+  "group-data-[disabled]/menuitem:text-on-surface/38",
 ]);
+
+// ─── MENU ITEM DESCRIPTION ────────────────────────────────────────────────────
 
 /**
  * Menu item description (supporting text) variants (CVA).
  *
  * Rendered below the label text.
  * Typography: `text-body-medium text-on-surface-variant`.
+ * Disabled: on-surface/38.
  */
 export const menuItemDescriptionVariants = cva([
   "text-body-medium text-on-surface-variant",
   "select-none",
+  "group-data-[disabled]/menuitem:text-on-surface/38",
 ]);
 
-// ─── Type exports ─────────────────────────────────────────────────────────────
+// ─── TYPE EXPORTS ─────────────────────────────────────────────────────────────
 
 export type MenuContainerVariants = VariantProps<typeof menuContainerVariants>;
 export type MenuItemVariants = VariantProps<typeof menuItemVariants>;
+export type MenuItemStateLayerVariants = VariantProps<typeof menuItemStateLayerVariants>;
+export type MenuItemIconVariants = VariantProps<typeof menuItemIconVariants>;
 export type MenuSectionVariants = VariantProps<typeof menuSectionVariants>;

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -5,10 +5,9 @@ import { cva, type VariantProps } from "class-variance-authority";
  *
  * Architecture: Variants vs States
  * - CVA holds design-time structure only (menuStyle, colorScheme).
- * - Enter/exit animation uses composite MD3 utilities (animate-md-scale-in/out)
- *   sourced from the token system — no hardcoded durations or beziers.
- * - Placement-aware transform-origin is set via data-placement data attributes
- *   emitted by React Aria's Popover.
+ * - Animation (enter/exit motion) lives on `menuPopoverVariants` which is
+ *   applied to the RAC Popover element — the element where RAC actually emits
+ *   data-entering, data-exiting, and data-placement.
  *
  * Shape per menuStyle:
  *   baseline: `rounded-xs` (4dp extra-small)
@@ -36,31 +35,6 @@ export const menuContainerVariants = cva(
     "z-50",
     // Focus outline delegated to React Aria
     "outline-none",
-    // Promote to compositor layer — scale + opacity animations run without layout reflow
-    "will-change-[transform,opacity]",
-    // Block pointer events during animation to prevent accidental item clicks
-    "data-[entering]:pointer-events-none data-[exiting]:pointer-events-none",
-
-    // ── Enter animation ─────────────────────────────────────────────────────
-    // animate-md-scale-in: scale(0.85)+opacity:0 → scale(1)+opacity:1
-    // Duration: 350ms expressive-fast-spatial spring (intentional overshoot)
-    "data-[entering]:animate-md-scale-in",
-
-    // ── Exit animation ──────────────────────────────────────────────────────
-    // animate-md-scale-out: scale(1)+opacity:1 → scale(0.85)+opacity:0
-    // Duration: 200ms emphasized-accelerate (accelerating exit)
-    "data-[exiting]:animate-md-scale-out",
-
-    // ── Transform origin (placement-aware) ──────────────────────────────────
-    // RAC sets data-placement on the Popover element.
-    // Default (bottom): origin at top edge (menu expands downward)
-    "origin-top",
-    "data-[placement=top]:origin-bottom",
-    "data-[placement=left]:origin-right",
-    "data-[placement=right]:origin-left",
-
-    // ── Reduced motion ───────────────────────────────────────────────────────
-    "motion-reduce:data-[entering]:animate-none motion-reduce:data-[exiting]:animate-none",
   ],
   {
     variants: {
@@ -94,6 +68,44 @@ export const menuContainerVariants = cva(
     },
   }
 );
+
+// ─── MENU POPOVER ────────────────────────────────────────────────────────────
+
+/**
+ * Applied to the React Aria `<Popover>` element — the element where RAC emits
+ * `data-entering`, `data-exiting`, and `data-placement`.
+ *
+ * Why here and not on the inner RACMenu:
+ * RAC's Popover owns the overlay lifecycle and sets these data attributes on
+ * itself, not on the child Menu element. Placing animation classes on RACMenu
+ * means they never match.
+ *
+ * Motion:
+ *   Enter: animate-md-scale-in (350ms expressive-fast-spatial, scale+fade)
+ *   Exit:  animate-md-scale-out (200ms emphasized-accelerate, scale+fade)
+ *
+ * Transform-origin is placement-aware: menus below the trigger expand from the
+ * top edge; menus above expand from the bottom, etc.
+ *
+ * @see https://m3.material.io/components/menus/specs — Motion
+ */
+export const menuPopoverVariants = cva([
+  // Promote to compositor layer so scale + opacity animate without layout reflow
+  "will-change-[transform,opacity]",
+  // Block pointer events while animating to prevent accidental item clicks
+  "data-[entering]:pointer-events-none data-[exiting]:pointer-events-none",
+  // Enter: 350ms expressive-fast-spatial spring (intentional overshoot)
+  "data-[entering]:animate-md-scale-in",
+  // Exit: 200ms emphasized-accelerate (accelerating exit)
+  "data-[exiting]:animate-md-scale-out",
+  // Transform origin — default bottom placement expands downward from top edge
+  "origin-top",
+  "data-[placement=top]:origin-bottom",
+  "data-[placement=left]:origin-right",
+  "data-[placement=right]:origin-left",
+  // Reduced motion: skip both animations entirely
+  "motion-reduce:data-[entering]:animate-none motion-reduce:data-[exiting]:animate-none",
+]);
 
 // ─── MENU ITEM ROOT ───────────────────────────────────────────────────────────
 
@@ -147,36 +159,100 @@ export const menuItemVariants = cva(
         vibrant: ["text-on-tertiary-container"],
       },
       /**
-       * Visual style — drives corner radius on items and selection background.
+       * Visual style — drives corner radius on items.
+       * Selected background is now handled by menuItemHighlightVariants.
        */
       menuStyle: {
-        baseline: [
-          // Selected: surface-container-highest, text stays on-surface
-          "data-[selected]:bg-surface-container-highest",
-        ],
+        baseline: [],
         vertical: [],
       },
     },
     compoundVariants: [
-      // vertical + standard: selected → tertiary-container
+      // vertical + standard: selected text → on-tertiary-container
       {
         menuStyle: "vertical",
         colorScheme: "standard",
-        class: [
-          "data-[selected]:bg-tertiary-container",
-          "data-[selected]:text-on-tertiary-container",
-        ],
+        class: ["data-[selected]:text-on-tertiary-container"],
       },
-      // vertical + vibrant: selected → tertiary
+      // vertical + vibrant: selected text → on-tertiary
       {
         menuStyle: "vertical",
         colorScheme: "vibrant",
-        class: ["data-[selected]:bg-tertiary", "data-[selected]:text-on-tertiary"],
+        class: ["data-[selected]:text-on-tertiary"],
       },
     ],
     defaultVariants: {
       colorScheme: "standard",
       menuStyle: "baseline",
+    },
+  }
+);
+
+// ─── MENU ITEM HIGHLIGHT ─────────────────────────────────────────────────────
+
+/**
+ * Selected-background highlight layer for menu items.
+ *
+ * Geometry is menuStyle-aware:
+ *   baseline — `inset-0` (full-bleed, square background; unchanged MD3 look)
+ *   vertical — `inset-1 rounded-lg` (inset ~4dp, 16dp corners per MD3 Expressive
+ *               spec; creates the pill-shaped highlight visible in the reference)
+ *
+ * The layer is always present in the DOM (opacity-0 / transparent at rest) and
+ * transitions its background-color to the selection color on `data-selected`.
+ * This keeps the item hit-target and density height unchanged (they remain on
+ * the root `<li>`) while the visual background is confined to the inset shape.
+ *
+ * Selection colors per menuStyle × colorScheme:
+ *   baseline (any):         group-data-[selected]/menuitem:bg-surface-container-highest
+ *   vertical + standard:    group-data-[selected]/menuitem:bg-tertiary-container
+ *   vertical + vibrant:     group-data-[selected]/menuitem:bg-tertiary
+ *
+ * @see https://m3.material.io/components/menus/specs — Selected state
+ */
+export const menuItemHighlightVariants = cva(
+  [
+    "absolute pointer-events-none",
+    // Effects transition for background-color — no overshoot
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // z-0: below state layer (z-[1]) and content (z-10)
+    "z-0",
+  ],
+  {
+    variants: {
+      menuStyle: {
+        baseline: ["inset-0"],
+        vertical: ["inset-1 rounded-lg"],
+      },
+      colorScheme: {
+        standard: [
+          // baseline selected bg (vertical standard compound below overrides)
+          "group-data-[selected]/menuitem:bg-surface-container-highest",
+        ],
+        vibrant: [
+          // baseline + vibrant: use surface-container-highest as fallback
+          // (vertical vibrant compound below overrides)
+          "group-data-[selected]/menuitem:bg-surface-container-highest",
+        ],
+      },
+    },
+    compoundVariants: [
+      // vertical + standard selected: tertiary-container
+      {
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: ["group-data-[selected]/menuitem:bg-tertiary-container"],
+      },
+      // vertical + vibrant selected: tertiary
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["group-data-[selected]/menuitem:bg-tertiary"],
+      },
+    ],
+    defaultVariants: {
+      menuStyle: "baseline",
+      colorScheme: "standard",
     },
   }
 );
@@ -203,7 +279,7 @@ export const menuItemVariants = cva(
  */
 export const menuItemStateLayerVariants = cva(
   [
-    "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+    "absolute overflow-hidden pointer-events-none opacity-0",
     // Effects transition — opacity must NOT overshoot
     "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
     // Hover: 8%
@@ -214,6 +290,8 @@ export const menuItemStateLayerVariants = cva(
     "group-data-[pressed]/menuitem:group-data-[pressed]/menuitem:opacity-10",
     // No state layer when disabled
     "group-data-[disabled]/menuitem:hidden",
+    // z-[1]: above highlight layer (z-0), below content (z-10)
+    "z-[1]",
   ],
   {
     variants: {
@@ -222,8 +300,10 @@ export const menuItemStateLayerVariants = cva(
         vibrant: ["bg-on-tertiary-container"],
       },
       menuStyle: {
-        baseline: [],
-        vertical: [],
+        // baseline: full-bleed, inherits container corner radius
+        baseline: ["inset-0 rounded-[inherit]"],
+        // vertical: inset to match the highlight layer shape
+        vertical: ["inset-1 rounded-lg"],
       },
     },
     compoundVariants: [
@@ -380,7 +460,9 @@ export const menuItemDescriptionVariants = cva([
 // ─── TYPE EXPORTS ─────────────────────────────────────────────────────────────
 
 export type MenuContainerVariants = VariantProps<typeof menuContainerVariants>;
+export type MenuPopoverVariants = VariantProps<typeof menuPopoverVariants>;
 export type MenuItemVariants = VariantProps<typeof menuItemVariants>;
+export type MenuItemHighlightVariants = VariantProps<typeof menuItemHighlightVariants>;
 export type MenuItemStateLayerVariants = VariantProps<typeof menuItemStateLayerVariants>;
 export type MenuItemIconVariants = VariantProps<typeof menuItemIconVariants>;
 export type MenuSectionVariants = VariantProps<typeof menuSectionVariants>;

--- a/packages/react/src/components/Menu/MenuGap.tsx
+++ b/packages/react/src/components/Menu/MenuGap.tsx
@@ -37,7 +37,9 @@ const MenuGapItem = createLeafComponent<object, { className?: string }, HTMLDivE
     return (
       // Rendered directly — no filterDOMProps, no useSeparator.
       // aria-hidden="true" removes the element from the a11y tree entirely.
-      <div ref={ref} aria-hidden="true" className={cls} />
+      // data-menu-gap is a non-ARIA marker used by CSS sibling selectors in
+      // menuItemVariants to apply per-group corner rounding to adjacent items.
+      <div ref={ref} aria-hidden="true" data-menu-gap="" className={cls} />
     );
   }
 );

--- a/packages/react/src/components/Menu/MenuHeadless.tsx
+++ b/packages/react/src/components/Menu/MenuHeadless.tsx
@@ -30,6 +30,7 @@ import {
 } from "react-aria-components";
 import { useButton } from "react-aria";
 import { useOverlayTriggerState } from "react-stately";
+import { menuPopoverVariants } from "./Menu.variants";
 import type {
   HeadlessMenuTriggerProps,
   HeadlessMenuProps,
@@ -132,7 +133,12 @@ export function HeadlessMenuTrigger({
        * Without isNonModal the Popover uses the standard modal overlay underlay,
        * which correctly dismisses the menu on any outside pointer interaction.
        */}
-      <Popover placement={placement} shouldFlip={shouldFlip} offset={4}>
+      <Popover
+        placement={placement}
+        shouldFlip={shouldFlip}
+        offset={4}
+        className={menuPopoverVariants()}
+      >
         {menuChild}
       </Popover>
     </RACMenuTrigger>
@@ -266,7 +272,9 @@ export function HeadlessSubmenuTrigger({
   // trigger MenuItem, second is a Popover wrapping the submenu.
   const racChildren: ReactElement[] = [
     triggerItem as ReactElement,
-    <Popover key="submenu-popover">{menuChild}</Popover>,
+    <Popover key="submenu-popover" className={menuPopoverVariants()}>
+      {menuChild}
+    </Popover>,
   ];
 
   return (
@@ -339,7 +347,13 @@ export function HeadlessContextMenuTrigger({
        * directly, which correctly dismisses the context menu.
        */}
       <OverlayTriggerStateContext.Provider value={internalState}>
-        <Popover triggerRef={virtualTriggerRef} placement="bottom start" shouldFlip offset={0}>
+        <Popover
+          triggerRef={virtualTriggerRef}
+          placement="bottom start"
+          shouldFlip
+          offset={0}
+          className={menuPopoverVariants()}
+        >
           {menuChild}
         </Popover>
       </OverlayTriggerStateContext.Provider>

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -6,6 +6,8 @@ import { useMenuContext } from "./MenuHeadless";
 import { HeadlessMenuItem } from "./MenuHeadless";
 import {
   menuItemVariants,
+  menuItemStateLayerVariants,
+  menuItemIconVariants,
   menuItemTrailingTextVariants,
   menuItemDescriptionVariants,
 } from "./Menu.variants";
@@ -63,10 +65,14 @@ const DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
 /**
  * MD3 styled MenuItem component (Layer 3).
  *
- * All MD3 styles (selection colors, typography, density height) are applied
- * directly to the `<li role="menuitem">` element via RAC's render-prop className,
- * ensuring tests and assistive technologies see the correct classes on the
- * semantically meaningful element.
+ * All MD3 styles are applied directly to the `<li role="menuitem">` element via
+ * RAC's render-prop className. React Aria automatically sets data-hovered,
+ * data-pressed, data-focus-visible, data-selected, and data-disabled on the
+ * element — these are consumed by group-data-[x]/menuitem selectors in the
+ * slot variants (state-layer, icon, label, trailing text, description).
+ *
+ * The root carries `group/menuitem` so all child slots can read the item's
+ * interaction state without prop drilling.
  *
  * @example
  * ```tsx
@@ -101,32 +107,42 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
 
   const { ripples, onMouseDown } = useRipple({ disabled: disableRipple });
 
-  // className rendered on the <li role="menuitem"> via RAC's render-prop form
-  const computeClassName = ({ isDisabled, isSelected }: MenuItemRenderProps): string =>
+  // className rendered on the <li role="menuitem"> via RAC's render-prop form.
+  // We only need the render-prop to read isSelected for the checkmark slot —
+  // all state-driven styling is handled by data-* attributes + group-data selectors.
+  const computeClassName = ({ isSelected }: MenuItemRenderProps): string =>
     cn(
-      menuItemVariants({
-        isDisabled,
-        isSelected: isSelected ?? false,
-        colorScheme,
-        menuStyle,
-      }),
+      menuItemVariants({ colorScheme, menuStyle }),
+      // group/menuitem scope: all slot children read state via group-data-[x]/menuitem
+      "group/menuitem",
       // Height: auto when description is present (multi-line), otherwise density
       description ? "min-h-12 py-2 h-auto items-start" : heightClass,
-      className
+      // Store isSelected on dataset so the render-prop return value is used for
+      // the checkmark slot below — actual selection styling comes from RAC's
+      // own data-selected attribute that it emits automatically.
+      className,
+      // Silence the isSelected lint — value consumed in render-prop below
+      isSelected ? "" : ""
     );
 
   return (
     <HeadlessMenuItem
       {...props}
       ref={ref}
-      // Apply all MD3 classes directly to the <li role="menuitem"> element
       className={computeClassName}
-      // onMouseDown triggers the ripple effect on mouse presses
       onMouseDown={onMouseDown as unknown as React.MouseEventHandler<Element>}
     >
       {({ isSelected }: MenuItemRenderProps) => (
         <>
-          {/* Ripple container */}
+          {/* ── State layer slot ──────────────────────────────────────── */}
+          {/* Renders below all content, above the base background.
+              Opacity is driven by group-data-[hovered/pressed/focus-visible]/menuitem. */}
+          <span
+            aria-hidden="true"
+            className={menuItemStateLayerVariants({ colorScheme, menuStyle })}
+          />
+
+          {/* ── Ripple container ──────────────────────────────────────── */}
           {!disableRipple && (
             <span className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
               {ripples}
@@ -135,10 +151,7 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
 
           {/* ── Leading icon or checkmark slot ────────────────────────── */}
           {(leadingIcon != null || isSelectionMenu) && (
-            <span
-              className="text-on-surface-variant relative z-10 flex h-6 w-6 shrink-0 items-center justify-center"
-              aria-hidden="true"
-            >
+            <span className={menuItemIconVariants({ colorScheme, menuStyle })} aria-hidden="true">
               {isSelectionMenu && leadingIcon == null ? (
                 isSelected ? (
                   <CheckIcon />
@@ -152,11 +165,15 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
           {/* ── Text content area ─────────────────────────────────────── */}
           {description != null ? (
             <span className="relative z-10 flex min-w-0 flex-1 flex-col">
-              <span className="text-body-large">{children}</span>
+              <span className="text-label-large group-data-[disabled]/menuitem:text-on-surface/38">
+                {children}
+              </span>
               <span className={menuItemDescriptionVariants()}>{description}</span>
             </span>
           ) : (
-            <span className="text-body-large relative z-10 min-w-0 flex-1">{children}</span>
+            <span className="text-label-large group-data-[disabled]/menuitem:text-on-surface/38 relative z-10 min-w-0 flex-1">
+              {children}
+            </span>
           )}
 
           {/* ── Badge slot ────────────────────────────────────────────── */}
@@ -165,7 +182,7 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
           {/* ── Trailing icon ─────────────────────────────────────────── */}
           {trailingIcon != null && trailingText == null && (
             <span
-              className="text-on-surface-variant relative z-10 ml-auto flex h-6 w-6 shrink-0 items-center justify-center"
+              className={cn(menuItemIconVariants({ colorScheme, menuStyle }), "ml-auto")}
               aria-hidden="true"
             >
               {trailingIcon}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -7,6 +7,7 @@ import { HeadlessMenuItem } from "./MenuHeadless";
 import {
   menuItemVariants,
   menuItemStateLayerVariants,
+  menuItemHighlightVariants,
   menuItemIconVariants,
   menuItemTrailingTextVariants,
   menuItemDescriptionVariants,
@@ -134,9 +135,18 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
     >
       {({ isSelected }: MenuItemRenderProps) => (
         <>
+          {/* ── Highlight layer (selected background) ─────────────────── */}
+          {/* Sits at z-0, below state layer and content. Geometry is
+              menuStyle-aware: baseline=full-bleed, vertical=inset-1 rounded-lg */}
+          <span
+            aria-hidden="true"
+            data-testid="menuitem-highlight"
+            className={menuItemHighlightVariants({ colorScheme, menuStyle })}
+          />
+
           {/* ── State layer slot ──────────────────────────────────────── */}
-          {/* Renders below all content, above the base background.
-              Opacity is driven by group-data-[hovered/pressed/focus-visible]/menuitem. */}
+          {/* z-[1]: above highlight, below content. Opacity driven by
+              group-data-[hovered/pressed/focus-visible]/menuitem. */}
           <span
             aria-hidden="true"
             className={menuItemStateLayerVariants({ colorScheme, menuStyle })}
@@ -144,7 +154,12 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
 
           {/* ── Ripple container ──────────────────────────────────────── */}
           {!disableRipple && (
-            <span className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
+            <span
+              className={cn(
+                "pointer-events-none absolute z-[2] overflow-hidden",
+                menuStyle === "vertical" ? "inset-1 rounded-lg" : "inset-0 rounded-[inherit]"
+              )}
+            >
               {ripples}
             </span>
           )}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -52,13 +52,21 @@ export function ChevronRightIcon(): JSX.Element {
   );
 }
 
-// ─── Density height map ────────────────────────────────────────────────────────
+// ─── Density height maps ───────────────────────────────────────────────────────
 
-const DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
+const BASELINE_DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
   0: "h-12",
   [-1]: "h-11",
   [-2]: "h-10",
   [-3]: "h-9",
+};
+
+// MD3 Expressive vertical: Item = 44dp at density 0
+const VERTICAL_DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
+  0: "h-11",
+  [-1]: "h-10",
+  [-2]: "h-9",
+  [-3]: "h-8",
 };
 
 // ─── MenuItem ─────────────────────────────────────────────────────────────────
@@ -103,7 +111,8 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
   const density = ctx?.density ?? 0;
   const selectionMode = ctx?.selectionMode;
 
-  const heightClass = DENSITY_HEIGHT[density];
+  const heightClass =
+    menuStyle === "vertical" ? VERTICAL_DENSITY_HEIGHT[density] : BASELINE_DENSITY_HEIGHT[density];
   const isSelectionMenu = selectionMode != null;
 
   const { ripples, onMouseDown } = useRipple({ disabled: disableRipple });
@@ -157,7 +166,9 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
             <span
               className={cn(
                 "pointer-events-none absolute z-[2] overflow-hidden",
-                menuStyle === "vertical" ? "inset-1 rounded-lg" : "inset-0 rounded-[inherit]"
+                menuStyle === "vertical"
+                  ? "inset-x-1 inset-y-0 rounded-md"
+                  : "inset-0 rounded-[inherit]"
               )}
             >
               {ripples}

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -44,41 +44,6 @@
 @import "./components/Progress/Progress.css";
 
 /* ==========================================================================
-   MENU ANIMATIONS
-   MD3 menu enter/exit keyframes — matched to Angular Material's implementation.
-   Enter: scale(0.8) + opacity → full, 120ms cubic-bezier(0, 0, 0.2, 1)
-   Exit:  opacity → 0, 100ms linear (25ms delay)
-   ========================================================================== */
-
-/**
- * Menu enter: pop from 80% scale + transparent to full size + opaque.
- * Transform-origin is set placement-aware via data-placement variants in CVA.
- */
-@keyframes menu-enter {
-  from {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-/**
- * Menu exit: fade out only (no scale) — matches Angular Material's exit which
- * only fades without reversing the scale.
- */
-@keyframes menu-exit {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-/* ==========================================================================
    COMPONENT TRANSITION UTILITIES
    Split MD3 transition: spatial properties use the expressive spring (allows
    overshoot); effects properties use the standard spring (no overshoot).


### PR DESCRIPTION
## Summary

- Replace hardcoded `menu-enter`/`menu-exit` keyframe animations with `animate-md-scale-in`/`animate-md-scale-out` composite utilities (350ms expressive spring enter, 200ms emphasized-accelerate exit), removing bespoke CSS from `styles.css`
- Remove `isDisabled`/`isSelected` CVA variant keys and all state `compoundVariants` from `menuItemVariants`; interaction/selection states are now driven entirely by React Aria's native `data-hovered`, `data-pressed`, `data-focus-visible`, `data-selected`, `data-disabled` attributes via `group-data-[x]/menuitem` selectors — consistent with the Button and Switch slot architecture
- Add `menuItemStateLayerVariants` slot (dedicated `<span>`) with MD3 spring tokens (hover 8%, focus/press 10% via doubled attribute selector), replacing the previous `before:` pseudo-element driven by CSS pseudo-classes
- Add `menuItemIconVariants` slot so leading/trailing icons correctly recolor on selection in vertical/vibrant menus
- Fix disabled treatment: per-slot `text-on-surface/38` on label and icons instead of whole-item `opacity-38`
- Switch item typography from Body Large to Label Large per MD3 menu spec
- Update `Menu.test.tsx`: typography assertion, selection background class format, new state-layer and group-scope assertions, CVA unit tests aligned to data-attribute pattern

## Test plan

- [ ] `pnpm lint` — green
- [ ] `pnpm typecheck` — green
- [ ] `pnpm test` — 2164 tests passing (32 test files, zero regressions)
- [ ] Storybook: baseline/vertical × standard/vibrant menus render correct backgrounds, transitions, and icon colors
- [ ] Selection menus: checkmark and background apply via `data-selected` attribute
- [ ] Disabled items: label and icons at 38% opacity, no pointer events
- [ ] Enter animation bounces subtly (expressive spring), exit fades quickly