### PR TITLE
chore: sync dev docs and storybook fixes to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5] - 2026-06-20
+
+### Changed
+
+#### `@tinybigui/react`
+
+- **Radio** — margin and layout alignment for MD3 touch-target and label spacing
+- **Storybook** — build tokens package before static Storybook export for Vercel deploy
+
+> See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) for full release notes.
+
+## [0.24.4] - 2026-06-17
+
+### Changed
+
+#### `@tinybigui/react`
+
+- **Radio** — error variant state layer and ring colors; invalid styles now override selected state in ring and state layer
+
+> See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) for full release notes.
+
+## [0.24.3] - 2026-06-17
+
+### Changed
+
+#### `@tinybigui/react`
+
+- **Checkbox** — margin and layout alignment for MD3 touch-target and label spacing
+
+> See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) for full release notes.
+
+## [0.24.2] - 2026-06-17
+
+### Changed
+
+#### `@tinybigui/tokens`
+
+- **`--md-ref-palette-neutral90`** — hex corrected from `#e6e1e5` to `#e6e0e9` per MD3 spec for `on-surface`, `inverse-surface`, and `surface-container-highest` consistency
+
+> See [packages/tokens/CHANGELOG.md](./packages/tokens/CHANGELOG.md) for full release notes.
+
+## [0.24.1] - 2026-06-17
+
+### Changed
+
+#### `@tinybigui/react`
+
+- **Button** — loading usage fix, outlined variant styling (`border-outline-variant`, `bg-transparent`), and disabled state `group-data-[disabled]/button` selectors
+
+> See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) for full release notes.
+
 ## [0.24.0] - 2026-06-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## ⚙️ Development Status
 
-> **Latest Release: v0.24.0** (2026-06-12)
+> **Latest Release: v0.24.5** (2026-06-20)
 >
 > **29 MD3 components** shipped across buttons, forms, navigation, feedback, and data display — all published to npm with **2,256 tests** passing.
 >
@@ -94,8 +94,8 @@ This is a monorepo containing multiple packages:
 
 | Package                                  | Description                   | Version | Status   |
 | ---------------------------------------- | ----------------------------- | ------- | -------- |
-| [`@tinybigui/react`](./packages/react)   | React components              | 0.24.0  | Released |
-| [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | 0.23.0  | Released |
+| [`@tinybigui/react`](./packages/react)   | React components              | 0.24.5  | Released |
+| [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | 0.24.2  | Released |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 
 ## Current Status
 
-**Current Version:** v0.24.0 (released 2026-06-12)  
+**Current Version:** v0.24.5 (released 2026-06-20)  
 **Next Release:** v0.25.0  
 **Status:** 29 components published to NPM; 2,256 tests passing
 
@@ -42,6 +42,11 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 | v0.22.0 | —       | Dialog MD3 expressive refactor — composite `animate-md-*` motion, hero icon slot, scroll dividers, reduced-motion support, architecture alignment                | Released 2026-06-10 |
 | v0.23.0 | —       | Menu MD3 expressive refactor — segmented vertical menus, `MenuItemGroup`, slot architecture; Button disabled container fix; `--opacity-*` token percentage fix   | Released 2026-06-11 |
 | v0.24.0 | —       | NavigationDrawer MD3 slot-based refactor — `DrawerHeadline`, spring modal animation, spec-accurate measurements/typography/motion; breaking API cleanup          | Released 2026-06-12 |
+| v0.24.1 | —       | Button loading usage fix, outlined variant styling, disabled state selector corrections                                                                          | Released 2026-06-17 |
+| v0.24.2 | —       | Tokens `neutral90` palette hex correction (`#e6e0e9` per MD3 spec) for surface and on-surface consistency                                                        | Released 2026-06-17 |
+| v0.24.3 | —       | Checkbox margin and layout alignment for MD3 touch-target and label spacing                                                                                      | Released 2026-06-17 |
+| v0.24.4 | —       | Radio error variant state layer and ring color overrides for invalid selected state                                                                              | Released 2026-06-17 |
+| v0.24.5 | —       | Radio margin and layout alignment for MD3 touch-target and label spacing; Storybook static export builds tokens before deploy                                    | Released 2026-06-20 |
 | v1.0.0  | Stable  | API frozen, documentation site, migration guides                                                                                                                 | Planned             |
 
 ## Completed Work

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,7 +12,7 @@ A modern, accessible React component library implementing Google's Material Desi
 
 ## ✅ Status
 
-> **Latest Release: v0.24.0** (2026-06-12)
+> **Latest Release: v0.24.5** (2026-06-20)
 >
 > **29 MD3 components** published to npm with full TypeScript support and WCAG 2.1 AA accessibility.
 >

--- a/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -11,7 +11,7 @@ import { ListItem } from "../List/ListItem";
 const SnapIndexIndicator = (): JSX.Element => {
   const { currentSnapIndex, snapPoints } = useBottomSheetContext();
   return (
-    <p className="text-label-medium text-on-surface-variant px-4 pb-2">
+    <p className="text-label-medium text-on-surface-variant px-6 pb-2">
       Snap:{" "}
       <span className="text-on-surface font-medium">
         {currentSnapIndex + 1} of {snapPoints.length}
@@ -77,7 +77,7 @@ const ModalDemo = (): JSX.Element => {
         snapPoints={["50%"]}
         aria-label="Share options"
       >
-        <div className="px-4 pb-4">
+        <div className="px-6 pb-4">
           <h2 className="text-title-medium text-on-surface mb-2">Share</h2>
           <List>
             <ListItem headline="Copy link" />
@@ -133,7 +133,7 @@ export const StandardBottomSheet: Story = {
         snapPoints={["30%", "60%"]}
         aria-label="Now playing"
       >
-        <div className="flex flex-col gap-3 px-4 pb-6">
+        <div className="flex flex-col gap-3 px-6 pb-6">
           <div>
             <p className="text-title-medium text-on-surface">Midnight Drive</p>
             <p className="text-body-medium text-on-surface-variant">The Coastal Waves</p>
@@ -175,7 +175,7 @@ const WithSnapPointsDemo = (): JSX.Element => {
         aria-label="Filter options"
       >
         <SnapIndexIndicator />
-        <div className="px-4 pb-4">
+        <div className="px-6 pb-4">
           <h2 className="text-title-medium text-on-surface mb-3">Filters</h2>
           <div className="flex flex-col gap-3">
             {["Price", "Rating", "Distance", "Category", "Availability"].map((label) => (
@@ -223,7 +223,7 @@ const SingleSnapPointDemo = (): JSX.Element => {
         snapPoints={["60%"]}
         aria-label="Details"
       >
-        <div className="px-4 pb-6">
+        <div className="px-6 pb-6">
           <h2 className="text-title-large text-on-surface">Bluetooth Speaker Pro</h2>
           <p className="text-label-large text-primary mt-1">$129.99</p>
           <p className="text-body-medium text-on-surface-variant mt-3">
@@ -291,7 +291,7 @@ const WithContentDemo = (): JSX.Element => {
         snapPoints={["40%", "75%"]}
         aria-label="Recent files"
       >
-        <div className="px-4 pb-4">
+        <div className="px-6 pb-4">
           <h2 className="text-title-medium text-on-surface mb-2">Recent files</h2>
         </div>
         <div className="overflow-y-auto">
@@ -348,7 +348,7 @@ const WithFormDemo = (): JSX.Element => {
         snapPoints={["70%"]}
         aria-label="Add new address"
       >
-        <div className="px-4 pb-6">
+        <div className="px-6 pb-6">
           <h2 className="text-title-medium text-on-surface mb-4">Add new address</h2>
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <label className="flex flex-col gap-1">
@@ -427,7 +427,7 @@ const ControlledOpenDemo = (): JSX.Element => {
         Close
       </Button>
       <BottomSheet variant="modal" open={open} onOpenChange={setOpen} aria-label="Notifications">
-        <div className="px-4 pb-4">
+        <div className="px-6 pb-4">
           <h2 className="text-title-medium text-on-surface mb-3">Notifications</h2>
           <List>
             <ListItem
@@ -481,7 +481,7 @@ const ScrimDismissDemo = (): JSX.Element => {
         snapPoints={["50%"]}
         aria-label="Settings"
       >
-        <div className="px-4 pb-4">
+        <div className="px-6 pb-4">
           <p className="text-label-large text-primary mb-4">
             Click the shaded area above to dismiss
           </p>
@@ -528,7 +528,7 @@ const ResponsiveLayoutDemo = (): JSX.Element => {
         snapPoints={["50%"]}
         aria-label="Options"
       >
-        <div className="px-4 pb-4">
+        <div className="px-6 pb-4">
           <p className="text-body-medium text-on-surface-variant mb-4">
             On this viewport, the sheet should show side margins and rounded corners. Resize the
             window to below 640px to see full-width behavior with square corners at the sides.
@@ -597,7 +597,7 @@ const PlaygroundDemo = ({
         snapPoints={snapPoints ?? ["50%"]}
         aria-label={ariaLabel ?? "Playground sheet"}
       >
-        <div className="px-4 pb-4">
+        <div className="px-6 pb-4">
           <h2 className="text-title-medium text-on-surface mb-3">Playground</h2>
           <List>
             <ListItem headline="Option one" supportingText="Configure via the controls panel" />

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -12,7 +12,7 @@ A comprehensive collection of Material Design 3 design tokens implemented as CSS
 
 ## ✅ Status
 
-> **Latest Release: v0.23.0** (2026-06-11)
+> **Latest Release: v0.24.2** (2026-06-17)
 >
 > Modular MD3 design tokens published to npm — use standalone imports (`color.css`, `motion.css`, `theme.css`, etc.) or the combined `tokens.css`.
 >


### PR DESCRIPTION
## Summary
- Sync documentation updates for v0.24.5 release (README, ROADMAP, CHANGELOG)
- Include BottomSheet Storybook padding alignment (`px-6` MD3 inset)

No package version changes — `@tinybigui/react` v0.24.5 and `@tinybigui/tokens` v0.24.2 are already published to npm.

## Test plan
- [x] Documentation and Storybook-only changes
- [x] No changeset or version bump required