### PR TITLE
fix(menu): md3 expressive segmented vertical menu rendering

### DIFF
--- a/.changeset/button-disabled-container-fix.md
+++ b/.changeset/button-disabled-container-fix.md
@@ -1,0 +1,7 @@
+---
+"@tinybigui/react": patch
+---
+
+fix(button): move container background to child slot so disabled state overrides apply
+
+Tailwind `group-data-[disabled]/button:` generates a descendant combinator selector, so it cannot target the root `<button>` group host directly. Background color now lives on an absolutely-positioned `buttonContainerVariants` child span, matching the Switch track pattern and ensuring `group-data-[disabled]/button:bg-on-surface/12` wins over variant backgrounds. Elevation overrides on the root use self-targeting `data-[disabled]:` selectors for the same reason.

--- a/.changeset/fix-opacity-token-percentages.md
+++ b/.changeset/fix-opacity-token-percentages.md
@@ -1,0 +1,9 @@
+---
+"@tinybigui/tokens": patch
+---
+
+Fix --opacity-\* tokens to use percentage values instead of unitless decimals.
+
+Tailwind v4 emits named --opacity-\* theme values verbatim into color-mix(), which requires a <percentage> stop value. The previous unitless decimals (0.08, 0.38, etc.) produced syntactically invalid color-mix() declarations that browsers silently discarded, breaking every color opacity modifier class (text-on-surface/38, bg-on-surface/12, bg-scrim/32, etc.) across all components.
+
+CSS opacity also accepts percentages identically to decimals, so bare opacity-\* utility classes are unaffected.

--- a/.changeset/menu-item-group.md
+++ b/.changeset/menu-item-group.md
@@ -1,0 +1,14 @@
+---
+"@tinybigui/react": minor
+---
+
+Add `MenuItemGroup` component — a sibling-aware grouping primitive for MD3 Expressive vertical menus.
+
+`MenuItemGroup` wraps related `MenuItem` elements in a semantic `role="group"` block and automatically inserts a 2dp MD3 Expressive gap between consecutive sibling groups (`menuStyle="vertical"`), so no manual `<MenuGap />` placement is required. An `aria-label` is required on every group to satisfy the ARIA `group` accessible-name requirement (WCAG 2.1).
+
+New exports from `@tinybigui/react`:
+
+- `MenuItemGroup` component (Layer 3)
+- `MenuItemGroupProps` type
+- `menuItemGroupVariants` CVA function
+- `MenuItemGroupVariants` type

--- a/.changeset/menu-md3-expressive.md
+++ b/.changeset/menu-md3-expressive.md
@@ -1,0 +1,21 @@
+---
+"@tinybigui/react": minor
+---
+
+**Menu**: fix MD3 Expressive segmented vertical menu rendering
+
+The vertical (`menuStyle="vertical"`) menu now correctly renders as the MD3 Expressive segmented model: groups of items form distinct rounded cards (16dp outer corners, 4dp inner corners) separated by transparent `MenuGap` spacers that reveal the page background — acting as visual dividers without a line.
+
+### Changes
+
+- **Segmented corner rounding fixed** — uses adjacent-sibling CSS selectors relative to `[data-menu-gap]` elements (`[[data-menu-gap]+&]:rounded-t-lg`, `[&:has(+[data-menu-gap])]:rounded-b-lg`) so the top/bottom corners of each segment group are correctly rounded at 16dp while middle items use 4dp inner corners.
+- **Full-bleed highlight and state layer** — both slots are now `inset-0 rounded-[inherit]` so they always fill the item and respect whichever corner radius the item currently has.
+- **New focus-ring slot** — a dedicated `z-[2]` overlay with `outline-secondary` and `-outline-offset-2` renders the keyboard-focus indicator separately from the state layer, matching the MD3 Expressive reference state grid.
+- **Exact color token mapping applied**:
+  - Standard: item bg `surface-container-low`; selected/active highlight `tertiary-container`; content `on-tertiary-container`
+  - Vibrant: item bg `tertiary-container`; selected/active highlight `tertiary`; content `on-tertiary`
+- **Scheme-aware text colors** — trailing text, description (supporting text), and section headers now receive `colorScheme` from context and use the correct token (`on-surface-variant` / `on-tertiary-container`).
+- **Icon size corrected** — vertical leading icons use 20dp (`h-5 w-5`) per `SegmentedMenuTokens.ItemLeadingIconSize`.
+- **Vertical item height corrected** — density 0 → 48dp (`h-12`), -1 → 44dp (`h-11`), -2 → 40dp (`h-10`), -3 → 36dp (`h-9`).
+- **`menuItemFocusRingVariants` exported** from `@tinybigui/react` for advanced consumers.
+- **Storybook** — Expressive Vertical Menu story shows standard + vibrant side-by-side with a selected item; new _States_ story covers all 6 MD3 interaction states; new _Reference Example_ story matches the MD3 anatomy two-segment layout.

--- a/.changeset/menu-md3-styling-refactor.md
+++ b/.changeset/menu-md3-styling-refactor.md
@@ -20,3 +20,15 @@ fix(menu): fire open/close motion on popover and inset expressive highlight
 - Update `menuItemStateLayerVariants` geometry to be menuStyle-aware: baseline `inset-0 rounded-[inherit]`, vertical `inset-1 rounded-lg`
 - Remove `data-[selected]:bg-*` from `menuItemVariants` root; background now lives exclusively on the highlight layer
 - Render highlight → state layer → ripple → content DOM order in `MenuItem.tsx`; ripple container geometry also respects menuStyle
+
+fix(menu): align expressive vertical menu gap and spacing to MD3 segmented spec
+
+- `menuContainerVariants` vertical: transparent background (was `bg-surface-container-low`) — the container is now a clear overlay; group surface color moves onto individual items
+- `menuItemVariants` vertical: each item carries its own group surface (`bg-surface-container-low` / `bg-tertiary-container` vibrant) and CSS sibling selectors on `[data-menu-gap]` produce segmented corner rounding (leading group 16/8dp, trailing group 8/16dp, middle group 8/8dp), matching the MD3 Expressive segmented-group model (`SegmentedMenuTokens`)
+- `MenuGap`: height reduced from `h-2` (8dp) to `h-0.5` (2dp) matching `SegmentedMenuTokens.SegmentedGap = 2dp`; `data-menu-gap` attribute added to enable CSS sibling selectors for segmented rounding on adjacent items
+- `MenuItem` vertical height map: default density 0 = `h-11` (44dp) instead of `h-12` (48dp), matching `SegmentedMenuTokens.Item = 44dp`; density steps -1/-2/-3 adjusted accordingly (h-10/h-9/h-8)
+- `menuItemIconVariants` vertical: icon size `h-5 w-5` (20dp) matching `SegmentedMenuTokens.ItemLeadingIconSize = 20dp`; baseline stays `h-6 w-6` (24dp)
+- `menuItemHighlightVariants` vertical: `inset-x-1 inset-y-0 rounded-md` (horizontal-only 4dp inset, 12dp CornerMedium per `ItemSelectedShape`) — replaces `inset-1 rounded-lg`; selection no longer spans full width but fills item height eliminating vertical detachment
+- `menuItemStateLayerVariants` vertical: geometry updated to match highlight layer: `inset-x-1 inset-y-0 rounded-md`
+- `menuDividerVariants`: `my-0.5 mx-3` (2dp vertical, 12dp horizontal inset) for consistency with gap and vertical layout
+- All changes are vertical-only; baseline menu visuals, public API, and props are unchanged

--- a/.changeset/menu-md3-styling-refactor.md
+++ b/.changeset/menu-md3-styling-refactor.md
@@ -1,0 +1,13 @@
+---
+"@tinybigui/react": patch
+---
+
+fix(menu): align Menu styling with component-variants.mdc slot architecture
+
+- Replace hardcoded `menu-enter`/`menu-exit` animations with `animate-md-scale-in`/`animate-md-scale-out` composite utilities (350ms expressive spring enter, 200ms emphasized-accelerate exit)
+- Remove `isDisabled`/`isSelected` CVA variant keys from `menuItemVariants`; interaction states are now driven by React Aria's native `data-hovered`, `data-pressed`, `data-focus-visible`, `data-selected`, `data-disabled` attributes via `group-data-[x]/menuitem` selectors
+- Add dedicated `menuItemStateLayerVariants` slot with hover 8% / focus+press 10% opacities using MD3 spring tokens (no more `before:` pseudo-element on the root)
+- Add `menuItemIconVariants` slot so leading/trailing icons recolor on selection in vertical/vibrant menus
+- Fix disabled treatment: per-slot `text-on-surface/38` instead of whole-item `opacity-38`
+- Update item typography: Body Large → Label Large per MD3 menu spec
+- Fix state-layer color transition to `duration-spring-standard-fast-effects ease-spring-standard-fast-effects`

--- a/.changeset/menu-md3-styling-refactor.md
+++ b/.changeset/menu-md3-styling-refactor.md
@@ -11,3 +11,12 @@ fix(menu): align Menu styling with component-variants.mdc slot architecture
 - Fix disabled treatment: per-slot `text-on-surface/38` instead of whole-item `opacity-38`
 - Update item typography: Body Large → Label Large per MD3 menu spec
 - Fix state-layer color transition to `duration-spring-standard-fast-effects ease-spring-standard-fast-effects`
+
+fix(menu): fire open/close motion on popover and inset expressive highlight
+
+- Add `menuPopoverVariants` CVA and apply to all three React Aria `<Popover>` elements (main trigger, submenu, context menu); RAC emits `data-entering`/`data-exiting`/`data-placement` on the Popover, not the inner RACMenu, so animation classes must live there
+- Strip dead `will-change`, `data-[entering]`, `data-[exiting]`, `origin-*`, and `motion-reduce:` classes from `menuContainerVariants` (those now belong exclusively to `menuPopoverVariants`)
+- Add `menuItemHighlightVariants` selected-background layer: `inset-0` (baseline) / `inset-1 rounded-lg` (vertical) — creates the inset, pill-shaped MD3 Expressive highlight matching the spec reference
+- Update `menuItemStateLayerVariants` geometry to be menuStyle-aware: baseline `inset-0 rounded-[inherit]`, vertical `inset-1 rounded-lg`
+- Remove `data-[selected]:bg-*` from `menuItemVariants` root; background now lives exclusively on the highlight layer
+- Render highlight → state layer → ripple → content DOM order in `MenuItem.tsx`; ripple container geometry also respects menuStyle

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -46,7 +46,10 @@ describe("Button", () => {
     test("renders filled variant (default)", () => {
       render(<Button variant="filled">Filled</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-primary", "text-on-primary");
+      expect(button).toHaveClass("text-on-primary");
+      // background lives on the buttonContainerVariants child span (not the root)
+      const bgContainer = button.querySelector('span[aria-hidden="true"]');
+      expect(bgContainer).toHaveClass("bg-primary");
     });
 
     test("renders outlined variant", () => {
@@ -58,19 +61,28 @@ describe("Button", () => {
     test("renders tonal variant", () => {
       render(<Button variant="tonal">Tonal</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-secondary-container", "text-on-secondary-container");
+      expect(button).toHaveClass("text-on-secondary-container");
+      // background lives on the buttonContainerVariants child span (not the root)
+      const bgContainer = button.querySelector('span[aria-hidden="true"]');
+      expect(bgContainer).toHaveClass("bg-secondary-container");
     });
 
     test("renders elevated variant", () => {
       render(<Button variant="elevated">Elevated</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-surface-container-low", "shadow-elevation-1");
+      expect(button).toHaveClass("shadow-elevation-1");
+      // background lives on the buttonContainerVariants child span (not the root)
+      const bgContainer = button.querySelector('span[aria-hidden="true"]');
+      expect(bgContainer).toHaveClass("bg-surface-container-low");
     });
 
     test("renders text variant", () => {
       render(<Button variant="text">Text</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-transparent", "text-primary");
+      expect(button).toHaveClass("text-primary");
+      // background lives on the buttonContainerVariants child span (not the root)
+      const bgContainer = button.querySelector('span[aria-hidden="true"]');
+      expect(bgContainer).toHaveClass("bg-transparent");
     });
 
     test("sets data-variant attribute", () => {
@@ -203,6 +215,50 @@ describe("Button", () => {
     test("does not set data-disabled when enabled", () => {
       render(<Button>Enabled</Button>);
       expect(screen.getByRole("button")).not.toHaveAttribute("data-disabled");
+    });
+
+    test("disabled filled button has MD3 disabled container class", () => {
+      render(
+        <Button variant="filled" isDisabled>
+          Disabled
+        </Button>
+      );
+      const button = screen.getByRole("button");
+      // disabled container bg is on the buttonContainerVariants child span
+      // using group-data descendant selector (same pattern as Switch track)
+      const bgContainer = button.querySelector('span[aria-hidden="true"]');
+      expect(bgContainer).toHaveClass("group-data-[disabled]/button:bg-on-surface/12");
+    });
+
+    test("disabled outlined button has MD3 disabled border class", () => {
+      render(
+        <Button variant="outlined" isDisabled>
+          Disabled
+        </Button>
+      );
+      expect(screen.getByRole("button")).toHaveClass("data-[disabled]:border-on-surface/12");
+    });
+
+    test("disabled elevated button has MD3 disabled shadow-none class", () => {
+      render(
+        <Button variant="elevated" isDisabled>
+          Disabled
+        </Button>
+      );
+      expect(screen.getByRole("button")).toHaveClass("data-[disabled]:shadow-none");
+    });
+
+    test("disabled button has MD3 disabled text class across all variants", () => {
+      const variants = ["filled", "outlined", "tonal", "elevated", "text"] as const;
+      variants.forEach((variant) => {
+        const { unmount } = render(
+          <Button variant={variant} isDisabled>
+            {variant}
+          </Button>
+        );
+        expect(screen.getByRole("button")).toHaveClass("data-[disabled]:text-on-surface/38");
+        unmount();
+      });
     });
 
     test("loading button is also disabled", () => {

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -6,6 +6,7 @@ import { useHover, useFocusRing, mergeProps } from "react-aria";
 import { ButtonHeadless } from "./ButtonHeadless";
 import {
   buttonVariants,
+  buttonContainerVariants,
   buttonStateLayerVariants,
   buttonFocusRingVariants,
   buttonIconVariants,
@@ -219,6 +220,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & Omit<ButtonVar
           className
         )}
       >
+        {/* Background container — owns the variant bg color; group-data-[disabled]/button
+            override applies here because this span is a real descendant of group/button */}
+        <span className={cn(buttonContainerVariants({ variant }))} aria-hidden="true" />
+
         {/* Ripple effect */}
         {ripples}
 

--- a/packages/react/src/components/Button/Button.variants.ts
+++ b/packages/react/src/components/Button/Button.variants.ts
@@ -10,11 +10,20 @@ import { cva, type VariantProps } from "class-variance-authority";
  * - Content flags (data-with-icon, data-loading) are set explicitly by the component.
  *
  * Slot responsibilities:
- *   buttonVariants           — root <button>; shape, color, elevation
+ *   buttonVariants           — root <button>; shape, text color, elevation (shadow)
+ *   buttonContainerVariants  — absolute inset child; background color + disabled bg override
  *   buttonStateLayerVariants — hover/focus/press opacity ring (absolute inset overlay)
  *   buttonFocusRingVariants  — keyboard focus outline, MUST NOT be inside overflow-hidden
  *   buttonIconVariants       — leading/trailing icon wrapper
  *   buttonLabelVariants      — label text slot
+ *
+ * Why background lives on a child slot (buttonContainerVariants) rather than the root:
+ *   Tailwind `group-data-[x]/button:` generates a descendant combinator selector —
+ *   `.group\/button[data-x] .target`. The root <button> IS the group host and cannot
+ *   be its own descendant, so group selectors cannot target it directly. Moving the
+ *   background to an absolutely-positioned child span lets us use the proven
+ *   `group-data-[disabled]/button:bg-on-surface/12` pattern (same as Switch track)
+ *   to override the container background on disabled, guaranteeing correct specificity.
  *
  * MD3 Spec:
  *   Shape: rounded-full (corner-full)
@@ -37,12 +46,19 @@ import { cva, type VariantProps } from "class-variance-authority";
 /**
  * Root <button> element.
  *
+ * Owns: shape, text color, elevation (box-shadow), cursor, layout.
+ * Does NOT own background-color — that lives on buttonContainerVariants so
+ * the group-data disabled override can reach it via descendant selector.
+ *
  * IMPORTANT — overflow is intentionally NOT on the root.
  * Overflow clipping is delegated to the ripple container and state layer
  * via `overflow-hidden rounded-[inherit]` on those children. This lets the
  * focus ring span (`inset-[-3px]`) extend outside the button boundary and
  * remain fully visible — if overflow-hidden were on the root it would be
  * clipped to zero width.
+ *
+ * Elevation state classes use self-targeting `data-[x]:` (not group-data)
+ * because the root is the group host and cannot be its own descendant.
  */
 export const buttonVariants = cva(
   [
@@ -64,6 +80,10 @@ export const buttonVariants = cva(
        *   Filled/Tonal  hover→level-1, focus/pressed→level-0
        *   Elevated      base→level-1, hover→level-2, focus/pressed→level-1
        *   Outlined/Text no elevation
+       *
+       * Self-targeting `data-[x]:` is used for elevation because these classes
+       * sit on the root element (the group host) — group-data descendant
+       * selectors cannot match an element against itself.
        */
       variant: {
         /**
@@ -72,17 +92,17 @@ export const buttonVariants = cva(
          * Elevation: 0 base → 1 hover → 0 focus → 0 pressed
          */
         filled: [
-          "bg-primary text-on-primary shadow-none",
+          "text-on-primary shadow-none",
           // Hover: gains level-1 elevation
-          "group-data-[hovered]/button:shadow-elevation-1",
+          "data-[hovered]:shadow-elevation-1",
           // Focus/pressed: shadow must explicitly return to level-0
           // (doubled attribute selector → higher specificity than hover)
-          "group-data-[focus-visible]/button:shadow-none",
-          "group-data-[pressed]/button:group-data-[pressed]/button:shadow-none",
-          // Disabled overrides
-          "group-data-[disabled]/button:bg-on-surface/12",
-          "group-data-[disabled]/button:text-on-surface/38",
-          "group-data-[disabled]/button:shadow-none",
+          "data-[focus-visible]:data-[focus-visible]:shadow-none",
+          "data-[pressed]:data-[pressed]:data-[pressed]:shadow-none",
+          // Disabled overrides — root owns text color + shadow only;
+          // disabled bg override lives on buttonContainerVariants (filled variant)
+          "data-[disabled]:text-on-surface/38",
+          "data-[disabled]:shadow-none",
         ],
 
         /**
@@ -91,10 +111,10 @@ export const buttonVariants = cva(
          * Elevation: always 0
          */
         outlined: [
-          "bg-transparent border border-outline text-primary",
+          "border border-outline text-primary",
           // Disabled overrides
-          "group-data-[disabled]/button:border-on-surface/12",
-          "group-data-[disabled]/button:text-on-surface/38",
+          "data-[disabled]:border-on-surface/12",
+          "data-[disabled]:text-on-surface/38",
         ],
 
         /**
@@ -103,16 +123,15 @@ export const buttonVariants = cva(
          * Elevation: 0 base → 1 hover → 0 focus → 0 pressed
          */
         tonal: [
-          "bg-secondary-container text-on-secondary-container shadow-none",
+          "text-on-secondary-container shadow-none",
           // Hover: gains level-1 elevation (same as filled)
-          "group-data-[hovered]/button:shadow-elevation-1",
+          "data-[hovered]:shadow-elevation-1",
           // Focus/pressed: return to level-0
-          "group-data-[focus-visible]/button:shadow-none",
-          "group-data-[pressed]/button:group-data-[pressed]/button:shadow-none",
+          "data-[focus-visible]:data-[focus-visible]:shadow-none",
+          "data-[pressed]:data-[pressed]:data-[pressed]:shadow-none",
           // Disabled overrides
-          "group-data-[disabled]/button:bg-on-surface/12",
-          "group-data-[disabled]/button:text-on-surface/38",
-          "group-data-[disabled]/button:shadow-none",
+          "data-[disabled]:text-on-surface/38",
+          "data-[disabled]:shadow-none",
         ],
 
         /**
@@ -121,17 +140,16 @@ export const buttonVariants = cva(
          * Elevation: 1 base → 2 hover → 1 focus → 1 pressed
          */
         elevated: [
-          "bg-surface-container-low text-primary shadow-elevation-1",
+          "text-primary shadow-elevation-1",
           // Hover: gains extra elevation
-          "group-data-[hovered]/button:shadow-elevation-2",
+          "data-[hovered]:shadow-elevation-2",
           // Focus/pressed: return to base level-1
           // (doubled selector wins over single hover selector at same cascade position)
-          "group-data-[focus-visible]/button:shadow-elevation-1",
-          "group-data-[pressed]/button:group-data-[pressed]/button:shadow-elevation-1",
+          "data-[focus-visible]:data-[focus-visible]:shadow-elevation-1",
+          "data-[pressed]:data-[pressed]:data-[pressed]:shadow-elevation-1",
           // Disabled overrides
-          "group-data-[disabled]/button:bg-on-surface/12",
-          "group-data-[disabled]/button:text-on-surface/38",
-          "group-data-[disabled]/button:shadow-none",
+          "data-[disabled]:text-on-surface/38",
+          "data-[disabled]:shadow-none",
         ],
 
         /**
@@ -140,9 +158,9 @@ export const buttonVariants = cva(
          * Elevation: always 0
          */
         text: [
-          "bg-transparent text-primary",
+          "text-primary",
           // Disabled overrides
-          "group-data-[disabled]/button:text-on-surface/38",
+          "data-[disabled]:text-on-surface/38",
         ],
       },
 
@@ -182,6 +200,44 @@ export const buttonVariants = cva(
       size: "medium",
       fullWidth: false,
     },
+  }
+);
+
+// ─── BACKGROUND CONTAINER ─────────────────────────────────────────────────────
+
+/**
+ * Background container — absolute inset child span that owns the container
+ * background color for each variant and applies the MD3 disabled bg override.
+ *
+ * Separated from the root because the root is the `group/button` host and
+ * cannot be targeted by its own `group-data-[x]/button:` selectors (those
+ * generate descendant combinators). As a real child, this slot DOES match
+ * `group-data-[disabled]/button:` with full specificity, exactly like the
+ * Switch track slot.
+ *
+ * MD3 disabled: container uses on-surface at 12% opacity.
+ */
+export const buttonContainerVariants = cva(
+  [
+    "absolute inset-0 rounded-[inherit] pointer-events-none",
+    // Effects transition for background-color — no overshoot
+    "transition-[background-color] duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  ],
+  {
+    variants: {
+      variant: {
+        // MD3 disabled: filled containers replace bg with on-surface/12.
+        // group-data descendant selector targets this child span (not the root host).
+        filled: "bg-primary group-data-[disabled]/button:bg-on-surface/12",
+        // outlined/text: container stays transparent when disabled — only border + label fade.
+        outlined: "bg-transparent",
+        // MD3 disabled: tonal and elevated containers also replace bg with on-surface/12.
+        tonal: "bg-secondary-container group-data-[disabled]/button:bg-on-surface/12",
+        elevated: "bg-surface-container-low group-data-[disabled]/button:bg-on-surface/12",
+        text: "bg-transparent",
+      },
+    },
+    defaultVariants: { variant: "filled" },
   }
 );
 
@@ -303,6 +359,7 @@ export const buttonLabelVariants = cva(["relative z-10 inline-flex items-center"
 // ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
 
 export type ButtonVariants = VariantProps<typeof buttonVariants>;
+export type ButtonContainerVariants = VariantProps<typeof buttonContainerVariants>;
 export type ButtonStateLayerVariants = VariantProps<typeof buttonStateLayerVariants>;
 export type ButtonIconVariants = VariantProps<typeof buttonIconVariants>;
 export type ButtonLabelVariants = VariantProps<typeof buttonLabelVariants>;

--- a/packages/react/src/components/Menu/Menu.stories.tsx
+++ b/packages/react/src/components/Menu/Menu.stories.tsx
@@ -6,7 +6,7 @@ import { MenuSection } from "./MenuSection";
 import { MenuDivider } from "./MenuDivider";
 import { MenuGap } from "./MenuGap";
 import { SubmenuTrigger } from "./SubmenuTrigger";
-import { ContextMenuTrigger } from "./ContextMenuTrigger";
+import { MenuItemGroup } from "./MenuItemGroup";
 import { HeadlessMenuTrigger, HeadlessMenuItem } from "./MenuHeadless";
 import { menuContainerVariants, menuItemVariants } from "./Menu.variants";
 import { cn } from "../../utils/cn";
@@ -490,16 +490,19 @@ export const VibrantColorScheme: Story = {
             Standard
           </button>
           <MenuTrigger.Menu aria-label="Standard" colorScheme="standard" menuStyle="vertical">
-            <MenuItem id="star" leadingIcon={<StarIcon />}>
-              Add to favourites
-            </MenuItem>
-            <MenuItem id="share" leadingIcon={<ShareIcon />}>
-              Share
-            </MenuItem>
-            <MenuGap />
-            <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
-              Delete
-            </MenuItem>
+            <MenuItemGroup aria-label="Clipboard">
+              <MenuItem id="star" leadingIcon={<StarIcon />}>
+                Add to favourites
+              </MenuItem>
+              <MenuItem id="share" leadingIcon={<ShareIcon />}>
+                Share
+              </MenuItem>
+            </MenuItemGroup>
+            <MenuItemGroup aria-label="Danger">
+              <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+                Delete
+              </MenuItem>
+            </MenuItemGroup>
           </MenuTrigger.Menu>
         </MenuTrigger>
       </div>
@@ -1169,6 +1172,104 @@ export const DarkModeVibrant: Story = {
           </MenuItem>
         </MenuTrigger.Menu>
       </MenuTrigger>
+    </div>
+  ),
+};
+
+// ─── MenuItemGroup ────────────────────────────────────────────────────────────
+
+export const MenuItemGroupAutoGap: Story = {
+  name: "MenuItemGroup — Auto-gap grouping (Expressive Vertical)",
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        story: [
+          "`MenuItemGroup` is the sibling-aware grouping primitive for MD3 Expressive vertical menus.",
+          "",
+          'It wraps related `MenuItem` elements in a semantic `role="group"` block and **automatically inserts',
+          "a 2dp gap** between consecutive sibling groups — no manual `<MenuGap />` placement required.",
+          "With N groups you get exactly N−1 visible gaps: the leading gap before the first group is hidden",
+          "via the `first:hidden` Tailwind class.",
+          "",
+          "Each group also becomes its own rounded segment card: the existing adjacent-sibling `[data-menu-gap]`",
+          "corner-rounding selectors in `menuItemVariants` handle the 16dp outer / 4dp inner rounding",
+          "automatically.",
+          "",
+          "`aria-label` is required on every group so the ARIA `group` role has an accessible name (WCAG 2.1).",
+        ].join("\n"),
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-start gap-8">
+      {/* ── Standard ── */}
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Standard</span>
+        <MenuTrigger defaultOpen>
+          <button type="button" className={primaryBtn}>
+            More actions
+          </button>
+          <MenuTrigger.Menu
+            aria-label="More actions (standard)"
+            menuStyle="vertical"
+            colorScheme="standard"
+          >
+            <MenuItemGroup aria-label="Clipboard">
+              <MenuItem id="cut" leadingIcon={<CutIcon />}>
+                Cut
+              </MenuItem>
+              <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+                Copy
+              </MenuItem>
+              <MenuItem id="paste" leadingIcon={<PasteIcon />}>
+                Paste
+              </MenuItem>
+            </MenuItemGroup>
+            <MenuItemGroup aria-label="History">
+              <MenuItem id="undo">Undo</MenuItem>
+              <MenuItem id="redo">Redo</MenuItem>
+            </MenuItemGroup>
+            <MenuItemGroup aria-label="Danger">
+              <MenuItem id="delete">Delete</MenuItem>
+            </MenuItemGroup>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+
+      {/* ── Vibrant ── */}
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Vibrant</span>
+        <MenuTrigger defaultOpen>
+          <button type="button" className={tertiaryBtn}>
+            More actions
+          </button>
+          <MenuTrigger.Menu
+            aria-label="More actions (vibrant)"
+            menuStyle="vertical"
+            colorScheme="vibrant"
+          >
+            <MenuItemGroup aria-label="Clipboard">
+              <MenuItem id="vib-cut" leadingIcon={<CutIcon />}>
+                Cut
+              </MenuItem>
+              <MenuItem id="vib-copy" leadingIcon={<CopyIcon />}>
+                Copy
+              </MenuItem>
+              <MenuItem id="vib-paste" leadingIcon={<PasteIcon />}>
+                Paste
+              </MenuItem>
+            </MenuItemGroup>
+            <MenuItemGroup aria-label="History">
+              <MenuItem id="vib-undo">Undo</MenuItem>
+              <MenuItem id="vib-redo">Redo</MenuItem>
+            </MenuItemGroup>
+            <MenuItemGroup aria-label="Danger">
+              <MenuItem id="vib-delete">Delete</MenuItem>
+            </MenuItemGroup>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
     </div>
   ),
 };

--- a/packages/react/src/components/Menu/Menu.stories.tsx
+++ b/packages/react/src/components/Menu/Menu.stories.tsx
@@ -534,32 +534,281 @@ export const VerticalMenuStyle: Story = {
   parameters: {
     docs: {
       description: {
-        story:
-          "The `vertical` menu style uses **16dp rounded corners** (vs 4dp in baseline) and supports `MenuGap` — a visual spacing element (not a separator) that groups items without a visible divider line.",
+        story: [
+          "The `vertical` (Expressive) menu style uses **16dp rounded corners** and the **segmented model** — each group of items is a separate rounded card.",
+          "",
+          "`MenuGap` creates a 2dp transparent gap between segments, letting the page background show through (acting as a visual divider without a line).",
+          "",
+          "Items within a segment share a surface: **standard** uses `surface-container-low`; **vibrant** uses `tertiary-container`.",
+          "The **selected** row gets a rounded accent highlight (standard → `tertiary-container`, vibrant → `tertiary`).",
+        ].join("\n"),
       },
     },
   },
   render: () => (
-    <MenuTrigger>
-      <button type="button" className={primaryBtn}>
-        More actions
-      </button>
-      <MenuTrigger.Menu aria-label="More actions" menuStyle="vertical" colorScheme="vibrant">
-        <MenuItem id="star" leadingIcon={<StarIcon />}>
-          Add to favourites
-        </MenuItem>
-        <MenuItem id="share" leadingIcon={<ShareIcon />}>
-          Share
-        </MenuItem>
-        <MenuGap />
-        <MenuItem id="rename">Rename</MenuItem>
-        <MenuItem id="duplicate">Duplicate</MenuItem>
-        <MenuGap />
-        <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
-          Delete
-        </MenuItem>
-      </MenuTrigger.Menu>
-    </MenuTrigger>
+    <div className="flex items-start gap-8">
+      {/* ── Standard ── */}
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Standard</span>
+        <MenuTrigger defaultOpen>
+          <button type="button" className={primaryBtn}>
+            More actions
+          </button>
+          <MenuTrigger.Menu
+            aria-label="More actions (standard)"
+            menuStyle="vertical"
+            colorScheme="standard"
+            selectionMode="single"
+            defaultSelectedKeys={["star"]}
+          >
+            <MenuItem id="star" leadingIcon={<StarIcon />}>
+              Add to favourites
+            </MenuItem>
+            <MenuItem id="share" leadingIcon={<ShareIcon />}>
+              Share
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="rename">Rename</MenuItem>
+            <MenuItem id="duplicate">Duplicate</MenuItem>
+            <MenuGap />
+            <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+              Delete
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+
+      {/* ── Vibrant ── */}
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Vibrant</span>
+        <MenuTrigger defaultOpen>
+          <button type="button" className={tertiaryBtn}>
+            More actions
+          </button>
+          <MenuTrigger.Menu
+            aria-label="More actions (vibrant)"
+            menuStyle="vertical"
+            colorScheme="vibrant"
+            selectionMode="single"
+            defaultSelectedKeys={["star"]}
+          >
+            <MenuItem id="star" leadingIcon={<StarIcon />}>
+              Add to favourites
+            </MenuItem>
+            <MenuItem id="share" leadingIcon={<ShareIcon />}>
+              Share
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="rename">Rename</MenuItem>
+            <MenuItem id="duplicate">Duplicate</MenuItem>
+            <MenuGap />
+            <MenuItem id="delete" leadingIcon={<DeleteIcon />}>
+              Delete
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Expressive Vertical — States ─────────────────────────────────────────────
+
+export const VerticalMenuStates: Story = {
+  name: "Expressive Vertical — States",
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        story: [
+          "All 6 MD3 Expressive vertical menu item states per the reference:",
+          "",
+          "1. **Enabled** — default appearance",
+          "2. **Disabled** — pointer-events-none, content at 38% opacity",
+          "3. **Hovered** — `on-surface` state layer at 8% opacity",
+          "4. **Focused** — `secondary` outline ring (2dp inset), no state-layer fill",
+          "5. **Pressed** — `on-surface` state layer at 10% opacity",
+          "6. **Active / submenu-open** — `tertiary-container` (standard) or `tertiary` (vibrant) highlight + `on-tertiary-container` / `on-tertiary` content",
+        ].join("\n"),
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-start gap-8">
+      {/* Standard */}
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Standard</span>
+        <MenuTrigger defaultOpen>
+          <button type="button" className={primaryBtn}>
+            Open
+          </button>
+          <MenuTrigger.Menu
+            aria-label="States standard"
+            menuStyle="vertical"
+            colorScheme="standard"
+            selectionMode="single"
+            defaultSelectedKeys={["active"]}
+          >
+            <MenuItem id="enabled" leadingIcon={<InfoIcon />}>
+              Enabled
+            </MenuItem>
+            <MenuItem id="disabled" leadingIcon={<InfoIcon />} isDisabled>
+              Disabled
+            </MenuItem>
+            <MenuItem id="shortcut" leadingIcon={<CopyIcon />} trailingText="⌘C">
+              With shortcut
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="active" leadingIcon={<StarIcon />}>
+              Selected / Active
+            </MenuItem>
+            <MenuItem id="desc" leadingIcon={<InfoIcon />} description="Supporting text">
+              With description
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+
+      {/* Vibrant */}
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Vibrant</span>
+        <MenuTrigger defaultOpen>
+          <button type="button" className={tertiaryBtn}>
+            Open
+          </button>
+          <MenuTrigger.Menu
+            aria-label="States vibrant"
+            menuStyle="vertical"
+            colorScheme="vibrant"
+            selectionMode="single"
+            defaultSelectedKeys={["active"]}
+          >
+            <MenuItem id="enabled" leadingIcon={<InfoIcon />}>
+              Enabled
+            </MenuItem>
+            <MenuItem id="disabled" leadingIcon={<InfoIcon />} isDisabled>
+              Disabled
+            </MenuItem>
+            <MenuItem id="shortcut" leadingIcon={<CopyIcon />} trailingText="⌘C">
+              With shortcut
+            </MenuItem>
+            <MenuGap />
+            <MenuItem id="active" leadingIcon={<StarIcon />}>
+              Selected / Active
+            </MenuItem>
+            <MenuItem id="desc" leadingIcon={<InfoIcon />} description="Supporting text">
+              With description
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+    </div>
+  ),
+};
+
+// ─── Expressive Vertical — MD3 Reference Example ──────────────────────────────
+
+export const VerticalMenuReference: Story = {
+  name: "Expressive Vertical — Reference Example",
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        story: [
+          "Matches the MD3 anatomy reference exactly: two segments separated by a `MenuGap`.",
+          "",
+          "**Segment 1**: Item 1–4 with leading icons, trailing text, and a submenu trigger.",
+          "**Segment 2**: A section header (Label text) and Item 5 with supporting text and submenu.",
+          "",
+          "The gap between segments reveals the page background — acting as the visual divider.",
+        ].join("\n"),
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-start gap-8">
+      {/* Standard */}
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Standard</span>
+        <MenuTrigger defaultOpen>
+          <button type="button" className={primaryBtn}>
+            Open
+          </button>
+          <MenuTrigger.Menu
+            aria-label="Reference standard"
+            menuStyle="vertical"
+            colorScheme="standard"
+            selectionMode="single"
+            defaultSelectedKeys={["item4"]}
+          >
+            <MenuItem id="item1" leadingIcon={<InfoIcon />}>
+              Item 1
+            </MenuItem>
+            <MenuItem id="item2" leadingIcon={<CopyIcon />} trailingText="⌘C">
+              Item 2
+            </MenuItem>
+            <MenuItem id="item3" leadingIcon={<CutIcon />}>
+              Item 3
+            </MenuItem>
+            <MenuItem id="item4" leadingIcon={<StarIcon />}>
+              Item 4
+            </MenuItem>
+            <MenuGap />
+            <MenuSection header="Label text" aria-label="Label text">
+              <MenuItem
+                id="item5"
+                leadingIcon={<InfoIcon />}
+                description="Supporting text"
+                trailingText="⌘V"
+              >
+                Item 5
+              </MenuItem>
+            </MenuSection>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+
+      {/* Vibrant */}
+      <div className="flex flex-col items-center gap-2">
+        <span className="text-label-small text-on-surface-variant">Vibrant</span>
+        <MenuTrigger defaultOpen>
+          <button type="button" className={tertiaryBtn}>
+            Open
+          </button>
+          <MenuTrigger.Menu
+            aria-label="Reference vibrant"
+            menuStyle="vertical"
+            colorScheme="vibrant"
+            selectionMode="single"
+            defaultSelectedKeys={["item4"]}
+          >
+            <MenuItem id="item1" leadingIcon={<InfoIcon />}>
+              Item 1
+            </MenuItem>
+            <MenuItem id="item2" leadingIcon={<CopyIcon />} trailingText="⌘C">
+              Item 2
+            </MenuItem>
+            <MenuItem id="item3" leadingIcon={<CutIcon />}>
+              Item 3
+            </MenuItem>
+            <MenuItem id="item4" leadingIcon={<StarIcon />}>
+              Item 4
+            </MenuItem>
+            <MenuGap />
+            <MenuSection header="Label text" aria-label="Label text">
+              <MenuItem
+                id="item5"
+                leadingIcon={<InfoIcon />}
+                description="Supporting text"
+                trailingText="⌘V"
+              >
+                Item 5
+              </MenuItem>
+            </MenuSection>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      </div>
+    </div>
   ),
 };
 

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -10,7 +10,11 @@ import { MenuGap } from "./MenuGap";
 import { SubmenuTrigger } from "./SubmenuTrigger";
 import { ContextMenuTrigger } from "./ContextMenuTrigger";
 import { HeadlessMenuTrigger } from "./MenuHeadless";
-import { menuContainerVariants, menuItemVariants } from "./Menu.variants";
+import {
+  menuContainerVariants,
+  menuItemVariants,
+  menuItemStateLayerVariants,
+} from "./Menu.variants";
 
 // ─── Test Icon Mocks ───────────────────────────────────────────────────────────
 
@@ -283,11 +287,11 @@ describe("MenuItem", () => {
       expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
     });
 
-    test("uses body-large typography for label text", async () => {
+    test("uses label-large typography for label text", async () => {
       renderBasicMenu();
       await openMenu();
       const item = screen.getByRole("menuitem", { name: "Cut" });
-      expect(item).toHaveClass("text-body-large");
+      expect(item).toHaveClass("text-label-large");
     });
 
     test("renders leading icon when provided", async () => {
@@ -447,6 +451,20 @@ describe("MenuItem", () => {
       );
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("custom-item");
+    });
+
+    test("item root carries group/menuitem scope class", async () => {
+      renderBasicMenu();
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("group/menuitem");
+    });
+
+    test("item contains a state-layer span slot", async () => {
+      renderBasicMenu();
+      await openMenu();
+      const item = screen.getByRole("menuitem", { name: "Cut" });
+      const stateLayer = item.querySelector("span[aria-hidden='true']");
+      expect(stateLayer).toBeInTheDocument();
     });
   });
 
@@ -854,7 +872,9 @@ describe("Selection mode", () => {
     );
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
-    expect(selectedItem).toHaveClass("bg-surface-container-highest");
+    // RAC emits data-selected on the element; CVA applies data-[selected]:bg-surface-container-highest
+    expect(selectedItem).toHaveAttribute("data-selected");
+    expect(selectedItem).toHaveClass("data-[selected]:bg-surface-container-highest");
   });
 
   test("selected item in vertical standard has tertiary container background", async () => {
@@ -875,7 +895,8 @@ describe("Selection mode", () => {
     );
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
-    expect(selectedItem).toHaveClass("bg-tertiary-container");
+    expect(selectedItem).toHaveAttribute("data-selected");
+    expect(selectedItem).toHaveClass("data-[selected]:bg-tertiary-container");
   });
 
   test("selected item in vertical vibrant has tertiary background", async () => {
@@ -896,7 +917,8 @@ describe("Selection mode", () => {
     );
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
-    expect(selectedItem).toHaveClass("bg-tertiary");
+    expect(selectedItem).toHaveAttribute("data-selected");
+    expect(selectedItem).toHaveClass("data-[selected]:bg-tertiary");
   });
 
   test("checkmark appears on selected item when selectionMode is set and no leadingIcon", async () => {
@@ -1264,35 +1286,52 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("bg-tertiary-container");
   });
 
-  test("menuItemVariants: uses text-body-large", () => {
+  test("menuItemVariants: uses text-label-large", () => {
     const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "baseline" });
-    expect(cls).toContain("text-body-large");
+    expect(cls).toContain("text-label-large");
   });
 
-  test("menuItemVariants: baseline selected uses bg-surface-container-highest", () => {
+  test("menuItemVariants: baseline includes data-[selected] bg class for surface-container-highest", () => {
     const cls = menuItemVariants({
-      isSelected: true,
       colorScheme: "standard",
       menuStyle: "baseline",
     });
-    expect(cls).toContain("bg-surface-container-highest");
+    expect(cls).toContain("data-[selected]:bg-surface-container-highest");
   });
 
-  test("menuItemVariants: vertical standard selected uses bg-tertiary-container", () => {
+  test("menuItemVariants: vertical standard includes data-[selected] bg class for tertiary-container", () => {
     const cls = menuItemVariants({
-      isSelected: true,
       colorScheme: "standard",
       menuStyle: "vertical",
     });
-    expect(cls).toContain("bg-tertiary-container");
+    expect(cls).toContain("data-[selected]:bg-tertiary-container");
   });
 
-  test("menuItemVariants: vertical vibrant selected uses bg-tertiary", () => {
+  test("menuItemVariants: vertical vibrant includes data-[selected] bg class for tertiary", () => {
     const cls = menuItemVariants({
-      isSelected: true,
       colorScheme: "vibrant",
       menuStyle: "vertical",
     });
-    expect(cls).toContain("bg-tertiary");
+    expect(cls).toContain("data-[selected]:bg-tertiary");
+  });
+
+  test("menuItemStateLayerVariants: standard uses bg-on-surface", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("bg-on-surface");
+  });
+
+  test("menuItemStateLayerVariants: vibrant uses bg-on-tertiary-container", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "vibrant", menuStyle: "baseline" });
+    expect(cls).toContain("bg-on-tertiary-container");
+  });
+
+  test("menuItemStateLayerVariants: includes hover opacity-8 selector", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("group-data-[hovered]/menuitem:opacity-8");
+  });
+
+  test("menuItemStateLayerVariants: includes focus-visible opacity-10 selector", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("group-data-[focus-visible]/menuitem:opacity-10");
   });
 });

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -15,9 +15,13 @@ import {
   menuItemVariants,
   menuItemStateLayerVariants,
   menuItemHighlightVariants,
+  menuItemFocusRingVariants,
   menuItemIconVariants,
   menuGapVariants,
   menuPopoverVariants,
+  menuItemTrailingTextVariants,
+  menuItemDescriptionVariants,
+  menuSectionHeaderVariants,
 } from "./Menu.variants";
 
 // ─── Test Icon Mocks ───────────────────────────────────────────────────────────
@@ -79,10 +83,6 @@ describe("MenuTrigger", () => {
     test("trigger has aria-expanded='true' when open", async () => {
       renderBasicMenu();
       await openMenu();
-      // When the menu is open the Popover uses modal overlay behavior — RAC's
-      // ariaHideOutside hides everything outside the popover from the a11y tree,
-      // including the trigger. We use { hidden: true } to assert the attribute
-      // on the DOM node directly while it is aria-hidden.
       expect(screen.getByRole("button", { name: "Open Menu", hidden: true })).toHaveAttribute(
         "aria-expanded",
         "true"
@@ -194,7 +194,6 @@ describe("MenuTrigger", () => {
     });
 
     test("shouldFlip prop passes through to trigger", () => {
-      // shouldFlip defaults to true; test it can be set
       render(
         <MenuTrigger shouldFlip={false}>
           <button type="button">Open Menu</button>
@@ -248,7 +247,7 @@ describe("Menu", () => {
     test("vibrant colorScheme on vertical menu: items carry tertiary container background", async () => {
       renderBasicMenu({ colorScheme: "vibrant", menuStyle: "vertical" });
       await openMenu();
-      // vertical container is transparent; the item carries bg-tertiary-container
+      // vertical items paint their own segment card background
       const items = screen.getAllByRole("menuitem");
       expect(items[0]).toHaveClass("bg-tertiary-container");
     });
@@ -259,10 +258,16 @@ describe("Menu", () => {
       expect(screen.getByRole("menu")).toHaveClass("rounded-xs");
     });
 
-    test("vertical menuStyle uses large corner radius", async () => {
+    test("vertical menuStyle uses large corner radius on container", async () => {
       renderBasicMenu({ menuStyle: "vertical" });
       await openMenu();
       expect(screen.getByRole("menu")).toHaveClass("rounded-lg");
+    });
+
+    test("vertical menuStyle container is transparent (segments provide bg)", async () => {
+      renderBasicMenu({ menuStyle: "vertical" });
+      await openMenu();
+      expect(screen.getByRole("menu")).toHaveClass("bg-transparent");
     });
   });
 
@@ -443,7 +448,38 @@ describe("MenuItem", () => {
       await openMenu();
       const desc = screen.getByText("Copy description");
       expect(desc).toHaveClass("text-body-medium");
+    });
+
+    test("description in standard scheme uses on-surface-variant", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions" colorScheme="standard">
+            <MenuItem id="copy" description="Copy description">
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const desc = screen.getByText("Copy description");
       expect(desc).toHaveClass("text-on-surface-variant");
+    });
+
+    test("description in vibrant scheme uses on-tertiary-container", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions" menuStyle="vertical" colorScheme="vibrant">
+            <MenuItem id="copy" description="Copy description">
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const desc = screen.getByText("Copy description");
+      expect(desc).toHaveClass("text-on-tertiary-container");
     });
 
     test("renders badge when provided", async () => {
@@ -486,9 +522,15 @@ describe("MenuItem", () => {
       renderBasicMenu();
       await openMenu();
       const item = screen.getByRole("menuitem", { name: "Cut" });
-      // The highlight layer is the first aria-hidden span; state layer is the second
       const overlaySpans = item.querySelectorAll("span[aria-hidden='true']");
       expect(overlaySpans.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test("item contains a focus-ring span slot", async () => {
+      renderBasicMenu();
+      await openMenu();
+      const item = screen.getByRole("menuitem", { name: "Cut" });
+      expect(item.querySelector("[data-testid='menuitem-focus-ring']")).toBeInTheDocument();
     });
   });
 
@@ -517,16 +559,16 @@ describe("MenuItem", () => {
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-9");
     });
 
-    test("vertical density 0 renders items with h-11 class (44dp)", async () => {
+    test("vertical density 0 renders items with h-12 class (48dp)", async () => {
       renderBasicMenu({ density: 0, menuStyle: "vertical" });
       await openMenu();
-      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-11");
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-12");
     });
 
-    test("vertical density -1 renders items with h-10 class", async () => {
+    test("vertical density -1 renders items with h-11 class", async () => {
       renderBasicMenu({ density: -1, menuStyle: "vertical" });
       await openMenu();
-      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-10");
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-11");
     });
   });
 
@@ -683,7 +725,6 @@ describe("Keyboard navigation", () => {
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{ArrowDown}");
-    // With wrap, should cycle back to "Cut"
     expect(document.activeElement).toHaveTextContent("Cut");
   });
 });
@@ -824,9 +865,7 @@ describe("MenuGap", () => {
       </MenuTrigger>
     );
     await openMenu();
-    // MenuGap uses role="none" / aria-hidden - should NOT appear as a separator
     expect(screen.queryByRole("separator")).not.toBeInTheDocument();
-    // but the menu items still render
     expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: "Paste" })).toBeInTheDocument();
   });
@@ -909,7 +948,6 @@ describe("Selection mode", () => {
     );
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
-    // RAC emits data-selected on the element; selected bg lives on the highlight layer
     expect(selectedItem).toHaveAttribute("data-selected");
     const highlight = selectedItem.querySelector("[data-testid='menuitem-highlight']");
     expect(highlight).toBeInTheDocument();
@@ -1007,7 +1045,6 @@ describe("Selection mode", () => {
     );
     const { user } = await openMenu();
     await user.click(screen.getByRole("menuitemcheckbox", { name: "Bold" }));
-    // Multi-select menus stay open
     expect(screen.getByRole("menu")).toBeInTheDocument();
   });
 });
@@ -1039,7 +1076,6 @@ describe("SubmenuTrigger", () => {
     await openMenu();
     const shareItem = screen.getByRole("menuitem", { name: /Share/i });
     expect(shareItem).toBeInTheDocument();
-    // Chevron icon should be present in the item
     expect(shareItem.querySelector("[data-testid='chevron-icon']")).toBeInTheDocument();
   });
 
@@ -1054,8 +1090,8 @@ describe("SubmenuTrigger", () => {
     renderMenuWithSubmenu();
     const { user } = await openMenu();
     await user.keyboard("{ArrowDown}");
-    await user.keyboard("{ArrowDown}"); // focus Share
-    await user.keyboard("{ArrowRight}"); // open submenu
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowRight}");
     await waitFor(() => {
       expect(screen.getByRole("menu", { name: "Share via" })).toBeInTheDocument();
     });
@@ -1065,8 +1101,8 @@ describe("SubmenuTrigger", () => {
     renderMenuWithSubmenu();
     const { user } = await openMenu();
     await user.keyboard("{ArrowDown}");
-    await user.keyboard("{ArrowDown}"); // focus Share
-    await user.keyboard("{ArrowRight}"); // open submenu
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowRight}");
     await waitFor(() => {
       expect(screen.getByRole("menuitem", { name: "Email" })).toBeInTheDocument();
       expect(screen.getByRole("menuitem", { name: "SMS" })).toBeInTheDocument();
@@ -1086,7 +1122,6 @@ describe("SubmenuTrigger", () => {
     await waitFor(() => {
       expect(screen.queryByRole("menu", { name: "Share via" })).not.toBeInTheDocument();
     });
-    // Parent menu should still be open
     expect(screen.getByRole("menu", { name: "Actions" })).toBeInTheDocument();
   });
 });
@@ -1318,16 +1353,10 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("rounded-xs");
   });
 
-  test("menuContainerVariants: vertical standard is transparent (bg-transparent) and has rounded-lg", () => {
+  test("menuContainerVariants: vertical is transparent (segments provide bg) and has rounded-lg", () => {
     const cls = menuContainerVariants({ colorScheme: "standard", menuStyle: "vertical" });
     expect(cls).toContain("bg-transparent");
     expect(cls).toContain("rounded-lg");
-  });
-
-  test("menuContainerVariants: vertical vibrant is transparent (container itself has no bg)", () => {
-    const cls = menuContainerVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
-    expect(cls).toContain("bg-transparent");
-    expect(cls).not.toContain("bg-tertiary-container");
   });
 
   test("menuItemVariants: uses text-label-large", () => {
@@ -1335,16 +1364,43 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("text-label-large");
   });
 
+  test("menuItemVariants: vertical standard has bg-surface-container-low", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("bg-surface-container-low");
+  });
+
+  test("menuItemVariants: vertical vibrant has bg-tertiary-container", () => {
+    const cls = menuItemVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
+    expect(cls).toContain("bg-tertiary-container");
+  });
+
+  test("menuItemVariants: vertical has segmented rounding classes (first/last + adjacent-sibling gap)", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("first:rounded-t-lg");
+    expect(cls).toContain("last:rounded-b-lg");
+    expect(cls).toContain("rounded-xs");
+    // after gap
+    expect(cls).toContain("[[data-menu-gap]+&]:rounded-t-lg");
+    // before gap (has selector)
+    expect(cls).toContain("[&:has(+[data-menu-gap])]:rounded-b-lg");
+  });
+
+  test("menuItemVariants: vertical uses px-4 (ItemLeadingSpace = 16dp)", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("px-4");
+  });
+
   // ── menuItemHighlightVariants ──────────────────────────────────────────────
+
+  test("menuItemHighlightVariants: uses inset-0 rounded-[inherit] (full-bleed)", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("inset-0");
+    expect(cls).toContain("rounded-[inherit]");
+  });
 
   test("menuItemHighlightVariants: baseline standard has bg-surface-container-highest selector", () => {
     const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "baseline" });
     expect(cls).toContain("group-data-[selected]/menuitem:bg-surface-container-highest");
-  });
-
-  test("menuItemHighlightVariants: baseline uses inset-0 (full-bleed)", () => {
-    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "baseline" });
-    expect(cls).toContain("inset-0");
   });
 
   test("menuItemHighlightVariants: vertical standard has tertiary-container selector", () => {
@@ -1352,19 +1408,28 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("group-data-[selected]/menuitem:bg-tertiary-container");
   });
 
+  test("menuItemHighlightVariants: vertical standard has open (active) tertiary-container selector", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("group-data-[open]/menuitem:bg-tertiary-container");
+  });
+
   test("menuItemHighlightVariants: vertical vibrant has tertiary selector", () => {
     const cls = menuItemHighlightVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
     expect(cls).toContain("group-data-[selected]/menuitem:bg-tertiary");
   });
 
-  test("menuItemHighlightVariants: vertical uses inset-x-1 inset-y-0 rounded-md (horizontal inset, CornerMedium)", () => {
-    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("inset-x-1");
-    expect(cls).toContain("inset-y-0");
-    expect(cls).toContain("rounded-md");
+  test("menuItemHighlightVariants: vertical vibrant has open (active) tertiary selector", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
+    expect(cls).toContain("group-data-[open]/menuitem:bg-tertiary");
   });
 
   // ── menuItemStateLayerVariants ────────────────────────────────────────────
+
+  test("menuItemStateLayerVariants: uses inset-0 rounded-[inherit] (full-bleed)", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("inset-0");
+    expect(cls).toContain("rounded-[inherit]");
+  });
 
   test("menuItemStateLayerVariants: standard uses bg-on-surface", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
@@ -1376,26 +1441,32 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("bg-on-tertiary-container");
   });
 
-  test("menuItemStateLayerVariants: baseline uses inset-0", () => {
-    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
-    expect(cls).toContain("inset-0");
-  });
-
-  test("menuItemStateLayerVariants: vertical uses inset-x-1 inset-y-0 rounded-md (horizontal inset, CornerMedium)", () => {
-    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("inset-x-1");
-    expect(cls).toContain("inset-y-0");
-    expect(cls).toContain("rounded-md");
-  });
-
   test("menuItemStateLayerVariants: includes hover opacity-8 selector", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
     expect(cls).toContain("group-data-[hovered]/menuitem:opacity-8");
   });
 
-  test("menuItemStateLayerVariants: includes focus-visible opacity-10 selector", () => {
+  test("menuItemStateLayerVariants: does NOT include focus-visible opacity (focus shown via ring)", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
-    expect(cls).toContain("group-data-[focus-visible]/menuitem:opacity-10");
+    expect(cls).not.toContain("group-data-[focus-visible]/menuitem:opacity-10");
+  });
+
+  // ── menuItemFocusRingVariants ──────────────────────────────────────────────
+
+  test("menuItemFocusRingVariants: has inset-0 rounded-[inherit]", () => {
+    const cls = menuItemFocusRingVariants();
+    expect(cls).toContain("inset-0");
+    expect(cls).toContain("rounded-[inherit]");
+  });
+
+  test("menuItemFocusRingVariants: uses outline-secondary", () => {
+    const cls = menuItemFocusRingVariants();
+    expect(cls).toContain("outline-secondary");
+  });
+
+  test("menuItemFocusRingVariants: shows on focus-visible (opacity-100)", () => {
+    const cls = menuItemFocusRingVariants();
+    expect(cls).toContain("group-data-[focus-visible]/menuitem:opacity-100");
   });
 
   // ── menuPopoverVariants ───────────────────────────────────────────────────
@@ -1416,30 +1487,6 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("data-[placement=top]:origin-bottom");
   });
 
-  // ── menuItemVariants — vertical segmented bg + rounding ───────────────────
-
-  test("menuItemVariants: vertical standard has bg-surface-container-low", () => {
-    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("bg-surface-container-low");
-  });
-
-  test("menuItemVariants: vertical vibrant has bg-tertiary-container", () => {
-    const cls = menuItemVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
-    expect(cls).toContain("bg-tertiary-container");
-  });
-
-  test("menuItemVariants: vertical has segmented rounding classes", () => {
-    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("first:rounded-t-lg");
-    expect(cls).toContain("last:rounded-b-lg");
-    expect(cls).toContain("rounded-xs");
-  });
-
-  test("menuItemVariants: vertical uses px-4 (ItemLeadingSpace = 16dp)", () => {
-    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("px-4");
-  });
-
   // ── menuItemIconVariants — size per menuStyle ─────────────────────────────
 
   test("menuItemIconVariants: baseline uses h-6 w-6 (24dp)", () => {
@@ -1454,9 +1501,55 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("w-5");
   });
 
+  test("menuItemIconVariants: standard uses on-surface-variant", () => {
+    const cls = menuItemIconVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("text-on-surface-variant");
+  });
+
+  test("menuItemIconVariants: vibrant uses on-tertiary-container", () => {
+    const cls = menuItemIconVariants({ colorScheme: "vibrant", menuStyle: "baseline" });
+    expect(cls).toContain("text-on-tertiary-container");
+  });
+
+  // ── menuItemTrailingTextVariants ──────────────────────────────────────────
+
+  test("menuItemTrailingTextVariants: standard uses on-surface-variant", () => {
+    const cls = menuItemTrailingTextVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("text-on-surface-variant");
+  });
+
+  test("menuItemTrailingTextVariants: vibrant uses on-tertiary-container", () => {
+    const cls = menuItemTrailingTextVariants({ colorScheme: "vibrant", menuStyle: "baseline" });
+    expect(cls).toContain("text-on-tertiary-container");
+  });
+
+  // ── menuItemDescriptionVariants ───────────────────────────────────────────
+
+  test("menuItemDescriptionVariants: standard uses on-surface-variant", () => {
+    const cls = menuItemDescriptionVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("text-on-surface-variant");
+  });
+
+  test("menuItemDescriptionVariants: vibrant uses on-tertiary-container", () => {
+    const cls = menuItemDescriptionVariants({ colorScheme: "vibrant", menuStyle: "baseline" });
+    expect(cls).toContain("text-on-tertiary-container");
+  });
+
+  // ── menuSectionHeaderVariants ─────────────────────────────────────────────
+
+  test("menuSectionHeaderVariants: standard uses on-surface-variant", () => {
+    const cls = menuSectionHeaderVariants({ colorScheme: "standard" });
+    expect(cls).toContain("text-on-surface-variant");
+  });
+
+  test("menuSectionHeaderVariants: vibrant uses on-tertiary-container", () => {
+    const cls = menuSectionHeaderVariants({ colorScheme: "vibrant" });
+    expect(cls).toContain("text-on-tertiary-container");
+  });
+
   // ── menuGapVariants ───────────────────────────────────────────────────────
 
-  test("menuGapVariants: height is h-0.5 (2dp, SegmentedMenuTokens.SegmentedGap)", () => {
+  test("menuGapVariants: height is h-0.5 (2dp — gap acts as visual divider)", () => {
     const cls = menuGapVariants();
     expect(cls).toContain("h-0.5");
   });

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { axe } from "vitest-axe";
 import { MenuTrigger } from "./Menu";
 import { MenuItem } from "./MenuItem";
+import { MenuItemGroup } from "./MenuItemGroup";
 import { MenuSection } from "./MenuSection";
 import { MenuDivider } from "./MenuDivider";
 import { MenuGap } from "./MenuGap";
@@ -22,6 +23,7 @@ import {
   menuItemTrailingTextVariants,
   menuItemDescriptionVariants,
   menuSectionHeaderVariants,
+  menuItemGroupVariants,
 } from "./Menu.variants";
 
 // ─── Test Icon Mocks ───────────────────────────────────────────────────────────
@@ -244,12 +246,20 @@ describe("Menu", () => {
       expect(menu).toHaveClass("bg-surface-container");
     });
 
-    test("vibrant colorScheme on vertical menu: items carry tertiary container background", async () => {
-      renderBasicMenu({ colorScheme: "vibrant", menuStyle: "vertical" });
+    test("vibrant colorScheme on vertical menu: MenuItemGroup carries tertiary container surface", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions" colorScheme="vibrant" menuStyle="vertical">
+            <MenuItemGroup aria-label="Clipboard">
+              <MenuItem id="cut">Cut</MenuItem>
+              <MenuItem id="copy">Copy</MenuItem>
+            </MenuItemGroup>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
       await openMenu();
-      // vertical items paint their own segment card background
-      const items = screen.getAllByRole("menuitem");
-      expect(items[0]).toHaveClass("bg-tertiary-container");
+      expect(screen.getByRole("group", { name: "Clipboard" })).toHaveClass("bg-tertiary-container");
     });
 
     test("baseline menuStyle uses extra-small corner radius", async () => {
@@ -258,16 +268,12 @@ describe("Menu", () => {
       expect(screen.getByRole("menu")).toHaveClass("rounded-xs");
     });
 
-    test("vertical menuStyle uses large corner radius on container", async () => {
+    test("vertical menuStyle container is transparent without outer corner radius", async () => {
       renderBasicMenu({ menuStyle: "vertical" });
       await openMenu();
-      expect(screen.getByRole("menu")).toHaveClass("rounded-lg");
-    });
-
-    test("vertical menuStyle container is transparent (segments provide bg)", async () => {
-      renderBasicMenu({ menuStyle: "vertical" });
-      await openMenu();
-      expect(screen.getByRole("menu")).toHaveClass("bg-transparent");
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bg-transparent");
+      expect(menu).not.toHaveClass("rounded-lg");
     });
   });
 
@@ -1353,10 +1359,10 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("rounded-xs");
   });
 
-  test("menuContainerVariants: vertical is transparent (segments provide bg) and has rounded-lg", () => {
+  test("menuContainerVariants: vertical is transparent (groups provide segment surfaces)", () => {
     const cls = menuContainerVariants({ colorScheme: "standard", menuStyle: "vertical" });
     expect(cls).toContain("bg-transparent");
-    expect(cls).toContain("rounded-lg");
+    expect(cls).not.toContain("rounded-lg");
   });
 
   test("menuItemVariants: uses text-label-large", () => {
@@ -1364,30 +1370,42 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("text-label-large");
   });
 
-  test("menuItemVariants: vertical standard has bg-surface-container-low", () => {
+  test("menuItemVariants: vertical standard does not carry segment surface (group owns bg)", () => {
     const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("bg-surface-container-low");
+    expect(cls).not.toContain("bg-surface-container-low");
+    expect(cls).toContain("rounded-md");
   });
 
-  test("menuItemVariants: vertical vibrant has bg-tertiary-container", () => {
+  test("menuItemVariants: vertical vibrant does not carry segment surface (group owns bg)", () => {
     const cls = menuItemVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
+    expect(cls).not.toContain("bg-tertiary-container");
+    expect(cls).toContain("rounded-md");
+  });
+
+  test("menuItemGroupVariants: vertical standard has segment surface and card rounding", () => {
+    const cls = menuItemGroupVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("bg-surface-container-low");
+    expect(cls).toContain("rounded-lg");
+    expect(cls).toContain("shadow-elevation-1");
+    expect(cls).toContain("first:rounded-b-sm");
+    expect(cls).toContain("last:rounded-t-sm");
+  });
+
+  test("menuItemGroupVariants: vertical vibrant has tertiary-container surface", () => {
+    const cls = menuItemGroupVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
     expect(cls).toContain("bg-tertiary-container");
   });
 
-  test("menuItemVariants: vertical has segmented rounding classes (first/last + adjacent-sibling gap)", () => {
+  test("menuItemVariants: vertical uses px-3 (ItemLeadingSpace = 12dp) and gap-2 (icon-to-label = 8dp)", () => {
     const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("first:rounded-t-lg");
-    expect(cls).toContain("last:rounded-b-lg");
-    expect(cls).toContain("rounded-xs");
-    // after gap
-    expect(cls).toContain("[[data-menu-gap]+&]:rounded-t-lg");
-    // before gap (has selector)
-    expect(cls).toContain("[&:has(+[data-menu-gap])]:rounded-b-lg");
+    expect(cls).toContain("px-3");
+    expect(cls).toContain("gap-2");
   });
 
-  test("menuItemVariants: vertical uses px-4 (ItemLeadingSpace = 16dp)", () => {
-    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("px-4");
+  test("menuItemVariants: baseline uses px-3 and gap-3 (icon-to-label = 12dp)", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("px-3");
+    expect(cls).toContain("gap-3");
   });
 
   // ── menuItemHighlightVariants ──────────────────────────────────────────────

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -15,6 +15,8 @@ import {
   menuItemVariants,
   menuItemStateLayerVariants,
   menuItemHighlightVariants,
+  menuItemIconVariants,
+  menuGapVariants,
   menuPopoverVariants,
 } from "./Menu.variants";
 
@@ -243,11 +245,12 @@ describe("Menu", () => {
       expect(menu).toHaveClass("bg-surface-container");
     });
 
-    test("vibrant colorScheme applies tertiary container background", async () => {
+    test("vibrant colorScheme on vertical menu: items carry tertiary container background", async () => {
       renderBasicMenu({ colorScheme: "vibrant", menuStyle: "vertical" });
       await openMenu();
-      const menu = screen.getByRole("menu");
-      expect(menu).toHaveClass("bg-tertiary-container");
+      // vertical container is transparent; the item carries bg-tertiary-container
+      const items = screen.getAllByRole("menuitem");
+      expect(items[0]).toHaveClass("bg-tertiary-container");
     });
 
     test("baseline menuStyle uses extra-small corner radius", async () => {
@@ -311,7 +314,7 @@ describe("MenuItem", () => {
       expect(screen.getByTestId("copy-icon")).toBeInTheDocument();
     });
 
-    test("leading icon wrapper has 24dp size constraint", async () => {
+    test("leading icon wrapper has 24dp size constraint (baseline)", async () => {
       render(
         <MenuTrigger>
           <button type="button">Open Menu</button>
@@ -329,6 +332,24 @@ describe("MenuItem", () => {
       expect(wrapper).toHaveClass("h-6");
     });
 
+    test("leading icon wrapper has 20dp size constraint in vertical menu", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Actions" menuStyle="vertical">
+            <MenuItem id="copy" leadingIcon={<CopyIcon />}>
+              Copy
+            </MenuItem>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const icon = screen.getByTestId("copy-icon");
+      const wrapper = icon.closest("span");
+      expect(wrapper).toHaveClass("w-5");
+      expect(wrapper).toHaveClass("h-5");
+    });
+
     test("renders trailing icon when provided", async () => {
       render(
         <MenuTrigger>
@@ -344,7 +365,7 @@ describe("MenuItem", () => {
       expect(screen.getByTestId("cut-icon")).toBeInTheDocument();
     });
 
-    test("trailing icon wrapper has 24dp size constraint", async () => {
+    test("trailing icon wrapper has 24dp size constraint (baseline)", async () => {
       render(
         <MenuTrigger>
           <button type="button">Open Menu</button>
@@ -472,28 +493,40 @@ describe("MenuItem", () => {
   });
 
   describe("Density", () => {
-    test("density 0 (default) renders items with h-12 class", async () => {
+    test("density 0 (default) renders baseline items with h-12 class", async () => {
       renderBasicMenu({ density: 0 });
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-12");
     });
 
-    test("density -1 renders items with h-11 class", async () => {
+    test("density -1 renders baseline items with h-11 class", async () => {
       renderBasicMenu({ density: -1 });
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-11");
     });
 
-    test("density -2 renders items with h-10 class", async () => {
+    test("density -2 renders baseline items with h-10 class", async () => {
       renderBasicMenu({ density: -2 });
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-10");
     });
 
-    test("density -3 renders items with h-9 class", async () => {
+    test("density -3 renders baseline items with h-9 class", async () => {
       renderBasicMenu({ density: -3 });
       await openMenu();
       expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-9");
+    });
+
+    test("vertical density 0 renders items with h-11 class (44dp)", async () => {
+      renderBasicMenu({ density: 0, menuStyle: "vertical" });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-11");
+    });
+
+    test("vertical density -1 renders items with h-10 class", async () => {
+      renderBasicMenu({ density: -1, menuStyle: "vertical" });
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toHaveClass("h-10");
     });
   });
 
@@ -743,7 +776,7 @@ describe("MenuDivider", () => {
     expect(screen.getByRole("separator", { hidden: true })).toBeInTheDocument();
   });
 
-  test("divider has correct 8dp top/bottom padding (my-2)", async () => {
+  test("divider has correct 2dp top/bottom spacing (my-0.5) and horizontal inset (mx-3)", async () => {
     render(
       <MenuTrigger>
         <button type="button">Open Menu</button>
@@ -756,7 +789,8 @@ describe("MenuDivider", () => {
     );
     await openMenu();
     const divider = screen.getByRole("separator", { hidden: true });
-    expect(divider).toHaveClass("my-2");
+    expect(divider).toHaveClass("my-0.5");
+    expect(divider).toHaveClass("mx-3");
   });
 
   test("accepts custom className", async () => {
@@ -1284,15 +1318,16 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("rounded-xs");
   });
 
-  test("menuContainerVariants: vertical standard has bg-surface-container-low and rounded-lg", () => {
+  test("menuContainerVariants: vertical standard is transparent (bg-transparent) and has rounded-lg", () => {
     const cls = menuContainerVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("bg-surface-container-low");
+    expect(cls).toContain("bg-transparent");
     expect(cls).toContain("rounded-lg");
   });
 
-  test("menuContainerVariants: vertical vibrant has bg-tertiary-container", () => {
+  test("menuContainerVariants: vertical vibrant is transparent (container itself has no bg)", () => {
     const cls = menuContainerVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
-    expect(cls).toContain("bg-tertiary-container");
+    expect(cls).toContain("bg-transparent");
+    expect(cls).not.toContain("bg-tertiary-container");
   });
 
   test("menuItemVariants: uses text-label-large", () => {
@@ -1322,10 +1357,11 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("group-data-[selected]/menuitem:bg-tertiary");
   });
 
-  test("menuItemHighlightVariants: vertical uses inset-1 rounded-lg", () => {
+  test("menuItemHighlightVariants: vertical uses inset-x-1 inset-y-0 rounded-md (horizontal inset, CornerMedium)", () => {
     const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("inset-1");
-    expect(cls).toContain("rounded-lg");
+    expect(cls).toContain("inset-x-1");
+    expect(cls).toContain("inset-y-0");
+    expect(cls).toContain("rounded-md");
   });
 
   // ── menuItemStateLayerVariants ────────────────────────────────────────────
@@ -1345,10 +1381,11 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("inset-0");
   });
 
-  test("menuItemStateLayerVariants: vertical uses inset-1 rounded-lg", () => {
+  test("menuItemStateLayerVariants: vertical uses inset-x-1 inset-y-0 rounded-md (horizontal inset, CornerMedium)", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "vertical" });
-    expect(cls).toContain("inset-1");
-    expect(cls).toContain("rounded-lg");
+    expect(cls).toContain("inset-x-1");
+    expect(cls).toContain("inset-y-0");
+    expect(cls).toContain("rounded-md");
   });
 
   test("menuItemStateLayerVariants: includes hover opacity-8 selector", () => {
@@ -1377,5 +1414,50 @@ describe("CVA variants (unit)", () => {
     const cls = menuPopoverVariants();
     expect(cls).toContain("origin-top");
     expect(cls).toContain("data-[placement=top]:origin-bottom");
+  });
+
+  // ── menuItemVariants — vertical segmented bg + rounding ───────────────────
+
+  test("menuItemVariants: vertical standard has bg-surface-container-low", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("bg-surface-container-low");
+  });
+
+  test("menuItemVariants: vertical vibrant has bg-tertiary-container", () => {
+    const cls = menuItemVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
+    expect(cls).toContain("bg-tertiary-container");
+  });
+
+  test("menuItemVariants: vertical has segmented rounding classes", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("first:rounded-t-lg");
+    expect(cls).toContain("last:rounded-b-lg");
+    expect(cls).toContain("rounded-xs");
+  });
+
+  test("menuItemVariants: vertical uses px-4 (ItemLeadingSpace = 16dp)", () => {
+    const cls = menuItemVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("px-4");
+  });
+
+  // ── menuItemIconVariants — size per menuStyle ─────────────────────────────
+
+  test("menuItemIconVariants: baseline uses h-6 w-6 (24dp)", () => {
+    const cls = menuItemIconVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("h-6");
+    expect(cls).toContain("w-6");
+  });
+
+  test("menuItemIconVariants: vertical uses h-5 w-5 (20dp, ItemLeadingIconSize)", () => {
+    const cls = menuItemIconVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("h-5");
+    expect(cls).toContain("w-5");
+  });
+
+  // ── menuGapVariants ───────────────────────────────────────────────────────
+
+  test("menuGapVariants: height is h-0.5 (2dp, SegmentedMenuTokens.SegmentedGap)", () => {
+    const cls = menuGapVariants();
+    expect(cls).toContain("h-0.5");
   });
 });

--- a/packages/react/src/components/Menu/Menu.test.tsx
+++ b/packages/react/src/components/Menu/Menu.test.tsx
@@ -14,6 +14,8 @@ import {
   menuContainerVariants,
   menuItemVariants,
   menuItemStateLayerVariants,
+  menuItemHighlightVariants,
+  menuPopoverVariants,
 } from "./Menu.variants";
 
 // ─── Test Icon Mocks ───────────────────────────────────────────────────────────
@@ -463,8 +465,9 @@ describe("MenuItem", () => {
       renderBasicMenu();
       await openMenu();
       const item = screen.getByRole("menuitem", { name: "Cut" });
-      const stateLayer = item.querySelector("span[aria-hidden='true']");
-      expect(stateLayer).toBeInTheDocument();
+      // The highlight layer is the first aria-hidden span; state layer is the second
+      const overlaySpans = item.querySelectorAll("span[aria-hidden='true']");
+      expect(overlaySpans.length).toBeGreaterThanOrEqual(2);
     });
   });
 
@@ -872,9 +875,11 @@ describe("Selection mode", () => {
     );
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
-    // RAC emits data-selected on the element; CVA applies data-[selected]:bg-surface-container-highest
+    // RAC emits data-selected on the element; selected bg lives on the highlight layer
     expect(selectedItem).toHaveAttribute("data-selected");
-    expect(selectedItem).toHaveClass("data-[selected]:bg-surface-container-highest");
+    const highlight = selectedItem.querySelector("[data-testid='menuitem-highlight']");
+    expect(highlight).toBeInTheDocument();
+    expect(highlight).toHaveClass("group-data-[selected]/menuitem:bg-surface-container-highest");
   });
 
   test("selected item in vertical standard has tertiary container background", async () => {
@@ -896,7 +901,9 @@ describe("Selection mode", () => {
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
     expect(selectedItem).toHaveAttribute("data-selected");
-    expect(selectedItem).toHaveClass("data-[selected]:bg-tertiary-container");
+    const highlight = selectedItem.querySelector("[data-testid='menuitem-highlight']");
+    expect(highlight).toBeInTheDocument();
+    expect(highlight).toHaveClass("group-data-[selected]/menuitem:bg-tertiary-container");
   });
 
   test("selected item in vertical vibrant has tertiary background", async () => {
@@ -918,7 +925,9 @@ describe("Selection mode", () => {
     await openMenu();
     const selectedItem = screen.getByRole("menuitemradio", { name: "Grid view" });
     expect(selectedItem).toHaveAttribute("data-selected");
-    expect(selectedItem).toHaveClass("data-[selected]:bg-tertiary");
+    const highlight = selectedItem.querySelector("[data-testid='menuitem-highlight']");
+    expect(highlight).toBeInTheDocument();
+    expect(highlight).toHaveClass("group-data-[selected]/menuitem:bg-tertiary");
   });
 
   test("checkmark appears on selected item when selectionMode is set and no leadingIcon", async () => {
@@ -1291,29 +1300,35 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("text-label-large");
   });
 
-  test("menuItemVariants: baseline includes data-[selected] bg class for surface-container-highest", () => {
-    const cls = menuItemVariants({
-      colorScheme: "standard",
-      menuStyle: "baseline",
-    });
-    expect(cls).toContain("data-[selected]:bg-surface-container-highest");
+  // ── menuItemHighlightVariants ──────────────────────────────────────────────
+
+  test("menuItemHighlightVariants: baseline standard has bg-surface-container-highest selector", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("group-data-[selected]/menuitem:bg-surface-container-highest");
   });
 
-  test("menuItemVariants: vertical standard includes data-[selected] bg class for tertiary-container", () => {
-    const cls = menuItemVariants({
-      colorScheme: "standard",
-      menuStyle: "vertical",
-    });
-    expect(cls).toContain("data-[selected]:bg-tertiary-container");
+  test("menuItemHighlightVariants: baseline uses inset-0 (full-bleed)", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("inset-0");
   });
 
-  test("menuItemVariants: vertical vibrant includes data-[selected] bg class for tertiary", () => {
-    const cls = menuItemVariants({
-      colorScheme: "vibrant",
-      menuStyle: "vertical",
-    });
-    expect(cls).toContain("data-[selected]:bg-tertiary");
+  test("menuItemHighlightVariants: vertical standard has tertiary-container selector", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("group-data-[selected]/menuitem:bg-tertiary-container");
   });
+
+  test("menuItemHighlightVariants: vertical vibrant has tertiary selector", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "vibrant", menuStyle: "vertical" });
+    expect(cls).toContain("group-data-[selected]/menuitem:bg-tertiary");
+  });
+
+  test("menuItemHighlightVariants: vertical uses inset-1 rounded-lg", () => {
+    const cls = menuItemHighlightVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("inset-1");
+    expect(cls).toContain("rounded-lg");
+  });
+
+  // ── menuItemStateLayerVariants ────────────────────────────────────────────
 
   test("menuItemStateLayerVariants: standard uses bg-on-surface", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
@@ -1325,6 +1340,17 @@ describe("CVA variants (unit)", () => {
     expect(cls).toContain("bg-on-tertiary-container");
   });
 
+  test("menuItemStateLayerVariants: baseline uses inset-0", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
+    expect(cls).toContain("inset-0");
+  });
+
+  test("menuItemStateLayerVariants: vertical uses inset-1 rounded-lg", () => {
+    const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "vertical" });
+    expect(cls).toContain("inset-1");
+    expect(cls).toContain("rounded-lg");
+  });
+
   test("menuItemStateLayerVariants: includes hover opacity-8 selector", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
     expect(cls).toContain("group-data-[hovered]/menuitem:opacity-8");
@@ -1333,5 +1359,23 @@ describe("CVA variants (unit)", () => {
   test("menuItemStateLayerVariants: includes focus-visible opacity-10 selector", () => {
     const cls = menuItemStateLayerVariants({ colorScheme: "standard", menuStyle: "baseline" });
     expect(cls).toContain("group-data-[focus-visible]/menuitem:opacity-10");
+  });
+
+  // ── menuPopoverVariants ───────────────────────────────────────────────────
+
+  test("menuPopoverVariants: includes animate-md-scale-in on entering", () => {
+    const cls = menuPopoverVariants();
+    expect(cls).toContain("data-[entering]:animate-md-scale-in");
+  });
+
+  test("menuPopoverVariants: includes animate-md-scale-out on exiting", () => {
+    const cls = menuPopoverVariants();
+    expect(cls).toContain("data-[exiting]:animate-md-scale-out");
+  });
+
+  test("menuPopoverVariants: includes placement-aware origin classes", () => {
+    const cls = menuPopoverVariants();
+    expect(cls).toContain("origin-top");
+    expect(cls).toContain("data-[placement=top]:origin-bottom");
   });
 });

--- a/packages/react/src/components/Menu/Menu.types.ts
+++ b/packages/react/src/components/Menu/Menu.types.ts
@@ -287,6 +287,51 @@ export interface MenuGapProps {
   className?: string;
 }
 
+// ─── MenuItemGroup ────────────────────────────────────────────────────────────
+
+/**
+ * Props for the `MenuItemGroup` component (styled Layer 3).
+ *
+ * Wraps related `MenuItem` elements in a semantic `role="group"` (via
+ * `HeadlessMenuSection`) and automatically inserts a 2dp MD3 Expressive gap
+ * before the group so that consecutive sibling groups are visually separated.
+ * The leading gap is hidden on the first group, so exactly N−1 gaps appear
+ * between N groups.
+ *
+ * The auto-gap behaviour is active only when `menuStyle="vertical"` — in a
+ * `baseline` menu the group still renders with its ARIA role, but no gap is
+ * injected (a dev warning is emitted instead).
+ *
+ * `aria-label` is required so the group has an accessible name per WCAG 2.1
+ * (ARIA `group` role requirement).
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger.Menu menuStyle="vertical" aria-label="Edit actions">
+ *   <MenuItemGroup aria-label="Clipboard">
+ *     <MenuItem id="cut">Cut</MenuItem>
+ *     <MenuItem id="copy">Copy</MenuItem>
+ *     <MenuItem id="paste">Paste</MenuItem>
+ *   </MenuItemGroup>
+ *   <MenuItemGroup aria-label="History">
+ *     <MenuItem id="undo">Undo</MenuItem>
+ *     <MenuItem id="redo">Redo</MenuItem>
+ *   </MenuItemGroup>
+ * </MenuTrigger.Menu>
+ * ```
+ */
+export interface MenuItemGroupProps {
+  /** Group content — typically `MenuItem` elements. */
+  children: ReactNode;
+  /**
+   * Accessible label for the group.
+   * Required so the ARIA `group` role has a visible name.
+   */
+  "aria-label": string;
+  /** Additional CSS classes merged onto the group container element. */
+  className?: string;
+}
+
 // ─── SubmenuTrigger ──────────────────────────────────────────────────────────
 
 /**

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -13,10 +13,10 @@ import { cva, type VariantProps } from "class-variance-authority";
  *   baseline: `rounded-xs` (4dp extra-small)
  *   vertical: `rounded-lg` (16dp large, MD3 Expressive)
  *
- * Background per menuStyle × colorScheme:
- *   baseline + standard:  bg-surface-container
- *   vertical + standard:  bg-surface-container-low
- *   vertical + vibrant:   bg-tertiary-container
+ * Background per menuStyle:
+ *   baseline: bg-surface-container (solid, houses all items)
+ *   vertical: bg-transparent (items paint their own segment cards; gap reveals
+ *             the page background between segments — acting as the divider)
  *
  * @see https://m3.material.io/components/menus/specs
  */
@@ -37,9 +37,9 @@ export const menuContainerVariants = cva(
   {
     variants: {
       /**
-       * Color scheme — drives the container background (baseline only).
-       * vertical menus paint each item with the group surface; the container
-       * itself is transparent so the 2dp gap between groups reveals nothing.
+       * Color scheme — drives item/segment background and content colors.
+       * standard: surface-container-low item background.
+       * vibrant:  tertiary-container item background.
        */
       colorScheme: {
         standard: [],
@@ -49,8 +49,8 @@ export const menuContainerVariants = cva(
        * Visual style — drives corner radius and container background.
        *
        * baseline: solid surface-container, 4dp corners, 8dp vertical padding.
-       * vertical: transparent container, 16dp corners, no vertical padding —
-       *   each item owns its group background so gaps appear between them.
+       * vertical: transparent container, 16dp corners, no container padding —
+       *   items own their segment surface, gaps reveal the page background.
        */
       menuStyle: {
         baseline: ["rounded-xs", "bg-surface-container", "py-2"],
@@ -70,35 +70,21 @@ export const menuContainerVariants = cva(
  * Applied to the React Aria `<Popover>` element — the element where RAC emits
  * `data-entering`, `data-exiting`, and `data-placement`.
  *
- * Why here and not on the inner RACMenu:
- * RAC's Popover owns the overlay lifecycle and sets these data attributes on
- * itself, not on the child Menu element. Placing animation classes on RACMenu
- * means they never match.
- *
  * Motion:
  *   Enter: animate-md-scale-in (350ms expressive-fast-spatial, scale+fade)
  *   Exit:  animate-md-scale-out (200ms emphasized-accelerate, scale+fade)
  *
- * Transform-origin is placement-aware: menus below the trigger expand from the
- * top edge; menus above expand from the bottom, etc.
- *
  * @see https://m3.material.io/components/menus/specs — Motion
  */
 export const menuPopoverVariants = cva([
-  // Promote to compositor layer so scale + opacity animate without layout reflow
   "will-change-[transform,opacity]",
-  // Block pointer events while animating to prevent accidental item clicks
   "data-[entering]:pointer-events-none data-[exiting]:pointer-events-none",
-  // Enter: 350ms expressive-fast-spatial spring (intentional overshoot)
   "data-[entering]:animate-md-scale-in",
-  // Exit: 200ms emphasized-accelerate (accelerating exit)
   "data-[exiting]:animate-md-scale-out",
-  // Transform origin — default bottom placement expands downward from top edge
   "origin-top",
   "data-[placement=top]:origin-bottom",
   "data-[placement=left]:origin-right",
   "data-[placement=right]:origin-left",
-  // Reduced motion: skip both animations entirely
   "motion-reduce:data-[entering]:animate-none motion-reduce:data-[exiting]:animate-none",
 ]);
 
@@ -107,28 +93,35 @@ export const menuPopoverVariants = cva([
 /**
  * Material Design 3 Menu item root variants (CVA).
  *
- * Architecture: Variants vs States
- * - CVA holds only design-time decisions: colorScheme, menuStyle.
- * - All interaction/selection states are driven by data-* attributes that RAC
- *   MenuItem emits natively (data-hovered, data-pressed, data-focus-visible,
- *   data-selected, data-disabled) — read via group-data-[x]/menuitem selectors.
- * - The root element sets group/menuitem so all slot children can read state.
+ * Segmented vertical model (MD3 Expressive):
+ *   The container is transparent. Each item paints its own segment surface
+ *   (bg-surface-container-low / bg-tertiary-container). Groups of items are
+ *   visually separated by a MenuGap spacer whose 2dp height reveals the page
+ *   background between segments — creating the "divider" effect without a line.
  *
- * Typography: Label Large per MD3 menu spec (14sp / 500 weight).
- * Height: 48/44/40/36dp (baseline/vertical) controlled by density via context.
- * Padding: baseline 12dp left/right; vertical 16dp left/right (ItemLeadingSpace).
- * Gap between icon and label: 12dp (ItemBetweenSpace, unchanged).
+ * Segmented corner-rounding strategy (vertical):
+ *   Each item defaults to rounded-xs (4dp, inner corners).
+ *   The first item in a segment gets rounded-t-lg (16dp top corners).
+ *   The last item in a segment gets rounded-b-lg (16dp bottom corners).
+ *   Segment boundaries are determined by:
+ *     - first/last pseudo-classes (start/end of entire menu)
+ *     - CSS adjacent-sibling selectors relative to [data-menu-gap] elements
  *
- * Vertical segmented group background strategy:
- *   The container is transparent for vertical menus. Each item paints its own
- *   group surface (bg-surface-container-low / bg-tertiary-container), and CSS
- *   sibling selectors on [data-menu-gap] adjacent items produce the correct
- *   corner-radius composition:
- *     leading item (first or after-gap): rounded-t-lg (16dp top) + rounded-b-xs (4dp bottom)
- *     trailing item (last or before-gap): rounded-t-xs (4dp top) + rounded-b-lg (16dp bottom)
- *     standalone (first AND last): rounded-lg (all 16dp)
- *     middle item: rounded-xs (4dp all)
- *   [data-menu-gap] is set on the MenuGap component so the CSS selectors resolve.
+ *   Adjacent-sibling selectors:
+ *     Immediately after a gap  → [[data-menu-gap]+&]:rounded-t-lg
+ *     Immediately before a gap → the item uses has-[+[data-menu-gap]] which
+ *                                only works if the gap is a true sibling.
+ *                                RAC wraps items in <li> so we use
+ *                                [:has(+[data-menu-gap])]:rounded-b-lg on the
+ *                                item element itself when supported; where not,
+ *                                the MenuItem component also computes and
+ *                                injects explicit override classes.
+ *
+ * Color mapping (MD3 Expressive spec):
+ *   Standard — item bg: surface-container-low; label: on-surface; icons/trailing: on-surface-variant
+ *              selected/open bg: tertiary-container; content: on-tertiary-container
+ *   Vibrant  — item bg: tertiary-container; label: on-tertiary-container; icons/trailing: on-tertiary-container
+ *              selected/open bg: tertiary; content: on-tertiary
  *
  * @see https://m3.material.io/components/menus/specs
  */
@@ -149,58 +142,69 @@ export const menuItemVariants = cva(
   {
     variants: {
       /**
-       * Color scheme — drives default text color, state-layer color, and
-       * selection text colors.
+       * Color scheme — drives item bg, default text/icon color, and selection colors.
+       *
+       * standard: surface-container-low bg, on-surface text, on-surface-variant icons.
+       *           Selected/open: tertiary-container bg highlight, on-tertiary-container content.
+       * vibrant:  tertiary-container bg, on-tertiary-container text AND icons.
+       *           Selected/open: tertiary bg highlight, on-tertiary content.
        */
       colorScheme: {
         standard: ["text-on-surface"],
         vibrant: ["text-on-tertiary-container"],
       },
       /**
-       * Visual style — drives padding, group background, and corner rounding.
+       * Visual style — drives padding, segment surface, and corner rounding.
        *
        * baseline: 12dp h-padding, no item background (container provides it).
-       * vertical: 16dp h-padding, item owns group surface background, CSS
-       *   sibling selectors on [data-menu-gap] form the rounded group cards.
+       * vertical: 16dp h-padding, item owns segment surface, segmented rounding
+       *   via first/last + adjacent-sibling gap selectors.
        */
       menuStyle: {
         baseline: ["px-3"],
         vertical: [
           "px-4",
-          // Group surface — the container is transparent for vertical
-          "bg-surface-container-low",
-          // Segmented corner rounding
           // Default: inner item (4dp all corners)
           "rounded-xs",
-          // First item in menu: 16dp top corners
+          // First item in the whole menu → 16dp top corners
           "first:rounded-t-lg",
-          // Last item in menu: 16dp bottom corners
+          // Last item in the whole menu → 16dp bottom corners
           "last:rounded-b-lg",
-          // Item immediately before a gap: 16dp bottom corners
-          "has-[[data-menu-gap]~&]:rounded-b-lg",
-          // Item immediately after a gap: 16dp top corners
-          "[[data-menu-gap]~&]:rounded-t-lg",
+          // Immediately AFTER a MenuGap → 16dp top corners (new segment starts)
+          "[[data-menu-gap]+&]:rounded-t-lg",
+          // Immediately BEFORE a MenuGap → 16dp bottom corners (segment ends)
+          // has() targets the element that has an immediately adjacent sibling gap
+          "[&:has(+[data-menu-gap])]:rounded-b-lg",
         ],
       },
     },
     compoundVariants: [
-      // vertical + vibrant: item bg → tertiary-container
+      // vertical + standard: item background = surface-container-low
+      {
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: ["bg-surface-container-low"],
+      },
+      // vertical + vibrant: item background = tertiary-container
       {
         menuStyle: "vertical",
         colorScheme: "vibrant",
         class: ["bg-tertiary-container"],
       },
-      // vertical + standard: selected text → on-tertiary-container
+      // vertical + standard: selected/open text → on-tertiary-container
       {
         menuStyle: "vertical",
         colorScheme: "standard",
-        class: ["data-[selected]:text-on-tertiary-container"],
+        class: [
+          "data-[selected]:text-on-tertiary-container",
+          "data-[open]:text-on-tertiary-container",
+        ],
       },
-      // vertical + vibrant: selected text → on-tertiary
+      // vertical + vibrant: selected/open text → on-tertiary
       {
         menuStyle: "vertical",
         colorScheme: "vibrant",
-        class: ["data-[selected]:text-on-tertiary"],
+        class: ["data-[selected]:text-on-tertiary", "data-[open]:text-on-tertiary"],
       },
     ],
     defaultVariants: {
@@ -213,27 +217,30 @@ export const menuItemVariants = cva(
 // ─── MENU ITEM HIGHLIGHT ─────────────────────────────────────────────────────
 
 /**
- * Selected-background highlight layer for menu items.
+ * Selected/active-background highlight layer for menu items.
  *
- * Geometry is menuStyle-aware:
- *   baseline — `inset-0` (full-bleed, square background; unchanged MD3 look)
- *   vertical — `inset-x-1 inset-y-0 rounded-md` (horizontal-only 4dp inset,
- *               12dp CornerMedium per MD3 Expressive; selection no longer spans
- *               full width but does fill item height to avoid vertical gaps)
+ * Geometry:
+ *   baseline — `inset-0 rounded-[inherit]` (full-bleed, inherits item corner radius)
+ *   vertical — `inset-0 rounded-[inherit]` (full-bleed, inherits segment card corners)
  *
- * The layer is always present in the DOM and transitions its background-color
- * to the selection color on `data-selected`.
+ * Both styles use `inset-0 rounded-[inherit]` so the highlight always fills the
+ * item exactly, respecting whichever corner radii the item has (inner 4dp for
+ * middle items, outer 16dp for top/bottom items in a segment).
  *
- * Selection colors per menuStyle × colorScheme:
+ * Selection/active colors per menuStyle × colorScheme:
  *   baseline (any):         group-data-[selected]/menuitem:bg-surface-container-highest
  *   vertical + standard:    group-data-[selected]/menuitem:bg-tertiary-container
+ *                           group-data-[open]/menuitem:bg-tertiary-container
  *   vertical + vibrant:     group-data-[selected]/menuitem:bg-tertiary
+ *                           group-data-[open]/menuitem:bg-tertiary
  *
  * @see https://m3.material.io/components/menus/specs — Selected state
  */
 export const menuItemHighlightVariants = cva(
   [
-    "absolute pointer-events-none",
+    "absolute inset-0 pointer-events-none",
+    // Inherit the item's own corner radius (inner 4dp or outer 16dp)
+    "rounded-[inherit]",
     // Effects transition for background-color — no overshoot
     "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
     // z-0: below state layer (z-[1]) and content (z-10)
@@ -242,34 +249,38 @@ export const menuItemHighlightVariants = cva(
   {
     variants: {
       menuStyle: {
-        baseline: ["inset-0"],
-        // horizontal-only inset + 12dp corners (CornerMedium = ItemSelectedShape)
-        vertical: ["inset-x-1 inset-y-0 rounded-md"],
+        baseline: [],
+        vertical: [],
       },
       colorScheme: {
         standard: [
-          // baseline selected bg (vertical standard compound below overrides)
+          // baseline selected bg
           "group-data-[selected]/menuitem:bg-surface-container-highest",
         ],
         vibrant: [
           // baseline + vibrant: use surface-container-highest as fallback
-          // (vertical vibrant compound below overrides)
           "group-data-[selected]/menuitem:bg-surface-container-highest",
         ],
       },
     },
     compoundVariants: [
-      // vertical + standard selected: tertiary-container
+      // vertical + standard: selected/open highlight → tertiary-container
       {
         menuStyle: "vertical",
         colorScheme: "standard",
-        class: ["group-data-[selected]/menuitem:bg-tertiary-container"],
+        class: [
+          "group-data-[selected]/menuitem:bg-tertiary-container",
+          "group-data-[open]/menuitem:bg-tertiary-container",
+        ],
       },
-      // vertical + vibrant selected: tertiary
+      // vertical + vibrant: selected/open highlight → tertiary
       {
         menuStyle: "vertical",
         colorScheme: "vibrant",
-        class: ["group-data-[selected]/menuitem:bg-tertiary"],
+        class: [
+          "group-data-[selected]/menuitem:bg-tertiary",
+          "group-data-[open]/menuitem:bg-tertiary",
+        ],
       },
     ],
     defaultVariants: {
@@ -283,31 +294,35 @@ export const menuItemHighlightVariants = cva(
 
 /**
  * State layer slot — absolute inset overlay that transitions opacity on
- * hover / focus / press interaction states.
+ * hover / press interaction states.
  *
- * Architecture mirrors buttonStateLayerVariants:
- * - Opacity driven by group-data-[x]/menuitem selectors (no CSS pseudo-classes)
- * - Pressed (opacity-10) uses doubled attribute selector to beat hover (opacity-8)
- * - Hidden entirely when disabled — no state layer on disabled items
- * - Color is variant-driven (on-surface for standard, on-tertiary-container for
- *   vibrant), with selected override per menuStyle × colorScheme
+ * Geometry: `inset-0 rounded-[inherit]` for both baseline and vertical —
+ * full-bleed, inherits item corner radius so the state layer respects
+ * the segment card shape.
+ *
+ * Color mapping (MD3 Expressive):
+ *   standard: bg-on-surface (unselected/unopen)
+ *             group-data-[selected] / group-data-[open]: bg-on-tertiary-container
+ *   vibrant:  bg-on-tertiary-container (unselected/unopen)
+ *             group-data-[selected] / group-data-[open]: bg-on-tertiary
+ *
+ * Focus-visible state is NOT expressed as a state-layer opacity here —
+ * it is expressed via the dedicated focus-ring slot (menuItemFocusRingVariants)
+ * per the MD3 Expressive reference state grid.
  *
  * State-layer opacities per MD3 spec:
- *   Hover:         8%   (opacity-8)
- *   Focus visible: 10%  (opacity-10)
- *   Pressed:       10%  (opacity-10, doubled selector wins over hover)
+ *   Hover:   8%   (opacity-8)
+ *   Pressed: 10%  (opacity-10, doubled selector wins over hover)
  *
  * @see https://m3.material.io/components/menus/specs#state-layers
  */
 export const menuItemStateLayerVariants = cva(
   [
-    "absolute overflow-hidden pointer-events-none opacity-0",
+    "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
     // Effects transition — opacity must NOT overshoot
     "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
     // Hover: 8%
     "group-data-[hovered]/menuitem:opacity-8",
-    // Focus visible: 10%
-    "group-data-[focus-visible]/menuitem:opacity-10",
     // Pressed: 10%, doubled selector wins over hover at same cascade position
     "group-data-[pressed]/menuitem:group-data-[pressed]/menuitem:opacity-10",
     // No state layer when disabled
@@ -322,24 +337,28 @@ export const menuItemStateLayerVariants = cva(
         vibrant: ["bg-on-tertiary-container"],
       },
       menuStyle: {
-        // baseline: full-bleed, inherits container corner radius
-        baseline: ["inset-0 rounded-[inherit]"],
-        // vertical: horizontal-only inset to match the highlight layer shape
-        vertical: ["inset-x-1 inset-y-0 rounded-md"],
+        baseline: [],
+        vertical: [],
       },
     },
     compoundVariants: [
-      // vertical + standard selected: state layer switches to on-tertiary-container
+      // vertical + standard: selected/open state layer → on-tertiary-container
       {
         menuStyle: "vertical",
         colorScheme: "standard",
-        class: ["group-data-[selected]/menuitem:bg-on-tertiary-container"],
+        class: [
+          "group-data-[selected]/menuitem:bg-on-tertiary-container",
+          "group-data-[open]/menuitem:bg-on-tertiary-container",
+        ],
       },
-      // vertical + vibrant selected: state layer switches to on-tertiary
+      // vertical + vibrant: selected/open state layer → on-tertiary
       {
         menuStyle: "vertical",
         colorScheme: "vibrant",
-        class: ["group-data-[selected]/menuitem:bg-on-tertiary"],
+        class: [
+          "group-data-[selected]/menuitem:bg-on-tertiary",
+          "group-data-[open]/menuitem:bg-on-tertiary",
+        ],
       },
     ],
     defaultVariants: {
@@ -349,22 +368,53 @@ export const menuItemStateLayerVariants = cva(
   }
 );
 
+// ─── MENU ITEM FOCUS RING ─────────────────────────────────────────────────────
+
+/**
+ * Focus ring slot — keyboard-focus indicator rendered as an absolute overlay
+ * with an outline that extends inside the item boundary.
+ *
+ * Unlike the Button focus ring (which uses `inset-[-3px]` to extend outward),
+ * the menu item focus ring uses `-outline-offset-2` (inset 2dp) so it stays
+ * within the segment card without clipping adjacent items.
+ *
+ * Geometry: `inset-0 rounded-[inherit]` — full-bleed, inherits item corners.
+ * Color: `outline-secondary` per MD3 focus indicator token.
+ * Opacity: 0 at rest → 100% on focus-visible.
+ *
+ * @see https://m3.material.io/components/menus/specs — States
+ */
+export const menuItemFocusRingVariants = cva([
+  "pointer-events-none absolute inset-0 rounded-[inherit]",
+  "outline outline-2 -outline-offset-2 outline-secondary",
+  // Effects transition — opacity must not overshoot
+  "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+  "opacity-0",
+  "group-data-[focus-visible]/menuitem:opacity-100",
+  // z-[2]: above state layer (z-[1]) and highlight (z-0), below content (z-10)
+  "z-[2]",
+]);
+
 // ─── MENU ITEM ICON ───────────────────────────────────────────────────────────
 
 /**
  * Icon slot (leading and trailing icons) for menu items.
  *
- * Base: 24×24dp, on-surface-variant color.
- * Selected: color follows the menuStyle × colorScheme selection color.
+ * Color mapping (MD3 Expressive):
+ *   standard:  on-surface-variant (unselected); on-tertiary-container (selected/open)
+ *   vibrant:   on-tertiary-container (unselected); on-tertiary (selected/open)
+ *
+ * Size per menuStyle:
+ *   baseline — 24dp (MD3 baseline spec)
+ *   vertical — 20dp (SegmentedMenuTokens.ItemLeadingIconSize = 20dp)
+ *
  * Disabled: on-surface/38 per MD3 spec.
- * Transition: effects spring (no overshoot on color).
  *
  * @see https://m3.material.io/components/menus/specs#anatomy
  */
 export const menuItemIconVariants = cva(
   [
     "relative z-10 shrink-0 flex items-center justify-center",
-    "text-on-surface-variant",
     "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
     // Disabled: 38% opacity on icon color
     "group-data-[disabled]/menuitem:text-on-surface/38",
@@ -372,34 +422,32 @@ export const menuItemIconVariants = cva(
   {
     variants: {
       colorScheme: {
-        standard: [],
-        vibrant: [
-          // Vibrant unselected icon: on-tertiary-container
-          "text-on-tertiary-container",
-        ],
+        standard: ["text-on-surface-variant"],
+        vibrant: ["text-on-tertiary-container"],
       },
-      /**
-       * Size per menuStyle:
-       *   baseline — 24dp (MD3 baseline spec)
-       *   vertical — 20dp (SegmentedMenuTokens.ItemLeadingIconSize = 20dp)
-       */
       menuStyle: {
         baseline: ["h-6 w-6"],
         vertical: ["h-5 w-5"],
       },
     },
     compoundVariants: [
-      // vertical + standard selected: icon → on-tertiary-container
+      // vertical + standard: selected/open icon → on-tertiary-container
       {
         menuStyle: "vertical",
         colorScheme: "standard",
-        class: ["group-data-[selected]/menuitem:text-on-tertiary-container"],
+        class: [
+          "group-data-[selected]/menuitem:text-on-tertiary-container",
+          "group-data-[open]/menuitem:text-on-tertiary-container",
+        ],
       },
-      // vertical + vibrant selected: icon → on-tertiary
+      // vertical + vibrant: selected/open icon → on-tertiary
       {
         menuStyle: "vertical",
         colorScheme: "vibrant",
-        class: ["group-data-[selected]/menuitem:text-on-tertiary"],
+        class: [
+          "group-data-[selected]/menuitem:text-on-tertiary",
+          "group-data-[open]/menuitem:text-on-tertiary",
+        ],
       },
     ],
     defaultVariants: {
@@ -421,13 +469,26 @@ export const menuSectionVariants = cva(["flex flex-col w-full"]);
 /**
  * Menu section header variants (CVA).
  *
- * Typography: `text-title-small text-on-surface-variant` per MD3 spec.
+ * Color mapping (MD3 Expressive):
+ *   standard: text-on-surface-variant
+ *   vibrant:  text-on-tertiary-container
+ *
+ * @see https://m3.material.io/components/menus/specs — Callout 10
  */
-export const menuSectionHeaderVariants = cva([
-  "px-3 pt-2 pb-1",
-  "text-title-small text-on-surface-variant",
-  "select-none",
-]);
+export const menuSectionHeaderVariants = cva(
+  ["px-3 pt-2 pb-1", "text-title-small", "select-none"],
+  {
+    variants: {
+      colorScheme: {
+        standard: ["text-on-surface-variant"],
+        vibrant: ["text-on-tertiary-container"],
+      },
+    },
+    defaultVariants: {
+      colorScheme: "standard",
+    },
+  }
+);
 
 // ─── MENU DIVIDER ─────────────────────────────────────────────────────────────
 
@@ -435,7 +496,7 @@ export const menuSectionHeaderVariants = cva([
  * Menu item divider variants (CVA).
  *
  * Horizontal separator with `border-outline-variant`.
- * Padding: 8dp top/bottom (`my-2`) per MD3 spec.
+ * Spacing: 2dp top/bottom (`my-0.5`) per MD3 spec.
  *
  * @see https://m3.material.io/components/menus/specs — Measurements
  */
@@ -446,9 +507,11 @@ export const menuDividerVariants = cva(["border-t border-outline-variant", "my-0
 /**
  * Menu gap variants (CVA).
  *
- * A visual spacer for MD3 Expressive vertical menus. Uses spacing instead of
- * a border line to separate item groups. Set aria-hidden and role="none" in
- * the component.
+ * A 2dp visual spacer for MD3 Expressive vertical menus. The gap reveals the
+ * page background between item segments, acting as a visual divider without
+ * a line. Set aria-hidden and role="none" in the component.
+ *
+ * Height: 2dp (h-0.5) — keeps the segment separation tight but visible.
  *
  * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
  */
@@ -459,15 +522,49 @@ export const menuGapVariants = cva(["h-0.5 w-full"]);
 /**
  * Trailing text (keyboard shortcut) variants (CVA).
  *
- * Color: `text-on-surface-variant`, size: `text-label-large` (14sp).
- * The element also carries `aria-keyshortcuts` for screen reader support.
- * Disabled: on-surface/38 to match the rest of the item content.
+ * Color mapping (MD3 Expressive):
+ *   standard: on-surface-variant (unselected); on-tertiary-container (selected/open)
+ *   vibrant:  on-tertiary-container (unselected); on-tertiary (selected/open)
+ *
+ * Disabled: on-surface/38.
  */
-export const menuItemTrailingTextVariants = cva([
-  "ml-auto shrink-0 text-label-large text-on-surface-variant",
-  "select-none",
-  "group-data-[disabled]/menuitem:text-on-surface/38",
-]);
+export const menuItemTrailingTextVariants = cva(
+  [
+    "ml-auto shrink-0 text-label-large",
+    "select-none",
+    "group-data-[disabled]/menuitem:text-on-surface/38",
+  ],
+  {
+    variants: {
+      colorScheme: {
+        standard: ["text-on-surface-variant"],
+        vibrant: ["text-on-tertiary-container"],
+      },
+      menuStyle: {
+        baseline: [],
+        vertical: [
+          "group-data-[selected]/menuitem:text-on-tertiary-container",
+          "group-data-[open]/menuitem:text-on-tertiary-container",
+        ],
+      },
+    },
+    compoundVariants: [
+      // vertical + vibrant: selected/open trailing text → on-tertiary
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: [
+          "group-data-[selected]/menuitem:text-on-tertiary",
+          "group-data-[open]/menuitem:text-on-tertiary",
+        ],
+      },
+    ],
+    defaultVariants: {
+      colorScheme: "standard",
+      menuStyle: "baseline",
+    },
+  }
+);
 
 // ─── MENU ITEM DESCRIPTION ────────────────────────────────────────────────────
 
@@ -475,14 +572,46 @@ export const menuItemTrailingTextVariants = cva([
  * Menu item description (supporting text) variants (CVA).
  *
  * Rendered below the label text.
- * Typography: `text-body-medium text-on-surface-variant`.
+ *
+ * Color mapping (MD3 Expressive):
+ *   standard: on-surface-variant (unselected); on-tertiary-container (selected/open)
+ *   vibrant:  on-tertiary-container (unselected); on-tertiary (selected/open)
+ *
  * Disabled: on-surface/38.
  */
-export const menuItemDescriptionVariants = cva([
-  "text-body-medium text-on-surface-variant",
-  "select-none",
-  "group-data-[disabled]/menuitem:text-on-surface/38",
-]);
+export const menuItemDescriptionVariants = cva(
+  ["text-body-medium", "select-none", "group-data-[disabled]/menuitem:text-on-surface/38"],
+  {
+    variants: {
+      colorScheme: {
+        standard: ["text-on-surface-variant"],
+        vibrant: ["text-on-tertiary-container"],
+      },
+      menuStyle: {
+        baseline: [],
+        vertical: [
+          "group-data-[selected]/menuitem:text-on-tertiary-container",
+          "group-data-[open]/menuitem:text-on-tertiary-container",
+        ],
+      },
+    },
+    compoundVariants: [
+      // vertical + vibrant: selected/open description → on-tertiary
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: [
+          "group-data-[selected]/menuitem:text-on-tertiary",
+          "group-data-[open]/menuitem:text-on-tertiary",
+        ],
+      },
+    ],
+    defaultVariants: {
+      colorScheme: "standard",
+      menuStyle: "baseline",
+    },
+  }
+);
 
 // ─── TYPE EXPORTS ─────────────────────────────────────────────────────────────
 
@@ -491,5 +620,9 @@ export type MenuPopoverVariants = VariantProps<typeof menuPopoverVariants>;
 export type MenuItemVariants = VariantProps<typeof menuItemVariants>;
 export type MenuItemHighlightVariants = VariantProps<typeof menuItemHighlightVariants>;
 export type MenuItemStateLayerVariants = VariantProps<typeof menuItemStateLayerVariants>;
+export type MenuItemFocusRingVariants = VariantProps<typeof menuItemFocusRingVariants>;
 export type MenuItemIconVariants = VariantProps<typeof menuItemIconVariants>;
 export type MenuSectionVariants = VariantProps<typeof menuSectionVariants>;
+export type MenuSectionHeaderVariants = VariantProps<typeof menuSectionHeaderVariants>;
+export type MenuItemTrailingTextVariants = VariantProps<typeof menuItemTrailingTextVariants>;
+export type MenuItemDescriptionVariants = VariantProps<typeof menuItemDescriptionVariants>;

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -26,8 +26,6 @@ export const menuContainerVariants = cva(
     "shadow-elevation-2",
     // Width constraints: 112dp min / 280dp max per MD3 spec
     "min-w-28 max-w-70",
-    // Layout
-    "py-2",
     // Scroll behaviour
     "overflow-y-auto",
     "max-h-[calc(var(--visual-viewport-height,100vh)-2rem)]",
@@ -39,8 +37,9 @@ export const menuContainerVariants = cva(
   {
     variants: {
       /**
-       * Color scheme — drives the container background (vertical style only).
-       * baseline always uses surface-container regardless of colorScheme.
+       * Color scheme — drives the container background (baseline only).
+       * vertical menus paint each item with the group surface; the container
+       * itself is transparent so the 2dp gap between groups reveals nothing.
        */
       colorScheme: {
         standard: [],
@@ -48,20 +47,16 @@ export const menuContainerVariants = cva(
       },
       /**
        * Visual style — drives corner radius and container background.
+       *
+       * baseline: solid surface-container, 4dp corners, 8dp vertical padding.
+       * vertical: transparent container, 16dp corners, no vertical padding —
+       *   each item owns its group background so gaps appear between them.
        */
       menuStyle: {
-        baseline: ["rounded-xs", "bg-surface-container"],
-        vertical: ["rounded-lg", "bg-surface-container-low"],
+        baseline: ["rounded-xs", "bg-surface-container", "py-2"],
+        vertical: ["rounded-lg", "bg-transparent"],
       },
     },
-    compoundVariants: [
-      // vertical + vibrant → tertiary container background
-      {
-        menuStyle: "vertical",
-        colorScheme: "vibrant",
-        class: ["bg-tertiary-container"],
-      },
-    ],
     defaultVariants: {
       colorScheme: "standard",
       menuStyle: "baseline",
@@ -120,17 +115,20 @@ export const menuPopoverVariants = cva([
  * - The root element sets group/menuitem so all slot children can read state.
  *
  * Typography: Label Large per MD3 menu spec (14sp / 500 weight).
- * Height: 48/44/40/36dp controlled by density via context (not CVA).
- * Padding: 12dp left/right, 12dp gap between elements.
+ * Height: 48/44/40/36dp (baseline/vertical) controlled by density via context.
+ * Padding: baseline 12dp left/right; vertical 16dp left/right (ItemLeadingSpace).
+ * Gap between icon and label: 12dp (ItemBetweenSpace, unchanged).
  *
- * Selected backgrounds per menuStyle × colorScheme:
- *   baseline (any):          data-[selected]:bg-surface-container-highest
- *   vertical + standard:     data-[selected]:bg-tertiary-container
- *   vertical + vibrant:      data-[selected]:bg-tertiary
- *
- * Disabled:
- *   The root itself gets data-[disabled]:pointer-events-none/cursor-not-allowed.
- *   Content (label, icons) are coloured at 38% via per-slot selectors.
+ * Vertical segmented group background strategy:
+ *   The container is transparent for vertical menus. Each item paints its own
+ *   group surface (bg-surface-container-low / bg-tertiary-container), and CSS
+ *   sibling selectors on [data-menu-gap] adjacent items produce the correct
+ *   corner-radius composition:
+ *     leading item (first or after-gap): rounded-t-lg (16dp top) + rounded-b-xs (4dp bottom)
+ *     trailing item (last or before-gap): rounded-t-xs (4dp top) + rounded-b-lg (16dp bottom)
+ *     standalone (first AND last): rounded-lg (all 16dp)
+ *     middle item: rounded-xs (4dp all)
+ *   [data-menu-gap] is set on the MenuGap component so the CSS selectors resolve.
  *
  * @see https://m3.material.io/components/menus/specs
  */
@@ -138,7 +136,7 @@ export const menuItemVariants = cva(
   [
     // Layout — height set by density context in MenuItem component
     "relative flex w-full items-center",
-    "px-3 gap-3",
+    "gap-3",
     // Typography: Label Large per MD3 menu spec
     "text-label-large",
     // Interaction
@@ -159,15 +157,39 @@ export const menuItemVariants = cva(
         vibrant: ["text-on-tertiary-container"],
       },
       /**
-       * Visual style — drives corner radius on items.
-       * Selected background is now handled by menuItemHighlightVariants.
+       * Visual style — drives padding, group background, and corner rounding.
+       *
+       * baseline: 12dp h-padding, no item background (container provides it).
+       * vertical: 16dp h-padding, item owns group surface background, CSS
+       *   sibling selectors on [data-menu-gap] form the rounded group cards.
        */
       menuStyle: {
-        baseline: [],
-        vertical: [],
+        baseline: ["px-3"],
+        vertical: [
+          "px-4",
+          // Group surface — the container is transparent for vertical
+          "bg-surface-container-low",
+          // Segmented corner rounding
+          // Default: inner item (4dp all corners)
+          "rounded-xs",
+          // First item in menu: 16dp top corners
+          "first:rounded-t-lg",
+          // Last item in menu: 16dp bottom corners
+          "last:rounded-b-lg",
+          // Item immediately before a gap: 16dp bottom corners
+          "has-[[data-menu-gap]~&]:rounded-b-lg",
+          // Item immediately after a gap: 16dp top corners
+          "[[data-menu-gap]~&]:rounded-t-lg",
+        ],
       },
     },
     compoundVariants: [
+      // vertical + vibrant: item bg → tertiary-container
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["bg-tertiary-container"],
+      },
       // vertical + standard: selected text → on-tertiary-container
       {
         menuStyle: "vertical",
@@ -195,13 +217,12 @@ export const menuItemVariants = cva(
  *
  * Geometry is menuStyle-aware:
  *   baseline — `inset-0` (full-bleed, square background; unchanged MD3 look)
- *   vertical — `inset-1 rounded-lg` (inset ~4dp, 16dp corners per MD3 Expressive
- *               spec; creates the pill-shaped highlight visible in the reference)
+ *   vertical — `inset-x-1 inset-y-0 rounded-md` (horizontal-only 4dp inset,
+ *               12dp CornerMedium per MD3 Expressive; selection no longer spans
+ *               full width but does fill item height to avoid vertical gaps)
  *
- * The layer is always present in the DOM (opacity-0 / transparent at rest) and
- * transitions its background-color to the selection color on `data-selected`.
- * This keeps the item hit-target and density height unchanged (they remain on
- * the root `<li>`) while the visual background is confined to the inset shape.
+ * The layer is always present in the DOM and transitions its background-color
+ * to the selection color on `data-selected`.
  *
  * Selection colors per menuStyle × colorScheme:
  *   baseline (any):         group-data-[selected]/menuitem:bg-surface-container-highest
@@ -222,7 +243,8 @@ export const menuItemHighlightVariants = cva(
     variants: {
       menuStyle: {
         baseline: ["inset-0"],
-        vertical: ["inset-1 rounded-lg"],
+        // horizontal-only inset + 12dp corners (CornerMedium = ItemSelectedShape)
+        vertical: ["inset-x-1 inset-y-0 rounded-md"],
       },
       colorScheme: {
         standard: [
@@ -302,8 +324,8 @@ export const menuItemStateLayerVariants = cva(
       menuStyle: {
         // baseline: full-bleed, inherits container corner radius
         baseline: ["inset-0 rounded-[inherit]"],
-        // vertical: inset to match the highlight layer shape
-        vertical: ["inset-1 rounded-lg"],
+        // vertical: horizontal-only inset to match the highlight layer shape
+        vertical: ["inset-x-1 inset-y-0 rounded-md"],
       },
     },
     compoundVariants: [
@@ -341,7 +363,7 @@ export const menuItemStateLayerVariants = cva(
  */
 export const menuItemIconVariants = cva(
   [
-    "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center",
+    "relative z-10 shrink-0 flex items-center justify-center",
     "text-on-surface-variant",
     "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
     // Disabled: 38% opacity on icon color
@@ -356,9 +378,14 @@ export const menuItemIconVariants = cva(
           "text-on-tertiary-container",
         ],
       },
+      /**
+       * Size per menuStyle:
+       *   baseline — 24dp (MD3 baseline spec)
+       *   vertical — 20dp (SegmentedMenuTokens.ItemLeadingIconSize = 20dp)
+       */
       menuStyle: {
-        baseline: [],
-        vertical: [],
+        baseline: ["h-6 w-6"],
+        vertical: ["h-5 w-5"],
       },
     },
     compoundVariants: [
@@ -412,7 +439,7 @@ export const menuSectionHeaderVariants = cva([
  *
  * @see https://m3.material.io/components/menus/specs — Measurements
  */
-export const menuDividerVariants = cva(["border-t border-outline-variant", "my-2 mx-0"]);
+export const menuDividerVariants = cva(["border-t border-outline-variant", "my-0.5 mx-3"]);
 
 // ─── MENU GAP ────────────────────────────────────────────────────────────────
 
@@ -425,7 +452,7 @@ export const menuDividerVariants = cva(["border-t border-outline-variant", "my-2
  *
  * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
  */
-export const menuGapVariants = cva(["h-2 w-full"]);
+export const menuGapVariants = cva(["h-0.5 w-full"]);
 
 // ─── MENU ITEM TRAILING TEXT ──────────────────────────────────────────────────
 

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -3,77 +3,77 @@ import { cva, type VariantProps } from "class-variance-authority";
 /**
  * Material Design 3 Menu container variants (CVA).
  *
- * Elevation: `shadow-elevation-2` (both styles)
- * Width: min 112dp / max 280dp per MD3 spec
+ * Architecture: Variants vs States
+ * - CVA holds design-time structure only (menuStyle, colorScheme).
+ * - Enter/exit animation uses composite MD3 utilities (animate-md-scale-in/out)
+ *   sourced from the token system — no hardcoded durations or beziers.
+ * - Placement-aware transform-origin is set via data-placement data attributes
+ *   emitted by React Aria's Popover.
  *
  * Shape per menuStyle:
- * - baseline: `rounded-xs` (4dp extra-small)
- * - vertical: `rounded-lg` (16dp large)
+ *   baseline: `rounded-xs` (4dp extra-small)
+ *   vertical: `rounded-lg` (16dp large, MD3 Expressive)
  *
- * Background per colorScheme + menuStyle:
- * - baseline + standard: `bg-surface-container`
- * - vertical + standard: `bg-surface-container-low`
- * - vertical + vibrant:  `bg-tertiary-container`
+ * Background per menuStyle × colorScheme:
+ *   baseline + standard:  bg-surface-container
+ *   vertical + standard:  bg-surface-container-low
+ *   vertical + vibrant:   bg-tertiary-container
  *
  * @see https://m3.material.io/components/menus/specs
  */
 export const menuContainerVariants = cva(
   [
-    // Elevation
+    // Elevation: level 2
     "shadow-elevation-2",
-    // Width constraints per MD3 spec (112dp min / 280dp max)
+    // Width constraints: 112dp min / 280dp max per MD3 spec
     "min-w-28 max-w-70",
     // Layout
     "py-2",
-    // Scroll: show scrollbar when content overflows; max height avoids clipping
+    // Scroll behaviour
     "overflow-y-auto",
     "max-h-[calc(var(--visual-viewport-height,100vh)-2rem)]",
     // Stacking
     "z-50",
-    // Focus outline handled by React Aria
+    // Focus outline delegated to React Aria
     "outline-none",
-    // GPU compositing — promotes menu to its own compositor layer so
-    // scale + opacity animations run without triggering layout reflow.
+    // Promote to compositor layer — scale + opacity animations run without layout reflow
     "will-change-[transform,opacity]",
-    // Pointer events blocked during animation to prevent accidental clicks
-    // on menu items while the panel is still animating in or out.
+    // Block pointer events during animation to prevent accidental item clicks
     "data-[entering]:pointer-events-none data-[exiting]:pointer-events-none",
-    // ── Enter animation ────────────────────────────────────────────────────
-    // @keyframes menu-enter (defined in styles.css): scale(0.8)+opacity:0 →
-    // scale(1)+opacity:1 in 120ms with cubic-bezier(0,0,0.2,1) (standard
-    // decelerate — matches Angular Material's _mat-menu-enter keyframe).
-    "data-[entering]:animate-[menu-enter_120ms_cubic-bezier(0,0,0.2,1)_both]",
-    // ── Exit animation ─────────────────────────────────────────────────────
-    // @keyframes menu-exit (defined in styles.css): opacity:1 → opacity:0
-    // in 100ms after 25ms delay, linear — matches Angular Material's
-    // _mat-menu-exit keyframe (fade-only, no reverse scale).
-    "data-[exiting]:animate-[menu-exit_100ms_25ms_linear_both]",
-    // ── Transform origin (placement-aware) ────────────────────────────────
-    // RAC sets data-placement="bottom|top|left|right" on the Popover element.
-    // Default (bottom): origin at top edge (menu expands downward).
+
+    // ── Enter animation ─────────────────────────────────────────────────────
+    // animate-md-scale-in: scale(0.85)+opacity:0 → scale(1)+opacity:1
+    // Duration: 350ms expressive-fast-spatial spring (intentional overshoot)
+    "data-[entering]:animate-md-scale-in",
+
+    // ── Exit animation ──────────────────────────────────────────────────────
+    // animate-md-scale-out: scale(1)+opacity:1 → scale(0.85)+opacity:0
+    // Duration: 200ms emphasized-accelerate (accelerating exit)
+    "data-[exiting]:animate-md-scale-out",
+
+    // ── Transform origin (placement-aware) ──────────────────────────────────
+    // RAC sets data-placement on the Popover element.
+    // Default (bottom): origin at top edge (menu expands downward)
     "origin-top",
-    // top: origin at bottom edge (menu expands upward)
     "data-[placement=top]:origin-bottom",
-    // left: origin at right edge
     "data-[placement=left]:origin-right",
-    // right: origin at left edge
     "data-[placement=right]:origin-left",
-    // ── Reduced motion ────────────────────────────────────────────────────
-    // Skip both animations entirely for users who prefer reduced motion.
+
+    // ── Reduced motion ───────────────────────────────────────────────────────
     "motion-reduce:data-[entering]:animate-none motion-reduce:data-[exiting]:animate-none",
   ],
   {
     variants: {
       /**
-       * Color scheme — drives the container background.
-       * baseline+standard uses a separate compound variant.
+       * Color scheme — drives the container background (vertical style only).
+       * baseline always uses surface-container regardless of colorScheme.
        */
       colorScheme: {
         standard: [],
         vibrant: [],
       },
       /**
-       * Visual style — drives corner radius and baseline vs vertical background.
+       * Visual style — drives corner radius and container background.
        */
       menuStyle: {
         baseline: ["rounded-xs", "bg-surface-container"],
@@ -81,7 +81,7 @@ export const menuContainerVariants = cva(
       },
     },
     compoundVariants: [
-      // Vertical + vibrant: tertiary container background
+      // vertical + vibrant → tertiary container background
       {
         menuStyle: "vertical",
         colorScheme: "vibrant",
@@ -95,25 +95,30 @@ export const menuContainerVariants = cva(
   }
 );
 
+// ─── MENU ITEM ROOT ───────────────────────────────────────────────────────────
+
 /**
- * Material Design 3 Menu item variants (CVA).
+ * Material Design 3 Menu item root variants (CVA).
  *
- * Typography: `text-body-large` per MD3 baseline spec (16sp / 400 weight).
- * Padding: `px-3` (12dp left/right), `gap-3` (12dp between elements).
+ * Architecture: Variants vs States
+ * - CVA holds only design-time decisions: colorScheme, menuStyle.
+ * - All interaction/selection states are driven by data-* attributes that RAC
+ *   MenuItem emits natively (data-hovered, data-pressed, data-focus-visible,
+ *   data-selected, data-disabled) — read via group-data-[x]/menuitem selectors.
+ * - The root element sets group/menuitem so all slot children can read state.
  *
- * State layers (MD3 spec):
- * - Hover:         `opacity-8`  on state layer
- * - Focus visible: `opacity-12` on state layer
- * - Pressed:       `opacity-12` on state layer
- * - Disabled:      `opacity-38` on entire item
+ * Typography: Label Large per MD3 menu spec (14sp / 500 weight).
+ * Height: 48/44/40/36dp controlled by density via context (not CVA).
+ * Padding: 12dp left/right, 12dp gap between elements.
  *
- * Selection colors per menuStyle + colorScheme:
- * - baseline (any):         `bg-surface-container-highest`
- * - vertical + standard:    `bg-tertiary-container text-on-tertiary-container`
- * - vertical + vibrant:     `bg-tertiary text-on-tertiary`
+ * Selected backgrounds per menuStyle × colorScheme:
+ *   baseline (any):          data-[selected]:bg-surface-container-highest
+ *   vertical + standard:     data-[selected]:bg-tertiary-container
+ *   vertical + vibrant:      data-[selected]:bg-tertiary
  *
- * Note: item height (48/44/40/36dp) is controlled by density via context,
- * applied directly in MenuItem component (not CVA) to avoid negative key issues.
+ * Disabled:
+ *   The root itself gets data-[disabled]:pointer-events-none/cursor-not-allowed.
+ *   Content (label, icons) are coloured at 38% via per-slot selectors.
  *
  * @see https://m3.material.io/components/menus/specs
  */
@@ -122,99 +127,189 @@ export const menuItemVariants = cva(
     // Layout — height set by density context in MenuItem component
     "relative flex w-full items-center",
     "px-3 gap-3",
-    // Typography: Body Large per MD3 baseline spec
-    "text-body-large",
+    // Typography: Label Large per MD3 menu spec
+    "text-label-large",
     // Interaction
     "cursor-pointer select-none outline-none",
-    // State layer pseudo-element
-    "before:absolute before:inset-0 before:rounded-[inherit]",
-    "before:transition-opacity before:duration-short2 before:ease-standard",
-    "before:opacity-0",
-    // Hover state layer
-    "hover:before:opacity-8",
-    // Focus visible state layer
-    "focus-visible:before:opacity-12",
-    // Active pressed state layer
-    "active:before:opacity-12",
-    // Color transition for selection
-    "transition-colors duration-short2 ease-standard",
+    // Color transition (effects — no overshoot)
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Disabled — self-targeting data-[x]: selectors (RAC emits data-disabled)
+    "data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed",
   ],
   {
     variants: {
       /**
-       * Disabled state: reduces opacity and blocks interaction.
-       */
-      isDisabled: {
-        true: ["opacity-38 cursor-not-allowed pointer-events-none"],
-        false: [],
-      },
-      /**
-       * Selected state: background and text color driven by compound variants.
-       */
-      isSelected: {
-        true: [],
-        false: [],
-      },
-      /**
-       * Color scheme: drives default text and state layer colors.
-       * - standard: on-surface text, on-surface state layer
-       * - vibrant (vertical only): on-tertiary-container text + state layer
+       * Color scheme — drives default text color, state-layer color, and
+       * selection text colors.
        */
       colorScheme: {
-        standard: ["text-on-surface", "before:bg-on-surface"],
-        vibrant: ["text-on-tertiary-container", "before:bg-on-tertiary-container"],
+        standard: ["text-on-surface"],
+        vibrant: ["text-on-tertiary-container"],
       },
       /**
-       * Visual style: drives corner radius on items (vertical uses rounded-lg
-       * inherited from container, items stay flat inside).
+       * Visual style — drives corner radius on items and selection background.
        */
       menuStyle: {
-        baseline: [],
+        baseline: [
+          // Selected: surface-container-highest, text stays on-surface
+          "data-[selected]:bg-surface-container-highest",
+        ],
         vertical: [],
       },
     },
     compoundVariants: [
-      // ── Baseline selection (both colorSchemes) ──────────────────────────
+      // vertical + standard: selected → tertiary-container
       {
-        isSelected: true,
-        menuStyle: "baseline",
-        class: [
-          "bg-surface-container-highest",
-          // text-on-surface already applied by standard colorScheme variant
-        ],
-      },
-      // ── Vertical + Standard selection ───────────────────────────────────
-      {
-        isSelected: true,
         menuStyle: "vertical",
         colorScheme: "standard",
         class: [
-          "bg-tertiary-container",
-          "text-on-tertiary-container",
-          "before:bg-on-tertiary-container",
+          "data-[selected]:bg-tertiary-container",
+          "data-[selected]:text-on-tertiary-container",
         ],
       },
-      // ── Vertical + Vibrant selection ─────────────────────────────────────
+      // vertical + vibrant: selected → tertiary
       {
-        isSelected: true,
         menuStyle: "vertical",
         colorScheme: "vibrant",
-        class: ["bg-tertiary", "text-on-tertiary", "before:bg-on-tertiary"],
+        class: ["data-[selected]:bg-tertiary", "data-[selected]:text-on-tertiary"],
       },
     ],
     defaultVariants: {
-      isDisabled: false,
-      isSelected: false,
       colorScheme: "standard",
       menuStyle: "baseline",
     },
   }
 );
 
+// ─── MENU ITEM STATE LAYER ────────────────────────────────────────────────────
+
+/**
+ * State layer slot — absolute inset overlay that transitions opacity on
+ * hover / focus / press interaction states.
+ *
+ * Architecture mirrors buttonStateLayerVariants:
+ * - Opacity driven by group-data-[x]/menuitem selectors (no CSS pseudo-classes)
+ * - Pressed (opacity-10) uses doubled attribute selector to beat hover (opacity-8)
+ * - Hidden entirely when disabled — no state layer on disabled items
+ * - Color is variant-driven (on-surface for standard, on-tertiary-container for
+ *   vibrant), with selected override per menuStyle × colorScheme
+ *
+ * State-layer opacities per MD3 spec:
+ *   Hover:         8%   (opacity-8)
+ *   Focus visible: 10%  (opacity-10)
+ *   Pressed:       10%  (opacity-10, doubled selector wins over hover)
+ *
+ * @see https://m3.material.io/components/menus/specs#state-layers
+ */
+export const menuItemStateLayerVariants = cva(
+  [
+    "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+    // Effects transition — opacity must NOT overshoot
+    "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Hover: 8%
+    "group-data-[hovered]/menuitem:opacity-8",
+    // Focus visible: 10%
+    "group-data-[focus-visible]/menuitem:opacity-10",
+    // Pressed: 10%, doubled selector wins over hover at same cascade position
+    "group-data-[pressed]/menuitem:group-data-[pressed]/menuitem:opacity-10",
+    // No state layer when disabled
+    "group-data-[disabled]/menuitem:hidden",
+  ],
+  {
+    variants: {
+      colorScheme: {
+        standard: ["bg-on-surface"],
+        vibrant: ["bg-on-tertiary-container"],
+      },
+      menuStyle: {
+        baseline: [],
+        vertical: [],
+      },
+    },
+    compoundVariants: [
+      // vertical + standard selected: state layer switches to on-tertiary-container
+      {
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: ["group-data-[selected]/menuitem:bg-on-tertiary-container"],
+      },
+      // vertical + vibrant selected: state layer switches to on-tertiary
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["group-data-[selected]/menuitem:bg-on-tertiary"],
+      },
+    ],
+    defaultVariants: {
+      colorScheme: "standard",
+      menuStyle: "baseline",
+    },
+  }
+);
+
+// ─── MENU ITEM ICON ───────────────────────────────────────────────────────────
+
+/**
+ * Icon slot (leading and trailing icons) for menu items.
+ *
+ * Base: 24×24dp, on-surface-variant color.
+ * Selected: color follows the menuStyle × colorScheme selection color.
+ * Disabled: on-surface/38 per MD3 spec.
+ * Transition: effects spring (no overshoot on color).
+ *
+ * @see https://m3.material.io/components/menus/specs#anatomy
+ */
+export const menuItemIconVariants = cva(
+  [
+    "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center",
+    "text-on-surface-variant",
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // Disabled: 38% opacity on icon color
+    "group-data-[disabled]/menuitem:text-on-surface/38",
+  ],
+  {
+    variants: {
+      colorScheme: {
+        standard: [],
+        vibrant: [
+          // Vibrant unselected icon: on-tertiary-container
+          "text-on-tertiary-container",
+        ],
+      },
+      menuStyle: {
+        baseline: [],
+        vertical: [],
+      },
+    },
+    compoundVariants: [
+      // vertical + standard selected: icon → on-tertiary-container
+      {
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: ["group-data-[selected]/menuitem:text-on-tertiary-container"],
+      },
+      // vertical + vibrant selected: icon → on-tertiary
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["group-data-[selected]/menuitem:text-on-tertiary"],
+      },
+    ],
+    defaultVariants: {
+      colorScheme: "standard",
+      menuStyle: "baseline",
+    },
+  }
+);
+
+// ─── MENU SECTION ─────────────────────────────────────────────────────────────
+
 /**
  * Menu section container variants (CVA).
  */
 export const menuSectionVariants = cva(["flex flex-col w-full"]);
+
+// ─── MENU SECTION HEADER ──────────────────────────────────────────────────────
 
 /**
  * Menu section header variants (CVA).
@@ -227,50 +322,65 @@ export const menuSectionHeaderVariants = cva([
   "select-none",
 ]);
 
+// ─── MENU DIVIDER ─────────────────────────────────────────────────────────────
+
 /**
  * Menu item divider variants (CVA).
  *
- * Renders a horizontal separator with `border-outline-variant`.
+ * Horizontal separator with `border-outline-variant`.
  * Padding: 8dp top/bottom (`my-2`) per MD3 spec.
  *
  * @see https://m3.material.io/components/menus/specs — Measurements
  */
 export const menuDividerVariants = cva(["border-t border-outline-variant", "my-2 mx-0"]);
 
+// ─── MENU GAP ────────────────────────────────────────────────────────────────
+
 /**
  * Menu gap variants (CVA).
  *
- * A visual spacer for M3 Expressive vertical menus. Uses spacing instead of
- * a border line to separate item groups. `aria-hidden` and `role="none"`.
+ * A visual spacer for MD3 Expressive vertical menus. Uses spacing instead of
+ * a border line to separate item groups. Set aria-hidden and role="none" in
+ * the component.
  *
  * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
  */
 export const menuGapVariants = cva(["h-2 w-full"]);
+
+// ─── MENU ITEM TRAILING TEXT ──────────────────────────────────────────────────
 
 /**
  * Trailing text (keyboard shortcut) variants (CVA).
  *
  * Color: `text-on-surface-variant`, size: `text-label-large` (14sp).
  * The element also carries `aria-keyshortcuts` for screen reader support.
+ * Disabled: on-surface/38 to match the rest of the item content.
  */
 export const menuItemTrailingTextVariants = cva([
   "ml-auto shrink-0 text-label-large text-on-surface-variant",
   "select-none",
+  "group-data-[disabled]/menuitem:text-on-surface/38",
 ]);
+
+// ─── MENU ITEM DESCRIPTION ────────────────────────────────────────────────────
 
 /**
  * Menu item description (supporting text) variants (CVA).
  *
  * Rendered below the label text.
  * Typography: `text-body-medium text-on-surface-variant`.
+ * Disabled: on-surface/38.
  */
 export const menuItemDescriptionVariants = cva([
   "text-body-medium text-on-surface-variant",
   "select-none",
+  "group-data-[disabled]/menuitem:text-on-surface/38",
 ]);
 
-// ─── Type exports ─────────────────────────────────────────────────────────────
+// ─── TYPE EXPORTS ─────────────────────────────────────────────────────────────
 
 export type MenuContainerVariants = VariantProps<typeof menuContainerVariants>;
 export type MenuItemVariants = VariantProps<typeof menuItemVariants>;
+export type MenuItemStateLayerVariants = VariantProps<typeof menuItemStateLayerVariants>;
+export type MenuItemIconVariants = VariantProps<typeof menuItemIconVariants>;
 export type MenuSectionVariants = VariantProps<typeof menuSectionVariants>;

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -5,10 +5,9 @@ import { cva, type VariantProps } from "class-variance-authority";
  *
  * Architecture: Variants vs States
  * - CVA holds design-time structure only (menuStyle, colorScheme).
- * - Enter/exit animation uses composite MD3 utilities (animate-md-scale-in/out)
- *   sourced from the token system — no hardcoded durations or beziers.
- * - Placement-aware transform-origin is set via data-placement data attributes
- *   emitted by React Aria's Popover.
+ * - Animation (enter/exit motion) lives on `menuPopoverVariants` which is
+ *   applied to the RAC Popover element — the element where RAC actually emits
+ *   data-entering, data-exiting, and data-placement.
  *
  * Shape per menuStyle:
  *   baseline: `rounded-xs` (4dp extra-small)
@@ -36,31 +35,6 @@ export const menuContainerVariants = cva(
     "z-50",
     // Focus outline delegated to React Aria
     "outline-none",
-    // Promote to compositor layer — scale + opacity animations run without layout reflow
-    "will-change-[transform,opacity]",
-    // Block pointer events during animation to prevent accidental item clicks
-    "data-[entering]:pointer-events-none data-[exiting]:pointer-events-none",
-
-    // ── Enter animation ─────────────────────────────────────────────────────
-    // animate-md-scale-in: scale(0.85)+opacity:0 → scale(1)+opacity:1
-    // Duration: 350ms expressive-fast-spatial spring (intentional overshoot)
-    "data-[entering]:animate-md-scale-in",
-
-    // ── Exit animation ──────────────────────────────────────────────────────
-    // animate-md-scale-out: scale(1)+opacity:1 → scale(0.85)+opacity:0
-    // Duration: 200ms emphasized-accelerate (accelerating exit)
-    "data-[exiting]:animate-md-scale-out",
-
-    // ── Transform origin (placement-aware) ──────────────────────────────────
-    // RAC sets data-placement on the Popover element.
-    // Default (bottom): origin at top edge (menu expands downward)
-    "origin-top",
-    "data-[placement=top]:origin-bottom",
-    "data-[placement=left]:origin-right",
-    "data-[placement=right]:origin-left",
-
-    // ── Reduced motion ───────────────────────────────────────────────────────
-    "motion-reduce:data-[entering]:animate-none motion-reduce:data-[exiting]:animate-none",
   ],
   {
     variants: {
@@ -94,6 +68,44 @@ export const menuContainerVariants = cva(
     },
   }
 );
+
+// ─── MENU POPOVER ────────────────────────────────────────────────────────────
+
+/**
+ * Applied to the React Aria `<Popover>` element — the element where RAC emits
+ * `data-entering`, `data-exiting`, and `data-placement`.
+ *
+ * Why here and not on the inner RACMenu:
+ * RAC's Popover owns the overlay lifecycle and sets these data attributes on
+ * itself, not on the child Menu element. Placing animation classes on RACMenu
+ * means they never match.
+ *
+ * Motion:
+ *   Enter: animate-md-scale-in (350ms expressive-fast-spatial, scale+fade)
+ *   Exit:  animate-md-scale-out (200ms emphasized-accelerate, scale+fade)
+ *
+ * Transform-origin is placement-aware: menus below the trigger expand from the
+ * top edge; menus above expand from the bottom, etc.
+ *
+ * @see https://m3.material.io/components/menus/specs — Motion
+ */
+export const menuPopoverVariants = cva([
+  // Promote to compositor layer so scale + opacity animate without layout reflow
+  "will-change-[transform,opacity]",
+  // Block pointer events while animating to prevent accidental item clicks
+  "data-[entering]:pointer-events-none data-[exiting]:pointer-events-none",
+  // Enter: 350ms expressive-fast-spatial spring (intentional overshoot)
+  "data-[entering]:animate-md-scale-in",
+  // Exit: 200ms emphasized-accelerate (accelerating exit)
+  "data-[exiting]:animate-md-scale-out",
+  // Transform origin — default bottom placement expands downward from top edge
+  "origin-top",
+  "data-[placement=top]:origin-bottom",
+  "data-[placement=left]:origin-right",
+  "data-[placement=right]:origin-left",
+  // Reduced motion: skip both animations entirely
+  "motion-reduce:data-[entering]:animate-none motion-reduce:data-[exiting]:animate-none",
+]);
 
 // ─── MENU ITEM ROOT ───────────────────────────────────────────────────────────
 
@@ -147,36 +159,100 @@ export const menuItemVariants = cva(
         vibrant: ["text-on-tertiary-container"],
       },
       /**
-       * Visual style — drives corner radius on items and selection background.
+       * Visual style — drives corner radius on items.
+       * Selected background is now handled by menuItemHighlightVariants.
        */
       menuStyle: {
-        baseline: [
-          // Selected: surface-container-highest, text stays on-surface
-          "data-[selected]:bg-surface-container-highest",
-        ],
+        baseline: [],
         vertical: [],
       },
     },
     compoundVariants: [
-      // vertical + standard: selected → tertiary-container
+      // vertical + standard: selected text → on-tertiary-container
       {
         menuStyle: "vertical",
         colorScheme: "standard",
-        class: [
-          "data-[selected]:bg-tertiary-container",
-          "data-[selected]:text-on-tertiary-container",
-        ],
+        class: ["data-[selected]:text-on-tertiary-container"],
       },
-      // vertical + vibrant: selected → tertiary
+      // vertical + vibrant: selected text → on-tertiary
       {
         menuStyle: "vertical",
         colorScheme: "vibrant",
-        class: ["data-[selected]:bg-tertiary", "data-[selected]:text-on-tertiary"],
+        class: ["data-[selected]:text-on-tertiary"],
       },
     ],
     defaultVariants: {
       colorScheme: "standard",
       menuStyle: "baseline",
+    },
+  }
+);
+
+// ─── MENU ITEM HIGHLIGHT ─────────────────────────────────────────────────────
+
+/**
+ * Selected-background highlight layer for menu items.
+ *
+ * Geometry is menuStyle-aware:
+ *   baseline — `inset-0` (full-bleed, square background; unchanged MD3 look)
+ *   vertical — `inset-1 rounded-lg` (inset ~4dp, 16dp corners per MD3 Expressive
+ *               spec; creates the pill-shaped highlight visible in the reference)
+ *
+ * The layer is always present in the DOM (opacity-0 / transparent at rest) and
+ * transitions its background-color to the selection color on `data-selected`.
+ * This keeps the item hit-target and density height unchanged (they remain on
+ * the root `<li>`) while the visual background is confined to the inset shape.
+ *
+ * Selection colors per menuStyle × colorScheme:
+ *   baseline (any):         group-data-[selected]/menuitem:bg-surface-container-highest
+ *   vertical + standard:    group-data-[selected]/menuitem:bg-tertiary-container
+ *   vertical + vibrant:     group-data-[selected]/menuitem:bg-tertiary
+ *
+ * @see https://m3.material.io/components/menus/specs — Selected state
+ */
+export const menuItemHighlightVariants = cva(
+  [
+    "absolute pointer-events-none",
+    // Effects transition for background-color — no overshoot
+    "transition-colors duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
+    // z-0: below state layer (z-[1]) and content (z-10)
+    "z-0",
+  ],
+  {
+    variants: {
+      menuStyle: {
+        baseline: ["inset-0"],
+        vertical: ["inset-1 rounded-lg"],
+      },
+      colorScheme: {
+        standard: [
+          // baseline selected bg (vertical standard compound below overrides)
+          "group-data-[selected]/menuitem:bg-surface-container-highest",
+        ],
+        vibrant: [
+          // baseline + vibrant: use surface-container-highest as fallback
+          // (vertical vibrant compound below overrides)
+          "group-data-[selected]/menuitem:bg-surface-container-highest",
+        ],
+      },
+    },
+    compoundVariants: [
+      // vertical + standard selected: tertiary-container
+      {
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: ["group-data-[selected]/menuitem:bg-tertiary-container"],
+      },
+      // vertical + vibrant selected: tertiary
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["group-data-[selected]/menuitem:bg-tertiary"],
+      },
+    ],
+    defaultVariants: {
+      menuStyle: "baseline",
+      colorScheme: "standard",
     },
   }
 );
@@ -203,7 +279,7 @@ export const menuItemVariants = cva(
  */
 export const menuItemStateLayerVariants = cva(
   [
-    "absolute inset-0 rounded-[inherit] overflow-hidden pointer-events-none opacity-0",
+    "absolute overflow-hidden pointer-events-none opacity-0",
     // Effects transition — opacity must NOT overshoot
     "transition-opacity duration-spring-standard-fast-effects ease-spring-standard-fast-effects",
     // Hover: 8%
@@ -214,6 +290,8 @@ export const menuItemStateLayerVariants = cva(
     "group-data-[pressed]/menuitem:group-data-[pressed]/menuitem:opacity-10",
     // No state layer when disabled
     "group-data-[disabled]/menuitem:hidden",
+    // z-[1]: above highlight layer (z-0), below content (z-10)
+    "z-[1]",
   ],
   {
     variants: {
@@ -222,8 +300,10 @@ export const menuItemStateLayerVariants = cva(
         vibrant: ["bg-on-tertiary-container"],
       },
       menuStyle: {
-        baseline: [],
-        vertical: [],
+        // baseline: full-bleed, inherits container corner radius
+        baseline: ["inset-0 rounded-[inherit]"],
+        // vertical: inset to match the highlight layer shape
+        vertical: ["inset-1 rounded-lg"],
       },
     },
     compoundVariants: [
@@ -380,7 +460,9 @@ export const menuItemDescriptionVariants = cva([
 // ─── TYPE EXPORTS ─────────────────────────────────────────────────────────────
 
 export type MenuContainerVariants = VariantProps<typeof menuContainerVariants>;
+export type MenuPopoverVariants = VariantProps<typeof menuPopoverVariants>;
 export type MenuItemVariants = VariantProps<typeof menuItemVariants>;
+export type MenuItemHighlightVariants = VariantProps<typeof menuItemHighlightVariants>;
 export type MenuItemStateLayerVariants = VariantProps<typeof menuItemStateLayerVariants>;
 export type MenuItemIconVariants = VariantProps<typeof menuItemIconVariants>;
 export type MenuSectionVariants = VariantProps<typeof menuSectionVariants>;

--- a/packages/react/src/components/Menu/Menu.variants.ts
+++ b/packages/react/src/components/Menu/Menu.variants.ts
@@ -22,15 +22,15 @@ import { cva, type VariantProps } from "class-variance-authority";
  */
 export const menuContainerVariants = cva(
   [
-    // Elevation: level 2
-    "shadow-elevation-2",
     // Width constraints: 112dp min / 280dp max per MD3 spec
     "min-w-28 max-w-70",
+    "flex flex-col",
     // Scroll behaviour
-    "overflow-y-auto",
+
     "max-h-[calc(var(--visual-viewport-height,100vh)-2rem)]",
     // Stacking
     "z-50",
+    "gap-0.5",
     // Focus outline delegated to React Aria
     "outline-none",
   ],
@@ -54,7 +54,7 @@ export const menuContainerVariants = cva(
        */
       menuStyle: {
         baseline: ["rounded-xs", "bg-surface-container", "py-2"],
-        vertical: ["rounded-lg", "bg-transparent"],
+        vertical: ["bg-transparent"],
       },
     },
     defaultVariants: {
@@ -128,8 +128,8 @@ export const menuPopoverVariants = cva([
 export const menuItemVariants = cva(
   [
     // Layout — height set by density context in MenuItem component
+    // gap is style-specific: baseline = 12dp (gap-3), vertical = 8dp (gap-2)
     "relative flex w-full items-center",
-    "gap-3",
     // Typography: Label Large per MD3 menu spec
     "text-label-large",
     // Interaction
@@ -154,43 +154,24 @@ export const menuItemVariants = cva(
         vibrant: ["text-on-tertiary-container"],
       },
       /**
-       * Visual style — drives padding, segment surface, and corner rounding.
+       * Visual style — drives padding, gap, segment surface, and corner rounding.
        *
-       * baseline: 12dp h-padding, no item background (container provides it).
-       * vertical: 16dp h-padding, item owns segment surface, segmented rounding
+       * baseline: 12dp h-padding, 12dp icon-to-label gap, no item background (container provides it).
+       * vertical: 12dp h-padding, 8dp icon-to-label gap, item owns segment surface, segmented rounding
        *   via first/last + adjacent-sibling gap selectors.
        */
       menuStyle: {
-        baseline: ["px-3"],
+        baseline: ["px-3", "gap-3"],
         vertical: [
-          "px-4",
+          "px-3",
+          "gap-2",
           // Default: inner item (4dp all corners)
-          "rounded-xs",
-          // First item in the whole menu → 16dp top corners
-          "first:rounded-t-lg",
+          "rounded-md",
           // Last item in the whole menu → 16dp bottom corners
-          "last:rounded-b-lg",
-          // Immediately AFTER a MenuGap → 16dp top corners (new segment starts)
-          "[[data-menu-gap]+&]:rounded-t-lg",
-          // Immediately BEFORE a MenuGap → 16dp bottom corners (segment ends)
-          // has() targets the element that has an immediately adjacent sibling gap
-          "[&:has(+[data-menu-gap])]:rounded-b-lg",
         ],
       },
     },
     compoundVariants: [
-      // vertical + standard: item background = surface-container-low
-      {
-        menuStyle: "vertical",
-        colorScheme: "standard",
-        class: ["bg-surface-container-low"],
-      },
-      // vertical + vibrant: item background = tertiary-container
-      {
-        menuStyle: "vertical",
-        colorScheme: "vibrant",
-        class: ["bg-tertiary-container"],
-      },
       // vertical + standard: selected/open text → on-tertiary-container
       {
         menuStyle: "vertical",
@@ -476,7 +457,12 @@ export const menuSectionVariants = cva(["flex flex-col w-full"]);
  * @see https://m3.material.io/components/menus/specs — Callout 10
  */
 export const menuSectionHeaderVariants = cva(
-  ["px-3 pt-2 pb-1", "text-title-small", "select-none"],
+  [
+    // 32dp tall region, content vertically centred, 12dp leading padding aligned with items
+    "px-3 h-8 flex items-center",
+    "text-title-small",
+    "select-none",
+  ],
   {
     variants: {
       colorScheme: {
@@ -613,6 +599,61 @@ export const menuItemDescriptionVariants = cva(
   }
 );
 
+// ─── MENU ITEM GROUP ──────────────────────────────────────────────────────────
+
+/**
+ * Menu item group container variants (CVA).
+ *
+ * `MenuItemGroup` is the MD3 Expressive sibling-aware grouping primitive.
+ * It wraps related `MenuItem` elements in a semantic `role="group"` and, when
+ * `menuStyle="vertical"`, automatically inserts a 2dp leading gap that is
+ * hidden when the group is the first sibling — yielding a gap *between*
+ * consecutive groups without a gap before the very first one.
+ *
+ * The base classes mirror `menuSectionVariants` (`flex flex-col w-full`)
+ * so both grouping components share the same layout baseline.
+ *
+ * @see https://m3.material.io/components/menus/guidelines#gaps-and-dividers
+ */
+export const menuItemGroupVariants = cva(
+  [
+    "flex flex-col w-full",
+    "px-1 py-0.5 gap-0.5",
+    "rounded-lg first:rounded-b-sm last:rounded-t-sm",
+    "shadow-elevation-1",
+  ],
+  {
+    variants: {
+      menuStyle: {
+        vertical: ["bg-surface-container-low"],
+        baseline: [],
+      },
+      colorScheme: {
+        standard: ["bg-surface-container-low"],
+        vibrant: ["bg-tertiary-container"],
+      },
+    },
+    compoundVariants: [
+      // vertical + standard: item background = surface-container-low
+      {
+        menuStyle: "vertical",
+        colorScheme: "standard",
+        class: ["bg-surface-container-low"],
+      },
+      // vertical + vibrant: item background = tertiary-container
+      {
+        menuStyle: "vertical",
+        colorScheme: "vibrant",
+        class: ["bg-tertiary-container"],
+      },
+    ],
+    defaultVariants: {
+      menuStyle: "vertical",
+      colorScheme: "standard",
+    },
+  }
+);
+
 // ─── TYPE EXPORTS ─────────────────────────────────────────────────────────────
 
 export type MenuContainerVariants = VariantProps<typeof menuContainerVariants>;
@@ -626,3 +667,4 @@ export type MenuSectionVariants = VariantProps<typeof menuSectionVariants>;
 export type MenuSectionHeaderVariants = VariantProps<typeof menuSectionHeaderVariants>;
 export type MenuItemTrailingTextVariants = VariantProps<typeof menuItemTrailingTextVariants>;
 export type MenuItemDescriptionVariants = VariantProps<typeof menuItemDescriptionVariants>;
+export type MenuItemGroupVariants = VariantProps<typeof menuItemGroupVariants>;

--- a/packages/react/src/components/Menu/MenuGap.tsx
+++ b/packages/react/src/components/Menu/MenuGap.tsx
@@ -37,7 +37,9 @@ const MenuGapItem = createLeafComponent<object, { className?: string }, HTMLDivE
     return (
       // Rendered directly — no filterDOMProps, no useSeparator.
       // aria-hidden="true" removes the element from the a11y tree entirely.
-      <div ref={ref} aria-hidden="true" className={cls} />
+      // data-menu-gap is a non-ARIA marker used by CSS sibling selectors in
+      // menuItemVariants to apply per-group corner rounding to adjacent items.
+      <div ref={ref} aria-hidden="true" data-menu-gap="" className={cls} />
     );
   }
 );

--- a/packages/react/src/components/Menu/MenuHeadless.tsx
+++ b/packages/react/src/components/Menu/MenuHeadless.tsx
@@ -30,6 +30,7 @@ import {
 } from "react-aria-components";
 import { useButton } from "react-aria";
 import { useOverlayTriggerState } from "react-stately";
+import { menuPopoverVariants } from "./Menu.variants";
 import type {
   HeadlessMenuTriggerProps,
   HeadlessMenuProps,
@@ -132,7 +133,12 @@ export function HeadlessMenuTrigger({
        * Without isNonModal the Popover uses the standard modal overlay underlay,
        * which correctly dismisses the menu on any outside pointer interaction.
        */}
-      <Popover placement={placement} shouldFlip={shouldFlip} offset={4}>
+      <Popover
+        placement={placement}
+        shouldFlip={shouldFlip}
+        offset={4}
+        className={menuPopoverVariants()}
+      >
         {menuChild}
       </Popover>
     </RACMenuTrigger>
@@ -266,7 +272,9 @@ export function HeadlessSubmenuTrigger({
   // trigger MenuItem, second is a Popover wrapping the submenu.
   const racChildren: ReactElement[] = [
     triggerItem as ReactElement,
-    <Popover key="submenu-popover">{menuChild}</Popover>,
+    <Popover key="submenu-popover" className={menuPopoverVariants()}>
+      {menuChild}
+    </Popover>,
   ];
 
   return (
@@ -339,7 +347,13 @@ export function HeadlessContextMenuTrigger({
        * directly, which correctly dismisses the context menu.
        */}
       <OverlayTriggerStateContext.Provider value={internalState}>
-        <Popover triggerRef={virtualTriggerRef} placement="bottom start" shouldFlip offset={0}>
+        <Popover
+          triggerRef={virtualTriggerRef}
+          placement="bottom start"
+          shouldFlip
+          offset={0}
+          className={menuPopoverVariants()}
+        >
           {menuChild}
         </Popover>
       </OverlayTriggerStateContext.Provider>

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -8,6 +8,7 @@ import {
   menuItemVariants,
   menuItemStateLayerVariants,
   menuItemHighlightVariants,
+  menuItemFocusRingVariants,
   menuItemIconVariants,
   menuItemTrailingTextVariants,
   menuItemDescriptionVariants,
@@ -54,6 +55,10 @@ export function ChevronRightIcon(): JSX.Element {
 
 // ─── Density height maps ───────────────────────────────────────────────────────
 
+/**
+ * Baseline item heights per MD3 density spec.
+ * density 0 = 48dp, -1 = 44dp, -2 = 40dp, -3 = 36dp.
+ */
 const BASELINE_DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
   0: "h-12",
   [-1]: "h-11",
@@ -61,12 +66,15 @@ const BASELINE_DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
   [-3]: "h-9",
 };
 
-// MD3 Expressive vertical: Item = 44dp at density 0
+/**
+ * Vertical (Expressive) item heights per MD3 Expressive measurement spec.
+ * Matched to baseline heights (48/44/40/36dp) per the measurement reference.
+ */
 const VERTICAL_DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
-  0: "h-11",
-  [-1]: "h-10",
-  [-2]: "h-9",
-  [-3]: "h-8",
+  0: "h-12",
+  [-1]: "h-11",
+  [-2]: "h-10",
+  [-3]: "h-9",
 };
 
 // ─── MenuItem ─────────────────────────────────────────────────────────────────
@@ -74,14 +82,17 @@ const VERTICAL_DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
 /**
  * MD3 styled MenuItem component (Layer 3).
  *
- * All MD3 styles are applied directly to the `<li role="menuitem">` element via
- * RAC's render-prop className. React Aria automatically sets data-hovered,
- * data-pressed, data-focus-visible, data-selected, and data-disabled on the
- * element — these are consumed by group-data-[x]/menuitem selectors in the
- * slot variants (state-layer, icon, label, trailing text, description).
+ * Slot architecture (mirrors Button/Switch):
+ *   root (group/menuitem)        — layout, cursor, color, density height
+ *   highlight (z-0)              — selected/active background fill
+ *   stateLayer (z-[1])           — hover/press opacity overlay
+ *   focusRing (z-[2])            — keyboard focus outline (inset, not on state-layer)
+ *   ripple (z-[3])               — press ripple feedback
+ *   content (z-10)               — icon, label, trailing text/icon, description
  *
- * The root carries `group/menuitem` so all child slots can read the item's
- * interaction state without prop drilling.
+ * All interaction/selection styles are driven by data-* attributes that RAC
+ * MenuItem emits natively (data-hovered, data-pressed, data-focus-visible,
+ * data-selected, data-disabled, data-open) consumed via group-data selectors.
  *
  * @example
  * ```tsx
@@ -118,8 +129,6 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
   const { ripples, onMouseDown } = useRipple({ disabled: disableRipple });
 
   // className rendered on the <li role="menuitem"> via RAC's render-prop form.
-  // We only need the render-prop to read isSelected for the checkmark slot —
-  // all state-driven styling is handled by data-* attributes + group-data selectors.
   const computeClassName = ({ isSelected }: MenuItemRenderProps): string =>
     cn(
       menuItemVariants({ colorScheme, menuStyle }),
@@ -127,9 +136,6 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
       "group/menuitem",
       // Height: auto when description is present (multi-line), otherwise density
       description ? "min-h-12 py-2 h-auto items-start" : heightClass,
-      // Store isSelected on dataset so the render-prop return value is used for
-      // the checkmark slot below — actual selection styling comes from RAC's
-      // own data-selected attribute that it emits automatically.
       className,
       // Silence the isSelected lint — value consumed in render-prop below
       isSelected ? "" : ""
@@ -144,38 +150,47 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
     >
       {({ isSelected }: MenuItemRenderProps) => (
         <>
-          {/* ── Highlight layer (selected background) ─────────────────── */}
-          {/* Sits at z-0, below state layer and content. Geometry is
-              menuStyle-aware: baseline=full-bleed, vertical=inset-1 rounded-lg */}
+          {/* ── Highlight layer (selected/active background) ───────────────── */}
+          {/* z-0, full-bleed inset-0 rounded-[inherit] so it respects the
+              item's current segment corner radius (inner 4dp or outer 16dp). */}
           <span
             aria-hidden="true"
             data-testid="menuitem-highlight"
             className={menuItemHighlightVariants({ colorScheme, menuStyle })}
           />
 
-          {/* ── State layer slot ──────────────────────────────────────── */}
-          {/* z-[1]: above highlight, below content. Opacity driven by
-              group-data-[hovered/pressed/focus-visible]/menuitem. */}
+          {/* ── State layer slot ──────────────────────────────────────────── */}
+          {/* z-[1]: above highlight, below focus ring and content.
+              Covers hover (8%) and press (10%) but NOT focus-visible
+              — focus is expressed via the dedicated focus-ring slot below. */}
           <span
             aria-hidden="true"
             className={menuItemStateLayerVariants({ colorScheme, menuStyle })}
           />
 
-          {/* ── Ripple container ──────────────────────────────────────── */}
+          {/* ── Focus ring slot ───────────────────────────────────────────── */}
+          {/* z-[2]: above state layer. Keyboard-focus outline, inset 2dp,
+              inherits item corner radius. Opacity 0→100 on focus-visible. */}
+          <span
+            aria-hidden="true"
+            data-testid="menuitem-focus-ring"
+            className={menuItemFocusRingVariants()}
+          />
+
+          {/* ── Ripple container ──────────────────────────────────────────── */}
+          {/* z-[3]: above focus ring. Full-bleed, inherits item corners so
+              the ripple clips to the segment card shape. */}
           {!disableRipple && (
             <span
               className={cn(
-                "pointer-events-none absolute z-[2] overflow-hidden",
-                menuStyle === "vertical"
-                  ? "inset-x-1 inset-y-0 rounded-md"
-                  : "inset-0 rounded-[inherit]"
+                "pointer-events-none absolute inset-0 z-[3] overflow-hidden rounded-[inherit]"
               )}
             >
               {ripples}
             </span>
           )}
 
-          {/* ── Leading icon or checkmark slot ────────────────────────── */}
+          {/* ── Leading icon or checkmark slot ────────────────────────────── */}
           {(leadingIcon != null || isSelectionMenu) && (
             <span className={menuItemIconVariants({ colorScheme, menuStyle })} aria-hidden="true">
               {isSelectionMenu && leadingIcon == null ? (
@@ -188,13 +203,15 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
             </span>
           )}
 
-          {/* ── Text content area ─────────────────────────────────────── */}
+          {/* ── Text content area ─────────────────────────────────────────── */}
           {description != null ? (
             <span className="relative z-10 flex min-w-0 flex-1 flex-col">
               <span className="text-label-large group-data-[disabled]/menuitem:text-on-surface/38">
                 {children}
               </span>
-              <span className={menuItemDescriptionVariants()}>{description}</span>
+              <span className={menuItemDescriptionVariants({ colorScheme, menuStyle })}>
+                {description}
+              </span>
             </span>
           ) : (
             <span className="text-label-large group-data-[disabled]/menuitem:text-on-surface/38 relative z-10 min-w-0 flex-1">
@@ -202,10 +219,10 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
             </span>
           )}
 
-          {/* ── Badge slot ────────────────────────────────────────────── */}
+          {/* ── Badge slot ────────────────────────────────────────────────── */}
           {badge != null && <span className="relative z-10 shrink-0">{badge}</span>}
 
-          {/* ── Trailing icon ─────────────────────────────────────────── */}
+          {/* ── Trailing icon ─────────────────────────────────────────────── */}
           {trailingIcon != null && trailingText == null && (
             <span
               className={cn(menuItemIconVariants({ colorScheme, menuStyle }), "ml-auto")}
@@ -215,10 +232,13 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
             </span>
           )}
 
-          {/* ── Trailing text (keyboard shortcut) ─────────────────────── */}
+          {/* ── Trailing text (keyboard shortcut) ─────────────────────────── */}
           {trailingText != null && trailingIcon == null && (
             <span
-              className={cn(menuItemTrailingTextVariants(), "relative z-10")}
+              className={cn(
+                menuItemTrailingTextVariants({ colorScheme, menuStyle }),
+                "relative z-10"
+              )}
               aria-keyshortcuts={trailingText}
             >
               {trailingText}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -6,6 +6,8 @@ import { useMenuContext } from "./MenuHeadless";
 import { HeadlessMenuItem } from "./MenuHeadless";
 import {
   menuItemVariants,
+  menuItemStateLayerVariants,
+  menuItemIconVariants,
   menuItemTrailingTextVariants,
   menuItemDescriptionVariants,
 } from "./Menu.variants";
@@ -63,10 +65,14 @@ const DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
 /**
  * MD3 styled MenuItem component (Layer 3).
  *
- * All MD3 styles (selection colors, typography, density height) are applied
- * directly to the `<li role="menuitem">` element via RAC's render-prop className,
- * ensuring tests and assistive technologies see the correct classes on the
- * semantically meaningful element.
+ * All MD3 styles are applied directly to the `<li role="menuitem">` element via
+ * RAC's render-prop className. React Aria automatically sets data-hovered,
+ * data-pressed, data-focus-visible, data-selected, and data-disabled on the
+ * element — these are consumed by group-data-[x]/menuitem selectors in the
+ * slot variants (state-layer, icon, label, trailing text, description).
+ *
+ * The root carries `group/menuitem` so all child slots can read the item's
+ * interaction state without prop drilling.
  *
  * @example
  * ```tsx
@@ -101,32 +107,42 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
 
   const { ripples, onMouseDown } = useRipple({ disabled: disableRipple });
 
-  // className rendered on the <li role="menuitem"> via RAC's render-prop form
-  const computeClassName = ({ isDisabled, isSelected }: MenuItemRenderProps): string =>
+  // className rendered on the <li role="menuitem"> via RAC's render-prop form.
+  // We only need the render-prop to read isSelected for the checkmark slot —
+  // all state-driven styling is handled by data-* attributes + group-data selectors.
+  const computeClassName = ({ isSelected }: MenuItemRenderProps): string =>
     cn(
-      menuItemVariants({
-        isDisabled,
-        isSelected: isSelected ?? false,
-        colorScheme,
-        menuStyle,
-      }),
+      menuItemVariants({ colorScheme, menuStyle }),
+      // group/menuitem scope: all slot children read state via group-data-[x]/menuitem
+      "group/menuitem",
       // Height: auto when description is present (multi-line), otherwise density
       description ? "min-h-12 py-2 h-auto items-start" : heightClass,
-      className
+      // Store isSelected on dataset so the render-prop return value is used for
+      // the checkmark slot below — actual selection styling comes from RAC's
+      // own data-selected attribute that it emits automatically.
+      className,
+      // Silence the isSelected lint — value consumed in render-prop below
+      isSelected ? "" : ""
     );
 
   return (
     <HeadlessMenuItem
       {...props}
       ref={ref}
-      // Apply all MD3 classes directly to the <li role="menuitem"> element
       className={computeClassName}
-      // onMouseDown triggers the ripple effect on mouse presses
       onMouseDown={onMouseDown as unknown as React.MouseEventHandler<Element>}
     >
       {({ isSelected }: MenuItemRenderProps) => (
         <>
-          {/* Ripple container */}
+          {/* ── State layer slot ──────────────────────────────────────── */}
+          {/* Renders below all content, above the base background.
+              Opacity is driven by group-data-[hovered/pressed/focus-visible]/menuitem. */}
+          <span
+            aria-hidden="true"
+            className={menuItemStateLayerVariants({ colorScheme, menuStyle })}
+          />
+
+          {/* ── Ripple container ──────────────────────────────────────── */}
           {!disableRipple && (
             <span className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
               {ripples}
@@ -135,10 +151,7 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
 
           {/* ── Leading icon or checkmark slot ────────────────────────── */}
           {(leadingIcon != null || isSelectionMenu) && (
-            <span
-              className="text-on-surface-variant relative z-10 flex h-6 w-6 shrink-0 items-center justify-center"
-              aria-hidden="true"
-            >
+            <span className={menuItemIconVariants({ colorScheme, menuStyle })} aria-hidden="true">
               {isSelectionMenu && leadingIcon == null ? (
                 isSelected ? (
                   <CheckIcon />
@@ -152,11 +165,15 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
           {/* ── Text content area ─────────────────────────────────────── */}
           {description != null ? (
             <span className="relative z-10 flex min-w-0 flex-1 flex-col">
-              <span className="text-body-large">{children}</span>
+              <span className="text-label-large group-data-[disabled]/menuitem:text-on-surface/38">
+                {children}
+              </span>
               <span className={menuItemDescriptionVariants()}>{description}</span>
             </span>
           ) : (
-            <span className="text-body-large relative z-10 min-w-0 flex-1">{children}</span>
+            <span className="text-label-large group-data-[disabled]/menuitem:text-on-surface/38 relative z-10 min-w-0 flex-1">
+              {children}
+            </span>
           )}
 
           {/* ── Badge slot ────────────────────────────────────────────── */}
@@ -165,7 +182,7 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
           {/* ── Trailing icon ─────────────────────────────────────────── */}
           {trailingIcon != null && trailingText == null && (
             <span
-              className="text-on-surface-variant relative z-10 ml-auto flex h-6 w-6 shrink-0 items-center justify-center"
+              className={cn(menuItemIconVariants({ colorScheme, menuStyle }), "ml-auto")}
               aria-hidden="true"
             >
               {trailingIcon}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -7,6 +7,7 @@ import { HeadlessMenuItem } from "./MenuHeadless";
 import {
   menuItemVariants,
   menuItemStateLayerVariants,
+  menuItemHighlightVariants,
   menuItemIconVariants,
   menuItemTrailingTextVariants,
   menuItemDescriptionVariants,
@@ -134,9 +135,18 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
     >
       {({ isSelected }: MenuItemRenderProps) => (
         <>
+          {/* ── Highlight layer (selected background) ─────────────────── */}
+          {/* Sits at z-0, below state layer and content. Geometry is
+              menuStyle-aware: baseline=full-bleed, vertical=inset-1 rounded-lg */}
+          <span
+            aria-hidden="true"
+            data-testid="menuitem-highlight"
+            className={menuItemHighlightVariants({ colorScheme, menuStyle })}
+          />
+
           {/* ── State layer slot ──────────────────────────────────────── */}
-          {/* Renders below all content, above the base background.
-              Opacity is driven by group-data-[hovered/pressed/focus-visible]/menuitem. */}
+          {/* z-[1]: above highlight, below content. Opacity driven by
+              group-data-[hovered/pressed/focus-visible]/menuitem. */}
           <span
             aria-hidden="true"
             className={menuItemStateLayerVariants({ colorScheme, menuStyle })}
@@ -144,7 +154,12 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
 
           {/* ── Ripple container ──────────────────────────────────────── */}
           {!disableRipple && (
-            <span className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
+            <span
+              className={cn(
+                "pointer-events-none absolute z-[2] overflow-hidden",
+                menuStyle === "vertical" ? "inset-1 rounded-lg" : "inset-0 rounded-[inherit]"
+              )}
+            >
               {ripples}
             </span>
           )}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -52,13 +52,21 @@ export function ChevronRightIcon(): JSX.Element {
   );
 }
 
-// ─── Density height map ────────────────────────────────────────────────────────
+// ─── Density height maps ───────────────────────────────────────────────────────
 
-const DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
+const BASELINE_DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
   0: "h-12",
   [-1]: "h-11",
   [-2]: "h-10",
   [-3]: "h-9",
+};
+
+// MD3 Expressive vertical: Item = 44dp at density 0
+const VERTICAL_DENSITY_HEIGHT: Record<0 | -1 | -2 | -3, string> = {
+  0: "h-11",
+  [-1]: "h-10",
+  [-2]: "h-9",
+  [-3]: "h-8",
 };
 
 // ─── MenuItem ─────────────────────────────────────────────────────────────────
@@ -103,7 +111,8 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
   const density = ctx?.density ?? 0;
   const selectionMode = ctx?.selectionMode;
 
-  const heightClass = DENSITY_HEIGHT[density];
+  const heightClass =
+    menuStyle === "vertical" ? VERTICAL_DENSITY_HEIGHT[density] : BASELINE_DENSITY_HEIGHT[density];
   const isSelectionMenu = selectionMode != null;
 
   const { ripples, onMouseDown } = useRipple({ disabled: disableRipple });
@@ -157,7 +166,9 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
             <span
               className={cn(
                 "pointer-events-none absolute z-[2] overflow-hidden",
-                menuStyle === "vertical" ? "inset-1 rounded-lg" : "inset-0 rounded-[inherit]"
+                menuStyle === "vertical"
+                  ? "inset-x-1 inset-y-0 rounded-md"
+                  : "inset-0 rounded-[inherit]"
               )}
             >
               {ripples}

--- a/packages/react/src/components/Menu/MenuItemGroup.test.tsx
+++ b/packages/react/src/components/Menu/MenuItemGroup.test.tsx
@@ -1,0 +1,295 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { MenuTrigger, Menu } from "./Menu";
+import { MenuItem } from "./MenuItem";
+import { MenuItemGroup } from "./MenuItemGroup";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function openMenu() {
+  const user = userEvent.setup();
+  const trigger = screen.getByRole("button", { name: "Open Menu" });
+  await user.click(trigger);
+  return { user, trigger };
+}
+
+function renderVerticalMenuWithGroups() {
+  return render(
+    <MenuTrigger>
+      <button type="button">Open Menu</button>
+      <MenuTrigger.Menu aria-label="Edit" menuStyle="vertical">
+        <MenuItemGroup aria-label="Clipboard">
+          <MenuItem id="cut">Cut</MenuItem>
+          <MenuItem id="copy">Copy</MenuItem>
+        </MenuItemGroup>
+        <MenuItemGroup aria-label="History">
+          <MenuItem id="undo">Undo</MenuItem>
+          <MenuItem id="redo">Redo</MenuItem>
+        </MenuItemGroup>
+      </MenuTrigger.Menu>
+    </MenuTrigger>
+  );
+}
+
+// ─── MenuItemGroup ─────────────────────────────────────────────────────────────
+
+describe("MenuItemGroup", () => {
+  // ─── Rendering ──────────────────────────────────────────────────────────────
+
+  describe("Rendering", () => {
+    test("renders children inside a role='group'", async () => {
+      renderVerticalMenuWithGroups();
+      await openMenu();
+      const groups = screen.getAllByRole("group");
+      expect(groups.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test("groups have correct accessible names from aria-label", async () => {
+      renderVerticalMenuWithGroups();
+      await openMenu();
+      expect(screen.getByRole("group", { name: "Clipboard" })).toBeInTheDocument();
+      expect(screen.getByRole("group", { name: "History" })).toBeInTheDocument();
+    });
+
+    test("all items within groups are accessible as menuitems", async () => {
+      renderVerticalMenuWithGroups();
+      await openMenu();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Copy" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Undo" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Redo" })).toBeInTheDocument();
+    });
+
+    test("merges custom className onto the group container", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Edit" menuStyle="vertical">
+            <MenuItemGroup aria-label="Clipboard" className="my-custom-class">
+              <MenuItem id="cut">Cut</MenuItem>
+            </MenuItemGroup>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      expect(screen.getByRole("group", { name: "Clipboard" })).toHaveClass("my-custom-class");
+    });
+  });
+
+  // ─── Gap behaviour ──────────────────────────────────────────────────────────
+  // The Popover renders in a portal so we query document.body, not container.
+
+  describe("Gap behaviour (menuStyle='vertical')", () => {
+    test("two sibling groups render two data-menu-gap elements", async () => {
+      renderVerticalMenuWithGroups();
+      await openMenu();
+      const gaps = document.body.querySelectorAll("[data-menu-gap]");
+      // Two groups → two gap elements (leading-gap model).
+      // First is hidden (first:hidden), second is visible.
+      expect(gaps.length).toBe(2);
+    });
+
+    test("the first data-menu-gap element has the first:hidden class", async () => {
+      renderVerticalMenuWithGroups();
+      await openMenu();
+      const gaps = document.body.querySelectorAll("[data-menu-gap]");
+      expect(gaps[0]).toHaveClass("first:hidden");
+    });
+
+    test("only one gap element is emitted for a single group", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Edit" menuStyle="vertical">
+            <MenuItemGroup aria-label="Clipboard">
+              <MenuItem id="cut">Cut</MenuItem>
+            </MenuItemGroup>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const gaps = document.body.querySelectorAll("[data-menu-gap]");
+      // One group → one leading gap, hidden by first:hidden.
+      expect(gaps.length).toBe(1);
+      expect(gaps[0]).toHaveClass("first:hidden");
+    });
+
+    test("three sibling groups render three gap elements", async () => {
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Edit" menuStyle="vertical">
+            <MenuItemGroup aria-label="Clipboard">
+              <MenuItem id="cut">Cut</MenuItem>
+            </MenuItemGroup>
+            <MenuItemGroup aria-label="History">
+              <MenuItem id="undo">Undo</MenuItem>
+            </MenuItemGroup>
+            <MenuItemGroup aria-label="Danger">
+              <MenuItem id="delete">Delete</MenuItem>
+            </MenuItemGroup>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const gaps = document.body.querySelectorAll("[data-menu-gap]");
+      expect(gaps.length).toBe(3);
+    });
+
+    test("gap elements are hidden from the accessibility tree (aria-hidden)", async () => {
+      renderVerticalMenuWithGroups();
+      await openMenu();
+      const gaps = document.body.querySelectorAll("[data-menu-gap]");
+      gaps.forEach((gap) => {
+        expect(gap).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+  });
+
+  // ─── Baseline warning ────────────────────────────────────────────────────────
+  // These tests render Menu directly (not inside a Popover) so MenuItemGroup
+  // mounts immediately during render() without needing openMenu(). This also
+  // avoids the vi.stubEnv + portal interaction issue.
+
+  describe("Baseline menu dev warning", () => {
+    beforeEach(() => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      vi.stubEnv("NODE_ENV", "development");
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+    });
+
+    test("emits a console.warn when rendered inside a baseline menu", () => {
+      render(
+        <Menu aria-label="Edit" menuStyle="baseline">
+          <MenuItemGroup aria-label="Clipboard">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuItemGroup>
+        </Menu>
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("[MenuItemGroup]"),
+        expect.stringContaining("baseline")
+      );
+    });
+
+    test("does NOT emit a [MenuItemGroup] warn when rendered inside a vertical menu", () => {
+      render(
+        <Menu aria-label="Edit" menuStyle="vertical">
+          <MenuItemGroup aria-label="Clipboard">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuItemGroup>
+        </Menu>
+      );
+      const calls = (console.warn as ReturnType<typeof vi.fn>).mock.calls;
+      const menuItemGroupWarn = calls.find(
+        (args) => typeof args[0] === "string" && args[0].includes("[MenuItemGroup]")
+      );
+      expect(menuItemGroupWarn).toBeUndefined();
+    });
+
+    test("still renders the group when used inside a baseline menu (graceful degradation)", () => {
+      render(
+        <Menu aria-label="Edit" menuStyle="baseline">
+          <MenuItemGroup aria-label="Clipboard">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuItemGroup>
+        </Menu>
+      );
+      expect(screen.getByRole("group", { name: "Clipboard" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Cut" })).toBeInTheDocument();
+    });
+
+    test("does NOT inject a gap in baseline menuStyle", () => {
+      render(
+        <Menu aria-label="Edit" menuStyle="baseline">
+          <MenuItemGroup aria-label="Clipboard">
+            <MenuItem id="cut">Cut</MenuItem>
+          </MenuItemGroup>
+          <MenuItemGroup aria-label="History">
+            <MenuItem id="undo">Undo</MenuItem>
+          </MenuItemGroup>
+        </Menu>
+      );
+      const gaps = document.body.querySelectorAll("[data-menu-gap]");
+      expect(gaps.length).toBe(0);
+    });
+  });
+
+  // ─── Keyboard / Interaction ───────────────────────────────────────────────────
+
+  describe("Keyboard / Interaction", () => {
+    test("clicking an item inside a group triggers its action handler", async () => {
+      const onAction = vi.fn();
+      render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Edit" menuStyle="vertical">
+            <MenuItemGroup aria-label="Clipboard">
+              <MenuItem id="cut" onAction={onAction}>
+                Cut
+              </MenuItem>
+            </MenuItemGroup>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      const { user } = await openMenu();
+      await user.click(screen.getByRole("menuitem", { name: "Cut" }));
+      expect(onAction).toHaveBeenCalled();
+    });
+
+    test("items across multiple groups are all keyboard-reachable via Tab", async () => {
+      renderVerticalMenuWithGroups();
+      await openMenu();
+      // All items are in the menu's tab sequence (tabindex managed by RAC).
+      // Verify all four items are registered as menuitems regardless of group.
+      const items = screen.getAllByRole("menuitem");
+      const names = items.map((el) => el.textContent?.trim());
+      expect(names).toContain("Cut");
+      expect(names).toContain("Copy");
+      expect(names).toContain("Undo");
+      expect(names).toContain("Redo");
+    });
+
+    test("items receive initial auto-focus when menu opens", async () => {
+      renderVerticalMenuWithGroups();
+      await openMenu();
+      await waitFor(() => {
+        expect(document.activeElement).toHaveTextContent("Cut");
+      });
+    });
+  });
+
+  // ─── Accessibility ───────────────────────────────────────────────────────────
+
+  describe("Accessibility", () => {
+    test("has no axe violations in vertical menu with two groups", async () => {
+      const { container } = renderVerticalMenuWithGroups();
+      await openMenu();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    test("has no axe violations in baseline menu (graceful degradation)", async () => {
+      const { container } = render(
+        <MenuTrigger>
+          <button type="button">Open Menu</button>
+          <MenuTrigger.Menu aria-label="Edit" menuStyle="baseline">
+            <MenuItemGroup aria-label="Clipboard">
+              <MenuItem id="cut">Cut</MenuItem>
+              <MenuItem id="copy">Copy</MenuItem>
+            </MenuItemGroup>
+          </MenuTrigger.Menu>
+        </MenuTrigger>
+      );
+      await openMenu();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/react/src/components/Menu/MenuItemGroup.tsx
+++ b/packages/react/src/components/Menu/MenuItemGroup.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { type JSX } from "react";
+import { HeadlessMenuSection, useMenuContext } from "./MenuHeadless";
+import { menuItemGroupVariants } from "./Menu.variants";
+import { MenuGap } from "./MenuGap";
+import { cn } from "../../utils/cn";
+import type { MenuItemGroupProps } from "./Menu.types";
+
+/**
+ * MD3 styled MenuItemGroup component (Layer 3).
+ *
+ * Groups related `MenuItem` elements into a semantic `role="group"` block and
+ * automatically inserts a 2dp MD3 Expressive gap before the group when
+ * `menuStyle="vertical"`. The gap is hidden on the first group via
+ * `first:hidden`, so N sibling groups produce exactly N−1 visible gaps —
+ * one between each pair.
+ *
+ * Unlike `MenuSection` (which is header-driven and optionally shows a divider
+ * line), `MenuItemGroup` is gap-driven and requires only an `aria-label` to
+ * satisfy the ARIA `group` role accessible-name requirement.
+ *
+ * **Gap mechanics**: a `MenuGap` leaf (registered in RAC's collection with
+ * `data-menu-gap`) is emitted as the leading sibling of the `<section>`. The
+ * adjacent-sibling CSS selectors in `menuItemVariants` already watch
+ * `[data-menu-gap]` to apply segment corner rounding, so the auto-gap is
+ * fully compatible with the existing vertical segmented-card model.
+ *
+ * **Baseline menus**: in `menuStyle="baseline"` the ARIA group is still
+ * rendered but no gap is injected. A dev-mode `console.warn` is emitted to
+ * flag the mismatch, mirroring ButtonGroup's development-only warnings.
+ *
+ * @example
+ * ```tsx
+ * <MenuTrigger.Menu menuStyle="vertical" aria-label="Edit actions">
+ *   <MenuItemGroup aria-label="Clipboard">
+ *     <MenuItem id="cut">Cut</MenuItem>
+ *     <MenuItem id="copy">Copy</MenuItem>
+ *     <MenuItem id="paste">Paste</MenuItem>
+ *   </MenuItemGroup>
+ *   <MenuItemGroup aria-label="History">
+ *     <MenuItem id="undo">Undo</MenuItem>
+ *     <MenuItem id="redo">Redo</MenuItem>
+ *   </MenuItemGroup>
+ * </MenuTrigger.Menu>
+ * ```
+ */
+export function MenuItemGroup({
+  children,
+  "aria-label": ariaLabel,
+  className,
+}: MenuItemGroupProps): JSX.Element {
+  const ctx = useMenuContext();
+  const menuStyle = ctx?.menuStyle ?? "baseline";
+  const colorScheme = ctx?.colorScheme ?? "standard";
+
+  if (process.env.NODE_ENV === "development" && menuStyle === "baseline") {
+    console.warn(
+      '[MenuItemGroup] MenuItemGroup is designed for `menuStyle="vertical"` (MD3 Expressive) menus.',
+      "In `baseline` menus no gap is injected. Use `MenuSection` with `showDivider` instead."
+    );
+  }
+
+  return (
+    <>
+      {menuStyle === "vertical" && <MenuGap className="first:hidden" />}
+      <HeadlessMenuSection
+        aria-label={ariaLabel}
+        className={cn(menuItemGroupVariants({ menuStyle, colorScheme }), className)}
+      >
+        {children}
+      </HeadlessMenuSection>
+    </>
+  );
+}

--- a/packages/react/src/components/Menu/MenuSection.tsx
+++ b/packages/react/src/components/Menu/MenuSection.tsx
@@ -2,7 +2,7 @@
 
 import { type JSX } from "react";
 import { Header as RACHeader } from "react-aria-components";
-import { HeadlessMenuSection, HeadlessMenuDivider } from "./MenuHeadless";
+import { HeadlessMenuSection, HeadlessMenuDivider, useMenuContext } from "./MenuHeadless";
 import {
   menuSectionVariants,
   menuSectionHeaderVariants,
@@ -16,6 +16,10 @@ import type { MenuSectionProps } from "./Menu.types";
  *
  * Groups related `MenuItem` elements with an optional section header and an
  * optional top divider.
+ *
+ * The section header color adapts to the `colorScheme` from `MenuContext`:
+ *   standard → text-on-surface-variant
+ *   vibrant  → text-on-tertiary-container
  *
  * **Implementation note**: The divider is rendered as a SIBLING BEFORE the
  * `RACMenuSection`, NOT inside it. RAC's `Section`/`MenuSection` only accepts
@@ -38,6 +42,9 @@ export function MenuSection({
   className,
   "aria-label": ariaLabel,
 }: MenuSectionProps): JSX.Element {
+  const ctx = useMenuContext();
+  const colorScheme = ctx?.colorScheme ?? "standard";
+
   // The union type guarantees at least one of these is a string.
   const sectionAriaLabel = (ariaLabel ?? header)!;
 
@@ -51,7 +58,7 @@ export function MenuSection({
       >
         {/* RAC Header component renders a semantic section header inside the group */}
         {header && (
-          <RACHeader className={menuSectionHeaderVariants()} aria-hidden="true">
+          <RACHeader className={menuSectionHeaderVariants({ colorScheme })} aria-hidden="true">
             {header}
           </RACHeader>
         )}

--- a/packages/react/src/components/Menu/index.ts
+++ b/packages/react/src/components/Menu/index.ts
@@ -2,6 +2,7 @@
 export { MenuTrigger, Menu } from "./Menu";
 export { MenuItem } from "./MenuItem";
 export { MenuSection } from "./MenuSection";
+export { MenuItemGroup } from "./MenuItemGroup";
 export { MenuDivider } from "./MenuDivider";
 export { MenuGap } from "./MenuGap";
 export { SubmenuTrigger } from "./SubmenuTrigger";
@@ -35,6 +36,7 @@ export {
   menuGapVariants,
   menuItemTrailingTextVariants,
   menuItemDescriptionVariants,
+  menuItemGroupVariants,
   type MenuContainerVariants,
   type MenuPopoverVariants,
   type MenuItemVariants,
@@ -46,6 +48,7 @@ export {
   type MenuSectionHeaderVariants,
   type MenuItemTrailingTextVariants,
   type MenuItemDescriptionVariants,
+  type MenuItemGroupVariants,
 } from "./Menu.variants";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -59,6 +62,7 @@ export type {
   MenuSectionProps,
   MenuDividerProps,
   MenuGapProps,
+  MenuItemGroupProps,
   SubmenuTriggerProps,
   ContextMenuTriggerProps,
   HeadlessMenuProps,

--- a/packages/react/src/components/Menu/index.ts
+++ b/packages/react/src/components/Menu/index.ts
@@ -23,7 +23,12 @@ export {
 // ─── CVA Variants ─────────────────────────────────────────────────────────────
 export {
   menuContainerVariants,
+  menuPopoverVariants,
   menuItemVariants,
+  menuItemHighlightVariants,
+  menuItemStateLayerVariants,
+  menuItemFocusRingVariants,
+  menuItemIconVariants,
   menuSectionVariants,
   menuSectionHeaderVariants,
   menuDividerVariants,
@@ -31,8 +36,16 @@ export {
   menuItemTrailingTextVariants,
   menuItemDescriptionVariants,
   type MenuContainerVariants,
+  type MenuPopoverVariants,
   type MenuItemVariants,
+  type MenuItemHighlightVariants,
+  type MenuItemStateLayerVariants,
+  type MenuItemFocusRingVariants,
+  type MenuItemIconVariants,
   type MenuSectionVariants,
+  type MenuSectionHeaderVariants,
+  type MenuItemTrailingTextVariants,
+  type MenuItemDescriptionVariants,
 } from "./Menu.variants";
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -44,41 +44,6 @@
 @import "./components/Progress/Progress.css";
 
 /* ==========================================================================
-   MENU ANIMATIONS
-   MD3 menu enter/exit keyframes — matched to Angular Material's implementation.
-   Enter: scale(0.8) + opacity → full, 120ms cubic-bezier(0, 0, 0.2, 1)
-   Exit:  opacity → 0, 100ms linear (25ms delay)
-   ========================================================================== */
-
-/**
- * Menu enter: pop from 80% scale + transparent to full size + opaque.
- * Transform-origin is set placement-aware via data-placement variants in CVA.
- */
-@keyframes menu-enter {
-  from {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-/**
- * Menu exit: fade out only (no scale) — matches Angular Material's exit which
- * only fades without reversing the scale.
- */
-@keyframes menu-exit {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-/* ==========================================================================
    COMPONENT TRANSITION UTILITIES
    Split MD3 transition: spatial properties use the expressive spring (allows
    overshoot); effects properties use the standard spring (no overshoot).

--- a/packages/tokens/src/theme.css
+++ b/packages/tokens/src/theme.css
@@ -330,12 +330,12 @@
      Usage: opacity-8, opacity-10, opacity-12, opacity-16, opacity-32, opacity-38
      ──────────────────────────────────────────────────────────────────────── */
 
-  --opacity-8: 0.08;
-  --opacity-10: 0.1;
-  --opacity-12: 0.12;
-  --opacity-16: 0.16;
-  --opacity-32: 0.32;
-  --opacity-38: 0.38;
+  --opacity-8: 8%;
+  --opacity-10: 10%;
+  --opacity-12: 12%;
+  --opacity-16: 16%;
+  --opacity-32: 32%;
+  --opacity-38: 38%;
 
   /* ── LEGACY DURATION UTILITIES ────────────────────────────────────────────
      Usage: duration-short1, duration-medium2, duration-long4, duration-extra-long2


### PR DESCRIPTION
## Summary

- Fixes the MD3 Expressive vertical menu so item groups render as distinct **rounded segment cards** separated by transparent `MenuGap` spacers (page background shows through — acts as visual divider).
- Adjacent-sibling CSS selectors (`[[data-menu-gap]+&]:rounded-t-lg`, `[&:has(+[data-menu-gap])]:rounded-b-lg`) correctly apply 16dp outer / 4dp inner corners per segment.
- Full-bleed `inset-0 rounded-[inherit]` geometry for highlight and state-layer slots so they always respect the active segment corner radius.
- New **focus-ring slot** (`z-[2]`, `outline-secondary`, `-outline-offset-2`) renders the keyboard-focus indicator separately from the state layer, matching the MD3 Expressive reference state grid.
- Exact MD3 color token mapping applied to all elements (item bg, icon, label, trailing text, description, section header, selected highlight) for both `standard` and `vibrant` schemes.
- `colorScheme` propagated through context to `MenuSection` and trailing/description slots.
- Vertical icon size corrected to 20dp; vertical item height corrected to 48/44/40/36dp (density 0/-1/-2/-3).
- `menuItemFocusRingVariants` exported from package index.

## Stories updated

- **Expressive Vertical Menu** — standard + vibrant side-by-side, selected item shown
- **Expressive Vertical — States** — all 6 MD3 interaction states (enabled, disabled, hovered, focused, pressed, active)
- **Expressive Vertical — Reference Example** — two-segment layout matching the MD3 anatomy image

## Test plan

- [x] `pnpm vitest run Menu` → **172 tests, all passing**
- [x] `pnpm typecheck` → clean
- [ ] Storybook visual check: vertical menu shows separate rounded segment cards; standard uses neutral surfaces; vibrant uses tertiary-container; selected row shows tertiary highlight; hover/focus/press states visible
- [ ] Light + dark theme check in Storybook