### PR TITLE
docs: update version references to v0.24.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.6] - 2026-06-21
+
+### Changed
+
+#### `@tinybigui/react`
+
+- Documentation sync — README, ROADMAP, and CHANGELOG updated to reflect v0.24.1–v0.24.5 patch releases
+
+> See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) for full release notes.
+
 ## [0.24.5] - 2026-06-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## ⚙️ Development Status
 
-> **Latest Release: v0.24.5** (2026-06-20)
+> **Latest Release: v0.24.6** (2026-06-21)
 >
 > **29 MD3 components** shipped across buttons, forms, navigation, feedback, and data display — all published to npm with **2,256 tests** passing.
 >
@@ -94,7 +94,7 @@ This is a monorepo containing multiple packages:
 
 | Package                                  | Description                   | Version | Status   |
 | ---------------------------------------- | ----------------------------- | ------- | -------- |
-| [`@tinybigui/react`](./packages/react)   | React components              | 0.24.5  | Released |
+| [`@tinybigui/react`](./packages/react)   | React components              | 0.24.6  | Released |
 | [`@tinybigui/tokens`](./packages/tokens) | Design tokens (CSS variables) | 0.24.2  | Released |
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 
 ## Current Status
 
-**Current Version:** v0.24.5 (released 2026-06-20)  
+**Current Version:** v0.24.6 (released 2026-06-21)  
 **Next Release:** v0.25.0  
 **Status:** 29 components published to NPM; 2,256 tests passing
 
@@ -47,6 +47,7 @@ This document outlines the development roadmap for TinyBigUI, a Material Design 
 | v0.24.3 | —       | Checkbox margin and layout alignment for MD3 touch-target and label spacing                                                                                      | Released 2026-06-17 |
 | v0.24.4 | —       | Radio error variant state layer and ring color overrides for invalid selected state                                                                              | Released 2026-06-17 |
 | v0.24.5 | —       | Radio margin and layout alignment for MD3 touch-target and label spacing; Storybook static export builds tokens before deploy                                    | Released 2026-06-20 |
+| v0.24.6 | —       | Documentation sync — README, ROADMAP, and CHANGELOG updated to reflect v0.24.1–v0.24.5 patch releases                                                            | Released 2026-06-21 |
 | v1.0.0  | Stable  | API frozen, documentation site, migration guides                                                                                                                 | Planned             |
 
 ## Completed Work

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,7 +12,7 @@ A modern, accessible React component library implementing Google's Material Desi
 
 ## ✅ Status
 
-> **Latest Release: v0.24.5** (2026-06-20)
+> **Latest Release: v0.24.6** (2026-06-21)
 >
 > **29 MD3 components** published to npm with full TypeScript support and WCAG 2.1 AA accessibility.
 >


### PR DESCRIPTION
Update README, ROADMAP, and CHANGELOG to reflect published v0.24.6 release.