### PR TITLE
chore: release v0.24.7

### DIFF
--- a/.changeset/fix-divider-horizontal-width.md
+++ b/.changeset/fix-divider-horizontal-width.md
@@ -1,0 +1,5 @@
+---
+"@tinybigui/react": patch
+---
+
+Remove forced full-width styling from horizontal dividers so they respect container layout.

--- a/.changeset/fix-divider-horizontal-width.md
+++ b/.changeset/fix-divider-horizontal-width.md
@@ -1,5 +1,0 @@
----
-"@tinybigui/react": patch
----
-
-Remove forced full-width styling from horizontal dividers so they respect container layout.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinybigui/react
 
+## 0.24.7
+
+### Patch Changes
+
+- a0632c6: Remove forced full-width styling from horizontal dividers so they respect container layout.
+
 ## 0.24.6
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybigui/react",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Material Design 3 React components built with Tailwind CSS",
   "keywords": [
     "react",

--- a/packages/react/src/components/Divider/Divider.test.tsx
+++ b/packages/react/src/components/Divider/Divider.test.tsx
@@ -40,7 +40,8 @@ describe("Divider", () => {
     test("applies horizontal size class for horizontal orientation", () => {
       render(<Divider />);
       const el = screen.getByRole("separator");
-      expect(el).toHaveClass("w-full");
+      expect(el).toHaveClass("h-[var(--md-divider-thickness)]");
+      expect(el).not.toHaveClass("w-full");
     });
 
     test("applies vertical size class for vertical orientation", () => {

--- a/packages/react/src/components/Divider/Divider.variants.ts
+++ b/packages/react/src/components/Divider/Divider.variants.ts
@@ -50,7 +50,7 @@ export const dividerVariants = cva(
        *              inline size is --md-divider-thickness
        */
       orientation: {
-        horizontal: "w-full h-[var(--md-divider-thickness)]",
+        horizontal: "h-[var(--md-divider-thickness)]",
         vertical: "self-stretch h-auto w-[var(--md-divider-thickness)]",
       },
 


### PR DESCRIPTION
## Summary

Release v0.24.7 with a divider horizontal orientation fix.

## Changelog

### @tinybigui/react 0.24.7

**Patch Changes**

- Remove forced full-width styling from horizontal dividers so they respect container layout.

## Test plan

- [x] CI green on release branch
- [ ] Merge with **Create a merge commit** (no squash)
- [ ] Publish GitHub Release `v0.24.7` after merge