### PR TITLE
chore: release v0.24.4

### DIFF
--- a/.changeset/radio-error-variant-fix.md
+++ b/.changeset/radio-error-variant-fix.md
@@ -1,0 +1,7 @@
+---
+"@tinybigui/react": patch
+---
+
+Radio: fix error variant state layer and ring colors
+
+Use important modifiers on invalid state styles so error colors correctly override selected state in the ring and state layer.

--- a/.changeset/radio-error-variant-fix.md
+++ b/.changeset/radio-error-variant-fix.md
@@ -1,7 +1,0 @@
----
-"@tinybigui/react": patch
----
-
-Radio: fix error variant state layer and ring colors
-
-Use important modifiers on invalid state styles so error colors correctly override selected state in the ring and state layer.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tinybigui/react
 
+## 0.24.4
+
+### Patch Changes
+
+- f02378a: Radio: fix error variant state layer and ring colors
+
+  Use important modifiers on invalid state styles so error colors correctly override selected state in the ring and state layer.
+
 ## 0.24.3
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/react",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "Material Design 3 React components built with Tailwind CSS",
   "keywords": [
     "react",

--- a/packages/react/src/components/Radio/Radio.variants.ts
+++ b/packages/react/src/components/Radio/Radio.variants.ts
@@ -110,7 +110,7 @@ export const radioStateLayerVariants = cva([
   // Selected state-layer color
   "group-data-[selected]/radio:bg-primary",
   // Error state-layer color (overrides selected via cascade position)
-  "group-data-[invalid]/radio:bg-error",
+  "group-data-[invalid]/radio:!bg-error",
   // Interaction opacities (MD3: hover 8%, focus/pressed 10%)
   "group-data-[hovered]/radio:opacity-8",
   "group-data-[focus-visible]/radio:opacity-10",
@@ -135,7 +135,7 @@ export const radioRingVariants = cva([
   // Selected — border becomes primary
   "group-data-[selected]/radio:border-primary",
   // Error — placed after selected so it overrides by cascade order
-  "group-data-[invalid]/radio:border-error",
+  "group-data-[invalid]/radio:!border-error",
   // Disabled — on-surface/38 opacity value
   "group-data-[disabled]/radio:border-on-surface/38",
 ]);


### PR DESCRIPTION
## Summary

Release v0.24.4 — Radio error variant state layer and ring color fix.

## Changelog

### @tinybigui/react 0.24.4

**Radio:** fix error variant state layer and ring colors

Use important modifiers on invalid state styles so error colors correctly override selected state in the ring and state layer.

## Test plan

- [x] Radio unit tests pass
- [x] Changeset consumed, version bumped to 0.24.4