### PR TITLE
chore: release v0.24.6

### DIFF
--- a/.changeset/docs-readme-sync.md
+++ b/.changeset/docs-readme-sync.md
@@ -1,0 +1,5 @@
+---
+"@tinybigui/react": patch
+---
+
+docs: sync package and root READMEs, ROADMAP, and CHANGELOG for v0.24.5 release notes

--- a/.changeset/docs-readme-sync.md
+++ b/.changeset/docs-readme-sync.md
@@ -1,5 +1,0 @@
----
-"@tinybigui/react": patch
----
-
-docs: sync package and root READMEs, ROADMAP, and CHANGELOG for v0.24.5 release notes

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinybigui/react
 
+## 0.24.6
+
+### Patch Changes
+
+- e361426: docs: sync package and root READMEs, ROADMAP, and CHANGELOG for v0.24.5 release notes
+
 ## 0.24.5
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/react",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "description": "Material Design 3 React components built with Tailwind CSS",
   "keywords": [
     "react",


### PR DESCRIPTION
## Summary

Documentation-only patch release to refresh npm package README and changelog metadata.

### @tinybigui/react 0.24.6

- docs: sync package and root READMEs, ROADMAP, and CHANGELOG for v0.24.5 release notes

## Test plan
- [x] Documentation-only change; no component API or styling changes
- [x] Version bump via changesets