### PR TITLE
fix(divider): adjust horizontal orientation width styling

### DIFF
--- a/.changeset/fix-divider-horizontal-width.md
+++ b/.changeset/fix-divider-horizontal-width.md
@@ -1,0 +1,5 @@
+---
+"@tinybigui/react": patch
+---
+
+Remove forced full-width styling from horizontal dividers so they respect container layout.

--- a/packages/react/src/components/Divider/Divider.test.tsx
+++ b/packages/react/src/components/Divider/Divider.test.tsx
@@ -40,7 +40,8 @@ describe("Divider", () => {
     test("applies horizontal size class for horizontal orientation", () => {
       render(<Divider />);
       const el = screen.getByRole("separator");
-      expect(el).toHaveClass("w-full");
+      expect(el).toHaveClass("h-[var(--md-divider-thickness)]");
+      expect(el).not.toHaveClass("w-full");
     });
 
     test("applies vertical size class for vertical orientation", () => {

--- a/packages/react/src/components/Divider/Divider.variants.ts
+++ b/packages/react/src/components/Divider/Divider.variants.ts
@@ -50,7 +50,7 @@ export const dividerVariants = cva(
        *              inline size is --md-divider-thickness
        */
       orientation: {
-        horizontal: "w-full h-[var(--md-divider-thickness)]",
+        horizontal: "h-[var(--md-divider-thickness)]",
         vertical: "self-stretch h-auto w-[var(--md-divider-thickness)]",
       },
 


### PR DESCRIPTION
## Summary

- Remove `w-full` from horizontal divider orientation so the divider respects its container layout instead of forcing full width

## Test plan

- [ ] Verify horizontal divider renders correctly in constrained containers
- [ ] Verify vertical divider behavior is unchanged
- [ ] Storybook divider stories render as expected