### PR TITLE
chore: release v0.24.3

### DIFF
--- a/.changeset/fix-checkbox-layout.md
+++ b/.changeset/fix-checkbox-layout.md
@@ -1,7 +1,0 @@
----
-"@tinybigui/react": patch
----
-
-**Checkbox:** fix margin and layout alignment for checkbox variants
-
-Adjust root negative margin, control padding, and label spacing to match MD3 touch-target and label alignment spec.

--- a/.changeset/fix-checkbox-layout.md
+++ b/.changeset/fix-checkbox-layout.md
@@ -1,0 +1,7 @@
+---
+"@tinybigui/react": patch
+---
+
+**Checkbox:** fix margin and layout alignment for checkbox variants
+
+Adjust root negative margin, control padding, and label spacing to match MD3 touch-target and label alignment spec.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tinybigui/react
 
+## 0.24.3
+
+### Patch Changes
+
+- 9ae0cbb: **Checkbox:** fix margin and layout alignment for checkbox variants
+
+  Adjust root negative margin, control padding, and label spacing to match MD3 touch-target and label alignment spec.
+
 ## 0.24.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/react",
-  "version": "0.24.1",
+  "version": "0.24.3",
   "description": "Material Design 3 React components built with Tailwind CSS",
   "keywords": [
     "react",

--- a/packages/react/src/components/Checkbox/Checkbox.variants.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.variants.ts
@@ -35,7 +35,7 @@ import { cva, type VariantProps } from "class-variance-authority";
  * the cursor/pointer restriction. Opacity is applied here at 38% when disabled.
  */
 export const checkboxRootVariants = cva([
-  "relative inline-flex items-center cursor-pointer select-none",
+  "relative inline-flex items-center cursor-pointer select-none -ml-3.75",
   "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
   "data-[disabled]:opacity-38",
 ]);
@@ -50,7 +50,7 @@ export const checkboxRootVariants = cva([
  */
 export const checkboxControlVariants = cva([
   "relative flex items-center justify-center flex-shrink-0",
-  "w-10 h-10 rounded-full",
+  "w-10 h-10 rounded-full m-1",
   "overflow-hidden",
 ]);
 
@@ -186,7 +186,7 @@ export const checkboxIconVariants = cva([
  * Text label next to the control.
  * Disabled opacity is inherited from the root's data-[disabled]:opacity-38.
  */
-export const checkboxLabelVariants = cva(["text-body-large text-on-surface select-none ml-4"]);
+export const checkboxLabelVariants = cva(["text-body-large text-on-surface select-none"]);
 
 // ─── EXPORTED TYPES ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Release v0.24.3 — checkbox margin and layout alignment fix.

## Changelog

### @tinybigui/react 0.24.3

**Checkbox:** fix margin and layout alignment for checkbox variants

Adjust root negative margin, control padding, and label spacing to match MD3 touch-target and label alignment spec.

## Test plan

- [x] Checkbox unit tests pass (49/49)
- [x] Changeset consumed, version bumped to 0.24.3