### PR TITLE
fix(storybook): build tokens before storybook static export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,45 @@ jobs:
           fi
           echo "✅ All dist directories exist"
 
-  # Job 5: All Checks Passed (Required status check)
+  # Job 5: Storybook Static Build
+  storybook:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 📚 Build Storybook
+        run: pnpm --filter @tinybigui/react build-storybook
+
+      - name: 📦 Check storybook-static output
+        run: |
+          if [ ! -d "packages/react/storybook-static" ]; then
+            echo "❌ Storybook static output not generated"
+            exit 1
+          fi
+          echo "✅ Storybook static output exists"
+
+  # Job 6: All Checks Passed (Required status check)
   all-checks:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [quality, typecheck, test, build]
+    needs: [quality, typecheck, test, build, storybook]
     if: always()
     
     steps:
@@ -165,6 +199,10 @@ jobs:
           fi
           if [ "${{ needs.build.result }}" != "success" ]; then
             echo "❌ Build failed"
+            exit 1
+          fi
+          if [ "${{ needs.storybook.result }}" != "success" ]; then
+            echo "❌ Storybook build failed"
             exit 1
           fi
           echo "✅ All checks passed!"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,7 +56,7 @@
     "test:watch": "vitest",
     "clean": "rm -rf dist",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "pnpm --filter @tinybigui/tokens build && storybook build",
     "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {

--- a/packages/react/src/components/AppBar/AppBar.stories.tsx
+++ b/packages/react/src/components/AppBar/AppBar.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { AppBar } from "./AppBar";

--- a/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState, type JSX } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { BottomSheet } from "./BottomSheet";

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { within, userEvent, expect } from "storybook/test";

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type React from "react";

--- a/packages/react/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { CalendarDate } from "@internationalized/date";

--- a/packages/react/src/components/Slider/Slider.stories.tsx
+++ b/packages/react/src/components/Slider/Slider.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Slider } from "./Slider";

--- a/packages/react/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { TimePicker } from "./TimePicker";


### PR DESCRIPTION
## Summary

- Build `@tinybigui/tokens` before `storybook build` so `@tinybigui/tokens/preset.css` resolves from `dist/`
- Add a CI job that runs `build-storybook` to catch Vercel deployment regressions
- Remove unnecessary `"use client"` directives from 7 story files (Vite warnings only, not the root failure)

## Root cause

Vercel runs `pnpm build-storybook` from `packages/react`, but `packages/tokens/dist/` is gitignored and never generated. Storybook's Tailwind pipeline imports `@tinybigui/tokens/preset.css`, which exports to `./dist/preset.css`.

## Vercel portal (no changes required)

Existing portal settings are correct. Build Command stays `pnpm build-storybook` — the tokens prebuild is now baked into that script.

| Setting | Value |
|---|---|
| Root Directory | `packages/react` |
| Include files outside root | Enabled |
| Install Command | `pnpm install` |
| Build Command | `pnpm build-storybook` |
| Output Directory | `storybook-static` |

After merge, redeploy on Vercel and confirm the build log shows token generation before Storybook preview build.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm --filter @tinybigui/react build-storybook`
- [ ] CI Storybook job passes
- [ ] Vercel deployment succeeds after merge + redeploy