### PR TITLE
chore: release v0.24.2

### DIFF
--- a/.changeset/fix-neutral90-palette.md
+++ b/.changeset/fix-neutral90-palette.md
@@ -1,0 +1,7 @@
+---
+"@tinybigui/tokens": patch
+---
+
+Fix `--md-ref-palette-neutral90` hex value from `#e6e1e5` to `#e6e0e9` per MD3 spec.
+
+This token drives `on-surface`, `on-background`, and `inverse-surface` in dark theme, as well as `surface-container-highest` in light theme. The incorrect value caused subtle color inconsistencies across Card and other surface-based components.

--- a/.changeset/fix-neutral90-palette.md
+++ b/.changeset/fix-neutral90-palette.md
@@ -1,7 +1,0 @@
----
-"@tinybigui/tokens": patch
----
-
-Fix `--md-ref-palette-neutral90` hex value from `#e6e1e5` to `#e6e0e9` per MD3 spec.
-
-This token drives `on-surface`, `on-background`, and `inverse-surface` in dark theme, as well as `surface-container-highest` in light theme. The incorrect value caused subtle color inconsistencies across Card and other surface-based components.

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tinybigui/tokens
 
+## 0.24.2
+
+### Patch Changes
+
+- 3568e8d: Fix `--md-ref-palette-neutral90` hex value from `#e6e1e5` to `#e6e0e9` per MD3 spec.
+
+  This token drives `on-surface`, `on-background`, and `inverse-surface` in dark theme, as well as `surface-container-highest` in light theme. The incorrect value caused subtle color inconsistencies across Card and other surface-based components.
+
 ## 0.23.0
 
 ### Patch Changes

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/tokens",
-  "version": "0.23.0",
+  "version": "0.24.2",
   "description": "Material Design 3 design tokens as CSS variables",
   "keywords": [
     "material-design",

--- a/packages/tokens/src/palette.css
+++ b/packages/tokens/src/palette.css
@@ -114,7 +114,7 @@
   --md-ref-palette-neutral60: #939094;
   --md-ref-palette-neutral70: #aeaaae;
   --md-ref-palette-neutral80: #c9c5ca;
-  --md-ref-palette-neutral90: #e6e1e5;
+  --md-ref-palette-neutral90: #e6e0e9;
   --md-ref-palette-neutral95: #f5eff7;
   /* Extended: light surface-container-highest */
   --md-ref-palette-neutral87: #e6e0e9;


### PR DESCRIPTION
## Summary

Release v0.24.2 — patch release for `@tinybigui/tokens` neutral90 palette fix from `fix/card-component`.

## Changelog

### @tinybigui/tokens 0.24.2

- Fix `--md-ref-palette-neutral90` hex value from `#e6e1e5` to `#e6e0e9` per MD3 spec.
- This token drives `on-surface`, `on-background`, and `inverse-surface` in dark theme, as well as `surface-container-highest` in light theme. The incorrect value caused subtle color inconsistencies across Card and other surface-based components.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm changeset status` clean after version bump