### PR TITLE
docs: sync readme, roadmap, and changelog for v0.24.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5] - 2026-06-20
+
+### Changed
+
+#### `@tinybigui/react`
+
+- **Radio** — margin and layout alignment for MD3 touch-target and label spacing
+- **Storybook** — build tokens package before static Storybook export for Vercel deploy
+
+> See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) for full release notes.
+
+## [0.24.4] - 2026-06-17
+
+### Changed
+
+#### `@tinybigui/react`
+
+- **Radio** — error variant state layer and ring colors; invalid styles now override selected state in ring and state layer
+
+> See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) for full release notes.
+
+## [0.24.3] - 2026-06-17
+
+### Changed
+
+#### `@tinybigui/react`
+
+- **Checkbox** — margin and layout alignment for MD3 touch-target and label spacing
+
+> See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) for full release notes.
+
+## [0.24.2] - 2026-06-17
+
+### Changed
+
+#### `@tinybigui/tokens`
+
+- **`--md-ref-palette-neutral90`** — hex corrected from `#e6e1e5` to `#e6e0e9` per MD3 spec for `on-surface`, `inverse-surface`, and `surface-container-highest` consistency
+
+> See [packages/tokens/CHANGELOG.md](./packages/tokens/CHANGELOG.md) for full release notes.
+
+## [0.24.1] - 2026-06-17
+
+### Changed
+
+#### `@tinybigui/react`
+
+- **Button** — loading usage fix, outlined variant styling (`border-outline-variant`, `bg-transparent`), and disabled state `group-data-[disabled]/button` selectors
+
+> See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) for full release notes.
+
 ## [0.24.0] - 2026-06-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## ⚙️ Development Status
 
-> **Latest Release: v0.24.0** (2026-06-12)
+> **Latest Release: v0.24.5** (2026-06-20)
 >
 > **29 MD3 components** shipped across buttons, forms, navigation, feedback, and data display — all published to npm with **2,256 tests** passing.
 >
@@ -94,8 +94,8 @@ This is a monorepo containing multiple packages:
 
 | Package                                  | Description                   | Version | Status   |
 | ---------------------------------------- | ----------------------------- | ------- | -------- |
-| [`@tinybigui/react`](./packages/react)   | React components              | 0.24.0  | Released |
-| [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | 0.23.0  | Released |
+| [`@tinybigui/react`](./packages/react)   | React components              | 0.24.5  | Released |
+| [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | 0.24.2  | Released |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 
 ## Current Status
 
-**Current Version:** v0.24.0 (released 2026-06-12)  
+**Current Version:** v0.24.5 (released 2026-06-20)  
 **Next Release:** v0.25.0  
 **Status:** 29 components published to NPM; 2,256 tests passing
 
@@ -42,6 +42,11 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 | v0.22.0 | —       | Dialog MD3 expressive refactor — composite `animate-md-*` motion, hero icon slot, scroll dividers, reduced-motion support, architecture alignment                | Released 2026-06-10 |
 | v0.23.0 | —       | Menu MD3 expressive refactor — segmented vertical menus, `MenuItemGroup`, slot architecture; Button disabled container fix; `--opacity-*` token percentage fix   | Released 2026-06-11 |
 | v0.24.0 | —       | NavigationDrawer MD3 slot-based refactor — `DrawerHeadline`, spring modal animation, spec-accurate measurements/typography/motion; breaking API cleanup          | Released 2026-06-12 |
+| v0.24.1 | —       | Button loading usage fix, outlined variant styling, disabled state selector corrections                                                                          | Released 2026-06-17 |
+| v0.24.2 | —       | Tokens `neutral90` palette hex correction (`#e6e0e9` per MD3 spec) for surface and on-surface consistency                                                        | Released 2026-06-17 |
+| v0.24.3 | —       | Checkbox margin and layout alignment for MD3 touch-target and label spacing                                                                                      | Released 2026-06-17 |
+| v0.24.4 | —       | Radio error variant state layer and ring color overrides for invalid selected state                                                                              | Released 2026-06-17 |
+| v0.24.5 | —       | Radio margin and layout alignment for MD3 touch-target and label spacing; Storybook static export builds tokens before deploy                                    | Released 2026-06-20 |
 | v1.0.0  | Stable  | API frozen, documentation site, migration guides                                                                                                                 | Planned             |
 
 ## Completed Work

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,7 +12,7 @@ A modern, accessible React component library implementing Google's Material Desi
 
 ## ✅ Status
 
-> **Latest Release: v0.24.0** (2026-06-12)
+> **Latest Release: v0.24.5** (2026-06-20)
 >
 > **29 MD3 components** published to npm with full TypeScript support and WCAG 2.1 AA accessibility.
 >

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -12,7 +12,7 @@ A comprehensive collection of Material Design 3 design tokens implemented as CSS
 
 ## ✅ Status
 
-> **Latest Release: v0.23.0** (2026-06-11)
+> **Latest Release: v0.24.2** (2026-06-17)
 >
 > Modular MD3 design tokens published to npm — use standalone imports (`color.css`, `motion.css`, `theme.css`, etc.) or the combined `tokens.css`.
 >


### PR DESCRIPTION
## Summary
- Update root `README.md` and package READMEs to reflect published versions (`@tinybigui/react` v0.24.5, `@tinybigui/tokens` v0.24.2)
- Add v0.24.1–v0.24.5 entries to `ROADMAP.md` release timeline
- Add v0.24.1–v0.24.5 entries to root `CHANGELOG.md`

## Test plan
- [x] Documentation-only change
- [x] Version numbers match npm (`npm view @tinybigui/react version` → 0.24.5)