### PR TITLE
chore: release v0.24.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,45 @@ jobs:
           fi
           echo "✅ All dist directories exist"
 
-  # Job 5: All Checks Passed (Required status check)
+  # Job 5: Storybook Static Build
+  storybook:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 📚 Build Storybook
+        run: pnpm --filter @tinybigui/react build-storybook
+
+      - name: 📦 Check storybook-static output
+        run: |
+          if [ ! -d "packages/react/storybook-static" ]; then
+            echo "❌ Storybook static output not generated"
+            exit 1
+          fi
+          echo "✅ Storybook static output exists"
+
+  # Job 6: All Checks Passed (Required status check)
   all-checks:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [quality, typecheck, test, build]
+    needs: [quality, typecheck, test, build, storybook]
     if: always()
     
     steps:
@@ -165,6 +199,10 @@ jobs:
           fi
           if [ "${{ needs.build.result }}" != "success" ]; then
             echo "❌ Build failed"
+            exit 1
+          fi
+          if [ "${{ needs.storybook.result }}" != "success" ]; then
+            echo "❌ Storybook build failed"
             exit 1
           fi
           echo "✅ All checks passed!"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinybigui/react
 
+## 0.24.5
+
+### Patch Changes
+
+- Radio: adjust margin and layout for radio variants to match MD3 touch-target and label alignment spec.
+
 ## 0.24.4
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,7 +56,7 @@
     "test:watch": "vitest",
     "clean": "rm -rf dist",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "pnpm --filter @tinybigui/tokens build && storybook build",
     "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/react",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "Material Design 3 React components built with Tailwind CSS",
   "keywords": [
     "react",

--- a/packages/react/src/components/AppBar/AppBar.stories.tsx
+++ b/packages/react/src/components/AppBar/AppBar.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { AppBar } from "./AppBar";

--- a/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState, type JSX } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { BottomSheet } from "./BottomSheet";

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { within, userEvent, expect } from "storybook/test";

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type React from "react";

--- a/packages/react/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { CalendarDate } from "@internationalized/date";

--- a/packages/react/src/components/Radio/Radio.variants.ts
+++ b/packages/react/src/components/Radio/Radio.variants.ts
@@ -48,7 +48,7 @@ import { cva, type VariantProps } from "class-variance-authority";
  * don't need to handle cursor separately.
  */
 export const radioRootVariants = cva([
-  "relative inline-flex items-center cursor-pointer select-none",
+  "relative inline-flex items-center cursor-pointer select-none -ml-3.75",
   // Disabled state — self-targeting so children inherit via group
   "data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none",
   "data-[disabled]:opacity-38",
@@ -62,7 +62,7 @@ export const radioRootVariants = cva([
  */
 export const radioControlVariants = cva([
   "relative flex items-center justify-center flex-shrink-0",
-  "size-10", // 40dp touch target (MD3 spec)
+  "size-10 m-1", // 40dp touch target (MD3 spec)
 ]);
 
 // ─── FOCUS RING ───────────────────────────────────────────────────────────────
@@ -135,7 +135,7 @@ export const radioRingVariants = cva([
   // Selected — border becomes primary
   "group-data-[selected]/radio:border-primary",
   // Error — placed after selected so it overrides by cascade order
-  "group-data-[invalid]/radio:border-error",
+  "group-data-[invalid]/radio:!border-error",
   // Disabled — on-surface/38 opacity value
   "group-data-[disabled]/radio:border-on-surface/38",
 ]);
@@ -169,7 +169,7 @@ export const radioDotVariants = cva([
  * Text label next to the radio control.
  * Disabled opacity is inherited from root's data-[disabled]:opacity-38.
  */
-export const radioLabelVariants = cva(["text-body-medium text-on-surface select-none ml-4"]);
+export const radioLabelVariants = cva(["text-body-medium text-on-surface select-none"]);
 
 // ─── GROUP ────────────────────────────────────────────────────────────────────
 

--- a/packages/react/src/components/Slider/Slider.stories.tsx
+++ b/packages/react/src/components/Slider/Slider.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Slider } from "./Slider";

--- a/packages/react/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.stories.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { TimePicker } from "./TimePicker";


### PR DESCRIPTION
## Summary

Release v0.24.5 brings dev changes to main:

- **fix(storybook):** build `@tinybigui/tokens` before Storybook static export (fixes Vercel Storybook deployment)
- **fix(radio):** adjust margin and layout for radio variants
- **ci:** add Storybook build job to catch deployment regressions

## Changelog

### @tinybigui/react 0.24.5

- Radio: adjust margin and layout for radio variants to match MD3 touch-target and label alignment spec.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @tinybigui/react build-storybook`
- [ ] CI passes on release PR
- [ ] GitHub Release v0.24.5 published → NPM publish
- [ ] Vercel production redeploy on main succeeds