### PR TITLE
fix(switch): story layout, tooltip typography, and divider width

### DIFF
--- a/packages/react/src/components/Divider/Divider.variants.ts
+++ b/packages/react/src/components/Divider/Divider.variants.ts
@@ -50,7 +50,7 @@ export const dividerVariants = cva(
        *              inline size is --md-divider-thickness
        */
       orientation: {
-        horizontal: "w-full h-[var(--md-divider-thickness)]",
+        horizontal: "h-[var(--md-divider-thickness)]",
         vertical: "self-stretch h-auto w-[var(--md-divider-thickness)]",
       },
 

--- a/packages/react/src/components/Switch/Switch.stories.tsx
+++ b/packages/react/src/components/Switch/Switch.stories.tsx
@@ -257,7 +257,7 @@ export const FormIntegration: Story = {
     };
 
     return (
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} className="flex items-center gap-4">
         <Switch name="darkMode" value="enabled" defaultSelected>
           Dark mode
         </Switch>
@@ -284,7 +284,7 @@ export const AllStates: Story = {
       <div className="space-y-6">
         <div className="space-y-2">
           <h3 className="text-lg font-medium">Basic States</h3>
-          <div className="space-y-2">
+          <div className="flex items-center gap-4">
             <Switch>Off (default)</Switch>
             <Switch defaultSelected>On</Switch>
           </div>
@@ -292,7 +292,7 @@ export const AllStates: Story = {
 
         <div className="space-y-2">
           <h3 className="text-lg font-medium">With Icons</h3>
-          <div className="space-y-2">
+          <div className="flex items-center gap-4">
             <Switch icon={<IconClose />} selectedIcon={<IconCheck />}>
               Toggle with icons
             </Switch>
@@ -304,7 +304,7 @@ export const AllStates: Story = {
 
         <div className="space-y-2">
           <h3 className="text-lg font-medium">Disabled States</h3>
-          <div className="space-y-2">
+          <div className="flex items-center gap-4">
             <Switch isDisabled>Disabled (off)</Switch>
             <Switch isDisabled defaultSelected>
               Disabled (on)
@@ -314,7 +314,7 @@ export const AllStates: Story = {
 
         <div className="space-y-2">
           <h3 className="text-lg font-medium">Read-only States</h3>
-          <div className="space-y-2">
+          <div className="flex items-center gap-4">
             <Switch isReadOnly>Read-only (off)</Switch>
             <Switch isReadOnly defaultSelected>
               Read-only (on)
@@ -324,7 +324,7 @@ export const AllStates: Story = {
 
         <div className="space-y-2">
           <h3 className="text-lg font-medium">Without Labels</h3>
-          <div className="space-y-2">
+          <div className="flex items-center gap-4">
             <Switch aria-label="Toggle option 1" />
             <Switch aria-label="Toggle option 2" defaultSelected />
           </div>
@@ -356,7 +356,7 @@ export const Playground: Story = {
     return (
       <div className="space-y-4">
         <h3 className="text-lg font-medium">Device Settings</h3>
-        <div className="space-y-3">
+        <div className="flex items-center gap-4">
           <Switch
             isSelected={settings.bluetooth}
             onChange={updateSetting("bluetooth")}

--- a/packages/react/src/components/Tooltip/Tooltip.variants.ts
+++ b/packages/react/src/components/Tooltip/Tooltip.variants.ts
@@ -77,7 +77,7 @@ export const tooltipVariants = cva(
   [
     "z-50 inline-flex items-center w-fit",
     "min-h-6 rounded-xs px-2 py-1",
-    "text-body-small bg-inverse-surface text-inverse-on-surface",
+    "text-body-small tracking-[0.4px] bg-inverse-surface text-inverse-on-surface",
     "max-w-50",
   ],
   {
@@ -156,7 +156,9 @@ export const richTooltipVariants = cva(
  * - `text-on-surface-variant`— MD3 rich-tooltip subhead colour role
  * - `mb-1`                   — 4dp gap below title (before supporting text)
  */
-export const richTooltipTitleVariants = cva(["text-title-small text-on-surface-variant mb-1"]);
+export const richTooltipTitleVariants = cva([
+  "text-title-small font-medium text-on-surface-variant mb-1",
+]);
 
 /**
  * Rich tooltip supporting text body.


### PR DESCRIPTION
## Summary

- Update Switch Storybook stories to use horizontal flex layout for clearer visual comparison
- Improve Tooltip text readability with letter-spacing and medium font weight on rich tooltip titles
- Remove `w-full` from horizontal Divider variant so width follows container constraints

## Test plan

- [ ] Switch stories render correctly in Storybook (AllStates, FormIntegration, Playground)
- [ ] Tooltip plain and rich variants display correct typography
- [ ] Horizontal Divider respects parent width without forcing full width