### PR TITLE
fix(checkbox): adjust margin and layout for checkbox variants

### DIFF
--- a/.changeset/fix-checkbox-layout.md
+++ b/.changeset/fix-checkbox-layout.md
@@ -1,0 +1,7 @@
+---
+"@tinybigui/react": patch
+---
+
+**Checkbox:** fix margin and layout alignment for checkbox variants
+
+Adjust root negative margin, control padding, and label spacing to match MD3 touch-target and label alignment spec.

--- a/packages/react/src/components/Checkbox/Checkbox.variants.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.variants.ts
@@ -35,7 +35,7 @@ import { cva, type VariantProps } from "class-variance-authority";
  * the cursor/pointer restriction. Opacity is applied here at 38% when disabled.
  */
 export const checkboxRootVariants = cva([
-  "relative inline-flex items-center cursor-pointer select-none",
+  "relative inline-flex items-center cursor-pointer select-none -ml-3.75",
   "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
   "data-[disabled]:opacity-38",
 ]);
@@ -50,7 +50,7 @@ export const checkboxRootVariants = cva([
  */
 export const checkboxControlVariants = cva([
   "relative flex items-center justify-center flex-shrink-0",
-  "w-10 h-10 rounded-full",
+  "w-10 h-10 rounded-full m-1",
   "overflow-hidden",
 ]);
 
@@ -186,7 +186,7 @@ export const checkboxIconVariants = cva([
  * Text label next to the control.
  * Disabled opacity is inherited from the root's data-[disabled]:opacity-38.
  */
-export const checkboxLabelVariants = cva(["text-body-large text-on-surface select-none ml-4"]);
+export const checkboxLabelVariants = cva(["text-body-large text-on-surface select-none"]);
 
 // ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adjust checkbox root negative margin (`-ml-3.75`) for MD3 touch-target alignment
- Add control padding (`m-1`) on the state-layer container
- Remove redundant label left margin now handled by root offset

## Changeset

Patch bump for `@tinybigui/react`.

## Test plan

- [x] Checkbox unit tests pass (49/49)
- [ ] Visual check in Storybook — checkbox with and without label